### PR TITLE
docs(waves): add EngineFrame migration plan and execution board

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -20,6 +20,8 @@
 - `waves/WAE_SPEC_TRACEABILITY.md`: WAE/WAEMT spec-derived requirements and acceptance-criteria traceability matrix
 - `waves/TRANSPORT_SPEC_TRACEABILITY.md`: WSP/WTP/WDP transport spec-derived requirements and acceptance-criteria traceability matrix
 - `waves/TRANSPORT_RUST_PHASE_PLAN.md`: active phased implementation plan for `transport-rust` (FFI decode, streaming, protocol, and WTLS stages)
+- `waves/ENGINE_HOST_FRAME_MIGRATION_PLAN.md`: canonical migration plan for EngineFrame-based host integration
+- `waves/ENGINE_HOST_FRAME_WORK_ITEMS.md`: ticketized execution board for frame/input interface migration
 - `waves/TRANSPORT_ADJACENT_SPEC_TRACEABILITY.md`: HTTP/TCP/HTTPSM/WCMP transport-adjacent requirements and interoperability-boundary traceability
 - `waves/SECURITY_BOUNDARY_TRACEABILITY.md`: WTLS/TLS/end-to-end security traceability and Waves boundary policy mapping
 - `waves/SECURITY_PKI_SPEC_TRACEABILITY.md`: WAPCert/WPKI/WIM trust and PKI-profile boundary traceability

--- a/docs/waves/ENGINE_HOST_FRAME_MIGRATION_PLAN.md
+++ b/docs/waves/ENGINE_HOST_FRAME_MIGRATION_PLAN.md
@@ -1,0 +1,185 @@
+# Engine-Host Frame Interface Migration Plan
+
+Status: planning-ready  
+Last updated: 2026-03-03
+
+## Purpose
+
+Define a deterministic, multi-target rendering boundary where the engine emits structured frame data and hosts render it, without engine-generated HTML or host DOM-coupled assumptions.
+
+This plan is intentionally scoped to interface and rendering-boundary migration only.
+
+## Scope
+
+In scope:
+
+- engine output model migration from `RenderList` to `EngineFrame` (additive first)
+- engine input model migration from key-only calls to typed `EngineInputEvent` (additive first)
+- host adapter updates for:
+  - WASM browser harness (`engine-wasm/host-sample`)
+  - Waves Tauri frontend (`browser/frontend`)
+- contract-source and type-generation alignment across Rust and TypeScript
+- parity and determinism validation across native + wasm targets
+
+Out of scope:
+
+- protocol stack redesign
+- broad runtime feature expansion unrelated to interface migration
+- GPU renderer implementation (only compatibility posture)
+
+## Current Baseline (Observed)
+
+1. Engine already emits structured draw commands (`RenderList`, `DrawCmd::Text|Link`).
+2. WASM host sample already consumes draw commands and paints to Canvas2D.
+3. Tauri frontend currently converts draw commands into HTML string lines (`innerHTML`) for viewport presentation.
+4. Input flow is key-driven (`up/down/enter`) with host-triggered back and timer ticks; no click/scroll event boundary exists yet.
+5. Type contracts are partly centralized:
+   - generated host contracts from Rust (`ts-rs`) in `browser/contracts/generated/*`
+   - handwritten engine wasm contract in `engine-wasm/contracts/wml-engine.ts`
+
+## Target Architecture
+
+### Engine Output Boundary
+
+Engine returns a frame object with enough data for renderer independence:
+
+- `EngineFrame`
+  - `viewport`
+  - `drawCommands`
+  - optional `hitRegions` (for deterministic click mapping)
+  - optional `metadata` (diagnostics/version/feature flags)
+
+### Engine Input Boundary
+
+Engine accepts typed input events:
+
+- `EngineInputEvent`
+  - `KeyPress`
+  - `Click`
+  - `Scroll`
+  - optional future events (`Softkey`, `TextCommit`)
+
+### Host Responsibilities
+
+- renderer implementation selection (Canvas2D now, future GPU later)
+- mapping host/native/browser input into `EngineInputEvent`
+- transport, windowing, and side-effect policy remain host-owned
+
+### Engine Responsibilities
+
+- deterministic layout, navigation, focus, and hit-testing
+- deterministic frame generation (host-agnostic)
+- zero DOM/HTML assumptions
+
+## Compatibility Strategy
+
+Use additive migration with compatibility shims:
+
+1. Introduce new frame/input API while preserving existing `render()` and `handleKey()` paths.
+2. Migrate hosts to new APIs incrementally.
+3. Keep regression parity tests on both APIs until cutover.
+4. Remove legacy API only after parity gate is green.
+
+## Contract-First Plan
+
+Primary contract evolution sequence:
+
+1. Define canonical Rust-side interface types (`EngineFrame`, `DrawCommand`, `EngineInputEvent`, `EngineCommand`).
+2. Generate TypeScript bindings from Rust-owned types for host usage.
+3. Keep `engine-wasm/contracts/wml-engine.ts` aligned as contract surface until fully generator-backed.
+4. Update `browser/contracts/generated/engine-host.ts` generation pipeline for new methods and shapes.
+
+Contract guardrails:
+
+- no host-specific fields in engine-owned frame/input contracts
+- serialization-only target glue at adapters
+- contract changes require docs and parity-test updates in same change
+
+## Migration Phases
+
+### Phase F0: Contracts and Adapters (No Behavior Change)
+
+- define frame/input types
+- add engine API methods:
+  - `renderFrame() -> EngineFrame`
+  - `handleInput(event: EngineInputEvent)`
+- keep legacy methods with wrappers:
+  - `render()`
+  - `handleKey()`
+
+### Phase F1: Host Renderer Migration
+
+- update WASM host sample to consume `EngineFrame` path
+- replace Tauri frontend viewport HTML rendering with Canvas2D renderer adapter
+- keep presenter/session/timeline behavior unchanged outside rendering surface
+
+### Phase F2: Input Event Surface Expansion
+
+- add click and scroll routing from hosts to engine
+- implement deterministic hit testing in engine frame/hit-region model
+- keep keyboard path behavior identical
+
+### Phase F3: Internal Engine Boundary Cleanup
+
+- split current combined layout+draw generation into:
+  - layout phase
+  - paint phase
+- preserve draw ordering and focus determinism across targets
+
+### Phase F4: Cutover and Legacy Removal
+
+- require parity suite green on native + wasm for frame/input paths
+- remove legacy `RenderList` and key-only API surfaces
+- finalize docs and coverage mappings
+
+## Determinism and Parity Gates
+
+Must remain deterministic across native and wasm:
+
+- `loadDeckContext`
+- `handleInput(KeyPress)`
+- `renderFrame`
+- script invocation side effects
+- back-stack/focus transitions
+- timer-driven transitions
+
+Parity-critical coverage must include:
+
+- snapshot parity for frame command sequence
+- focus and navigation parity under identical input traces
+- click hit-target parity using frame/hit-region mapping fixtures
+
+## Risks and Mitigations
+
+1. Risk: contract drift between handwritten and generated TS types.
+- Mitigation: make Rust-owned contract generation authoritative and add CI drift checks.
+
+2. Risk: renderer-dependent text metrics affecting determinism.
+- Mitigation: keep engine layout in logical units (rows/cols) and avoid host-measured line wrapping.
+
+3. Risk: click semantics diverge by target host.
+- Mitigation: engine-owned hit-region identifiers in frame output; hosts send coordinates only.
+
+4. Risk: migration stalls due to dual-path complexity.
+- Mitigation: strict phase gates and explicit legacy removal criteria.
+
+## Documentation Update Requirements Per Phase
+
+Each migration phase PR must update:
+
+- `engine-wasm/contracts/wml-engine.ts`
+- `engine-wasm/README.md`
+- `browser/contracts/generated/engine-host.ts` (generated output)
+- `docs/waves/CONTRACT_REQUIREMENTS_MAPPING.md`
+- `docs/waves/SPEC_TEST_COVERAGE.md`
+- `docs/waves/ENGINE_HOST_FRAME_WORK_ITEMS.md` status
+
+## Acceptance Criteria (Program-Level)
+
+Migration is complete when:
+
+1. Engine no longer exposes legacy `RenderList`/`handleKey` API in primary host path.
+2. Both hosts consume `EngineFrame` and `EngineInputEvent`.
+3. Tauri viewport rendering no longer depends on HTML line injection.
+4. Native/wasm parity suite covers frame/input critical paths and passes.
+5. Contract and docs drift checks enforce boundary consistency in CI.

--- a/docs/waves/ENGINE_HOST_FRAME_WORK_ITEMS.md
+++ b/docs/waves/ENGINE_HOST_FRAME_WORK_ITEMS.md
@@ -1,0 +1,290 @@
+# Engine-Host Frame Migration Work Items
+
+Purpose: execution board for migrating Waves runtime/host integration to `EngineFrame` + `EngineInputEvent`.
+
+Status keys:
+
+- `todo`
+- `in-progress`
+- `blocked`
+- `done`
+
+## Program Guardrails
+
+1. Keep changes layered:
+- engine runtime logic in `engine-wasm/`
+- host rendering/input wiring in `browser/` and `engine-wasm/host-sample/`
+- no WBXML parsing in host TypeScript
+
+2. Contract-first policy:
+- update contract surfaces before implementation cutover
+- keep native and wasm behavior aligned
+
+3. Determinism policy:
+- preserve deterministic navigation, focus, and frame output ordering
+- no host-timing dependent layout logic
+
+4. Scope policy:
+- no broad refactor bundles; deliver phased, testable slices
+
+## Ticket Template
+
+1. `ID`
+2. `Status`
+3. `Depends On`
+4. `Files`
+5. `Build`
+6. `Tests`
+7. `Accept`
+8. `Notes` (optional)
+
+## Phase F0: Contract and API Introduction
+
+### F0-01 Define canonical frame/input contract types
+
+1. `Status`: `todo`
+2. `Depends On`: none
+3. `Files`:
+- `engine-wasm/engine/src/render/*`
+- `engine-wasm/contracts/wml-engine.ts`
+- `browser/src-tauri/src/contract_types.rs`
+- `browser/src-tauri/src/bin/generate_contracts.rs`
+4. `Build`:
+- Add additive types for:
+  - `EngineFrame`
+  - `DrawCommand` (new contract alias or replacement for `DrawCmd`)
+  - `EngineInputEvent`
+  - `EngineCommand` (if command queue is adopted)
+- Keep legacy `RenderList` contract available.
+5. `Tests`:
+- contract generation succeeds
+- TypeScript compile in `browser/frontend`
+6. `Accept`:
+- New frame/input types are exported in Rust and TS contracts without breaking current hosts.
+
+### F0-02 Add additive engine APIs with compatibility wrappers
+
+1. `Status`: `todo`
+2. `Depends On`: `F0-01`
+3. `Files`:
+- `engine-wasm/engine/src/lib.rs`
+- `engine-wasm/contracts/wml-engine.ts`
+- `browser/src-tauri/src/lib.rs`
+- `browser/contracts/generated/engine-host.ts`
+4. `Build`:
+- Add:
+  - `renderFrame()`
+  - `handleInput(event)`
+- Keep:
+  - `render()`
+  - `handleKey()`
+- Implement wrapper behavior so outputs stay equivalent for key-only flow.
+5. `Tests`:
+- `cd engine-wasm/engine && cargo test`
+- `cd browser/src-tauri && cargo test`
+6. `Accept`:
+- Old and new APIs return equivalent behavior for existing fixtures and key sequences.
+
+### F0-03 Contract drift guardrails for frame/input interfaces
+
+1. `Status`: `todo`
+2. `Depends On`: `F0-01`
+3. `Files`:
+- `scripts/` (new contract drift check)
+- `.github/workflows/*`
+- `docs/waves/CONTRACT_REQUIREMENTS_MAPPING.md`
+4. `Build`:
+- Add CI check that generated TS contracts are in sync with Rust contract types.
+5. `Tests`:
+- intentional drift causes CI/check failure
+6. `Accept`:
+- contract changes cannot merge with stale generated outputs.
+
+## Phase F1: Host Rendering Migration
+
+### F1-01 WASM host sample frame renderer adoption
+
+1. `Status`: `todo`
+2. `Depends On`: `F0-02`
+3. `Files`:
+- `engine-wasm/host-sample/renderer.ts`
+- `engine-wasm/host-sample/main.ts`
+- `engine-wasm/README.md`
+4. `Build`:
+- Consume `renderFrame()` and draw from frame contract.
+- Keep behavior and appearance stable.
+5. `Tests`:
+- host sample manual fixture checks
+6. `Accept`:
+- sample no longer depends on legacy `RenderList` call path.
+
+### F1-02 Tauri frontend viewport migration to Canvas2D
+
+1. `Status`: `todo`
+2. `Depends On`: `F0-02`
+3. `Files`:
+- `browser/frontend/src/app/browser-shell-template.ts`
+- `browser/frontend/src/app/browser-presenter.ts`
+- `browser/frontend/src/styles.css`
+- `browser/frontend/src/app/browser-presenter.test.ts`
+4. `Build`:
+- replace HTML line injection viewport path with canvas renderer adapter.
+- preserve skeleton, status, and timeline UX.
+5. `Tests`:
+- `pnpm --dir browser/frontend test`
+- `pnpm --dir browser/frontend build`
+6. `Accept`:
+- viewport rendering no longer uses `innerHTML` for deck content.
+- draw output parity remains stable for local fixtures.
+
+### F1-03 Navigation-state integration with frame rendering
+
+1. `Status`: `todo`
+2. `Depends On`: `F1-02`
+3. `Files`:
+- `browser/frontend/src/app/navigation-state.ts`
+- `browser/frontend/src/app/browser-controller.ts`
+- `browser/frontend/src/app/navigation-state.test.ts`
+4. `Build`:
+- keep render/snapshot sequencing deterministic with `engineRenderFrame`.
+5. `Tests`:
+- navigation-state tests cover render-after-load and render-after-input ordering.
+6. `Accept`:
+- no regressions in load/fetch/back/external-intent flows.
+
+## Phase F2: Input Event Expansion
+
+### F2-01 Add click event path with deterministic hit resolution
+
+1. `Status`: `todo`
+2. `Depends On`: `F0-02`
+3. `Files`:
+- `engine-wasm/engine/src/lib.rs`
+- `engine-wasm/engine/src/layout/*`
+- `browser/frontend/src/app/browser-controller.ts`
+- `engine-wasm/host-sample/main.ts`
+4. `Build`:
+- add host click -> `EngineInputEvent::Click` routing.
+- engine resolves click through frame/hit regions, not host-side link lookup.
+5. `Tests`:
+- engine fixture tests for click-target determinism
+- host integration tests for click navigation
+6. `Accept`:
+- click activation behavior matches keyboard activation targets.
+
+### F2-02 Add scroll event path and viewport offset semantics
+
+1. `Status`: `todo`
+2. `Depends On`: `F2-01`
+3. `Files`:
+- `engine-wasm/engine/src/lib.rs`
+- `engine-wasm/contracts/wml-engine.ts`
+- `browser/frontend/src/app/browser-controller.ts`
+4. `Build`:
+- support `EngineInputEvent::Scroll`.
+- define deterministic scroll clamping and frame offset behavior.
+5. `Tests`:
+- scroll boundary and repeatability tests in engine.
+6. `Accept`:
+- identical event traces produce identical visible frame windows.
+
+### F2-03 Softkey/input abstraction alignment
+
+1. `Status`: `todo`
+2. `Depends On`: `F2-01`
+3. `Files`:
+- `browser/frontend/src/app/keyboard.ts`
+- `browser/frontend/src/app/browser-controller.ts`
+- `engine-wasm/contracts/wml-engine.ts`
+4. `Build`:
+- map host keyboard/buttons into unified `EngineInputEvent` path.
+- keep legacy key APIs as compatibility layer until cutover.
+5. `Tests`:
+- keyboard and control-button regression tests.
+6. `Accept`:
+- single input abstraction path is used in host application code.
+
+## Phase F3: Engine Internal Boundary Split
+
+### F3-01 Separate layout and paint phases
+
+1. `Status`: `todo`
+2. `Depends On`: `F0-02`
+3. `Files`:
+- `engine-wasm/engine/src/layout/*`
+- `engine-wasm/engine/src/render/*`
+- `engine-wasm/engine/src/lib.rs`
+4. `Build`:
+- move draw-command emission into paint pass over layout output.
+- preserve current command ordering and focus semantics.
+5. `Tests`:
+- existing render snapshot tests
+- new tests for layout-output determinism independent from paint
+6. `Accept`:
+- layout and paint responsibilities are explicit and test-covered.
+
+### F3-02 Frame snapshot parity harness (native + wasm)
+
+1. `Status`: `todo`
+2. `Depends On`: `F3-01`
+3. `Files`:
+- `engine-wasm/engine/src/lib.rs`
+- `engine-wasm/engine/tests/*` (new if needed)
+- `docs/waves/SPEC_TEST_COVERAGE.md`
+4. `Build`:
+- add parity-critical snapshots for `renderFrame` and input traces.
+5. `Tests`:
+- `cd engine-wasm/engine && cargo test`
+6. `Accept`:
+- frame and navigation parity is verified across targets for critical flows.
+
+## Phase F4: Cutover and Legacy Removal
+
+### F4-01 Remove legacy render/input API from host paths
+
+1. `Status`: `todo`
+2. `Depends On`: `F1-03`, `F2-03`, `F3-02`
+3. `Files`:
+- `browser/frontend/src/*`
+- `engine-wasm/host-sample/*`
+- `browser/contracts/generated/*`
+- `engine-wasm/contracts/wml-engine.ts`
+4. `Build`:
+- stop calling legacy `render()`/`handleKey()` in host code.
+- retain compatibility only where needed for transition windows.
+5. `Tests`:
+- browser frontend tests/build
+- host-sample smoke checks
+6. `Accept`:
+- all active hosts run on frame/input API path.
+
+### F4-02 Legacy contract and wrapper removal (final)
+
+1. `Status`: `todo`
+2. `Depends On`: `F4-01`
+3. `Files`:
+- `engine-wasm/engine/src/lib.rs`
+- `engine-wasm/contracts/wml-engine.ts`
+- `browser/src-tauri/src/contract_types.rs`
+- `browser/src-tauri/src/bin/generate_contracts.rs`
+- docs references to legacy API
+4. `Build`:
+- remove legacy `RenderList`/`DrawCmd` wrappers and key-only APIs when no longer used.
+5. `Tests`:
+- engine, browser frontend, and tauri host tests/builds
+6. `Accept`:
+- contract surface is single-path (`EngineFrame` + `EngineInputEvent`) and documented.
+
+## Program Tracking
+
+Cross-reference docs:
+
+- migration architecture: `docs/waves/ENGINE_HOST_FRAME_MIGRATION_PLAN.md`
+- waves integration board: `docs/waves/WORK_ITEMS.md`
+- maintenance board: `docs/waves/MAINTENANCE_WORK_ITEMS.md`
+
+Completion gate:
+
+- all `F0-F4` tickets marked `done`
+- parity gates in `docs/waves/SPEC_TEST_COVERAGE.md` updated and passing
+- contract mapping updated in `docs/waves/CONTRACT_REQUIREMENTS_MAPPING.md`

--- a/docs/waves/MAINTENANCE_WORK_ITEMS.md
+++ b/docs/waves/MAINTENANCE_WORK_ITEMS.md
@@ -151,6 +151,27 @@ Status keys:
 5. `Accept`:
 - High-churn files are reduced and responsibilities are easier to review.
 
+### M1-09 Engine-host frame interface migration execution
+
+1. `Status`: `todo`
+2. `Files`:
+- `docs/waves/ENGINE_HOST_FRAME_MIGRATION_PLAN.md`
+- `docs/waves/ENGINE_HOST_FRAME_WORK_ITEMS.md`
+- `engine-wasm/contracts/wml-engine.ts`
+- `browser/src-tauri/src/contract_types.rs`
+- `browser/contracts/generated/engine-host.ts`
+3. `Build`:
+- Execute the `F0-F4` migration program to move active hosts onto structured frame/input contracts.
+- Keep migration additive and parity-gated until legacy path retirement.
+4. `Tests`:
+- `cd engine-wasm/engine && cargo test`
+- `cd browser/src-tauri && cargo test`
+- `pnpm --dir browser/frontend test`
+- `pnpm --dir browser/frontend build`
+5. `Accept`:
+- Active host paths use `EngineFrame` + `EngineInputEvent`.
+- Contract and coverage docs are updated in the same migration PRs.
+
 ### M0-01 Parser tag-boundary hardening (`<prev/>` false-positive)
 
 1. `Status`: `done`

--- a/docs/waves/WORK_ITEMS.md
+++ b/docs/waves/WORK_ITEMS.md
@@ -81,6 +81,21 @@ Sprint acceptance target:
 - All six tickets have executable acceptance fixtures mapped in `docs/waves/SPEC_TEST_COVERAGE.md`.
 - `docs/waves/WAVENAV_PLATFORM_COMPLIANCE_ANALYSIS.md` high-priority misses are reduced for history, cache, and script error semantics.
 
+## Frame Interface Migration Program (Planning-Ready)
+
+This migration track defines the engine-host rendering/input boundary transition from legacy render calls to structured frame/input contracts.
+
+Authoritative docs:
+
+- `docs/waves/ENGINE_HOST_FRAME_MIGRATION_PLAN.md`
+- `docs/waves/ENGINE_HOST_FRAME_WORK_ITEMS.md`
+
+Execution policy:
+
+1. Run migration tickets as additive boundary changes first (`F0`), then renderer/input cutover (`F1-F4`).
+2. Preserve native/wasm parity and deterministic runtime behavior at each phase gate.
+3. Keep migration scope limited to interface and rendering boundary unless explicitly expanded.
+
 ## Kickoff Guardrail (Historical)
 
 This board was prepared before implementation kickoff. Keep ticket statuses current as execution continues.


### PR DESCRIPTION
Adds canonical migration plan and F0-F4 ticket board for Engine↔Host structured frame/input interface migration; links docs into Waves work/maintenance indices for execution tracking