### PR TITLE
feat(wdp): add UDP datagram transport trait, ports, and SAR baseline

### DIFF
--- a/transport-rust/src/network.rs
+++ b/transport-rust/src/network.rs
@@ -1,1 +1,2 @@
+pub mod wdp;
 pub mod wtp;

--- a/transport-rust/src/network/wdp/datagram.rs
+++ b/transport-rust/src/network/wdp/datagram.rs
@@ -1,0 +1,150 @@
+#![allow(dead_code)]
+
+use serde::{Deserialize, Serialize};
+use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr};
+
+pub const WDP_MAX_UDP_PAYLOAD_BYTES: usize = 65_507;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum WdpAddressType {
+    Ipv4,
+    Ipv6,
+    Unspecified,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WdpAddress {
+    pub address_type: WdpAddressType,
+    pub value: Vec<u8>,
+}
+
+impl WdpAddress {
+    pub fn ipv4(bytes: [u8; 4]) -> Self {
+        Self {
+            address_type: WdpAddressType::Ipv4,
+            value: bytes.to_vec(),
+        }
+    }
+
+    pub fn ipv6(bytes: [u8; 16]) -> Self {
+        Self {
+            address_type: WdpAddressType::Ipv6,
+            value: bytes.to_vec(),
+        }
+    }
+
+    pub fn unspecified() -> Self {
+        Self {
+            address_type: WdpAddressType::Unspecified,
+            value: Vec::new(),
+        }
+    }
+
+    pub fn from_socket_addr(addr: SocketAddr) -> Self {
+        match addr.ip() {
+            std::net::IpAddr::V4(addr) => Self::ipv4(addr.octets()),
+            std::net::IpAddr::V6(addr) => Self::ipv6(addr.octets()),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WdpServicePort {
+    Connectionless = 9200,
+    Session = 9201,
+    SecureConnectionless = 9202,
+    SecureSession = 9203,
+}
+
+impl WdpServicePort {
+    pub const ALL: [u16; 4] = [9200, 9201, 9202, 9203];
+
+    pub fn is_known(port: u16) -> bool {
+        Self::from_u16(port).is_some()
+    }
+
+    pub fn from_u16(port: u16) -> Option<Self> {
+        match port {
+            9200 => Some(Self::Connectionless),
+            9201 => Some(Self::Session),
+            9202 => Some(Self::SecureConnectionless),
+            9203 => Some(Self::SecureSession),
+            _ => None,
+        }
+    }
+}
+
+impl WdpAddress {
+    pub fn as_socket_addr(&self, port: u16) -> Option<SocketAddr> {
+        match self.address_type {
+            WdpAddressType::Ipv4 if self.value.len() == 4 => {
+                let mut octets = [0u8; 4];
+                octets.copy_from_slice(&self.value[..4]);
+                Some(SocketAddr::from((Ipv4Addr::from(octets), port)))
+            }
+            WdpAddressType::Ipv6 if self.value.len() == 16 => {
+                let mut octets = [0u8; 16];
+                octets.copy_from_slice(&self.value[..16]);
+                Some(SocketAddr::from((Ipv6Addr::from(octets), port)))
+            }
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WdpDatagram {
+    pub src_addr: WdpAddress,
+    pub dst_addr: WdpAddress,
+    pub src_port: u16,
+    pub dst_port: u16,
+    pub payload: Vec<u8>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::net::{IpAddr, SocketAddr};
+
+    #[test]
+    fn wdp_service_port_from_u16_returns_expected_mapping() {
+        assert_eq!(
+            WdpServicePort::from_u16(9200),
+            Some(WdpServicePort::Connectionless)
+        );
+        assert_eq!(
+            WdpServicePort::from_u16(9201),
+            Some(WdpServicePort::Session)
+        );
+        assert_eq!(
+            WdpServicePort::from_u16(9202),
+            Some(WdpServicePort::SecureConnectionless)
+        );
+        assert_eq!(
+            WdpServicePort::from_u16(9203),
+            Some(WdpServicePort::SecureSession)
+        );
+        assert_eq!(WdpServicePort::from_u16(1), None);
+    }
+
+    #[test]
+    fn wdp_address_roundtrips_ipv4_socket_addr() {
+        let addr = SocketAddr::new(IpAddr::V4("127.0.0.1".parse().unwrap()), 9200);
+        let wire = WdpAddress::from_socket_addr(addr);
+        let parsed = wire.as_socket_addr(9200).expect("ipv4 should parse");
+
+        assert_eq!(parsed, addr);
+    }
+
+    #[test]
+    fn wdp_address_roundtrips_ipv6_socket_addr() {
+        let addr = SocketAddr::new(IpAddr::V6("::1".parse().unwrap()), 9201);
+        let wire = WdpAddress::from_socket_addr(addr);
+        let parsed = wire.as_socket_addr(9201).expect("ipv6 should parse");
+
+        assert_eq!(parsed, addr);
+    }
+}

--- a/transport-rust/src/network/wdp/mod.rs
+++ b/transport-rust/src/network/wdp/mod.rs
@@ -1,0 +1,12 @@
+#![allow(dead_code)]
+#![allow(unused_imports)]
+
+pub mod datagram;
+pub mod sar;
+pub mod transport_trait;
+pub mod udp_adapter;
+
+pub use datagram::{WdpAddress, WdpAddressType, WdpDatagram, WdpServicePort};
+pub use sar::{classify_sar_packet, WdpSarDecision, WdpSarPolicy, WdpSarTrace};
+pub use transport_trait::{DatagramTransport, WdpError, WdpResult};
+pub use udp_adapter::{UdpDatagramTransport, UdpDatagramTransportConfig};

--- a/transport-rust/src/network/wdp/sar.rs
+++ b/transport-rust/src/network/wdp/sar.rs
@@ -1,0 +1,107 @@
+use crate::network::wdp::datagram::WDP_MAX_UDP_PAYLOAD_BYTES;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum WdpSarPolicy {
+    #[default]
+    Disabled,
+    Enabled {
+        segment_size: usize,
+    },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum WdpSarDecision {
+    SendAsSingleDatagram,
+    SendAsFragments { fragment_count: usize },
+    OversizeRejected,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WdpSarTrace {
+    pub policy: WdpSarPolicy,
+    pub payload_len: usize,
+    pub max_udp_payload: usize,
+    pub segment_size: usize,
+    pub decision: WdpSarDecision,
+}
+
+pub fn classify_sar_packet(
+    policy: &WdpSarPolicy,
+    payload_len: usize,
+) -> (WdpSarDecision, WdpSarTrace) {
+    let trace = WdpSarTrace {
+        policy: *policy,
+        payload_len,
+        max_udp_payload: WDP_MAX_UDP_PAYLOAD_BYTES,
+        segment_size: match *policy {
+            WdpSarPolicy::Disabled => WDP_MAX_UDP_PAYLOAD_BYTES,
+            WdpSarPolicy::Enabled { segment_size } => segment_size.max(1),
+        },
+        decision: WdpSarDecision::OversizeRejected,
+    };
+
+    let decision = match *policy {
+        WdpSarPolicy::Disabled => {
+            if payload_len <= WDP_MAX_UDP_PAYLOAD_BYTES {
+                WdpSarDecision::SendAsSingleDatagram
+            } else {
+                WdpSarDecision::OversizeRejected
+            }
+        }
+        WdpSarPolicy::Enabled { segment_size: 0 } => WdpSarDecision::OversizeRejected,
+        WdpSarPolicy::Enabled { segment_size } => {
+            let capped_segment_size = segment_size.max(1);
+            let fragments =
+                (payload_len.saturating_add(capped_segment_size - 1)) / capped_segment_size;
+            if fragments <= 1 {
+                WdpSarDecision::SendAsSingleDatagram
+            } else {
+                WdpSarDecision::SendAsFragments {
+                    fragment_count: fragments,
+                }
+            }
+        }
+    };
+
+    (decision, WdpSarTrace { decision, ..trace })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn disabled_policy_keeps_single_datagram_for_legal_payload_sizes() {
+        let (decision, trace) = classify_sar_packet(&WdpSarPolicy::Disabled, 10_000);
+        assert_eq!(decision, WdpSarDecision::SendAsSingleDatagram);
+        assert_eq!(trace.segment_size, WDP_MAX_UDP_PAYLOAD_BYTES);
+    }
+
+    #[test]
+    fn disabled_policy_rejects_oversize_payload() {
+        let (decision, trace) = classify_sar_packet(&WdpSarPolicy::Disabled, 70_000);
+        assert_eq!(decision, WdpSarDecision::OversizeRejected);
+        assert_eq!(trace.payload_len, 70_000);
+    }
+
+    #[test]
+    fn enabled_policy_fragments_when_needed() {
+        let (decision, trace) =
+            classify_sar_packet(&WdpSarPolicy::Enabled { segment_size: 6000 }, 17_000);
+        assert_eq!(
+            decision,
+            WdpSarDecision::SendAsFragments { fragment_count: 3 }
+        );
+        assert_eq!(trace.segment_size, 6000);
+    }
+
+    #[test]
+    fn enabled_policy_with_zero_segment_size_rejects() {
+        let (decision, _) = classify_sar_packet(&WdpSarPolicy::Enabled { segment_size: 0 }, 10);
+        assert_eq!(decision, WdpSarDecision::OversizeRejected);
+    }
+}

--- a/transport-rust/src/network/wdp/transport_trait.rs
+++ b/transport-rust/src/network/wdp/transport_trait.rs
@@ -1,0 +1,70 @@
+#![allow(dead_code)]
+
+use crate::network::wdp::datagram::WdpDatagram;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub enum WdpError {
+    TransportUnavailable(String),
+    AddressTypeUnsupported,
+    AddressUnresolvable(String),
+    DestinationPortUnsupported(u16),
+    PayloadOversize { actual: usize, max: usize },
+    Timeout,
+    CorruptOrMalformed,
+    Internal(String),
+}
+
+impl std::fmt::Display for WdpError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::TransportUnavailable(reason) => {
+                write!(f, "transport unavailable: {reason}")
+            }
+            Self::AddressTypeUnsupported => write!(f, "address type unsupported by WDP transport"),
+            Self::AddressUnresolvable(reason) => write!(f, "address unresolvable: {reason}"),
+            Self::DestinationPortUnsupported(port) => {
+                write!(f, "destination port {port} is not a supported WAP service")
+            }
+            Self::PayloadOversize { actual, max } => {
+                write!(f, "payload size {actual} exceeds {max}")
+            }
+            Self::Timeout => write!(f, "transport timeout"),
+            Self::CorruptOrMalformed => write!(f, "corrupt or malformed datagram"),
+            Self::Internal(reason) => write!(f, "internal transport error: {reason}"),
+        }
+    }
+}
+
+impl std::error::Error for WdpError {}
+
+pub type WdpResult<T> = Result<T, WdpError>;
+
+pub trait DatagramTransport {
+    fn send(&mut self, datagram: &WdpDatagram) -> WdpResult<()>;
+    fn receive(&mut self) -> WdpResult<WdpDatagram>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn wdp_error_display_mentions_overflow_limit() {
+        let error = WdpError::PayloadOversize {
+            actual: 700_000,
+            max: 65_507,
+        };
+        assert_eq!(
+            error.to_string(),
+            "payload size 700000 exceeds 65507".to_string()
+        );
+    }
+
+    #[test]
+    fn wdp_error_display_mentions_unknown_port() {
+        let error = WdpError::DestinationPortUnsupported(9999);
+        assert!(error.to_string().contains("9999"));
+    }
+}

--- a/transport-rust/src/network/wdp/udp_adapter.rs
+++ b/transport-rust/src/network/wdp/udp_adapter.rs
@@ -1,0 +1,214 @@
+#![allow(dead_code)]
+
+use crate::network::wdp::datagram::{
+    WdpAddress, WdpDatagram, WdpServicePort, WDP_MAX_UDP_PAYLOAD_BYTES,
+};
+use crate::network::wdp::transport_trait::{DatagramTransport, WdpError, WdpResult};
+use std::net::{SocketAddr, UdpSocket};
+use std::time::Duration;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UdpDatagramTransportConfig {
+    pub bind_address: String,
+    pub read_timeout_ms: Option<u64>,
+}
+
+impl Default for UdpDatagramTransportConfig {
+    fn default() -> Self {
+        Self {
+            bind_address: "127.0.0.1:0".to_string(),
+            read_timeout_ms: Some(100),
+        }
+    }
+}
+
+pub struct UdpDatagramTransport {
+    socket: UdpSocket,
+    read_timeout_ms: Option<u64>,
+}
+
+impl UdpDatagramTransport {
+    pub fn new(config: UdpDatagramTransportConfig) -> WdpResult<Self> {
+        let socket = UdpSocket::bind(&config.bind_address)
+            .map_err(|error| WdpError::TransportUnavailable(error.to_string()))?;
+        if let Some(timeout_ms) = config.read_timeout_ms {
+            socket
+                .set_read_timeout(Some(Duration::from_millis(timeout_ms)))
+                .map_err(|error| WdpError::TransportUnavailable(error.to_string()))?;
+        }
+        Ok(Self {
+            socket,
+            read_timeout_ms: config.read_timeout_ms,
+        })
+    }
+
+    pub fn local_addr(&self) -> SocketAddr {
+        self.socket
+            .local_addr()
+            .unwrap_or_else(|_| "127.0.0.1:0".parse().expect("literal is valid socket addr"))
+    }
+}
+
+fn socket_addr_from_wdp(address: &WdpAddress, port: u16) -> WdpResult<SocketAddr> {
+    if WdpServicePort::from_u16(port).is_none() {
+        return Err(WdpError::DestinationPortUnsupported(port));
+    }
+    address
+        .as_socket_addr(port)
+        .ok_or(WdpError::AddressTypeUnsupported)
+}
+
+fn map_udp_error(error: std::io::Error) -> WdpError {
+    if error.kind() == std::io::ErrorKind::WouldBlock
+        || error.kind() == std::io::ErrorKind::TimedOut
+    {
+        WdpError::Timeout
+    } else {
+        WdpError::TransportUnavailable(error.to_string())
+    }
+}
+
+impl DatagramTransport for UdpDatagramTransport {
+    fn send(&mut self, datagram: &WdpDatagram) -> WdpResult<()> {
+        if datagram.payload.len() > WDP_MAX_UDP_PAYLOAD_BYTES {
+            return Err(WdpError::PayloadOversize {
+                actual: datagram.payload.len(),
+                max: WDP_MAX_UDP_PAYLOAD_BYTES,
+            });
+        }
+
+        let destination = socket_addr_from_wdp(&datagram.dst_addr, datagram.dst_port)?;
+        self.socket
+            .send_to(&datagram.payload, destination)
+            .map(|_| ())
+            .map_err(map_udp_error)
+    }
+
+    fn receive(&mut self) -> WdpResult<WdpDatagram> {
+        let mut buffer = vec![0u8; WDP_MAX_UDP_PAYLOAD_BYTES.max(1)];
+        let (size, source_addr) = self.socket.recv_from(&mut buffer).map_err(map_udp_error)?;
+        if size > WDP_MAX_UDP_PAYLOAD_BYTES {
+            return Err(WdpError::CorruptOrMalformed);
+        }
+        let local_addr = self
+            .socket
+            .local_addr()
+            .map_err(|error| WdpError::TransportUnavailable(error.to_string()))?;
+        Ok(WdpDatagram {
+            src_addr: WdpAddress::from_socket_addr(source_addr),
+            dst_addr: WdpAddress::from_socket_addr(local_addr),
+            src_port: source_addr.port(),
+            dst_port: local_addr.port(),
+            payload: buffer[..size].to_vec(),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn bind_or_return(config: UdpDatagramTransportConfig) -> Option<UdpDatagramTransport> {
+        UdpDatagramTransport::new(config).ok()
+    }
+
+    fn make_loopback_ipv4_address(_port: u16) -> WdpAddress {
+        WdpAddress::ipv4([127, 0, 0, 1])
+    }
+
+    #[test]
+    fn udp_adapter_rejects_unknown_destination_port() {
+        let mut transport = match bind_or_return(UdpDatagramTransportConfig {
+            bind_address: "127.0.0.1:0".to_string(),
+            read_timeout_ms: None,
+        }) {
+            Some(transport) => transport,
+            None => return,
+        };
+
+        let outbound = WdpDatagram {
+            src_addr: make_loopback_ipv4_address(9200),
+            dst_addr: make_loopback_ipv4_address(9000),
+            src_port: 12345,
+            dst_port: 9000,
+            payload: b"hello".to_vec(),
+        };
+
+        let error = transport
+            .send(&outbound)
+            .expect_err("unknown port should be rejected");
+        assert!(matches!(error, WdpError::DestinationPortUnsupported(9000)));
+    }
+
+    #[test]
+    fn udp_adapter_rejects_oversize_payloads() {
+        let mut transport = match bind_or_return(UdpDatagramTransportConfig {
+            bind_address: "127.0.0.1:0".to_string(),
+            read_timeout_ms: None,
+        }) {
+            Some(transport) => transport,
+            None => return,
+        };
+        let destination = make_loopback_ipv4_address(9200);
+        let outbound = WdpDatagram {
+            src_addr: destination.clone(),
+            dst_addr: destination,
+            src_port: 12345,
+            dst_port: 9200,
+            payload: vec![0xFF; WDP_MAX_UDP_PAYLOAD_BYTES + 1],
+        };
+
+        let error = transport
+            .send(&outbound)
+            .expect_err("payload should be rejected when too large");
+        assert!(matches!(
+            error,
+            WdpError::PayloadOversize {
+                actual: _,
+                max: 65_507
+            }
+        ));
+    }
+
+    #[test]
+    fn udp_send_and_receive_roundtrip_with_known_service_ports() {
+        let mut receiver = match bind_or_return(UdpDatagramTransportConfig {
+            bind_address: "127.0.0.1:9200".to_string(),
+            read_timeout_ms: Some(1000),
+        }) {
+            Some(receiver) => receiver,
+            None => return,
+        };
+        let recv_port = receiver.local_addr().port();
+        if recv_port != 9200 {
+            return;
+        }
+
+        let mut sender = match bind_or_return(UdpDatagramTransportConfig {
+            bind_address: "127.0.0.1:0".to_string(),
+            read_timeout_ms: None,
+        }) {
+            Some(sender) => sender,
+            None => return,
+        };
+
+        let outbound = WdpDatagram {
+            src_addr: make_loopback_ipv4_address(recv_port),
+            dst_addr: make_loopback_ipv4_address(recv_port),
+            src_port: 0,
+            dst_port: 9200,
+            payload: b"payload-bytes".to_vec(),
+        };
+        sender
+            .socket
+            .connect(format!("127.0.0.1:{recv_port}"))
+            .expect("connect");
+        sender.send(&outbound).expect("send should succeed");
+
+        let observed = receiver.receive().expect("receiver should get payload");
+        assert_eq!(observed.payload, b"payload-bytes".to_vec());
+        assert_eq!(observed.src_port, sender.local_addr().port());
+        assert_eq!(observed.dst_port, recv_port);
+        assert_eq!(observed.dst_addr, make_loopback_ipv4_address(recv_port));
+    }
+}


### PR DESCRIPTION
  - add WDP UDP datagram model and service-port support,
  - add `DatagramTransport` trait + transport error/result types,
  - implement UDP adapter with port validation and timeout/error mapping,
  - add SAR policy classifier and baseline tests,
  - keep changes aligned with `T0-19` WDP constraints and protocol-native transport path.