### PR TITLE
Waves usability & graceful-failure: dialog visibility, toast queue, ARIA, follow-up backlog

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ The legacy/demo stack still exists for compatibility testing (`gateway-kannel/`,
 
 Secondary docs:
 
+- Usability and graceful-failure backlog: `docs/waves/USABILITY_RESILIENCE_BACKLOG.md`
 - Legacy test environment guide: `docs/wap-test-environment/README.md`
 - Browser emulator quickstart: `docs/browser-emulator/README.md`
 - Spec-processing subproject: `spec-processing/README.md`

--- a/browser/frontend/src/app/browser-controller.behavior.test.ts
+++ b/browser/frontend/src/app/browser-controller.behavior.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import type { HostSessionState } from '../../../contracts/transport';
+import type { FetchResponse, HostSessionState } from '../../../contracts/transport';
 import type { BrowserShellRefs } from './browser-shell-template';
 import { BrowserController } from './browser-controller';
 import { BrowserPresenter } from './browser-presenter';
@@ -176,6 +176,16 @@ const createHostClient = () => {
 
 afterEach(() => {
   document.body.innerHTML = '';
+});
+
+const gatewayTimeoutResponse = (): FetchResponse => ({
+  ok: false,
+  status: 504,
+  finalUrl: 'http://example.test/network.wml',
+  contentType: 'text/plain',
+  error: { code: 'GATEWAY_TIMEOUT', message: 'gateway timed out' },
+  timingMs: { encode: 0, udpRtt: 0, decode: 0 },
+  engineDeckInput: undefined
 });
 
 describe('BrowserController behavior coverage', () => {
@@ -385,5 +395,48 @@ describe('BrowserController behavior coverage', () => {
       controller as unknown as { tickEngineTimerRuntime(): Promise<void> }
     ).tickEngineTimerRuntime();
     expect(hostClient.engineAdvanceTimeMs).toHaveBeenCalledTimes(1);
+  });
+
+  it('clears the frozen skeleton placeholder when the very first deck load fails', async () => {
+    const refs = createRefs();
+    const presenter = new BrowserPresenter(refs, initialSession, 20);
+    const hostClient = createHostClient();
+    // Fail the very first engine load (the default local example, loaded
+    // during init()) so the skeleton shown for the app's first-ever render
+    // never gets replaced by real content.
+    vi.mocked(hostClient.engineLoadDeckContextFrame).mockRejectedValue(new Error('boom'));
+    const controller = new BrowserController(hostClient as never, presenter, refs);
+
+    await expect(controller.init('<wml><card id="seed"/></wml>')).rejects.toThrow('boom');
+
+    expect(presenter.hasRenderedDeck()).toBe(false);
+    // Previously setViewportSkeleton(false) only removed the CSS class,
+    // leaving the shimmering bars + "waiting for first render" hint frozen
+    // in the viewport forever even though the load already failed.
+    expect(refs.viewportEl.querySelector('.skeleton-hint')).toBeNull();
+    expect(refs.viewportEl.querySelector('.skeleton-line')).toBeNull();
+    expect(refs.viewportEl.classList.contains('viewport-skeleton')).toBe(false);
+  });
+
+  it('shows a toast for a non-transport-unavailable fetch failure kind', async () => {
+    const refs = createRefs();
+    const presenter = new BrowserPresenter(refs, initialSession, 20);
+    const hostClient = createHostClient();
+    vi.mocked(hostClient.fetchDeck).mockResolvedValue(gatewayTimeoutResponse() as never);
+    const controller = new BrowserController(hostClient as never, presenter, refs);
+    await controller.init('<wml><card id="seed"/></wml>');
+    await (controller as any).setRunMode('network', { loadLocalOnEnter: false });
+
+    refs.fetchUrlInput.value = 'http://example.test/network.wml';
+    document.querySelector<HTMLButtonElement>('#btn-fetch-url')?.click();
+    await flushAsyncWork();
+
+    // Previously only TRANSPORT_UNAVAILABLE reached the toast; other failure
+    // kinds (timeout, non-200, malformed payload) only updated the quieter
+    // status panel. Every navigation-failure kind must now also toast.
+    expect(refs.toastEl.textContent).toBe(WAVES_COPY.status.fetchFailed('gateway timed out'));
+    expect(refs.toastEl.className).toBe('toast toast-error');
+    // Status panel behavior is preserved, not replaced.
+    expect(presenter.getSessionState().lastError).toBe('gateway timed out');
   });
 });

--- a/browser/frontend/src/app/browser-controller.ts
+++ b/browser/frontend/src/app/browser-controller.ts
@@ -72,6 +72,9 @@ export class BrowserController {
         onNetworkUnavailable: () => {
           this.presenter.showToast(WAVES_COPY.status.networkUnavailableToast, 'error');
         },
+        onNavigationError: (message) => {
+          this.presenter.showToast(WAVES_COPY.status.fetchFailed(message), 'error');
+        },
         onStateEvent: (action, details) => {
           this.presenter.recordTimeline(action, 'state', details);
         }

--- a/browser/frontend/src/app/browser-presenter.test.ts
+++ b/browser/frontend/src/app/browser-presenter.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { HostSessionState } from '../../../contracts/transport';
 import type { BrowserShellRefs } from './browser-shell-template';
 import { BrowserPresenter } from './browser-presenter';
+import { WAVES_COPY } from './waves-copy';
 
 const createRefs = (): BrowserShellRefs => {
   const viewportEl = document.createElement('div');
@@ -153,6 +154,112 @@ describe('BrowserPresenter', () => {
     expect(refs.snapshotEl.textContent).toContain('"activeCardId": "home"');
     expect(refs.transportResponseEl.textContent).toContain('"status": 200');
     expect(refs.activeUrlLabelEl.textContent).toBe('http://local.test/start.wml');
+  });
+
+  it('clears the frozen skeleton placeholder markup when a first load fails', () => {
+    const refs = createRefs();
+    const presenter = new BrowserPresenter(refs, initialSession, 20);
+
+    presenter.setViewportSkeleton(true);
+    expect(refs.viewportEl.querySelector('.skeleton-hint')).not.toBeNull();
+
+    // First load failed before any deck ever rendered: hiding the skeleton
+    // must clear the placeholder markup (shimmering bars + hint text), not
+    // just the CSS class, or it stays frozen on screen forever.
+    presenter.setViewportSkeleton(false);
+
+    expect(refs.viewportEl.classList.contains('viewport-skeleton')).toBe(false);
+    expect(refs.viewportEl.getAttribute('aria-busy')).toBe('false');
+    expect(refs.viewportEl.querySelector('.skeleton-hint')).toBeNull();
+    expect(refs.viewportEl.innerHTML).toBe('');
+  });
+
+  it('does not touch viewport markup when hiding the skeleton after a successful render', () => {
+    const refs = createRefs();
+    const presenter = new BrowserPresenter(refs, initialSession, 20);
+
+    presenter.setViewportSkeleton(true);
+    presenter.drawRenderList({
+      draw: [{ type: 'text', text: 'hello', x: 0, y: 0 }]
+    });
+
+    // Redundant setViewportSkeleton(false) calls after a successful render
+    // (e.g. from a caller's finally block) must not wipe the real content.
+    presenter.setViewportSkeleton(false);
+
+    expect(refs.viewportEl.textContent).toContain('hello');
+  });
+
+  it('queues a toast instead of clobbering one that is still showing', () => {
+    vi.useFakeTimers();
+    try {
+      const refs = createRefs();
+      const presenter = new BrowserPresenter(refs, initialSession, 20);
+
+      presenter.showToast('first message', 'error', 1000);
+      expect(refs.toastEl.textContent).toBe('first message');
+      expect(refs.toastEl.className).toBe('toast toast-error');
+
+      // Fired before the first toast's TTL elapses -- must not clobber it.
+      presenter.showToast('second message', 'ok', 1000);
+      expect(refs.toastEl.textContent).toBe('first message');
+
+      vi.advanceTimersByTime(1000);
+      expect(refs.toastEl.textContent).toBe('second message');
+      expect(refs.toastEl.className).toBe('toast toast-ok');
+
+      vi.advanceTimersByTime(1000);
+      expect(refs.toastEl.className).toBe('toast toast-hidden');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('announces a new script dialog request as a toast', () => {
+    vi.useFakeTimers();
+    try {
+      const refs = createRefs();
+      const presenter = new BrowserPresenter(refs, initialSession, 20);
+
+      presenter.setSnapshot({
+        activeCardId: 'home',
+        focusedLinkIndex: 0,
+        baseUrl: 'http://local.test/start.wml',
+        contentType: 'text/vnd.wap.wml',
+        lastScriptDialogRequests: [{ type: 'confirm', message: 'Proceed?' }],
+        lastScriptTimerRequests: []
+      });
+
+      expect(refs.toastEl.textContent).toBe(WAVES_COPY.status.scriptDialogConfirm('Proceed?'));
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('does not re-announce the same dialog request across repeated snapshots', () => {
+    vi.useFakeTimers();
+    try {
+      const refs = createRefs();
+      const presenter = new BrowserPresenter(refs, initialSession, 20);
+      const baseSnapshot = {
+        activeCardId: 'home',
+        focusedLinkIndex: 0,
+        baseUrl: 'http://local.test/start.wml',
+        contentType: 'text/vnd.wap.wml',
+        lastScriptDialogRequests: [{ type: 'alert' as const, message: 'Hi' }],
+        lastScriptTimerRequests: []
+      };
+
+      presenter.setSnapshot(baseSnapshot);
+      expect(refs.toastEl.textContent).toBe(WAVES_COPY.status.scriptDialogAlert('Hi'));
+
+      refs.toastEl.textContent = '__unchanged__';
+      presenter.setSnapshot({ ...baseSnapshot });
+
+      expect(refs.toastEl.textContent).toBe('__unchanged__');
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('exports timeline data through a blob download', () => {

--- a/browser/frontend/src/app/browser-presenter.ts
+++ b/browser/frontend/src/app/browser-presenter.ts
@@ -1,5 +1,9 @@
 import type { FetchResponse, HostSessionState } from '../../../contracts/transport';
-import type { EngineRuntimeSnapshot, RenderList } from '../../../contracts/engine';
+import type {
+  EngineRuntimeSnapshot,
+  RenderList,
+  ScriptDialogRequestSnapshot
+} from '../../../contracts/engine';
 import {
   appendTimelineEntry,
   buildTimelineExport as buildTimelineExportPayload,
@@ -27,7 +31,10 @@ export class BrowserPresenter {
   private timelineState = createTimelineState();
 
   private toastTimer: ReturnType<typeof setTimeout> | undefined;
+  private toastShowing = false;
+  private toastQueue: Array<{ message: string; tone: 'error' | 'ok'; ttlMs: number }> = [];
   private hasRenderedContent = false;
+  private announcedDialogRequests: readonly ScriptDialogRequestSnapshot[] = [];
   private latestSnapshot: EngineRuntimeSnapshot | null = null;
   private latestTransportResponse: FetchResponse | null = null;
   private sessionStateText = '';
@@ -129,27 +136,57 @@ export class BrowserPresenter {
 
     this.refs.viewportEl.classList.remove('viewport-skeleton');
     this.refs.viewportEl.setAttribute('aria-busy', 'false');
+    if (!this.hasRenderedContent) {
+      // Nothing has ever successfully rendered yet, so the viewport still
+      // contains the injected skeleton placeholder markup (shimmering bars +
+      // "waiting for first render" hint). Removing just the CSS class above
+      // does not stop that markup from sitting there indefinitely if the
+      // load that was supposed to replace it instead failed. Clear it so a
+      // failed first load doesn't leave a frozen "still loading" viewport
+      // behind the real error, which is surfaced via status/toast instead.
+      this.refs.viewportEl.innerHTML = '';
+    }
   }
 
   showToast(
     message: string,
     tone: 'error' | 'ok' = 'error',
-    ttlMs = WAVES_CONFIG.toastTtlMs
+    ttlMs: number = WAVES_CONFIG.toastTtlMs
   ): void {
+    if (this.toastShowing) {
+      this.toastQueue.push({ message, tone, ttlMs });
+      return;
+    }
+    this.presentToast(message, tone, ttlMs);
+  }
+
+  private presentToast(message: string, tone: 'error' | 'ok', ttlMs: number): void {
+    this.toastShowing = true;
+    this.refs.toastEl.textContent = message;
+    this.refs.toastEl.className = `toast toast-${tone}`;
     if (this.toastTimer) {
       clearTimeout(this.toastTimer);
     }
-    this.refs.toastEl.textContent = message;
-    this.refs.toastEl.className = `toast toast-${tone}`;
     this.toastTimer = setTimeout(() => {
-      this.refs.toastEl.className = 'toast toast-hidden';
+      this.dismissToastAndShowNext();
     }, ttlMs);
+  }
+
+  private dismissToastAndShowNext(): void {
+    this.refs.toastEl.className = 'toast toast-hidden';
+    this.toastShowing = false;
+    this.toastTimer = undefined;
+    const next = this.toastQueue.shift();
+    if (next) {
+      this.presentToast(next.message, next.tone, next.ttlMs);
+    }
   }
 
   setSnapshot(snapshot: EngineRuntimeSnapshot): void {
     this.latestSnapshot = snapshot;
     this.snapshotDirty = true;
     this.flushDeveloperPanels();
+    this.announceScriptDialogRequests(snapshot.lastScriptDialogRequests);
   }
 
   getSnapshot(): EngineRuntimeSnapshot | null {
@@ -229,6 +266,27 @@ export class BrowserPresenter {
     }
   }
 
+  // Waves' WMLScript runtime resolves confirm()/prompt()/alert() calls to a
+  // deterministic default (see engine-wasm/engine/src/wavescript/stdlib/dialogs.rs)
+  // rather than blocking for real interactive input - there is no modal to show.
+  // The frontend previously only used `lastScriptDialogRequests` for
+  // change-detection and never surfaced it, so a script-triggered dialog was
+  // invisible. Announce it via toast instead of building an interactive
+  // dialog subsystem, which would be scope creep beyond this deterministic MVP.
+  private announceScriptDialogRequests(requests: readonly ScriptDialogRequestSnapshot[]): void {
+    if (requests.length === 0) {
+      this.announcedDialogRequests = requests;
+      return;
+    }
+    if (dialogRequestListsEqual(requests, this.announcedDialogRequests)) {
+      return;
+    }
+    this.announcedDialogRequests = requests;
+    for (const request of requests) {
+      this.showToast(describeScriptDialogRequest(request), 'ok');
+    }
+  }
+
   private writeTextIfChanged<T extends HTMLElement>(
     element: T,
     currentText: string,
@@ -249,3 +307,40 @@ const escapeHtml = (input: string): string =>
     .replaceAll('>', '&gt;')
     .replaceAll('"', '&quot;')
     .replaceAll("'", '&#39;');
+
+const dialogRequestListsEqual = (
+  a: readonly ScriptDialogRequestSnapshot[],
+  b: readonly ScriptDialogRequestSnapshot[]
+): boolean => {
+  if (a === b) {
+    return true;
+  }
+  if (a.length !== b.length) {
+    return false;
+  }
+  return a.every((request, index) => {
+    const other = b[index];
+    return (
+      other !== undefined &&
+      request.type === other.type &&
+      request.message === other.message &&
+      ('defaultValue' in request ? request.defaultValue : undefined) ===
+        ('defaultValue' in other ? other.defaultValue : undefined)
+    );
+  });
+};
+
+// Mirrors the engine's deterministic dialog resolution
+// (engine-wasm/engine/src/wavescript/stdlib/dialogs.rs): confirm() always
+// resolves to false/Cancel and prompt() always resolves to its declared
+// default value (or empty string). Describing the resolved value here keeps
+// the announcement accurate without the engine needing to round-trip it.
+const describeScriptDialogRequest = (request: ScriptDialogRequestSnapshot): string => {
+  if (request.type === 'alert') {
+    return WAVES_COPY.status.scriptDialogAlert(request.message);
+  }
+  if (request.type === 'confirm') {
+    return WAVES_COPY.status.scriptDialogConfirm(request.message);
+  }
+  return WAVES_COPY.status.scriptDialogPrompt(request.message, request.defaultValue ?? '');
+};

--- a/browser/frontend/src/app/browser-shell-template.test.ts
+++ b/browser/frontend/src/app/browser-shell-template.test.ts
@@ -14,5 +14,9 @@ describe('mountBrowserShell', () => {
     expect(document.querySelectorAll('#fetch-url')).toHaveLength(1);
     expect(document.querySelectorAll('#base-url')).toHaveLength(1);
     expect(refs.viewportEl.getAttribute('tabindex')).toBe('0');
+
+    const softkeyRow = document.querySelector('.softkey-row');
+    expect(softkeyRow?.getAttribute('role')).toBe('group');
+    expect(softkeyRow?.getAttribute('aria-label')).toBeTruthy();
   });
 });

--- a/browser/frontend/src/app/browser-shell-template.ts
+++ b/browser/frontend/src/app/browser-shell-template.ts
@@ -52,7 +52,7 @@ const browserShellTemplate = () => `
           <div class="skeleton-line"></div>
           <div class="skeleton-hint">${WAVES_COPY.shell.firstRenderPending}</div>
         </div>
-        <div class="softkey-row">
+        <div class="softkey-row" role="group" aria-label="Softkey navigation">
           <button id="btn-up" class="btn">${WAVES_COPY.shell.up}</button>
           <button id="btn-enter" class="btn">${WAVES_COPY.shell.select}</button>
           <button id="btn-down" class="btn">${WAVES_COPY.shell.down}</button>

--- a/browser/frontend/src/app/navigation-state.load.test.ts
+++ b/browser/frontend/src/app/navigation-state.load.test.ts
@@ -58,6 +58,100 @@ describe('navigation-state load behavior', () => {
     expect(networkUnavailable).toBe(1);
   });
 
+  it('fires onNavigationError for transport failures, alongside onNetworkUnavailable', async () => {
+    let networkUnavailable = 0;
+    const navigationErrors: string[] = [];
+    const host = createHostClientMock({
+      fetchDeck: async () =>
+        fetchOk({
+          ok: false,
+          status: 0,
+          contentType: 'text/plain',
+          error: { code: 'TRANSPORT_UNAVAILABLE', message: 'offline' },
+          engineDeckInput: undefined,
+          wml: undefined
+        })
+    });
+    const machine = createNavigationStateMachine(host, 'http://seed.test', {
+      onNetworkUnavailable: () => {
+        networkUnavailable += 1;
+      },
+      onNavigationError: (message) => {
+        navigationErrors.push(message);
+      }
+    });
+
+    await machine.loadTransportUrl({
+      url: 'http://example.test/start.wml',
+      source: 'user',
+      followExternalIntent: true
+    });
+
+    expect(networkUnavailable).toBe(1);
+    expect(navigationErrors).toEqual(['offline']);
+  });
+
+  it('fires onNavigationError (but not onNetworkUnavailable) for non-transport-unavailable failure kinds', async () => {
+    let networkUnavailable = 0;
+    const navigationErrors: string[] = [];
+    const host = createHostClientMock({
+      fetchDeck: async () =>
+        fetchOk({
+          ok: false,
+          status: 504,
+          contentType: 'text/plain',
+          error: { code: 'GATEWAY_TIMEOUT', message: 'gateway timed out' },
+          engineDeckInput: undefined,
+          wml: undefined
+        })
+    });
+    const machine = createNavigationStateMachine(host, 'http://seed.test', {
+      onNetworkUnavailable: () => {
+        networkUnavailable += 1;
+      },
+      onNavigationError: (message) => {
+        navigationErrors.push(message);
+      }
+    });
+
+    await machine.loadTransportUrl({
+      url: 'http://example.test/start.wml',
+      source: 'user',
+      followExternalIntent: true
+    });
+
+    expect(networkUnavailable).toBe(0);
+    expect(navigationErrors).toEqual(['gateway timed out']);
+  });
+
+  it('fires onNavigationError when the fetch succeeds but returns no WML payload', async () => {
+    const navigationErrors: string[] = [];
+    const host = createHostClientMock({
+      fetchDeck: async () =>
+        fetchOk({
+          ok: true,
+          status: 200,
+          engineDeckInput: undefined,
+          wml: undefined
+        })
+    });
+    const machine = createNavigationStateMachine(host, 'http://seed.test', {
+      onNavigationError: (message) => {
+        navigationErrors.push(message);
+      }
+    });
+
+    const result = await machine.loadTransportUrl({
+      url: 'http://example.test/start.wml',
+      source: 'user',
+      followExternalIntent: true
+    });
+
+    expect(result).toBeNull();
+    expect(machine.getSessionState().navigationStatus).toBe('error');
+    expect(navigationErrors).toHaveLength(1);
+  });
+
   it('does not push duplicate history entry when reload uses pushHistory=false', async () => {
     const machine = createNavigationStateMachine(createHostClientMock(), 'http://seed.test');
 

--- a/browser/frontend/src/app/navigation-state.ts
+++ b/browser/frontend/src/app/navigation-state.ts
@@ -53,6 +53,15 @@ export interface NavigationHooks {
   onRender?(render: RenderList): void;
   onTransportResponse?(response: FetchResponse | null): void;
   onNetworkUnavailable?(): void;
+  /**
+   * Fired for every navigation failure that transitions navigationStatus to
+   * 'error' (timeout, non-200/protocol error, malformed/missing payload,
+   * external-intent hop limit) - including TRANSPORT_UNAVAILABLE, which also
+   * fires the more specific onNetworkUnavailable hook. Lets callers surface a
+   * consistent, visible failure indicator (e.g. a toast) regardless of which
+   * failure kind occurred, instead of only the quieter status-panel text.
+   */
+  onNavigationError?(message: string): void;
   onStateEvent?(action: string, details?: Record<string, unknown>): void;
 }
 
@@ -213,6 +222,7 @@ export const createNavigationStateMachine = (
       if (transport.error?.code === 'TRANSPORT_UNAVAILABLE') {
         hooks.onNetworkUnavailable?.();
       }
+      hooks.onNavigationError?.(errorMessage);
       return null;
     }
 
@@ -230,6 +240,7 @@ export const createNavigationStateMachine = (
         contentType: transport.contentType,
         lastError: WAVES_COPY.errors.missingWmlPayload
       });
+      hooks.onNavigationError?.(WAVES_COPY.errors.missingWmlPayload);
       return null;
     }
 
@@ -303,6 +314,7 @@ export const createNavigationStateMachine = (
         if (hop === maxExternalIntentHops) {
           const message = `External intent hop limit reached (${maxExternalIntentHops}).`;
           mergeSessionState({ navigationStatus: 'error', lastError: message });
+          hooks.onNavigationError?.(message);
         }
       }
     }

--- a/browser/frontend/src/app/waves-copy.ts
+++ b/browser/frontend/src/app/waves-copy.ts
@@ -103,7 +103,12 @@ const locale = {
     fetchedAndLoadedDeck: (url: string) => `Fetched and loaded deck from ${url}`,
     networkUnavailableToast: 'No network available currently. WAP server/gateway is unreachable.',
     networkUnavailable: 'No network available currently. Could not reach WAP server/gateway.',
-    error: (message: string) => `Error: ${message}`
+    error: (message: string) => `Error: ${message}`,
+    scriptDialogAlert: (message: string) => `Script alert("${message}") shown.`,
+    scriptDialogConfirm: (message: string) =>
+      `Script confirm("${message}") - Waves answered: Cancel (deterministic default).`,
+    scriptDialogPrompt: (message: string, value: string) =>
+      `Script prompt("${message}") - Waves answered: "${value}" (deterministic default).`
   }
 } as const;
 

--- a/browser/frontend/src/components/primitives/wml-render-primitives.test.ts
+++ b/browser/frontend/src/components/primitives/wml-render-primitives.test.ts
@@ -28,4 +28,19 @@ describe('wml-render-primitives', () => {
     expect(html).toContain('is-focused');
     expect(html).toContain('&lt;unsafe&gt;');
   });
+
+  it('marks the focused link with role="link" and aria-current for assistive tech', () => {
+    const html = renderWmlViewportHtml({
+      draw: [
+        { type: 'link', x: 0, y: 0, text: 'Focused', focused: true, href: '#home' },
+        { type: 'link', x: 0, y: 1, text: 'Unfocused', focused: false, href: '#other' }
+      ]
+    });
+
+    expect(html).toContain('role="link" aria-current="true"');
+    const unfocusedMatch = html.match(/<span class="wml-segment wml-segment-link"[^>]*>Unfocused/);
+    expect(unfocusedMatch).toBeTruthy();
+    expect(unfocusedMatch?.[0]).toContain('role="link"');
+    expect(unfocusedMatch?.[0]).not.toContain('aria-current');
+  });
 });

--- a/browser/frontend/src/components/primitives/wml-render-primitives.ts
+++ b/browser/frontend/src/components/primitives/wml-render-primitives.ts
@@ -42,10 +42,16 @@ export const renderWmlViewportHtml = (renderList: RenderList): string => {
       const segmentHtml = segments
         .map((segment) => {
           const classes = ['wml-segment', `wml-segment-${segment.kind}`];
+          const attrs: string[] = [];
+          if (segment.kind === 'link') {
+            attrs.push('role="link"');
+          }
           if (segment.focused) {
             classes.push('is-focused');
+            attrs.push('aria-current="true"');
           }
-          return `<span class="${classes.join(' ')}">${escapeHtml(segment.text)}</span>`;
+          const attrHtml = attrs.length > 0 ? ` ${attrs.join(' ')}` : '';
+          return `<span class="${classes.join(' ')}"${attrHtml}>${escapeHtml(segment.text)}</span>`;
         })
         .join('');
       return `<div class="line">${segmentHtml}</div>`;

--- a/browser/frontend/src/components/status-panel.test.ts
+++ b/browser/frontend/src/components/status-panel.test.ts
@@ -20,6 +20,22 @@ describe('WvStatusPanel', () => {
     el.remove();
   });
 
+  it('exposes the status text as a polite live region for screen readers', async () => {
+    if (!customElements.get(TAG)) {
+      customElements.define(TAG, WvStatusPanel);
+    }
+    const el = document.createElement(TAG) as WvStatusPanel;
+    document.body.appendChild(el);
+
+    el.setStatus('Ready.', 'ok');
+    await el.updateComplete;
+    const root = el.shadowRoot?.querySelector<HTMLDivElement>('#status-root');
+    expect(root?.getAttribute('aria-live')).toBe('polite');
+    expect(root?.getAttribute('role')).toBe('status');
+
+    el.remove();
+  });
+
   it('reacts to attribute updates', async () => {
     if (!customElements.get(TAG)) {
       customElements.define(TAG, WvStatusPanel);

--- a/browser/frontend/src/components/status-panel.ts
+++ b/browser/frontend/src/components/status-panel.ts
@@ -60,7 +60,14 @@ export class WvStatusPanel extends LitElement {
   }
 
   override render() {
-    return html`<div class=${`status status-${this.tone}`} id="status-root">${this.message}</div>`;
+    return html`<div
+      class=${`status status-${this.tone}`}
+      id="status-root"
+      role="status"
+      aria-live="polite"
+    >
+      ${this.message}
+    </div>`;
   }
 }
 

--- a/docs/waves/MAINTENANCE_WORK_ITEMS.md
+++ b/docs/waves/MAINTENANCE_WORK_ITEMS.md
@@ -179,6 +179,49 @@ Completed maintenance tickets are archived in:
 - `cargo test` stays green for `transport-rust`; native fetch behavior is unchanged for existing passing fixtures/smokes.
 - `docs/waves/NETWORK_PROFILE_DECISION_RECORD.md` / `TRANSPORT_RUST_PHASE_PLAN.md` updated to reflect that `wap-net-core` is genuinely live end-to-end, not just profile-gated.
 
+### M1-19 `fetch_policy.rs` pre-flight destination check is shallow relative to the enforced check (2026-07-24)
+
+1. `Status`: `todo`
+2. `Priority`: `P3`
+3. `Files`:
+- `transport-rust/src/fetch_policy.rs` (`classify_destination_host`, `validate_fetch_destination`)
+- `transport-rust/src/fetch_runtime/execution.rs` (`PolicyDnsResolver`)
+- `transport-rust/src/native_fetch.rs` (`resolve_fetch_destination_addresses`)
+4. `Finding`:
+- `classify_destination_host` treats every non-`localhost`/`*.localhost` hostname as `Public` — a fast pre-flight check only. The authoritative SSRF guard is the DNS-resolution-time check (`PolicyDnsResolver` in `execution.rs`, and `resolve_fetch_destination_addresses` for the native path), confirmed present, correctly ordered, and tested. Not a live hole today, but nothing stops a future refactor from trusting the shallow pre-flight check in isolation and quietly dropping the resolution-time enforcement.
+5. `Recommendation`:
+- Add a regression test (or an inline invariant comment referencing the resolution-time check) that fails loudly if `validate_fetch_destination` is ever called as the sole gate without the resolver-level check also running.
+6. `Accept`:
+- A future refactor that removes the resolution-time check without also updating the pre-flight check fails a test, rather than silently reopening the class of bug.
+
+### M1-20 Gateway-bridged fetch profile force-sets `AllowPrivate` with no invariant test
+
+1. `Status`: `todo`
+2. `Priority`: `P3`
+3. `Files`:
+- `transport-rust/src/fetch_runtime/execution.rs` (`destination_policy` override for `wap://`/`waps://` traffic)
+- `transport-rust/src/gateway.rs` (`GATEWAY_HTTP_BASE`)
+4. `Finding`:
+- For the default `gateway-bridged` profile, `destination_policy` is force-set to `AllowPrivate` because the upstream target is the operator-configured `GATEWAY_HTTP_BASE`, not the original WAP URL. This is intentional and appears safe (the gateway base is env-configured, not attacker-influenced) but rests entirely on `GATEWAY_HTTP_BASE` never becoming attacker-settable — there's no test pinning that invariant.
+5. `Recommendation`:
+- Add a test asserting `GATEWAY_HTTP_BASE` is read only from process environment/config, never from request-supplied data, so a future change can't silently make it attacker-influenced without breaking a test.
+6. `Accept`:
+- A regression test exists that would fail if `GATEWAY_HTTP_BASE` (or its equivalent) became derivable from untrusted input.
+
+### M1-21 `fetch_host.rs` gateway-transport-fallback host scope unconfirmed
+
+1. `Status`: `todo`
+2. `Priority`: `P3`
+3. `Files`:
+- `browser/src-tauri/src/fetch_host.rs` (`default_fetch_transport_fallback`)
+- `transport-rust/src/gateway.rs`
+4. `Finding`:
+- `default_fetch_transport_fallback()` (the gateway-bridged fallback path for failed `wap`/`waps` GET requests) reads `WAVES_FETCH_TRANSPORT_FALLBACK` with no host/scope restriction visible in `fetch_host.rs` itself; enforcement of where the `GatewayBridged` profile can actually connect lives entirely in `transport-rust`/`gateway.rs`, outside this file's audit scope when it was originally reviewed.
+5. `Recommendation`:
+- Confirm (with a test, not just a read-through) that the gateway transport path is constrained the same way `native_fetch` is — i.e. it can't be pointed at an arbitrary host via this fallback env var.
+6. `Accept`:
+- A test demonstrates the gateway-fallback path cannot be redirected to an arbitrary non-configured host.
+
 ### M1-03 Engine API generator design and bootstrap (non-priority)
 
 1. `Status`: `todo`

--- a/docs/waves/USABILITY_RESILIENCE_BACKLOG.md
+++ b/docs/waves/USABILITY_RESILIENCE_BACKLOG.md
@@ -1,0 +1,146 @@
+# Waves Usability & Resilience Backlog (2026-07-24)
+
+Follow-up backlog from a usability/graceful-failure audit of the Waves browser
+frontend, grounded against Chromium's own stated design principles ("no god
+objects," "content not chrome," keyboard/screen-reader access as core not
+afterthought), Firefox's network-error-page pattern (plain-language error +
+visible retry), and Nielsen Norman's usability heuristics (visibility of
+system status; help users recognize, diagnose, and recover from errors;
+consistency and standards).
+
+Sources: [Chromium browser design principles](https://chromium.googlesource.com/chromium/src/+/lkgr/docs/chrome_browser_design_principles.md), [Chromium User Experience](https://www.chromium.org/user-experience/), [NN/g 10 usability heuristics](https://www.nngroup.com/articles/usability-heuristics-complex-applications/), [Firefox network error page design](https://wiki.mozilla.org/Firefox/Projects/Network_Error_Pages).
+
+The higher-severity items from this same audit pass (WMLScript dialog
+visibility, frozen first-load skeleton, toast queueing, uniform
+fetch-failure toasting, focused-link/softkey ARIA) were fixed directly —
+see the PR that lands alongside this doc. This file tracks what was
+deliberately deferred.
+
+## How to use
+
+Same convention as `MAINTENANCE_WORK_ITEMS.md`: each entry is a
+self-contained story with status/priority/files/finding/recommendation/
+acceptance. Pull one into a branch when picked up; update status in place.
+
+## Current queue
+
+### U1 No progress indication on repeat navigations
+
+1. `Status`: `todo`
+2. `Priority`: `P2`
+3. `Files`:
+- `browser/frontend/src/app/browser-controller.ts` (navigation trigger sites)
+- `browser/frontend/src/app/browser-presenter.ts`
+- `browser/frontend/src/components/status-panel.ts`
+4. `Finding`:
+- The shimmering skeleton loading state only ever shows for the very first deck render (`needsFirstRenderSkeleton = !this.presenter.hasRenderedDeck()`). Every subsequent navigation (link click, reload, back/forward, external intent) has zero in-progress indicator beyond a status-panel text color change — the viewport itself just sits static with the old content until the new response lands.
+- Under real network latency (`WAVES_CONFIG.transportFetchTimeoutMs` = 5000ms plus a retry), a slow-but-working load is visually indistinguishable from a stuck one unless the user is actively watching the status panel text.
+5. `Recommendation`:
+- Reuse the existing skeleton/progress affordance (or a lighter inline spinner) for every navigation, not just the first, gated by a short delay (e.g. only show if the fetch hasn't resolved within ~150-200ms) so instant local-mode loads don't flash it unnecessarily.
+6. `Accept`:
+- Any navigation that takes longer than the short delay threshold shows a visible in-progress state in the viewport itself, not just the status panel.
+
+### U2 Deck-parse and script-trap errors are indistinguishable from network errors
+
+1. `Status`: `todo`
+2. `Priority`: `P2`
+3. `Files`:
+- `browser/frontend/src/app/navigation-state.ts` (`EngineRuntimeSnapshot` fields: `lastScriptExecutionOk`, `lastScriptExecutionTrap`, `lastScriptExecutionErrorClass`, `lastScriptExecutionErrorCategory`)
+- `browser/frontend/src/app/browser-controller.ts`
+- `browser/frontend/src/app/waves-copy.ts`
+4. `Finding`:
+- The engine already exposes a proper error taxonomy for script traps (`lastScriptExecutionErrorClass`/`errorCategory`), but the frontend only reads these fields for render change-detection (`engineSnapshotsEqual`) — never to change a status message or visual state. A malformed WML payload, a network timeout, and a WMLScript fatal trap all produce the exact same generic "error" status-panel text today.
+5. `Recommendation`:
+- Branch the status/toast message on the actual failure category (network vs. malformed-payload vs. script-trap) using data the engine already computes, so users (and anyone debugging a deck) can tell which layer failed without opening the dev drawer.
+6. `Accept`:
+- The three failure classes produce visibly distinct, correctly-worded status messages.
+
+### U3 Back button never reflects "no history" state
+
+1. `Status`: `todo`
+2. `Priority`: `P3`
+3. `Files`:
+- `browser/frontend/src/app/browser-controller.ts`
+- `browser/frontend/src/app/browser-shell-template.ts`
+4. `Finding`:
+- `#btn-back` is never disabled, even when there is provably no back history (`navigateBackWithFallback` returns `'none'`). Both Chrome and Firefox dim/disable their back button at the start of history as a passive "don't bother" signal rather than requiring the user to click and read a status message.
+5. `Recommendation`:
+- Track back-availability in render state and toggle `disabled`/`aria-disabled` on `#btn-back` accordingly. Low effort, matches an established platform convention.
+6. `Accept`:
+- Back button is disabled exactly when there is no engine or host history to go back to.
+
+### U4 Color palette hardcoded and duplicated, no shared design tokens
+
+1. `Status`: `todo`
+2. `Priority`: `P3`
+3. `Files`:
+- `browser/frontend/src/styles.css`
+- `browser/frontend/src/components/status-panel.ts`
+- `browser/frontend/src/components/surface-panel.ts`
+- `browser/frontend/src/vendor/win95/win95.css` (read-only reference, third-party)
+4. `Finding`:
+- Only `--motion-fast`/`--motion-base`/`--ease-standard`/`--waves-teal` exist as CSS custom properties. Everything else (status-panel tones, toast tones, win95-gray palette) is hardcoded hex, repeated independently in `styles.css` and inline in each Lit component's `static styles`.
+5. `Recommendation`:
+- Extract a small shared token set (status/toast semantic colors at minimum) into `:root` custom properties, consumed by both plain CSS and the Lit components' `css` templates.
+6. `Accept`:
+- Status/toast/error colors are defined once and referenced everywhere, not restated.
+
+### U5 No runtime-configurable timeout/contrast/font-size
+
+1. `Status`: `todo`
+2. `Priority`: `P4` (likely won't do — flagging for a scope decision, not recommending)
+3. `Files`:
+- `browser/frontend/src/app/waves-config.ts`
+4. `Finding`:
+- All UX-relevant timing/behavior constants (`transportFetchTimeoutMs`, `transportFetchRetries`, `networkProbeMaxAttempts/DelayMs/TimeoutMs`, `toastTtlMs`, `engineTimerTickMs`) are compile-time constants with no UI to change them at runtime; same for any visual accessibility preference (contrast, font size).
+5. `Recommendation`:
+- Before investing here, get an explicit call on scope: AGENTS.md frames this repo as a deterministic MVP emulator, not a modern-browser feature-parity target. This may be intentionally out of scope. Do not build a settings panel speculatively.
+6. `Accept`:
+- N/A until a scope decision is made.
+
+### U6 `BrowserPresenter` has no `dispose()` lifecycle symmetry
+
+1. `Status`: `todo`
+2. `Priority`: `P3`
+3. `Files`:
+- `browser/frontend/src/app/browser-presenter.ts`
+- `browser/frontend/src/app/browser-controller.ts`
+4. `Finding`:
+- `BrowserPresenter`'s constructor registers a `devDrawerEl.addEventListener('toggle', ...)` with no matching teardown; `BrowserController.dispose()` never disposes its presenter. Currently harmless because `mountBrowserShell` replaces `#app.innerHTML` wholesale on every bootstrap/HMR cycle, dropping the old listener with the old DOM — but the class has no lifecycle symmetry with the controller that owns it.
+5. `Recommendation`:
+- Add a `dispose()` to `BrowserPresenter` that removes its listener(s); call it from `BrowserController.dispose()`.
+6. `Accept`:
+- Presenter listeners are torn down explicitly, not just implicitly via DOM replacement.
+
+### U7 Debug-panel full-JSON reserialize on every mutation
+
+1. `Status`: `todo`
+2. `Priority`: `P3`
+3. `Files`:
+- `browser/frontend/src/app/browser-presenter.ts` (`flushDeveloperPanels`)
+4. `Finding`:
+- When the dev drawer is open, every session/snapshot/timeline mutation re-serializes the entire object graph via `JSON.stringify(..., null, 2)` rather than diffing. Gated behind `devDrawerEl.open` and dirty flags already (better than the original 2026-03-15 review's "every update" finding), but still O(n) per mutation while open.
+5. `Recommendation`:
+- Not urgent — developer-facing panel, not user-facing. Revisit only if it shows up in real profiling, or bundle into a future `M1-08` follow-up pass.
+6. `Accept`:
+- N/A — low priority, informational.
+
+### U8 `marketing-site/global.css` is a single 1261-line unsplit stylesheet
+
+1. `Status`: `todo`
+2. `Priority`: `P4`
+3. `Files`:
+- `marketing-site/src/styles/global.css`
+4. `Finding`:
+- No component-level splitting; will get harder to maintain as the site grows. Not broken today.
+5. `Recommendation`:
+- Defer until the next marketing-site change that touches styling meaningfully; not worth a standalone pass.
+6. `Accept`:
+- N/A — cosmetic, low priority.
+
+## Also tracked elsewhere (not duplicated here)
+
+- `BrowserController` god-file decomposition — tracked as `M1-08` in `docs/waves/MAINTENANCE_WORK_ITEMS.md` (status: residual/opportunistic per that ticket's own notes).
+- `network::wsp` dead-code-vs-live-fetch-path split — tracked as `M1-18`.
+- `fetch_policy.rs` shallow destination-check hardening, gateway-bridged `AllowPrivate` invariant pinning, and `fetch_host.rs` gateway-transport-fallback host-scope confirmation — transport/tauri-layer hardening items surfaced in the same audit; see the maintenance doc entries `M1-19`/`M1-20`/`M1-21` added alongside this file.
+- Full field-level IPC response-shape validation (currently only a null/undefined boundary guard) — deliberately partial; revisit as its own scoped design decision (schema library vs. hand-rolled checks), not bundled here.


### PR DESCRIPTION
## Summary

Follow-up to #280. Usability/resilience audit of the Waves browser frontend, grounded against Chromium's own stated design principles, Firefox's error-page pattern, and Nielsen Norman's usability heuristics. Fixed the items that were silently broken or inaccessible rather than just rough; everything else is written up as a follow-up backlog, not dropped.

### Fixed: status/notification gaps (silently broken, not just rough)
- **WMLScript dialogs had zero UI.** Confirmed via `wavescript/stdlib/dialogs.rs` that `confirm()`/`prompt()` are auto-resolved deterministically by the engine (no blocking on real input — consistent with this repo's deterministic-MVP model per AGENTS.md). The frontend captured this in snapshot state but never surfaced it. Now announces each dialog request and its deterministic outcome via toast — visibility only, no new interactive modal subsystem.
- **Frozen skeleton on first-load failure.** Only the CSS class was cleared on failure, not the underlying shimmer placeholder markup — the "waiting for render" animation kept running under an error the user had to go find in the status panel.
- **Toast had no queue.** A second `showToast()` call clobbered the first in place; two failures in quick succession meant the user only ever saw the second one.
- **Most fetch failures never reached the toast**, only the (quieter, easier-to-miss) status panel. Only one failure kind reached the more visible surface. All navigation-error paths now toast consistently.

### Fixed: accessibility gaps
- Focused WML link now carries `role="link"`/`aria-current="true"`, not just a CSS color change.
- Softkey row (`#btn-up/#btn-down/#btn-enter`) gets `role="group" aria-label="Softkey navigation"`.
- Status panel — the primary navigation/error feedback channel — gets `role="status" aria-live="polite"`, matching the toast and local-example-notes regions which already had it.
- One item deferred: moving real DOM focus onto the active link segment needs `browser-controller.ts`'s render path, which the parallel notification-fix work was actively editing — logged as a follow-up rather than risking a collision.

### Follow-up backlog (not done here, written up instead)
New `docs/waves/USABILITY_RESILIENCE_BACKLOG.md` covers: no progress indication on repeat navigations, deck-parse/script-trap errors indistinguishable from network errors, back button never reflects "no history" state, hardcoded/duplicated color palette, a runtime-settings scope question, `BrowserPresenter` missing `dispose()`, debug-panel reserialization perf, and the marketing-site CSS split. Plus three transport/tauri hardening tickets (`M1-19`/`M1-20`/`M1-21`) added to `docs/waves/MAINTENANCE_WORK_ITEMS.md` for the shallow destination pre-check, the gateway `AllowPrivate` invariant, and the gateway-fallback host-scope confirmation — all surfaced by the original audit but not yet ticketed.

## Test plan
- [x] `pnpm --dir browser/frontend test`: 117/117 passing
- [x] `pnpm --dir browser/frontend run typecheck`: clean
- [x] Full local pre-push hook suite (fmt, clippy, tests across all three Rust crates, frontend typecheck): all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)