### PR TITLE
browser: harden host CSP and shell mount URL sink handling (M1-14)

### DIFF
--- a/browser/frontend/README.md
+++ b/browser/frontend/README.md
@@ -75,6 +75,11 @@ Internationalization baseline:
 - User-facing labels/status/error copy is sourced from `src/app/waves-copy.ts`.
 - Runtime tuning/constants are sourced from `src/app/waves-config.ts`.
 
+Security baseline:
+
+- Shell mount avoids interpolating runtime startup URL values into HTML strings; URL fields are assigned via
+  input element properties after mount (`mountBrowserShell`).
+
 Local checks:
 
 ```bash

--- a/browser/frontend/src/app/browser-shell-template.test.ts
+++ b/browser/frontend/src/app/browser-shell-template.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+import { mountBrowserShell } from './browser-shell-template';
+import { WAVES_CONFIG } from './waves-config';
+
+describe('mountBrowserShell', () => {
+  it('assigns runtime URL values via element properties after mount', () => {
+    document.body.innerHTML = '<div id="app"></div>';
+    const injectedUrl = 'http://example.test/start.wml?x=%22%3Cscript%3E';
+    const refs = mountBrowserShell(injectedUrl);
+
+    expect(refs.fetchUrlInput.value).toBe(injectedUrl);
+    expect(refs.baseUrlInput.value).toBe(WAVES_CONFIG.defaultDebugBaseUrl);
+    expect(document.querySelectorAll('#fetch-url')).toHaveLength(1);
+    expect(document.querySelectorAll('#base-url')).toHaveLength(1);
+  });
+});

--- a/browser/frontend/src/app/browser-shell-template.ts
+++ b/browser/frontend/src/app/browser-shell-template.ts
@@ -96,7 +96,6 @@ const browserShellTemplate = () => `
               <div class="debug-raw-mode-content">
                 <label class="compact-field">
                   ${WAVES_COPY.shell.baseUrl}
-                  <input id="base-url" class="form-95" type="text" value="${WAVES_CONFIG.defaultDebugBaseUrl}" />
                   <input id="base-url" class="form-95" type="text" value="" />
                 </label>
                 <textarea id="wml-input" class="form-95"></textarea>

--- a/browser/src-tauri/tauri.conf.json
+++ b/browser/src-tauri/tauri.conf.json
@@ -23,7 +23,8 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: asset: tauri:; font-src 'self' data:; connect-src 'self' http://localhost:1420 ws://localhost:1420 http://127.0.0.1:1420 ws://127.0.0.1:1420; object-src 'none'; frame-ancestors 'none'; base-uri 'none'; form-action 'self'"
+      "csp": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: asset: tauri:; font-src 'self' data:; media-src 'self' data: blob:; connect-src 'self' ipc: http://ipc.localhost https://ipc.localhost; object-src 'none'; frame-src 'none'; frame-ancestors 'none'; base-uri 'none'; form-action 'self'",
+      "devCsp": "default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: asset: tauri:; font-src 'self' data:; media-src 'self' data: blob:; connect-src 'self' ipc: http://ipc.localhost https://ipc.localhost http://localhost:1420 ws://localhost:1420 http://127.0.0.1:1420 ws://127.0.0.1:1420; object-src 'none'; frame-src 'none'; frame-ancestors 'none'; base-uri 'none'; form-action 'self'"
     }
   },
   "bundle": {

--- a/docs/waves/MAINTENANCE_WORK_ITEMS.md
+++ b/docs/waves/MAINTENANCE_WORK_ITEMS.md
@@ -42,7 +42,7 @@ Completed maintenance tickets are archived in:
 
 ### M1-14 Browser host boundary hardening (CSP + DOM injection sinks)
 
-1. `Status`: `todo`
+1. `Status`: `done`
 2. `Priority`: `P0`
 3. `Files`:
 - `browser/src-tauri/tauri.conf.json`
@@ -63,6 +63,8 @@ Completed maintenance tickets are archived in:
 - Existing browser shell behavior remains intact in local and network modes.
 7. `Notes`:
 - Security audit follow-up for high-severity host boundary risk.
+- Landed explicit production and development CSP policies in Tauri config (`csp` + `devCsp`) instead of permissive/null posture.
+- Boot URL assignment path is contained to post-mount input property assignment (no runtime URL interpolation into shell HTML template strings).
 
 ### M1-15 Engine parser recursion guardrails (untrusted deck DoS hardening)
 

--- a/docs/waves/WORK_ITEMS.md
+++ b/docs/waves/WORK_ITEMS.md
@@ -71,12 +71,15 @@ Canonical sprint priority rule:
 Next execution block is architecture hardening across all active libraries before additional feature expansion:
 
 1. `M1-15` Engine parser recursion guardrails (untrusted deck DoS hardening) (`P0`).
-2. `M1-14` Browser host boundary hardening (CSP + DOM injection sinks) (`P0`).
-3. `M1-16` Transport/engine payload size guardrails (memory pressure hardening) (`P1`).
-4. `M1-17` Network fetch destination policy guardrails (SSRF/probing reduction) (`P1`).
-5. `M1-08` Split high-churn files into boundary modules (engine scope complete; browser/transport follow-ups remain).
-6. `M1-09` Engine-host frame interface migration execution.
-7. `M1-03` Engine API generator design/bootstrap (non-priority track in this sprint).
+2. `M1-16` Transport/engine payload size guardrails (memory pressure hardening) (`P1`).
+3. `M1-08` Split high-churn files into boundary modules (engine scope complete; browser/transport follow-ups remain).
+4. `M1-09` Engine-host frame interface migration execution.
+5. `M1-03` Engine API generator design/bootstrap (non-priority track in this sprint).
+
+Recently completed in this sprint:
+
+1. `M1-14` Browser host boundary hardening (CSP + DOM injection sinks) (`P0`).
+2. `M1-17` Network fetch destination policy guardrails (SSRF/probing reduction) (`P1`).
 
 Reference board: `docs/waves/MAINTENANCE_WORK_ITEMS.md`.
 


### PR DESCRIPTION
## Summary
- Complete `M1-14` browser host boundary hardening for CSP and DOM sink handling.
- Keep startup URL handling deterministic and safe while preserving existing shell behavior.

## What Changed
- Tightened Tauri security policy in [browser/src-tauri/tauri.conf.json](/Users/dsteele/repos/wap-labs/browser/src-tauri/tauri.conf.json):
  - explicit production `csp`
  - explicit `devCsp` for localhost/ws/wasm dev workflow
- Updated shell mount path in [browser/frontend/src/app/browser-shell-template.ts](/Users/dsteele/repos/wap-labs/browser/frontend/src/app/browser-shell-template.ts):
  - avoid runtime URL interpolation in HTML template for startup/base URL fields
  - assign URL values via input properties after mount
  - removed duplicated `#base-url` input merge artifact
- Added regression coverage in [browser/frontend/src/app/browser-shell-template.test.ts](/Users/dsteele/repos/wap-labs/browser/frontend/src/app/browser-shell-template.test.ts):
  - verifies mount-time URL property assignment
  - verifies unique `#fetch-url` and `#base-url` elements
- Updated docs:
  - [browser/frontend/README.md](/Users/dsteele/repos/wap-labs/browser/frontend/README.md)
  - [docs/waves/MAINTENANCE_WORK_ITEMS.md](/Users/dsteele/repos/wap-labs/docs/waves/MAINTENANCE_WORK_ITEMS.md)
  - [docs/waves/WORK_ITEMS.md](/Users/dsteele/repos/wap-labs/docs/waves/WORK_ITEMS.md)

## Validation
- `pnpm --dir browser/frontend test`
- `pnpm --dir browser/frontend typecheck`
- `pnpm --dir browser/frontend lint`
- `cargo test --manifest-path browser/src-tauri/Cargo.toml`

## Scope Notes
- Current git state includes local, uncommitted changes in 6 files for this hardening slice.
- Branch is currently `main`.
