### PR TITLE
Waves backlog slice 2: progress feedback, error clarity, back-button state, design tokens, invariant tests

### DIFF
--- a/browser/frontend/src/app/browser-controller.behavior.test.ts
+++ b/browser/frontend/src/app/browser-controller.behavior.test.ts
@@ -318,12 +318,20 @@ describe('BrowserController behavior coverage', () => {
     const controller = new BrowserController(hostClient as never, presenter, refs);
 
     await controller.init('<wml><card id="seed"/></wml>');
+    const backBtn = document.querySelector<HTMLButtonElement>('#btn-back');
+    // Fresh boot: no forward navigation has happened yet, so back starts
+    // disabled (see U3) -- a plain forward key press establishes history.
+    expect(backBtn?.disabled).toBe(true);
+    document.querySelector<HTMLButtonElement>('#btn-enter')?.click();
+    await flushAsyncWork();
+    expect(backBtn?.disabled).toBe(false);
+
     presenter.setSessionState({
       ...presenter.getSessionState(),
       activeCardId: 'current-card',
       focusedLinkIndex: 1
     });
-    document.querySelector<HTMLButtonElement>('#btn-back')?.click();
+    backBtn?.click();
     await flushAsyncWork();
 
     expect(hostClient.engineNavigateBackFrame).toHaveBeenCalledTimes(1);
@@ -349,6 +357,10 @@ describe('BrowserController behavior coverage', () => {
     const controller = new BrowserController(hostClient as never, presenter, refs);
 
     await controller.init('<wml><card id="seed"/></wml>');
+    // Establish forward history first so the back button isn't disabled
+    // (see U3) and the click below actually reaches the handler.
+    document.querySelector<HTMLButtonElement>('#btn-enter')?.click();
+    await flushAsyncWork();
     presenter.setSessionState({
       ...presenter.getSessionState(),
       activeCardId: 'current-card',
@@ -366,6 +378,9 @@ describe('BrowserController behavior coverage', () => {
     expect(drawRenderListSpy).not.toHaveBeenCalled();
     expect(setSnapshotSpy).not.toHaveBeenCalled();
     expect(refs.statusMessages.at(-1)).toBe(WAVES_COPY.status.navigateBackNone);
+    // The engine just proved there is no history; the button should reflect
+    // that definitively rather than staying enabled (see U3).
+    expect(document.querySelector<HTMLButtonElement>('#btn-back')?.disabled).toBe(true);
   });
 
   it('marks a keyboard action in-flight synchronously so a concurrent timer tick cannot interleave', async () => {
@@ -438,5 +453,132 @@ describe('BrowserController behavior coverage', () => {
     expect(refs.toastEl.className).toBe('toast toast-error');
     // Status panel behavior is preserved, not replaced.
     expect(presenter.getSessionState().lastError).toBe('gateway timed out');
+  });
+
+  it('words a malformed-deck-payload failure distinctly from a network failure', async () => {
+    // U2: a fetch that succeeded but returned no usable WML must not read
+    // like a network-layer "fetch failed" -- both toast and status text
+    // should say "Deck parse failed" instead.
+    const refs = createRefs();
+    const presenter = new BrowserPresenter(refs, initialSession, 20);
+    const hostClient = createHostClient();
+    vi.mocked(hostClient.fetchDeck).mockResolvedValue({
+      ok: true,
+      status: 200,
+      finalUrl: 'http://example.test/network.wml',
+      contentType: 'text/vnd.wap.wml',
+      wml: undefined,
+      timingMs: { encode: 0, udpRtt: 0, decode: 0 },
+      engineDeckInput: undefined
+    } as never);
+    const controller = new BrowserController(hostClient as never, presenter, refs);
+    await controller.init('<wml><card id="seed"/></wml>');
+    await (controller as any).setRunMode('network', { loadLocalOnEnter: false });
+
+    refs.fetchUrlInput.value = 'http://example.test/network.wml';
+    document.querySelector<HTMLButtonElement>('#btn-fetch-url')?.click();
+    await flushAsyncWork();
+
+    const expectedMessage = WAVES_COPY.status.deckParseFailed(
+      'Fetch succeeded but returned no WML payload.'
+    );
+    expect(refs.toastEl.textContent).toBe(expectedMessage);
+    expect(refs.statusMessages.at(-1)).toBe(expectedMessage);
+  });
+
+  it('shows a delayed in-progress hint for a slow network navigation but not for the enabling mode-switch load', async () => {
+    // U1: repeat navigations (not just the very first render) get an
+    // in-progress indicator once they run past the short delay threshold.
+    vi.useFakeTimers();
+    try {
+      const refs = createRefs();
+      const presenter = new BrowserPresenter(refs, initialSession, 20);
+      const hostClient = createHostClient();
+      const controller = new BrowserController(hostClient as never, presenter, refs);
+
+      await controller.init('<wml><card id="seed"/></wml>');
+      // The periodic engine timer tick is irrelevant to this test and its
+      // mocked engineAdvanceTimeMs response would otherwise trigger an
+      // unrelated re-render mid-delay, incidentally canceling the pending
+      // indicator this test is trying to observe.
+      (controller as any).timerRuntime.stop();
+      await (controller as any).setRunMode('network', { loadLocalOnEnter: false });
+      // setRunMode kicks off the startup network probe, which also calls
+      // hostClient.fetchDeck -- let that settle against the default (fast,
+      // successful) mock before installing the pending mock below, so it
+      // doesn't steal the mockImplementationOnce meant for the button click.
+      await vi.advanceTimersByTimeAsync(0);
+
+      let resolveFetch: (() => void) | undefined;
+      vi.mocked(hostClient.fetchDeck).mockImplementationOnce(
+        (request: { url: string }) =>
+          new Promise((resolve) => {
+            resolveFetch = () =>
+              resolve({
+                ok: true,
+                status: 200,
+                finalUrl: request.url,
+                contentType: 'text/vnd.wap.wml',
+                wml: '<wml><card id="home"><p>ok</p></card></wml>',
+                timingMs: { encode: 0, udpRtt: 0, decode: 0 },
+                engineDeckInput: {
+                  wmlXml: '<wml><card id="home"><p>ok</p></card></wml>',
+                  baseUrl: request.url,
+                  contentType: 'text/vnd.wap.wml'
+                }
+              });
+          })
+      );
+
+      refs.fetchUrlInput.value = 'http://example.test/slow.wml';
+      document.querySelector<HTMLButtonElement>('#btn-fetch-url')?.click();
+      // Flush the microtask/zero-delay-timer chain up to (but not through)
+      // the still-pending fetchDeck call, so beginNavigationProgress() has
+      // already been invoked and its delay timer scheduled.
+      await vi.advanceTimersByTimeAsync(0);
+
+      // Still well under the delay threshold: no indicator yet.
+      await vi.advanceTimersByTimeAsync(50);
+      expect(refs.viewportEl.classList.contains('viewport-skeleton')).toBe(false);
+
+      // Past the delay threshold and the fetch still hasn't resolved.
+      await vi.advanceTimersByTimeAsync(200);
+      expect(refs.viewportEl.classList.contains('viewport-skeleton')).toBe(true);
+      expect(refs.viewportEl.querySelector('.viewport-navigation-hint')).not.toBeNull();
+
+      resolveFetch?.();
+      // Still under fake timers here -- flushAsyncWork's real setTimeout(0)
+      // would never fire, so drain via the fake-timer equivalent instead.
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(refs.viewportEl.classList.contains('viewport-skeleton')).toBe(false);
+      expect(refs.viewportEl.querySelector('.viewport-navigation-hint')).toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('tracks back-button availability from host history in network mode', async () => {
+    const refs = createRefs();
+    const presenter = new BrowserPresenter(refs, initialSession, 20);
+    const hostClient = createHostClient();
+    const controller = new BrowserController(hostClient as never, presenter, refs);
+
+    await controller.init('<wml><card id="seed"/></wml>');
+    await (controller as any).setRunMode('network', { loadLocalOnEnter: false });
+    const backBtn = document.querySelector<HTMLButtonElement>('#btn-back');
+    // No page has been fetched yet in this mode -- nothing to go back to.
+    expect(backBtn?.disabled).toBe(true);
+
+    refs.fetchUrlInput.value = 'http://example.test/page-one.wml';
+    document.querySelector<HTMLButtonElement>('#btn-fetch-url')?.click();
+    await flushAsyncWork();
+    // Still the first page fetched in this mode -- nothing before it yet.
+    expect(backBtn?.disabled).toBe(true);
+
+    refs.fetchUrlInput.value = 'http://example.test/page-two.wml';
+    document.querySelector<HTMLButtonElement>('#btn-fetch-url')?.click();
+    await flushAsyncWork();
+    expect(backBtn?.disabled).toBe(false);
   });
 });

--- a/browser/frontend/src/app/browser-controller.ts
+++ b/browser/frontend/src/app/browser-controller.ts
@@ -8,7 +8,8 @@ import type { TauriHostClient } from '../../../contracts/generated/tauri-host-cl
 import { EngineTimerRuntime } from './engine-timer-runtime';
 import { FocusedControlEditController, type ControlEditDisposition } from './focused-control-edit';
 import { resolveKeyboardIntent } from './keyboard';
-import { createNavigationStateMachine } from './navigation-state';
+import { createNavigationStateMachine, type NavigationErrorKind } from './navigation-state';
+import { canHistoryBack } from '../session-history';
 import { StartupNetworkProbeController } from './startup-network-probe';
 import { defaultStartUrl } from './defaults';
 import type { BrowserPresenter } from './browser-presenter';
@@ -48,6 +49,19 @@ export class BrowserController {
   private runMode: RunMode = 'local';
   private activeLocalExampleKey = defaultLocalDeckExample().key;
   private lastNetworkUrl: string;
+  // U2: set by the navigation state machine's onNavigationError hook just
+  // before loadTransportUrl below reads state.navigationStatus === 'error',
+  // so the status text can be worded distinctly for a network-layer failure
+  // vs. a deck that fetched fine but didn't parse into usable WML.
+  private lastNavigationErrorKind: NavigationErrorKind = 'network';
+  // U3: back-button availability tracking. Network mode has an exact answer
+  // (host history array); local mode has no engine-exposed "nav stack depth"
+  // to query without attempting a (destructive) back navigation, so this is
+  // maintained as a frontend-side approximation: reset false on every fresh
+  // engine deck load (which always clears the engine's nav stack) and set
+  // true whenever a forward card change is observed while in local mode.
+  private localBackAvailable = false;
+  private backBtnEl: HTMLButtonElement | null = null;
 
   constructor(hostClient: TauriHostClient, presenter: BrowserPresenter, refs: BrowserShellRefs) {
     this.hostClient = hostClient;
@@ -72,11 +86,25 @@ export class BrowserController {
         onNetworkUnavailable: () => {
           this.presenter.showToast(WAVES_COPY.status.networkUnavailableToast, 'error');
         },
-        onNavigationError: (message) => {
-          this.presenter.showToast(WAVES_COPY.status.fetchFailed(message), 'error');
+        onNavigationError: (message, kind) => {
+          this.lastNavigationErrorKind = kind;
+          this.presenter.showToast(
+            kind === 'parse'
+              ? WAVES_COPY.status.deckParseFailed(message)
+              : WAVES_COPY.status.fetchFailed(message),
+            'error'
+          );
         },
         onStateEvent: (action, details) => {
           this.presenter.recordTimeline(action, 'state', details);
+          if (action === 'engine-load-deck-context') {
+            // Every engineLoadDeckContextFrame call (local or network)
+            // clears the engine's nav stack; keep the local back-availability
+            // approximation in sync so it doesn't go stale across a mode
+            // switch (see U3).
+            this.localBackAvailable = false;
+            this.updateBackButtonAvailability();
+          }
         }
       },
       WAVES_CONFIG.maxExternalIntentHops
@@ -102,8 +130,10 @@ export class BrowserController {
       advanceNetwork: (deltaMs) => this.navigation.applyEngineTimerTick(deltaMs),
       getSessionState: () => this.presenter.getSessionState(),
       renderLocalSnapshot: async (snapshot) => {
+        const previousActiveCardId = this.presenter.getSessionState().activeCardId;
         this.applyFrame(await this.hostClient.engineRenderFrame(), snapshot);
         this.syncLocalSessionFromSnapshot(snapshot);
+        this.noteLocalForwardNavigation(previousActiveCardId, snapshot.activeCardId);
       },
       handleExternalIntent: async (intentUrl, snapshot) => {
         if (this.runMode === 'local') {
@@ -172,6 +202,7 @@ export class BrowserController {
     this.startupProbe.cancel();
     this.timerRuntime.stop();
     this.unbindListeners();
+    this.presenter.dispose();
   }
 
   private bindListeners(): void {
@@ -202,6 +233,10 @@ export class BrowserController {
           });
           const snapshot = frame.snapshot;
           this.applyFrame(frame);
+          // This always loads directly through the engine, clearing its nav
+          // stack regardless of which mode is active (see U3).
+          this.localBackAvailable = false;
+          this.updateBackButtonAvailability();
           this.presenter.patchSessionState({
             navigationStatus: 'loaded',
             requestedUrl: this.refs.baseUrlInput.value,
@@ -334,6 +369,7 @@ export class BrowserController {
 
     const backBtn = document.querySelector<HTMLButtonElement>('#btn-back');
     if (backBtn) {
+      this.backBtnEl = backBtn;
       this.bindEvent(
         backBtn,
         'click',
@@ -349,6 +385,7 @@ export class BrowserController {
         })
       );
     }
+    this.updateBackButtonAvailability();
 
     const snapshotBtn = document.querySelector<HTMLButtonElement>('#btn-snapshot');
     if (snapshotBtn) {
@@ -461,6 +498,35 @@ export class BrowserController {
     }
   }
 
+  // U3: toggles disabled/aria-disabled on #btn-back to match Chrome/Firefox's
+  // "dim the back button at the start of history" convention, instead of
+  // requiring a click + status-message read to discover there's nowhere to
+  // go back to.
+  private updateBackButtonAvailability(): void {
+    if (!this.backBtnEl) {
+      return;
+    }
+    const available =
+      this.runMode === 'local'
+        ? this.localBackAvailable
+        : canHistoryBack(this.navigation.getHistoryState());
+    this.backBtnEl.disabled = !available;
+    this.backBtnEl.setAttribute('aria-disabled', String(!available));
+  }
+
+  // See localBackAvailable above: a forward card change while in local mode
+  // means the engine's nav stack just grew, so back becomes available.
+  private noteLocalForwardNavigation(
+    previousCardId: string | undefined,
+    nextCardId: string | undefined
+  ): void {
+    if (this.runMode !== 'local' || previousCardId === nextCardId) {
+      return;
+    }
+    this.localBackAvailable = true;
+    this.updateBackButtonAvailability();
+  }
+
   private async setRunMode(mode: RunMode, options: { loadLocalOnEnter: boolean }): Promise<void> {
     this.startupProbe.cancel();
     this.navigation.cancelPendingNavigation();
@@ -473,12 +539,14 @@ export class BrowserController {
       if (options.loadLocalOnEnter || !this.presenter.hasRenderedDeck()) {
         await this.loadSelectedLocalDeck();
       }
+      this.updateBackButtonAvailability();
       return;
     }
 
     this.presenter.setStatus(WAVES_COPY.status.networkModeEnabled);
     this.refs.fetchUrlInput.value = this.lastNetworkUrl || defaultStartUrl();
     this.startupProbe.start();
+    this.updateBackButtonAvailability();
   }
 
   private async loadSelectedLocalDeck(): Promise<void> {
@@ -518,10 +586,7 @@ export class BrowserController {
 
   private async loadLocalDeck(example: LocalDeckExample): Promise<void> {
     await this.setViewportCols();
-    const needsFirstRenderSkeleton = !this.presenter.hasRenderedDeck();
-    if (needsFirstRenderSkeleton) {
-      this.presenter.setViewportSkeleton(true);
-    }
+    const endNavigationProgress = this.presenter.beginNavigationProgress();
 
     try {
       this.presenter.setStatus(WAVES_COPY.status.loading(example.baseUrl));
@@ -532,6 +597,8 @@ export class BrowserController {
       });
       const snapshot = frame.snapshot;
       this.applyFrame(frame);
+      // A fresh deck load always clears the engine's nav stack (see U3).
+      this.localBackAvailable = false;
       if (!this.bootDeckReadyEmitted) {
         this.bootDeckReadyEmitted = true;
         this.presenter.setBootPhase('deck-ready');
@@ -554,9 +621,8 @@ export class BrowserController {
       this.timerRuntime.applySnapshot(snapshot);
       this.presenter.setStatus(WAVES_COPY.status.loadedLocalDeck(example.label));
     } finally {
-      if (needsFirstRenderSkeleton && !this.presenter.hasRenderedDeck()) {
-        this.presenter.setViewportSkeleton(false);
-      }
+      endNavigationProgress();
+      this.updateBackButtonAvailability();
     }
   }
 
@@ -767,12 +833,14 @@ export class BrowserController {
   }
 
   private async applyEngineKey(key: EngineKey): Promise<void> {
+    const previousActiveCardId = this.presenter.getSessionState().activeCardId;
     const localFrame =
       this.runMode === 'local' ? await this.hostClient.engineHandleKeyFrame({ key }) : null;
     const snapshot = localFrame ? localFrame.snapshot : await this.navigation.applyEngineKey(key);
     if (this.runMode === 'local' && localFrame) {
       this.applyFrame(localFrame, snapshot);
       this.syncLocalSessionFromSnapshot(snapshot);
+      this.noteLocalForwardNavigation(previousActiveCardId, snapshot.activeCardId);
     }
     this.timerRuntime.applySnapshot(snapshot);
     if (snapshot.externalNavigationIntent) {
@@ -816,31 +884,39 @@ export class BrowserController {
   }
 
   private async navigateBackWithFallback(): Promise<'engine' | 'host' | 'none'> {
-    if (this.runMode === 'local') {
-      const before = {
-        activeCardId: this.presenter.getSessionState().activeCardId,
-        focusedLinkIndex: this.presenter.getSessionState().focusedLinkIndex ?? 0
-      };
-      const frame = await this.hostClient.engineNavigateBackFrame();
-      const after = frame.snapshot;
-      const engineHandled =
-        before.activeCardId !== after.activeCardId ||
-        before.focusedLinkIndex !== after.focusedLinkIndex;
-      if (!engineHandled) {
-        return 'none';
+    const endNavigationProgress = this.presenter.beginNavigationProgress();
+    try {
+      if (this.runMode === 'local') {
+        const before = {
+          activeCardId: this.presenter.getSessionState().activeCardId,
+          focusedLinkIndex: this.presenter.getSessionState().focusedLinkIndex ?? 0
+        };
+        const frame = await this.hostClient.engineNavigateBackFrame();
+        const after = frame.snapshot;
+        const engineHandled =
+          before.activeCardId !== after.activeCardId ||
+          before.focusedLinkIndex !== after.focusedLinkIndex;
+        if (!engineHandled) {
+          // Definitive ground truth: the engine's nav stack was already empty.
+          this.localBackAvailable = false;
+          return 'none';
+        }
+        this.applyFrame(frame);
+        this.syncLocalSessionFromSnapshot(after);
+        return 'engine';
       }
-      this.applyFrame(frame);
-      this.syncLocalSessionFromSnapshot(after);
-      return 'engine';
-    }
 
-    const mode = await this.navigation.navigateBackWithFallback();
-    const state = this.navigation.getSessionState();
-    const resolvedUrl = state.finalUrl ?? state.requestedUrl;
-    if (resolvedUrl) {
-      this.refs.fetchUrlInput.value = resolvedUrl;
+      const mode = await this.navigation.navigateBackWithFallback();
+      const state = this.navigation.getSessionState();
+      const resolvedUrl = state.finalUrl ?? state.requestedUrl;
+      if (resolvedUrl) {
+        this.refs.fetchUrlInput.value = resolvedUrl;
+      }
+      return mode;
+    } finally {
+      endNavigationProgress();
+      this.updateBackButtonAvailability();
     }
-    return mode;
   }
 
   private async loadTransportUrl(
@@ -857,10 +933,7 @@ export class BrowserController {
     }
     await this.setViewportCols();
     const requestedUrl = url.trim();
-    const needsFirstRenderSkeleton = !this.presenter.hasRenderedDeck();
-    if (needsFirstRenderSkeleton) {
-      this.presenter.setViewportSkeleton(true);
-    }
+    const endNavigationProgress = this.presenter.beginNavigationProgress();
     if (source === 'user') {
       this.presenter.setStatus(WAVES_COPY.status.loading(requestedUrl));
     } else if (source === 'external-intent') {
@@ -891,10 +964,11 @@ export class BrowserController {
         this.lastNetworkUrl = requestedUrl;
       }
       if (state.navigationStatus === 'error') {
+        const message = state.lastError ?? WAVES_COPY.errors.unknownTransportFailure;
         this.presenter.setStatus(
-          WAVES_COPY.status.fetchFailed(
-            state.lastError ?? WAVES_COPY.errors.unknownTransportFailure
-          )
+          this.lastNavigationErrorKind === 'parse'
+            ? WAVES_COPY.status.deckParseFailed(message)
+            : WAVES_COPY.status.fetchFailed(message)
         );
       } else if (state.navigationStatus === 'loaded' && state.finalUrl) {
         this.presenter.setStatus(WAVES_COPY.status.fetchedAndLoadedDeck(state.finalUrl));
@@ -905,9 +979,8 @@ export class BrowserController {
 
       return snapshot;
     } finally {
-      if (needsFirstRenderSkeleton && !this.presenter.hasRenderedDeck()) {
-        this.presenter.setViewportSkeleton(false);
-      }
+      endNavigationProgress();
+      this.updateBackButtonAvailability();
     }
   }
 

--- a/browser/frontend/src/app/browser-presenter.test.ts
+++ b/browser/frontend/src/app/browser-presenter.test.ts
@@ -262,6 +262,178 @@ describe('BrowserPresenter', () => {
     }
   });
 
+  it('shows the first-render skeleton immediately with no delay', () => {
+    const refs = createRefs();
+    const presenter = new BrowserPresenter(refs, initialSession, 20);
+
+    const endProgress = presenter.beginNavigationProgress();
+
+    // No timers involved for the very first render -- it appears synchronously.
+    expect(refs.viewportEl.classList.contains('viewport-skeleton')).toBe(true);
+    expect(refs.viewportEl.querySelector('.skeleton-hint')).not.toBeNull();
+
+    endProgress();
+    expect(refs.viewportEl.classList.contains('viewport-skeleton')).toBe(false);
+    expect(refs.viewportEl.innerHTML).toBe('');
+  });
+
+  it('does not flash an in-progress indicator for a repeat navigation that resolves within the delay', () => {
+    vi.useFakeTimers();
+    try {
+      const refs = createRefs();
+      const presenter = new BrowserPresenter(refs, initialSession, 20);
+      presenter.drawRenderList({ draw: [{ type: 'text', text: 'hello', x: 0, y: 0 }] });
+
+      const endProgress = presenter.beginNavigationProgress(180);
+      // Resolves fast (well under the delay threshold).
+      vi.advanceTimersByTime(50);
+      expect(refs.viewportEl.classList.contains('viewport-skeleton')).toBe(false);
+      expect(refs.viewportEl.querySelector('.viewport-navigation-hint')).toBeNull();
+
+      endProgress();
+      expect(refs.viewportEl.classList.contains('viewport-skeleton')).toBe(false);
+      expect(refs.viewportEl.querySelector('.viewport-navigation-hint')).toBeNull();
+      // Existing content must never be touched by a navigation that never
+      // visibly showed progress.
+      expect(refs.viewportEl.textContent).toContain('hello');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('shows a lightweight in-progress hint for a repeat navigation slower than the delay', () => {
+    vi.useFakeTimers();
+    try {
+      const refs = createRefs();
+      const presenter = new BrowserPresenter(refs, initialSession, 20);
+      presenter.drawRenderList({ draw: [{ type: 'text', text: 'hello', x: 0, y: 0 }] });
+
+      const endProgress = presenter.beginNavigationProgress(180);
+      vi.advanceTimersByTime(180);
+
+      expect(refs.viewportEl.classList.contains('viewport-skeleton')).toBe(true);
+      expect(refs.viewportEl.getAttribute('aria-busy')).toBe('true');
+      const hint = refs.viewportEl.querySelector('.viewport-navigation-hint');
+      expect(hint).not.toBeNull();
+      expect(hint?.textContent).toBe(WAVES_COPY.shell.navigationPending);
+      // Existing content must stay on screen underneath the hint.
+      expect(refs.viewportEl.textContent).toContain('hello');
+
+      endProgress();
+      expect(refs.viewportEl.classList.contains('viewport-skeleton')).toBe(false);
+      expect(refs.viewportEl.querySelector('.viewport-navigation-hint')).toBeNull();
+      expect(refs.viewportEl.textContent).toContain('hello');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('cancels a pending in-progress delay if a fresh render arrives first', () => {
+    vi.useFakeTimers();
+    try {
+      const refs = createRefs();
+      const presenter = new BrowserPresenter(refs, initialSession, 20);
+      presenter.drawRenderList({ draw: [{ type: 'text', text: 'first', x: 0, y: 0 }] });
+
+      const endProgress = presenter.beginNavigationProgress(180);
+      vi.advanceTimersByTime(50);
+      presenter.drawRenderList({ draw: [{ type: 'text', text: 'second', x: 0, y: 0 }] });
+      vi.advanceTimersByTime(200);
+
+      // The delayed indicator must not appear after the render already landed.
+      expect(refs.viewportEl.classList.contains('viewport-skeleton')).toBe(false);
+      expect(refs.viewportEl.textContent).toContain('second');
+
+      endProgress();
+      expect(refs.viewportEl.textContent).toContain('second');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('announces a fatal WMLScript trap as a distinctly worded toast', () => {
+    vi.useFakeTimers();
+    try {
+      const refs = createRefs();
+      const presenter = new BrowserPresenter(refs, initialSession, 20);
+
+      presenter.setSnapshot({
+        activeCardId: 'home',
+        focusedLinkIndex: 0,
+        baseUrl: 'http://local.test/start.wml',
+        contentType: 'text/vnd.wap.wml',
+        lastScriptDialogRequests: [],
+        lastScriptTimerRequests: [],
+        lastScriptExecutionOk: false,
+        lastScriptExecutionTrap: 'vm: stack overflow (limit=64)',
+        lastScriptExecutionErrorClass: 'fatal',
+        lastScriptExecutionErrorCategory: 'resource'
+      });
+
+      expect(refs.toastEl.textContent).toBe(
+        WAVES_COPY.status.scriptExecutionFailed(
+          'resource limit error',
+          'vm: stack overflow (limit=64)'
+        )
+      );
+      expect(refs.toastEl.className).toBe('toast toast-error');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('does not re-announce the same sticky script trap across repeated snapshots', () => {
+    vi.useFakeTimers();
+    try {
+      const refs = createRefs();
+      const presenter = new BrowserPresenter(refs, initialSession, 20);
+      const baseSnapshot = {
+        activeCardId: 'home',
+        focusedLinkIndex: 0,
+        baseUrl: 'http://local.test/start.wml',
+        contentType: 'text/vnd.wap.wml',
+        lastScriptDialogRequests: [],
+        lastScriptTimerRequests: [],
+        lastScriptExecutionOk: false,
+        lastScriptExecutionTrap: 'vm: type error (expected number)',
+        lastScriptExecutionErrorClass: 'fatal',
+        lastScriptExecutionErrorCategory: 'computational'
+      };
+
+      presenter.setSnapshot(baseSnapshot);
+      expect(refs.toastEl.textContent).toBe(
+        WAVES_COPY.status.scriptExecutionFailed(
+          'computation error',
+          'vm: type error (expected number)'
+        )
+      );
+
+      refs.toastEl.textContent = '__unchanged__';
+      // lastScriptExecutionOk is sticky on the engine side -- a later
+      // snapshot carrying the exact same trap must not re-toast.
+      presenter.setSnapshot({ ...baseSnapshot });
+
+      expect(refs.toastEl.textContent).toBe('__unchanged__');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('removes the dev-drawer toggle listener on dispose', () => {
+    const refs = createRefs();
+    const presenter = new BrowserPresenter(refs, initialSession, 20);
+
+    presenter.patchSessionState({ navigationStatus: 'loaded' });
+    presenter.dispose();
+
+    refs.devDrawerEl.open = true;
+    refs.devDrawerEl.dispatchEvent(new Event('toggle'));
+
+    // flushDeveloperPanels would normally populate this once the drawer
+    // opens; after dispose, the listener is gone so it stays empty.
+    expect(refs.sessionStateEl.textContent).toBe('');
+  });
+
   it('exports timeline data through a blob download', () => {
     const refs = createRefs();
     const presenter = new BrowserPresenter(refs, initialSession, 20);

--- a/browser/frontend/src/app/browser-presenter.ts
+++ b/browser/frontend/src/app/browser-presenter.ts
@@ -21,6 +21,8 @@ import { renderWmlViewportHtml } from '../components/primitives/wml-render-primi
 
 export type BootPhase = 'booting' | 'shell-ready' | 'engine-ready' | 'deck-ready';
 
+const REPEAT_NAV_HINT_CLASS = 'viewport-navigation-hint';
+
 export class BrowserPresenter {
   private readonly refs: BrowserShellRefs;
 
@@ -35,6 +37,11 @@ export class BrowserPresenter {
   private toastQueue: Array<{ message: string; tone: 'error' | 'ok'; ttlMs: number }> = [];
   private hasRenderedContent = false;
   private announcedDialogRequests: readonly ScriptDialogRequestSnapshot[] = [];
+  private announcedScriptFailure: {
+    trap: string | undefined;
+    errorClass: string | undefined;
+    errorCategory: string | undefined;
+  } | null = null;
   private latestSnapshot: EngineRuntimeSnapshot | null = null;
   private latestTransportResponse: FetchResponse | null = null;
   private sessionStateText = '';
@@ -45,14 +52,33 @@ export class BrowserPresenter {
   private timelineDirty = true;
   private snapshotDirty = true;
   private transportResponseDirty = true;
+  private navigationProgressTimer: ReturnType<typeof setTimeout> | undefined;
+  private readonly handleDevDrawerToggle = (): void => {
+    this.flushDeveloperPanels();
+  };
 
   constructor(refs: BrowserShellRefs, initialSession: HostSessionState, maxTimelineEvents: number) {
     this.refs = refs;
     this.maxTimelineEvents = maxTimelineEvents;
     this.hostSessionState = initialSession;
-    this.refs.devDrawerEl.addEventListener('toggle', () => {
-      this.flushDeveloperPanels();
-    });
+    this.refs.devDrawerEl.addEventListener('toggle', this.handleDevDrawerToggle);
+  }
+
+  // U6: mirrors the listener registered in the constructor so BrowserController
+  // (which owns this presenter) has a symmetric teardown to call from its own
+  // dispose(). Currently harmless because mountBrowserShell replaces #app's
+  // innerHTML wholesale on every bootstrap/HMR cycle (dropping the old
+  // listener with the old DOM), but the class should not rely on that.
+  dispose(): void {
+    this.refs.devDrawerEl.removeEventListener('toggle', this.handleDevDrawerToggle);
+    if (this.navigationProgressTimer) {
+      clearTimeout(this.navigationProgressTimer);
+      this.navigationProgressTimer = undefined;
+    }
+    if (this.toastTimer) {
+      clearTimeout(this.toastTimer);
+      this.toastTimer = undefined;
+    }
   }
 
   getSessionState(): HostSessionState {
@@ -130,6 +156,12 @@ export class BrowserPresenter {
           <div class="skeleton-line"></div>
           <div class="skeleton-hint">${escapeHtml(WAVES_COPY.shell.firstRenderPending)}</div>
         `;
+      } else {
+        // A repeat navigation (link click, reload, back/forward, external
+        // intent) -- content is already on screen, so don't wipe it. Append a
+        // small non-destructive hint reusing the existing skeleton-hint style
+        // instead of building a separate progress affordance (see U1).
+        this.showRepeatNavigationHint();
       }
       return;
     }
@@ -145,7 +177,62 @@ export class BrowserPresenter {
       // failed first load doesn't leave a frozen "still loading" viewport
       // behind the real error, which is surfaced via status/toast instead.
       this.refs.viewportEl.innerHTML = '';
+    } else {
+      this.hideRepeatNavigationHint();
     }
+  }
+
+  // U1: shows a lightweight in-progress indicator for any navigation beyond
+  // the very first deck render, gated behind a short delay so instant
+  // local-mode loads never flash it. The very first render keeps its
+  // existing immediate, full-skeleton behavior. Returns a callback the
+  // caller must invoke (typically from a `finally`) once the navigation
+  // settles, which cancels the pending delay or clears the indicator if it
+  // already appeared. Callers are expected to run one navigation at a time
+  // (already true for every current call site), so this does not attempt to
+  // coordinate overlapping in-flight calls.
+  beginNavigationProgress(delayMs: number = WAVES_CONFIG.navigationProgressDelayMs): () => void {
+    if (!this.hasRenderedContent) {
+      this.setViewportSkeleton(true);
+      return () => {
+        this.setViewportSkeleton(false);
+      };
+    }
+
+    if (this.navigationProgressTimer) {
+      clearTimeout(this.navigationProgressTimer);
+      this.navigationProgressTimer = undefined;
+    }
+    let fired = false;
+    this.navigationProgressTimer = setTimeout(() => {
+      this.navigationProgressTimer = undefined;
+      fired = true;
+      this.setViewportSkeleton(true);
+    }, delayMs);
+
+    return () => {
+      if (this.navigationProgressTimer) {
+        clearTimeout(this.navigationProgressTimer);
+        this.navigationProgressTimer = undefined;
+      }
+      if (fired) {
+        this.setViewportSkeleton(false);
+      }
+    };
+  }
+
+  private showRepeatNavigationHint(): void {
+    if (this.refs.viewportEl.querySelector(`.${REPEAT_NAV_HINT_CLASS}`)) {
+      return;
+    }
+    const hint = document.createElement('div');
+    hint.className = `skeleton-hint ${REPEAT_NAV_HINT_CLASS}`;
+    hint.textContent = WAVES_COPY.shell.navigationPending;
+    this.refs.viewportEl.append(hint);
+  }
+
+  private hideRepeatNavigationHint(): void {
+    this.refs.viewportEl.querySelector(`.${REPEAT_NAV_HINT_CLASS}`)?.remove();
   }
 
   showToast(
@@ -187,6 +274,7 @@ export class BrowserPresenter {
     this.snapshotDirty = true;
     this.flushDeveloperPanels();
     this.announceScriptDialogRequests(snapshot.lastScriptDialogRequests);
+    this.announceScriptExecutionFailure(snapshot);
   }
 
   getSnapshot(): EngineRuntimeSnapshot | null {
@@ -201,6 +289,12 @@ export class BrowserPresenter {
 
   drawRenderList(renderList: RenderList): void {
     this.hasRenderedContent = true;
+    // Real content just landed -- cancel any pending delayed in-progress
+    // indicator so it can't appear after the fact (see beginNavigationProgress).
+    if (this.navigationProgressTimer) {
+      clearTimeout(this.navigationProgressTimer);
+      this.navigationProgressTimer = undefined;
+    }
     this.setViewportSkeleton(false);
     this.refs.viewportEl.innerHTML = renderWmlViewportHtml(renderList);
   }
@@ -287,6 +381,39 @@ export class BrowserPresenter {
     }
   }
 
+  // U2: the engine already classifies script failures via lastScriptExecutionOk
+  // / lastScriptExecutionTrap / lastScriptExecutionErrorClass /
+  // lastScriptExecutionErrorCategory (see EngineRuntimeSnapshot in
+  // navigation-state.ts), but until now the frontend only read those fields
+  // for render change-detection and never surfaced them -- so a WMLScript
+  // fatal trap produced no visible message distinct from a normal action.
+  // `lastScriptExecutionOk` is sticky on the engine side (it reflects the
+  // *last* script that ran, not "this render"), so track what was already
+  // announced and only toast again when the trap actually changes -- the same
+  // dedup shape as announceScriptDialogRequests above.
+  private announceScriptExecutionFailure(snapshot: EngineRuntimeSnapshot): void {
+    if (snapshot.lastScriptExecutionOk !== false) {
+      return;
+    }
+    const current = {
+      trap: snapshot.lastScriptExecutionTrap,
+      errorClass: snapshot.lastScriptExecutionErrorClass,
+      errorCategory: snapshot.lastScriptExecutionErrorCategory
+    };
+    if (
+      this.announcedScriptFailure &&
+      this.announcedScriptFailure.trap === current.trap &&
+      this.announcedScriptFailure.errorClass === current.errorClass &&
+      this.announcedScriptFailure.errorCategory === current.errorCategory
+    ) {
+      return;
+    }
+    this.announcedScriptFailure = current;
+    const categoryLabel = describeScriptErrorCategory(current.errorCategory);
+    const message = current.trap ?? WAVES_COPY.errors.unknownTransportFailure;
+    this.showToast(WAVES_COPY.status.scriptExecutionFailed(categoryLabel, message), 'error');
+  }
+
   private writeTextIfChanged<T extends HTMLElement>(
     element: T,
     currentText: string,
@@ -329,6 +456,18 @@ const dialogRequestListsEqual = (
     );
   });
 };
+
+// Mirrors the engine's ScriptErrorCategoryLiteral taxonomy
+// (engine-wasm/engine/src/engine_script_types.rs) into user-facing wording.
+const SCRIPT_ERROR_CATEGORY_LABELS: Record<string, string> = {
+  computational: 'computation error',
+  integrity: 'data integrity error',
+  resource: 'resource limit error',
+  'host-binding': 'host binding error'
+};
+
+const describeScriptErrorCategory = (category: string | undefined): string =>
+  (category && SCRIPT_ERROR_CATEGORY_LABELS[category]) || 'script error';
 
 // Mirrors the engine's deterministic dialog resolution
 // (engine-wasm/engine/src/wavescript/stdlib/dialogs.rs): confirm() always

--- a/browser/frontend/src/app/navigation-state.load.test.ts
+++ b/browser/frontend/src/app/navigation-state.load.test.ts
@@ -124,6 +124,34 @@ describe('navigation-state load behavior', () => {
     expect(navigationErrors).toEqual(['gateway timed out']);
   });
 
+  it('reports a network-layer transport failure as the "network" error kind', async () => {
+    const navigationErrors: Array<{ message: string; kind: string }> = [];
+    const host = createHostClientMock({
+      fetchDeck: async () =>
+        fetchOk({
+          ok: false,
+          status: 504,
+          contentType: 'text/plain',
+          error: { code: 'GATEWAY_TIMEOUT', message: 'gateway timed out' },
+          engineDeckInput: undefined,
+          wml: undefined
+        })
+    });
+    const machine = createNavigationStateMachine(host, 'http://seed.test', {
+      onNavigationError: (message, kind) => {
+        navigationErrors.push({ message, kind });
+      }
+    });
+
+    await machine.loadTransportUrl({
+      url: 'http://example.test/start.wml',
+      source: 'user',
+      followExternalIntent: true
+    });
+
+    expect(navigationErrors).toEqual([{ message: 'gateway timed out', kind: 'network' }]);
+  });
+
   it('fires onNavigationError when the fetch succeeds but returns no WML payload', async () => {
     const navigationErrors: string[] = [];
     const host = createHostClientMock({
@@ -150,6 +178,36 @@ describe('navigation-state load behavior', () => {
     expect(result).toBeNull();
     expect(machine.getSessionState().navigationStatus).toBe('error');
     expect(navigationErrors).toHaveLength(1);
+  });
+
+  it('reports a fetch that succeeded with no WML payload as the "parse" error kind', async () => {
+    // U2: distinguishes a deck that fetched fine but didn't parse from a
+    // network-layer failure, so the frontend can word them differently.
+    const navigationErrors: Array<{ message: string; kind: string }> = [];
+    const host = createHostClientMock({
+      fetchDeck: async () =>
+        fetchOk({
+          ok: true,
+          status: 200,
+          engineDeckInput: undefined,
+          wml: undefined
+        })
+    });
+    const machine = createNavigationStateMachine(host, 'http://seed.test', {
+      onNavigationError: (message, kind) => {
+        navigationErrors.push({ message, kind });
+      }
+    });
+
+    await machine.loadTransportUrl({
+      url: 'http://example.test/start.wml',
+      source: 'user',
+      followExternalIntent: true
+    });
+
+    expect(navigationErrors).toEqual([
+      { message: 'Fetch succeeded but returned no WML payload.', kind: 'parse' }
+    ]);
   });
 
   it('does not push duplicate history entry when reload uses pushHistory=false', async () => {

--- a/browser/frontend/src/app/navigation-state.ts
+++ b/browser/frontend/src/app/navigation-state.ts
@@ -28,6 +28,14 @@ import { WAVES_COPY } from './waves-copy';
 
 export type BackNavigationMode = 'engine' | 'host' | 'none';
 
+// Distinguishes *why* loadTransportUrl failed so callers can word the
+// status/toast message differently instead of a single generic "fetch
+// failed" for every case (see U2 in USABILITY_RESILIENCE_BACKLOG.md):
+// 'network' covers transport-layer failures (timeout, non-200, protocol
+// error, TRANSPORT_UNAVAILABLE, external-intent hop limit); 'parse' covers a
+// transport response that succeeded but carried no usable WML payload.
+export type NavigationErrorKind = 'network' | 'parse';
+
 export interface NavigationHostClient {
   fetchDeck(request: FetchRequest): Promise<FetchResponse>;
   engineLoadDeckContext(request: LoadDeckContextRequest): Promise<EngineRuntimeSnapshot>;
@@ -61,7 +69,7 @@ export interface NavigationHooks {
    * consistent, visible failure indicator (e.g. a toast) regardless of which
    * failure kind occurred, instead of only the quieter status-panel text.
    */
-  onNavigationError?(message: string): void;
+  onNavigationError?(message: string, kind: NavigationErrorKind): void;
   onStateEvent?(action: string, details?: Record<string, unknown>): void;
 }
 
@@ -222,7 +230,7 @@ export const createNavigationStateMachine = (
       if (transport.error?.code === 'TRANSPORT_UNAVAILABLE') {
         hooks.onNetworkUnavailable?.();
       }
-      hooks.onNavigationError?.(errorMessage);
+      hooks.onNavigationError?.(errorMessage, 'network');
       return null;
     }
 
@@ -240,7 +248,7 @@ export const createNavigationStateMachine = (
         contentType: transport.contentType,
         lastError: WAVES_COPY.errors.missingWmlPayload
       });
-      hooks.onNavigationError?.(WAVES_COPY.errors.missingWmlPayload);
+      hooks.onNavigationError?.(WAVES_COPY.errors.missingWmlPayload, 'parse');
       return null;
     }
 
@@ -314,7 +322,7 @@ export const createNavigationStateMachine = (
         if (hop === maxExternalIntentHops) {
           const message = `External intent hop limit reached (${maxExternalIntentHops}).`;
           mergeSessionState({ navigationStatus: 'error', lastError: message });
-          hooks.onNavigationError?.(message);
+          hooks.onNavigationError?.(message, 'network');
         }
       }
     }

--- a/browser/frontend/src/app/waves-config.ts
+++ b/browser/frontend/src/app/waves-config.ts
@@ -17,6 +17,10 @@ export const WAVES_CONFIG = {
   networkProbeDelayMs: 1200,
   networkProbeTimeoutMs: 1800,
   engineTimerTickMs: 100,
+  // Repeat navigations (not the very first deck render) only show an
+  // in-progress indicator if they take longer than this, so instant
+  // local-mode loads don't flash it (see U1 in USABILITY_RESILIENCE_BACKLOG.md).
+  navigationProgressDelayMs: 180,
   toastTtlMs: 6000,
   scriptTimerAnonymousIdPadLength: 6
 } as const;

--- a/browser/frontend/src/app/waves-copy.ts
+++ b/browser/frontend/src/app/waves-copy.ts
@@ -32,6 +32,7 @@ const locale = {
     runtimeSnapshot: 'Runtime Snapshot',
     eventTimeline: 'Event Timeline',
     firstRenderPending: 'Waiting for first deck render...',
+    navigationPending: 'Loading next page...',
     mode: 'Mode',
     localMode: 'Local',
     networkMode: 'Network',
@@ -100,6 +101,16 @@ const locale = {
     followingExternalIntent: (url: string) => `Following external intent: ${url}`,
     loadingPreviousPage: (url: string) => `Loading previous page: ${url}`,
     fetchFailed: (message: string) => `Fetch failed: ${message}`,
+    // Distinct from fetchFailed: the transport request itself succeeded, but the
+    // payload it returned could not be parsed/used as a WML deck. Kept as
+    // separate wording so users (and anyone debugging a deck) don't confuse a
+    // malformed-content failure with a network-layer one (see U2).
+    deckParseFailed: (message: string) => `Deck parse failed: ${message}`,
+    // Distinct wording for a WMLScript fatal trap, using the engine's own
+    // error-category taxonomy so it reads differently from both a network
+    // failure and a deck-parse failure (see U2).
+    scriptExecutionFailed: (categoryLabel: string, message: string) =>
+      `Script error (${categoryLabel}): ${message}`,
     fetchedAndLoadedDeck: (url: string) => `Fetched and loaded deck from ${url}`,
     networkUnavailableToast: 'No network available currently. WAP server/gateway is unreachable.',
     networkUnavailable: 'No network available currently. Could not reach WAP server/gateway.',

--- a/browser/frontend/src/components/primitives/surface-panel.ts
+++ b/browser/frontend/src/components/primitives/surface-panel.ts
@@ -11,22 +11,26 @@ export class WvSurfacePanel extends LitElement {
     }
 
     .panel {
-      border: 2px solid #808080;
-      border-right-color: #000000;
-      border-bottom-color: #000000;
-      background: #c0c0c0;
+      border: 2px solid var(--panel-border-mid);
+      border-right-color: var(--panel-border-dark);
+      border-bottom-color: var(--panel-border-dark);
+      background: var(--panel-bg);
     }
 
     .heading {
       margin: 0;
       padding: 4px 6px;
-      border-bottom: 1px solid #808080;
+      border-bottom: 1px solid var(--panel-border-mid);
       font-size: 12px;
       letter-spacing: 0;
       text-transform: none;
-      color: #ffffff;
+      color: var(--panel-heading-text);
       font-weight: 700;
-      background: linear-gradient(90deg, #000080 0%, #1084d0 100%);
+      background: linear-gradient(
+        90deg,
+        var(--panel-heading-gradient-start) 0%,
+        var(--panel-heading-gradient-end) 100%
+      );
     }
 
     .body {

--- a/browser/frontend/src/components/status-panel.test.ts
+++ b/browser/frontend/src/components/status-panel.test.ts
@@ -14,7 +14,7 @@ describe('WvStatusPanel', () => {
     el.setStatus('Ready.', 'ok');
     await el.updateComplete;
     const root = el.shadowRoot?.querySelector<HTMLDivElement>('#status-root');
-    expect(root?.textContent).toBe('Ready.');
+    expect(root?.textContent?.trim()).toBe('Ready.');
     expect(root?.className).toContain('status-ok');
 
     el.remove();
@@ -47,7 +47,7 @@ describe('WvStatusPanel', () => {
     el.setAttribute('tone', 'loading');
     await el.updateComplete;
     const root = el.shadowRoot?.querySelector<HTMLDivElement>('#status-root');
-    expect(root?.textContent).toBe('Loading...');
+    expect(root?.textContent?.trim()).toBe('Loading...');
     expect(root?.className).toContain('status-loading');
 
     el.remove();

--- a/browser/frontend/src/components/status-panel.ts
+++ b/browser/frontend/src/components/status-panel.ts
@@ -13,35 +13,35 @@ export class WvStatusPanel extends LitElement {
     }
 
     .status {
-      border: 2px solid #808080;
-      border-top-color: #000000;
-      border-left-color: #000000;
+      border: 2px solid var(--panel-border-mid);
+      border-top-color: var(--panel-border-dark);
+      border-left-color: var(--panel-border-dark);
       padding: 8px;
       font-size: 13px;
       min-height: 44px;
-      background: #ffffff;
-      color: #222222;
+      background: var(--status-idle-bg);
+      color: var(--status-idle-text);
       line-height: 1.35;
     }
 
     .status-idle {
-      background: #ffffff;
-      color: #222222;
+      background: var(--status-idle-bg);
+      color: var(--status-idle-text);
     }
 
     .status-loading {
-      background: #ffffcc;
-      color: #222222;
+      background: var(--status-loading-bg);
+      color: var(--status-loading-text);
     }
 
     .status-ok {
-      background: #ccffcc;
-      color: #222222;
+      background: var(--status-ok-bg);
+      color: var(--status-ok-text);
     }
 
     .status-error {
-      background: #ffcccc;
-      color: #222222;
+      background: var(--status-error-bg);
+      color: var(--status-error-text);
     }
   `;
 

--- a/browser/frontend/src/styles.css
+++ b/browser/frontend/src/styles.css
@@ -6,6 +6,29 @@
   --motion-base: 180ms;
   --ease-standard: cubic-bezier(0.22, 1, 0.36, 1);
   --waves-teal: #008080;
+
+  /* Shared win95-style chrome tones (panel borders/background/heading) used
+     by wv-status-panel and wv-surface-panel. */
+  --panel-border-mid: #808080;
+  --panel-border-dark: #000000;
+  --panel-bg: #c0c0c0;
+  --panel-heading-text: #ffffff;
+  --panel-heading-gradient-start: #000080;
+  --panel-heading-gradient-end: #1084d0;
+
+  /* Status-panel semantic tones */
+  --status-idle-bg: #ffffff;
+  --status-idle-text: #222222;
+  --status-loading-bg: #ffffcc;
+  --status-loading-text: #222222;
+  --status-ok-bg: #ccffcc;
+  --status-ok-text: #222222;
+  --status-error-bg: #ffcccc;
+  --status-error-text: #222222;
+
+  /* Toast semantic tones */
+  --toast-ok-bg: #d8f8d8;
+  --toast-error-bg: #ffd6d6;
 }
 
 * {
@@ -188,11 +211,11 @@ textarea.form-95 {
 }
 
 .toast-error {
-  background: #ffd6d6;
+  background: var(--toast-error-bg);
 }
 
 .toast-ok {
-  background: #d8f8d8;
+  background: var(--toast-ok-bg);
 }
 
 .toast-hidden {

--- a/browser/src-tauri/src/tests/fetch_commands.rs
+++ b/browser/src-tauri/src/tests/fetch_commands.rs
@@ -349,6 +349,129 @@ fn fetch_deck_command_retries_native_wap_request_with_gateway_fallback_when_conf
 }
 
 #[test]
+fn fetch_deck_command_gateway_fallback_cannot_be_redirected_by_fallback_env_value() {
+    // M1-21 regression: `WAVES_FETCH_TRANSPORT_FALLBACK` (default_fetch_transport_fallback in
+    // fetch_host.rs) only selects *whether* the gateway-bridged fallback runs -- it is a strict
+    // enum toggle ("disabled" | "gateway-bridged") and carries no host/URL value of its own.
+    // The actual destination for the fallback leg is enforced entirely inside
+    // transport-rust (gateway::gateway_http_base / build_gateway_request, pinned by the
+    // transport-rust M1-20 regression test). This test exercises the REAL transport end to
+    // end (no mocked fetch_impl) to confirm the fallback path can only ever land on the
+    // operator-configured `GATEWAY_HTTP_BASE` -- never on a host derived from the fallback
+    // env var, from request headers, or from the original wap:// URL's own host/port.
+    let _guard = env_lock().lock().expect("env lock should succeed");
+    let previous_profile = std::env::var(super::waves_config::FETCH_TRANSPORT_PROFILE_ENV).ok();
+    let previous_fallback = std::env::var(super::waves_config::FETCH_TRANSPORT_FALLBACK_ENV).ok();
+    let previous_destination =
+        std::env::var(super::waves_config::FETCH_DESTINATION_POLICY_ENV).ok();
+    let previous_gateway_base = std::env::var("GATEWAY_HTTP_BASE").ok();
+
+    let listener =
+        std::net::TcpListener::bind("127.0.0.1:0").expect("bind local gateway stand-in listener");
+    let listener_addr = listener.local_addr().expect("read listener address");
+
+    let captured_request_line = std::sync::Arc::new(std::sync::Mutex::new(None::<String>));
+    let captured_for_thread = std::sync::Arc::clone(&captured_request_line);
+    let server = std::thread::spawn(move || {
+        use std::io::{BufRead, BufReader, Write};
+        let (stream, _) = listener
+            .accept()
+            .expect("accept gateway stand-in connection");
+        let mut reader = BufReader::new(stream.try_clone().expect("clone stream for reading"));
+        let mut request_line = String::new();
+        reader
+            .read_line(&mut request_line)
+            .expect("read request line from gateway stand-in connection");
+        *captured_for_thread
+            .lock()
+            .expect("captured request line lock should succeed") = Some(request_line);
+        let mut writer = stream;
+        let body = BASIC_NAV_WML;
+        let response = format!(
+            "HTTP/1.1 200 OK\r\nContent-Type: text/vnd.wap.wml\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+            body.len(),
+            body
+        );
+        writer
+            .write_all(response.as_bytes())
+            .expect("write gateway stand-in response");
+    });
+
+    std::env::set_var(
+        super::waves_config::FETCH_TRANSPORT_PROFILE_ENV,
+        super::waves_config::FETCH_TRANSPORT_PROFILE_WAP_NET_CORE,
+    );
+    std::env::set_var(
+        super::waves_config::FETCH_TRANSPORT_FALLBACK_ENV,
+        super::waves_config::FETCH_TRANSPORT_FALLBACK_GATEWAY_BRIDGED,
+    );
+    std::env::set_var(
+        super::waves_config::FETCH_DESTINATION_POLICY_ENV,
+        super::waves_config::FETCH_DESTINATION_POLICY_ALLOW_PRIVATE,
+    );
+    std::env::set_var("GATEWAY_HTTP_BASE", format!("http://{listener_addr}"));
+
+    // The native leg deliberately targets a port nothing listens on (matches the
+    // "127.0.0.1:9" convention used elsewhere in this suite) so it fails fast with
+    // TRANSPORT_UNAVAILABLE and triggers the gateway-bridged fallback.
+    let response = fetch_deck(FetchDeckRequest {
+        url: "wap://127.0.0.1:9/private-marker.wml".to_string(),
+        method: Some("GET".to_string()),
+        headers: None,
+        timeout_ms: Some(500),
+        retries: Some(0),
+        request_id: Some("req-fallback-host-scope".to_string()),
+        request_policy: Some(FetchRequestPolicy {
+            destination_policy: Some(FetchDestinationPolicy::AllowPrivate),
+            cache_control: None,
+            referer_url: None,
+            post_context: None,
+            ua_capability_profile: None,
+        }),
+    });
+
+    server
+        .join()
+        .expect("gateway stand-in server thread should exit");
+
+    if let Some(old) = previous_profile {
+        std::env::set_var(super::waves_config::FETCH_TRANSPORT_PROFILE_ENV, old);
+    } else {
+        std::env::remove_var(super::waves_config::FETCH_TRANSPORT_PROFILE_ENV);
+    }
+    if let Some(old) = previous_fallback {
+        std::env::set_var(super::waves_config::FETCH_TRANSPORT_FALLBACK_ENV, old);
+    } else {
+        std::env::remove_var(super::waves_config::FETCH_TRANSPORT_FALLBACK_ENV);
+    }
+    if let Some(old) = previous_destination {
+        std::env::set_var(super::waves_config::FETCH_DESTINATION_POLICY_ENV, old);
+    } else {
+        std::env::remove_var(super::waves_config::FETCH_DESTINATION_POLICY_ENV);
+    }
+    if let Some(old) = previous_gateway_base {
+        std::env::set_var("GATEWAY_HTTP_BASE", old);
+    } else {
+        std::env::remove_var("GATEWAY_HTTP_BASE");
+    }
+
+    assert!(
+        response.ok,
+        "expected gateway-bridged fallback to succeed against the configured gateway base: {:?}",
+        response.error
+    );
+    let request_line = captured_request_line
+        .lock()
+        .expect("captured request line lock should succeed")
+        .clone()
+        .expect("gateway stand-in listener should have received a request");
+    assert!(
+        request_line.starts_with("GET /private-marker.wml"),
+        "gateway fallback should target GATEWAY_HTTP_BASE with the original wap path, got: {request_line}"
+    );
+}
+
+#[test]
 #[ignore = "runs against external Kannel dev stack (make up)"]
 fn host_fetch_deck_command_native_wap_home_smoke_succeeds() {
     let _guard = env_lock().lock().expect("env lock should succeed");

--- a/docs/waves/MAINTENANCE_WORK_ITEMS.md
+++ b/docs/waves/MAINTENANCE_WORK_ITEMS.md
@@ -181,7 +181,7 @@ Completed maintenance tickets are archived in:
 
 ### M1-19 `fetch_policy.rs` pre-flight destination check is shallow relative to the enforced check (2026-07-24)
 
-1. `Status`: `todo`
+1. `Status`: `done`
 2. `Priority`: `P3`
 3. `Files`:
 - `transport-rust/src/fetch_policy.rs` (`classify_destination_host`, `validate_fetch_destination`)
@@ -193,10 +193,12 @@ Completed maintenance tickets are archived in:
 - Add a regression test (or an inline invariant comment referencing the resolution-time check) that fails loudly if `validate_fetch_destination` is ever called as the sole gate without the resolver-level check also running.
 6. `Accept`:
 - A future refactor that removes the resolution-time check without also updating the pre-flight check fails a test, rather than silently reopening the class of bug.
+7. `Resolution`:
+- Added `transport_resolution_time_check_blocks_private_answer_that_shallow_preflight_alone_would_allow` in `transport-rust/src/tests/fetch_mapping.rs`, which asserts the shallow pre-flight (`classify_destination_host`/`validate_fetch_destination`) passes a non-localhost domain, then asserts `validate_resolved_destination_addresses` (the shared function backing both `PolicyDnsResolver` and the native path) independently rejects a simulated private DNS answer for that same host. Combined with the pre-existing `http_client_rejects_private_dns_answer` (execution.rs) and `resolve_destination_socket_addr_rejects_private_peer_under_public_only` (native_fetch.rs) wiring tests, a removal of either resolution-time call site now fails a test. No enforcement logic changed.
 
 ### M1-20 Gateway-bridged fetch profile force-sets `AllowPrivate` with no invariant test
 
-1. `Status`: `todo`
+1. `Status`: `done`
 2. `Priority`: `P3`
 3. `Files`:
 - `transport-rust/src/fetch_runtime/execution.rs` (`destination_policy` override for `wap://`/`waps://` traffic)
@@ -207,10 +209,12 @@ Completed maintenance tickets are archived in:
 - Add a test asserting `GATEWAY_HTTP_BASE` is read only from process environment/config, never from request-supplied data, so a future change can't silently make it attacker-influenced without breaking a test.
 6. `Accept`:
 - A regression test exists that would fail if `GATEWAY_HTTP_BASE` (or its equivalent) became derivable from untrusted input.
+7. `Resolution`:
+- Added `transport_build_gateway_request_ignores_request_supplied_gateway_base_overrides` in `transport-rust/src/tests/request_gateway_policy.rs`. It calls `build_gateway_request` with headers and URL path/query attempting to smuggle an alternate base (`GATEWAY_HTTP_BASE`/`X-Gateway-Http-Base`/`X-Forwarded-Host`/`Host` headers, matching query key) and asserts the resolved gateway URL is unaffected — first against the default base, then against an operator-configured `GATEWAY_HTTP_BASE` env value, confirming the env value always wins over any request-supplied data. No enforcement logic changed.
 
 ### M1-21 `fetch_host.rs` gateway-transport-fallback host scope unconfirmed
 
-1. `Status`: `todo`
+1. `Status`: `done`
 2. `Priority`: `P3`
 3. `Files`:
 - `browser/src-tauri/src/fetch_host.rs` (`default_fetch_transport_fallback`)
@@ -221,6 +225,8 @@ Completed maintenance tickets are archived in:
 - Confirm (with a test, not just a read-through) that the gateway transport path is constrained the same way `native_fetch` is — i.e. it can't be pointed at an arbitrary host via this fallback env var.
 6. `Accept`:
 - A test demonstrates the gateway-fallback path cannot be redirected to an arbitrary non-configured host.
+7. `Resolution`: **Invariant confirmed to hold — no gap found.**
+- `WAVES_FETCH_TRANSPORT_FALLBACK` is a strict two-value enum switch (`disabled` | `gateway-bridged`) parsed in `default_fetch_transport_fallback()`; it carries no host/URL value itself and cannot smuggle one. When it selects the fallback, `fetch_deck_with_transport_executor` always retries with the hardcoded `FetchTransportProfile::GatewayBridged`, which routes through the same `build_gateway_request`/`GATEWAY_HTTP_BASE` machinery pinned by the M1-20 test — never a value derived from the fallback env var, request headers, or the original `wap://` URL's own host/port. Added `fetch_deck_command_gateway_fallback_cannot_be_redirected_by_fallback_env_value` in `browser/src-tauri/src/tests/fetch_commands.rs`, an end-to-end test using the real (unmocked) transport: a native attempt to an unreachable loopback port triggers the fallback, and the fallback is proven to land only on a local TCP listener bound to the test's `GATEWAY_HTTP_BASE`, receiving the original wap path unchanged. No enforcement logic changed.
 
 ### M1-03 Engine API generator design and bootstrap (non-priority)
 

--- a/docs/waves/USABILITY_RESILIENCE_BACKLOG.md
+++ b/docs/waves/USABILITY_RESILIENCE_BACKLOG.md
@@ -26,7 +26,7 @@ acceptance. Pull one into a branch when picked up; update status in place.
 
 ### U1 No progress indication on repeat navigations
 
-1. `Status`: `todo`
+1. `Status`: `done`
 2. `Priority`: `P2`
 3. `Files`:
 - `browser/frontend/src/app/browser-controller.ts` (navigation trigger sites)
@@ -42,7 +42,7 @@ acceptance. Pull one into a branch when picked up; update status in place.
 
 ### U2 Deck-parse and script-trap errors are indistinguishable from network errors
 
-1. `Status`: `todo`
+1. `Status`: `done`
 2. `Priority`: `P2`
 3. `Files`:
 - `browser/frontend/src/app/navigation-state.ts` (`EngineRuntimeSnapshot` fields: `lastScriptExecutionOk`, `lastScriptExecutionTrap`, `lastScriptExecutionErrorClass`, `lastScriptExecutionErrorCategory`)
@@ -57,7 +57,7 @@ acceptance. Pull one into a branch when picked up; update status in place.
 
 ### U3 Back button never reflects "no history" state
 
-1. `Status`: `todo`
+1. `Status`: `done`
 2. `Priority`: `P3`
 3. `Files`:
 - `browser/frontend/src/app/browser-controller.ts`
@@ -71,7 +71,7 @@ acceptance. Pull one into a branch when picked up; update status in place.
 
 ### U4 Color palette hardcoded and duplicated, no shared design tokens
 
-1. `Status`: `todo`
+1. `Status`: `done`
 2. `Priority`: `P3`
 3. `Files`:
 - `browser/frontend/src/styles.css`
@@ -100,7 +100,7 @@ acceptance. Pull one into a branch when picked up; update status in place.
 
 ### U6 `BrowserPresenter` has no `dispose()` lifecycle symmetry
 
-1. `Status`: `todo`
+1. `Status`: `done`
 2. `Priority`: `P3`
 3. `Files`:
 - `browser/frontend/src/app/browser-presenter.ts`

--- a/transport-rust/src/tests/fetch_mapping.rs
+++ b/transport-rust/src/tests/fetch_mapping.rs
@@ -754,6 +754,48 @@ fn transport_destination_policy_accepts_public_resolved_addresses() {
 }
 
 #[test]
+fn transport_resolution_time_check_blocks_private_answer_that_shallow_preflight_alone_would_allow()
+{
+    // M1-19 regression: `classify_destination_host` / `validate_fetch_destination` are a
+    // fast, shallow pre-flight check -- any hostname that isn't literally "localhost"/
+    // "*.localhost" (or a private/loopback IP literal) is classified `Public`, regardless of
+    // what it actually resolves to. The authoritative SSRF guard runs at DNS-resolution time
+    // (`PolicyDnsResolver` in fetch_runtime/execution.rs, and
+    // `resolve_fetch_destination_addresses` for the native path in native_fetch.rs), and both
+    // of those call sites delegate to `validate_resolved_destination_addresses`. This test
+    // pins the two-layer invariant directly: it fails if `validate_resolved_destination_addresses`
+    // is ever weakened to also treat a private resolved answer as acceptable, which is exactly
+    // what would happen if a future refactor collapsed the resolution-time check into the
+    // shallow pre-flight check.
+    let attacker_domain =
+        Url::parse("http://attacker-controlled.invalid/deck.wml").expect("url should parse");
+
+    // Shallow pre-flight: passes, because it never looks past the hostname text.
+    assert_eq!(
+        classify_destination_host(&attacker_domain),
+        Some(DestinationHostClass::Public),
+        "pre-flight classifies any non-localhost domain as public regardless of its DNS answer"
+    );
+    validate_fetch_destination(&attacker_domain, &FetchDestinationPolicy::PublicOnly).expect(
+        "pre-flight alone must NOT block this domain -- that shallowness is exactly what \
+         resolution-time enforcement exists to cover",
+    );
+
+    // Resolution-time: simulate the DNS answer this hostname could return in a DNS-rebinding
+    // scenario (attacker-controlled DNS pointing the domain at an internal address). The
+    // resolution-time layer inspects the resolved socket address, not the hostname text, and
+    // must independently reject it even though the pre-flight check above passed.
+    let rebound_answer = [SocketAddr::from(([10, 0, 0, 5], 80))];
+    let error = validate_resolved_destination_addresses(
+        &rebound_answer,
+        &FetchDestinationPolicy::PublicOnly,
+    )
+    .expect_err("resolution-time layer must block the private resolved address");
+    assert!(error.contains("public-only"));
+    assert!(error.contains("private"));
+}
+
+#[test]
 fn transport_fetch_blocks_loopback_when_policy_not_overridden() {
     let response = fetch_deck_in_process(FetchDeckRequest {
         request_id: Some("req-loopback-blocked".to_string()),

--- a/transport-rust/src/tests/request_gateway_policy.rs
+++ b/transport-rust/src/tests/request_gateway_policy.rs
@@ -137,6 +137,62 @@ fn transport_build_gateway_request_keeps_existing_host_header() {
 }
 
 #[test]
+fn transport_build_gateway_request_ignores_request_supplied_gateway_base_overrides() {
+    // M1-20 regression: `GATEWAY_HTTP_BASE` (transport-rust/src/gateway.rs::gateway_http_base)
+    // must be sourced only from process environment/config, never from request-supplied data
+    // (URL path/query, headers). This is what makes force-setting `AllowPrivate` for the
+    // gateway-bridged upstream target safe -- the actual upstream host is never
+    // attacker-influenced. Try every request-supplied surface `build_gateway_request` sees
+    // to smuggle an alternate base and confirm none of it changes the resolved gateway host.
+    with_env_removed_locked("GATEWAY_HTTP_BASE", || {
+        let mut headers = HashMap::new();
+        headers.insert(
+            "GATEWAY_HTTP_BASE".to_string(),
+            "http://evil.test".to_string(),
+        );
+        headers.insert(
+            "X-Gateway-Http-Base".to_string(),
+            "http://evil.test".to_string(),
+        );
+        headers.insert("X-Forwarded-Host".to_string(), "evil.test".to_string());
+        headers.insert("Host".to_string(), "evil.test".to_string());
+
+        let (gateway_url, _) = build_gateway_request(
+            "wap://example.test/home.wml?GATEWAY_HTTP_BASE=http://evil.test&host=evil.test",
+            "GET",
+            &headers,
+        )
+        .expect("gateway mapping should succeed");
+
+        assert!(
+            gateway_url.starts_with("http://localhost:13002"),
+            "gateway URL must stay pinned to the default GATEWAY_HTTP_BASE regardless of \
+             request-supplied headers/query, got: {gateway_url}"
+        );
+    });
+
+    // Same smuggling attempt, but with an operator-configured base present: the env value
+    // must still win over anything in the request.
+    with_env_var_locked("GATEWAY_HTTP_BASE", "http://127.0.0.1:19202", || {
+        let mut headers = HashMap::new();
+        headers.insert(
+            "GATEWAY_HTTP_BASE".to_string(),
+            "http://evil.test".to_string(),
+        );
+
+        let (gateway_url, _) =
+            build_gateway_request("wap://example.test/home.wml", "GET", &headers)
+                .expect("gateway mapping should succeed");
+
+        assert!(
+            gateway_url.starts_with("http://127.0.0.1:19202"),
+            "gateway URL must follow the operator-configured GATEWAY_HTTP_BASE, not \
+             request-supplied data, got: {gateway_url}"
+        );
+    });
+}
+
+#[test]
 fn apply_request_policy_adds_no_cache_headers_and_referer() {
     let mut headers = HashMap::new();
     headers.insert("X-Test".to_string(), "yes".to_string());


### PR DESCRIPTION
## Summary

Second follow-up slice, working through `docs/waves/USABILITY_RESILIENCE_BACKLOG.md` and the three `M1-19`/`M1-20`/`M1-21` hardening tickets from #281. U5 (runtime settings panel) and U7/U8 (debug-panel perf, marketing CSS split) stayed deferred per explicit scope call — matches what the doc already recommended.

### U1 — Progress indication on repeat navigations
Only the first deck load ever showed a loading state; every later navigation just sat static until content landed. Repeat navigations now show a lightweight in-progress hint after a short delay (so instant local-mode loads don't flash it), so a slow load no longer looks identical to a stuck one.

### U2 — Distinct error wording by failure class
Network failures, malformed deck payloads, and WMLScript fatal traps all produced the same generic "error" message, even though the engine already computes a proper error taxonomy the frontend just wasn't reading. Now branches messaging on the real cause.

### U3 — Back button reflects "no history" state
Was never disabled even with provably no history to go back to. Now tracks back-availability (network mode via existing history state, local mode via a tracked forward-navigation flag) and disables accordingly — matches the Chrome/Firefox convention.

### U4 — Shared color design tokens
Status/toast tones and win95 chrome colors were hardcoded independently in `styles.css` and inline in two Lit components. Extracted into named `:root` custom properties. Mechanical only — same colors, defined once.

### U6 — `BrowserPresenter` lifecycle symmetry
Added `dispose()` tearing down its toggle listener and pending timers, called from `BrowserController.dispose()`.

### Bonus: fixed an escaped pre-existing bug
While verifying U4, found `status-panel.test.ts` failing on a clean checkout of `main` (predates this branch, not introduced by anything here) — the component's `render()` template had `${this.message}` on its own line, so Lit rendered literal surrounding whitespace/newlines, breaking exact-match text assertions. Fixed by asserting on trimmed text content instead of fighting prettier's template reformatting every commit.

### M1-19 / M1-20 / M1-21 — transport/tauri hardening invariants
All three were "the real enforcement already exists and is correct, but nothing pins it as a regression test" situations, not live bugs:
- **M1-19**: proves the DNS-resolution-time SSRF check independently catches what the shallow pre-flight hostname check alone would miss.
- **M1-20**: proves `GATEWAY_HTTP_BASE` can't be overridden by request-supplied headers/query/body.
- **M1-21**: investigated whether the gateway-transport-fallback env var could be pointed at an arbitrary host — confirmed it can't (strict two-value enum, same `GATEWAY_HTTP_BASE`-pinned machinery as M1-20). Added an end-to-end test proving it.

## Test plan
- [x] `pnpm --dir browser/frontend test`: 129/129 passing
- [x] `pnpm --dir browser/frontend run typecheck`: clean
- [x] `cargo test` — transport-rust: 179+ passing
- [x] `cargo test` — browser/src-tauri: 60+ passing
- [x] Full local pre-push hook suite (fmt, clippy, tests across all three Rust crates, frontend typecheck): all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)