### PR TITLE
History Fidelity

### DIFF
--- a/browser/frontend/src/app/navigation-state.test.ts
+++ b/browser/frontend/src/app/navigation-state.test.ts
@@ -152,14 +152,26 @@ describe('navigation-state', () => {
   it('prefers engine back when runtime state changes', async () => {
     const machine = createNavigationStateMachine(
       createHostClientMock({
+        fetchDeck: async (request) =>
+          fetchOk({
+            finalUrl: request.url
+          }),
         engineSnapshot: async () => snapshot({ activeCardId: 'next', focusedLinkIndex: 0 }),
         engineNavigateBack: async () => snapshot({ activeCardId: 'home', focusedLinkIndex: 0 })
       }),
       'http://seed.test'
     );
 
+    await machine.loadTransportUrl({
+      url: 'http://example.test/start.wml',
+      source: 'user',
+      followExternalIntent: false
+    });
+
     const mode = await machine.navigateBackWithFallback();
     expect(mode).toBe('engine');
+    expect(machine.getHistoryState().index).toBe(0);
+    expect(machine.getHistoryState().entries[0]?.activeCardId).toBe('home');
   });
 
   it('falls back to host history when engine back is a no-op', async () => {

--- a/browser/frontend/src/app/navigation-state.ts
+++ b/browser/frontend/src/app/navigation-state.ts
@@ -318,7 +318,7 @@ export const createNavigationStateMachine = (
           hooks.onStateEvent?.('host-history-back', {
             historyIndex: hostHistory.index,
             url: previous.url,
-            restoredCardId: previous.activeCardId
+            restoredCardId: restoredSnapshot.activeCardId
           });
           return 'host';
         }


### PR DESCRIPTION
## Summary
This PR advances `A5-01` history entry fidelity in browser navigation state handling.

It ensures host URL history entries keep the latest known in-deck card identity and that host-history back replay emits and commits the actual restored card identity.

## Changes
- Update current history entry card snapshot after in-deck state transitions:
  - engine key handling
  - timer tick handling
  - engine-handled back
- During host-history back:
  - persist restored card identity after replay/optional `navigateToCard`
  - emit `host-history-back` event with actual restored card id
- Add regression coverage for:
  - restoring latest in-deck card snapshot on host-history back
  - committing restored card id into the selected history entry
  - `host-history-back` event payload fidelity (`restoredCardId`)

## Files
- [navigation-state.ts](/Users/dsteele/repos/wap-labs/browser/frontend/src/app/navigation-state.ts)
- [navigation-state.test.ts](/Users/dsteele/repos/wap-labs/browser/frontend/src/app/navigation-state.test.ts)

## Validation
- `pnpm --dir browser/frontend test -- --run src/app/navigation-state.test.ts`
- `pnpm --dir browser/frontend typecheck`

## Commits
- `f621903` feat(browser): preserve latest card snapshot in host history entries
- `e50a2bb` feat(browser): persist restored card identity on host-history back
- `5b0c23c` feat(browser): tighten history-back restored-card fidelity
- `a1b0d0c` test(browser): assert restored card id in host-history-back event
