### PR TITLE
R0-04 first slice: parse deck-level head/access elements (WML-C-30, WML-C-21)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,8 +1,15 @@
 @AGENTS.md
+@docs/agents/AGENT_STANDARDS.md
+@docs/agents/RUST_ENGINE_STEERING.md
+@docs/agents/RUST_TRANSPORT_STEERING.md
+@docs/agents/SHELL_STEERING.md
+@docs/agents/SCRIPTING_STEERING.md
 @docs/agents/COMPLIANCE_CONTEXT_RETRIEVAL.md
 
 # Claude Code repository entrypoint
 
-The imported files contain the shared architecture, compliance-retrieval, scope, test, and
-contribution rules for this repository. Apply the nearest nested `CLAUDE.md` if a future
-subdirectory adds more specific guidance.
+The imported files contain the shared architecture, layer, Rust/shell/scripting, compliance-
+retrieval, scope, test, and contribution rules for this repository. `AGENTS.md` is written for
+Codex's steering convention, which Claude Code does not auto-load on its own — these imports
+exist purely to pull the same steering in, not to duplicate it. Apply the nearest nested
+`CLAUDE.md` if a future subdirectory adds more specific guidance.

--- a/docs/waves/WAP_1_2_1_COMPLIANCE_PROGRAM.md
+++ b/docs/waves/WAP_1_2_1_COMPLIANCE_PROGRAM.md
@@ -38,7 +38,7 @@ All nine selected Class C family increments are complete at SCR level:
 
 - together they contain 712 effective source rows and 201 selected strict
   rows;
-- the selected implementation audit is 7 implemented, 84 partial, and 110
+- the selected implementation audit is 8 implemented, 85 partial, and 108
   missing;
 - every selected row has an implementation owner and work-item mapping;
 - `CONF-003` is complete: all nine families and all 201 selected parent rows
@@ -56,10 +56,10 @@ All nine selected Class C family increments are complete at SCR level:
   server/encoder rows not applicable to the client;
 - all four SCR actors and the `WML-C-32 -> WML-C-54` dependency are preserved;
 - every mandatory row has an implementation work-item lane;
-- the source-wide mandatory code audit finds 2 implemented, 23 partial, and
-  22 missing; the selected 39-row client subset is 2 implemented, 23 partial,
-  and 14 missing;
-- 25 rows have direct code symbols and runnable test evidence.
+- the source-wide mandatory code audit finds 3 implemented, 24 partial, and
+  20 missing; the selected 39-row client subset is 3 implemented, 24 partial,
+  and 12 missing;
+- 27 rows have direct code symbols and runnable test evidence.
 - 86 effective WAE SCR rows are extracted after applying the WAP-190 SIN
   chain, with another 22 removed rows retained as historical change records;
 - `WAESpec:MCF` selects 11 mandatory WAE client rows, while 40 optional client

--- a/docs/waves/WAP_1_2_1_WML_SCR_LEDGER.md
+++ b/docs/waves/WAP_1_2_1_WML_SCR_LEDGER.md
@@ -99,7 +99,7 @@ The source table contains one explicit SCR dependency:
 - Enhancements are never allowed to replace strict behavior.
 - Every mandatory row maps to a substantive implementation work item in
   addition to `R0-01`.
-- Direct executable evidence is linked for `25/76` rows. Existing thematic
+- Direct executable evidence is linked for `27/76` rows. Existing thematic
   tests are counted only when their path, test name, command, code symbol, and
   limitation are reviewed against the exact SCR feature.
 
@@ -107,15 +107,19 @@ The source table contains one explicit SCR dependency:
 
 | Assessment | Mandatory rows | Meaning |
 |---|---:|---|
-| `implemented` | 2 | Direct code/test evidence covers the SCR feature; profile applicability and release gates still apply |
-| `partial` | 23 | Direct behavior exists, but the cited clause has known uncovered semantics |
-| `missing` | 22 | No conforming implementation path exists; a substantive Phase R work item is attached |
+| `implemented` | 3 | Direct code/test evidence covers the SCR feature; profile applicability and release gates still apply |
+| `partial` | 24 | Direct behavior exists, but the cited clause has known uncovered semantics |
+| `missing` | 20 | No conforming implementation path exists; a substantive Phase R work item is attached |
 
-The two implemented rows are `WML-C-35` (`noop`) and `WML-C-53` (`wml`
-root). Across the 39 required Class C client rows, the audit currently records
-2 implemented, 23 partial, and 14 missing. This is not a compliance
-percentage: nested normative clauses, optional capabilities, cross-target
-parity, and release evidence still have separate gates.
+The three implemented rows are `WML-C-30` (`head`), `WML-C-35` (`noop`), and
+`WML-C-53` (`wml` root). `WML-C-21` (`access`) moved from missing to partial:
+the element's `domain`/`path` attributes are parsed and retained on the deck
+model, but enforcing the access-control policy against a referring URI is a
+host-boundary concern (`R0-07`), not yet implemented. Across the 39 required
+Class C client rows, the audit currently records 3 implemented, 24 partial,
+and 12 missing. This is not a compliance percentage: nested normative
+clauses, optional capabilities, cross-target parity, and release evidence
+still have separate gates.
 
 The first `CONF-003` slice now expands all 39 selected WML rows into 174
 deduplicated, section-hash-anchored clauses. Every clause has an inherited
@@ -123,11 +127,10 @@ owner/work mapping and a planned direct fixture. Clause implementation status
 remains `not-assessed`, so these records improve planning completeness without
 raising the implementation audit.
 
-The 14 missing required Class C client rows are:
+The 12 missing required Class C client rows are:
 
 - context/policy: `WML-C-11`, `WML-C-13`, `WML-C-14`;
-- task/structure: `WML-C-08`, `WML-C-20`, `WML-C-21`, `WML-C-30`,
-  `WML-C-47`, `WML-C-52`;
+- task/structure: `WML-C-08`, `WML-C-20`, `WML-C-47`, `WML-C-52`;
 - rendering/media: `WML-C-32`, `WML-C-46`, `WML-C-49`, `WML-C-50`,
   `WML-C-54`;
 

--- a/docs/waves/WML_191_FULL_STACK_COMPLIANCE_AUDIT.md
+++ b/docs/waves/WML_191_FULL_STACK_COMPLIANCE_AUDIT.md
@@ -60,7 +60,7 @@ WAE, WSP, WTP, WDP, or security-domain traceability docs.
 | Image semantics | 11.9, 15.1.6 | parser + renderer + host media | missing/partial | Minimal/none in engine renderer | Implement `img` element semantics and capability-gated hints |
 | UA semantics (access control, low-memory, errors, unknown DTD) | 12.1-12.4 | browser host + runtime | partial | Unknown-tag robustness exists | Add access control enforcement path, low-memory policy behavior, deterministic unknown-DTD handling |
 | WML binary representation and token tables | 14.x, 15.2 | transport/encoder tooling | partial | WBXML decode boundary present | Add encoder/validation tooling path and WBXML token/literal conformance fixtures |
-| Static conformance statement execution model | 15.x | all layers + QA tooling | partial (source + clause + mandatory audit) | 76-row source ledger; WAP-215 selects 39 required Class C client rows expanded into 174 clauses and assessed as 2 implemented / 23 partial / 14 missing; 25 exact test links across the full ledger | Execute direct fixtures, assess optional capabilities, close gaps, and add release CI gate |
+| Static conformance statement execution model | 15.x | all layers + QA tooling | partial (source + clause + mandatory audit) | 76-row source ledger; WAP-215 selects 39 required Class C client rows expanded into 174 clauses and assessed as 3 implemented / 24 partial / 12 missing; 27 exact test links across the full ledger | Execute direct fixtures, assess optional capabilities, close gaps, and add release CI gate |
 
 ## Major Gaps Not Fully Tracked Before This Audit
 

--- a/docs/waves/WORK_ITEMS.md
+++ b/docs/waves/WORK_ITEMS.md
@@ -1821,7 +1821,7 @@ Reference:
 
 ### R0-04 Parser semantic completeness for structure/task/form elements
 
-1. `Status`: `todo`
+1. `Status`: `in-progress`
 2. `Depends On`: `M1-07`
 3. `Files`:
 - `engine-wasm/engine/src/parser/wml_parser/*`
@@ -1837,6 +1837,10 @@ Reference:
 - Core WML element families in section `11` are represented or explicitly profile-gated.
 7. `Spec`:
 - `WML-21`, `WML-25`, `WML-26`, `WML-33`, `WML-34`, `WML-39`, `WML-40`, `WML-41`, `WML-43`, `WML-47`, `WML-48`, `WML-52`, `WML-53`, `WML-66`, `WML-67`, `WML-69`
+8. `Notes`:
+- `head` (`WML-C-30`) and `access` (`WML-C-21`) landed: the parser now recognizes deck-level `<head>` (not mistaken for a card) and extracts `<access domain= path=>` onto the deck model, rejecting a deck with more than one `<access>` element per section `11.3.1`. `access` is `partial`, not `implemented`, in the compliance ledger - parsing/storage is done, but enforcing the access-control policy against a referring URI is a host-boundary concern (`R0-07`). `meta` (`WML-C-34`, optional) is not yet represented.
+- `template` (`WML-C-47`) split out to `R0-12`: it is spec-inseparable from card/deck task shadowing (`WML-C-08`, section `9.6`) and requires a real named `do`/`onevent` binding model this codebase doesn't have yet, not a small addition alongside `head`/`access`.
+- Remaining scope: `do`/`onevent`/`select`/`option`/`optgroup`/`input`/`fieldset`/`timer` validity constraints beyond what's already parsed.
 
 ### R0-05 Renderer semantics completion (`11.8`/`11.9`)
 
@@ -1984,6 +1988,33 @@ Reference:
 - Cross-layer behavioral regressions are detectable in one reproducible replay lane with stable fixture outputs.
 7. `Spec`:
 - `WML-07`, `WML-18`, `RQ-WAE-008`, `RQ-WAE-016`, `RQ-TRN-004`
+
+### R0-12 Template element and card/deck task shadowing (`WML-C-47`, `WML-C-08`)
+
+1. `Status`: `todo`
+2. `Depends On`: `R0-02`, `R0-04`
+3. `Files`:
+- `engine-wasm/engine/src/runtime/card.rs`
+- `engine-wasm/engine/src/runtime/deck.rs`
+- `engine-wasm/engine/src/parser/wml_parser/mod.rs`
+- `engine-wasm/engine/src/parser/wml_parser/actions.rs`
+- `engine-wasm/engine/src/parser/wml_parser/tests.rs`
+- `docs/waves/WAP_1_2_1_WML_SCR_LEDGER.md`
+- `spec-processing/source-manifests/wap-1.2.1-wml-scr.json`
+- `spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json`
+4. `Build`:
+- Introduce a named `do[name]`/`onevent[type]` binding model (the current `Card` struct only has four special-cased single actions: `accept`, `onenterforward`, `onenterbackward`, `ontimer`) so deck-level (`template`) and card-level bindings can be represented independently.
+- Parse `<template>` at deck level (`do`/`onevent` children) per section `11.4`.
+- Implement card/deck task shadowing per section `9.6`: a card-level binding of a given name/type overrides ("shadows") a deck-level binding of the same name/type; a shadowing card-level binding that binds `noop` masks the event entirely (no side effects on either the card- or deck-level binding); an unshadowed deck-level binding stays active for cards that don't override it; an unshadowed binding that itself binds `noop` is also masked.
+5. `Tests`:
+- Fixture matrix covering: card overrides deck binding; card shadows deck binding with `noop` (fully masked); deck-level binding stays active when not shadowed; unshadowed `noop` binding (masked, no shadowing partner) - matching the three-card `<do>` example in section `9.6`.
+6. `Accept`:
+- `WML-C-47` (`template`) and `WML-C-08` (card/deck task shadowing) have direct code/test evidence, and the compliance ledger reflects it: obligation status in `wap-1.2.1-wml-scr.json`, parent-status mirrors in `wap-1.2.1-selected-normative-clauses.json`, and the drift-guard snapshots in `scripts/check-wap-conformance-ledger.mjs`/`scripts/check-requirement-status-drift.mjs`, following the same update pattern `R0-04`'s `head`/`access` slice used.
+7. `Spec`:
+- `WML-08`, `WML-47`, section `9.6`, section `9.7`, section `11.4`, section `11.5.1`
+8. `Notes`:
+- Split out of `R0-04`'s "parser semantic completeness" scope: `template`/shadowing turned out to need a real named-binding model and merge algorithm, not a small addition alongside `head`/`access`.
+- `WML-C-08` (shadowing) is formally covered by `R0-02`, which is `done` - per `AGENT_STANDARDS.md`'s backlog lifecycle policy, `R0-02`'s status is not reopened for this. This ticket is the scoped corrective follow-up for a gap the newer clause-level ledger (`CONF-003`) found in `R0-02`'s original coverage, not a reversal of `R0-02`'s completion.
 
 ## Phase S (Archived)
 

--- a/engine-wasm/engine/src/parser/wml_parser/head.rs
+++ b/engine-wasm/engine/src/parser/wml_parser/head.rs
@@ -1,0 +1,113 @@
+use crate::runtime::deck::DeckAccessControl;
+
+use super::xml::{XmlElement, XmlNode};
+
+/// Parses a deck's `<head>` element (WML-C-30, section 11.3) for its `<access>`
+/// child (WML-C-21, section 11.3.1). `<meta>` children (WML-C-34, optional) are
+/// not yet represented and are silently skipped, matching this parser's existing
+/// tolerant handling of unimplemented optional elements.
+///
+/// Per section 11.3.1, "It is an error for a deck to contain more than one
+/// access element" - that specific case is rejected. Multiple `<head>` elements
+/// at the deck level are not valid per the `wml = (head?, template?, card+)`
+/// content model; this parser tolerates them and honors only the first, for
+/// consistency with the existing first-wins duplicate-id handling elsewhere.
+pub(super) fn parse_deck_access_control(
+    head: &XmlElement,
+) -> Result<Option<DeckAccessControl>, String> {
+    let mut access_control = None;
+
+    for child in &head.children {
+        let XmlNode::Element(element) = child else {
+            continue;
+        };
+        if element.name != "access" {
+            continue;
+        }
+        if access_control.is_some() {
+            return Err(
+                "Malformed WML deck: <head> must not contain more than one <access> element"
+                    .to_string(),
+            );
+        }
+        access_control = Some(DeckAccessControl {
+            domain: element
+                .attr("domain")
+                .map(str::to_string)
+                .filter(|value| !value.is_empty()),
+            path: element
+                .attr("path")
+                .map(str::to_string)
+                .filter(|value| !value.is_empty()),
+        });
+    }
+
+    Ok(access_control)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_deck_access_control;
+    use crate::parser::wml_parser::xml::parse_xml_root;
+
+    fn head_element(wml: &str) -> super::XmlElement {
+        let root = parse_xml_root(wml).expect("wml should parse");
+        root.children
+            .into_iter()
+            .find_map(|node| match node {
+                super::XmlNode::Element(element) if element.name == "head" => Some(element),
+                _ => None,
+            })
+            .expect("wml should contain a <head> element")
+    }
+
+    #[test]
+    fn parses_domain_and_path_from_access_element() {
+        let head = head_element(
+            r#"<wml><head><access domain="wapforum.org" path="/cbb"/></head><card id="c"><p>x</p></card></wml>"#,
+        );
+
+        let access_control = parse_deck_access_control(&head)
+            .expect("access control should parse")
+            .expect("access control should be present");
+
+        assert_eq!(access_control.domain.as_deref(), Some("wapforum.org"));
+        assert_eq!(access_control.path.as_deref(), Some("/cbb"));
+    }
+
+    #[test]
+    fn missing_access_element_yields_no_access_control() {
+        let head = head_element(
+            r#"<wml><head><meta name="x" content="y"/></head><card id="c"><p>x</p></card></wml>"#,
+        );
+
+        assert_eq!(
+            parse_deck_access_control(&head).expect("should parse"),
+            None
+        );
+    }
+
+    #[test]
+    fn empty_domain_and_path_attributes_are_treated_as_unset() {
+        let head = head_element(
+            r#"<wml><head><access domain="" path=""/></head><card id="c"><p>x</p></card></wml>"#,
+        );
+
+        let access_control = parse_deck_access_control(&head)
+            .expect("access control should parse")
+            .expect("access control should be present");
+
+        assert_eq!(access_control.domain, None);
+        assert_eq!(access_control.path, None);
+    }
+
+    #[test]
+    fn more_than_one_access_element_is_a_parse_error() {
+        let head = head_element(
+            r#"<wml><head><access domain="a.com"/><access domain="b.com"/></head><card id="c"><p>x</p></card></wml>"#,
+        );
+
+        let err = parse_deck_access_control(&head).expect_err("duplicate access should error");
+        assert!(err.contains("more than one <access>"));
+    }
+}

--- a/engine-wasm/engine/src/parser/wml_parser/mod.rs
+++ b/engine-wasm/engine/src/parser/wml_parser/mod.rs
@@ -2,10 +2,12 @@ use crate::runtime::card::Card;
 use crate::runtime::deck::Deck;
 
 mod actions;
+mod head;
 mod nodes;
 mod xml;
 
 use actions::parse_card_actions;
+use head::parse_deck_access_control;
 use nodes::parse_card_nodes_xml;
 use xml::{parse_xml_root, XmlNode};
 
@@ -54,14 +56,28 @@ pub fn parse_wml(xml: &str) -> Result<Deck, String> {
     }
 
     let mut cards = Vec::new();
+    let mut access_control = None;
+    let mut seen_head = false;
     let mut budget = ParseBudget::default();
     for node in &root.children {
-        let XmlNode::Element(card) = node else {
+        let XmlNode::Element(element) = node else {
             continue;
         };
-        if card.name != "card" {
+        if element.name == "head" {
+            // The `wml` content model (`head?, template?, card+`) allows at most
+            // one `<head>`; a malformed deck with more than one is tolerated and
+            // only the first is honored, consistent with this parser's existing
+            // first-wins handling of other duplicate/invalid structures.
+            if !seen_head {
+                seen_head = true;
+                access_control = parse_deck_access_control(element)?;
+            }
             continue;
         }
+        if element.name != "card" {
+            continue;
+        }
+        let card = element;
 
         let id = card
             .attr("id")
@@ -90,7 +106,7 @@ pub fn parse_wml(xml: &str) -> Result<Deck, String> {
         return Err("No <card> elements found".to_string());
     }
 
-    Ok(Deck::new(cards))
+    Ok(Deck::new(cards, access_control))
 }
 
 fn map_xml_parse_error(err: String) -> String {

--- a/engine-wasm/engine/src/parser/wml_parser/tests.rs
+++ b/engine-wasm/engine/src/parser/wml_parser/tests.rs
@@ -722,3 +722,65 @@ fn xml_tree_build_allows_depth_at_the_budget_and_rejects_one_level_more() {
         "unexpected error message: {err}"
     );
 }
+
+#[test]
+fn parse_wml_populates_deck_access_control_from_head() {
+    let xml = r#"
+        <wml>
+          <head><access domain="wapforum.org" path="/cbb"/></head>
+          <card id="home"><p>Hi</p></card>
+        </wml>
+        "#;
+
+    let deck = parse_wml(xml).expect("deck should parse");
+    let access_control = deck
+        .access_control
+        .expect("deck should carry parsed access control");
+    assert_eq!(access_control.domain.as_deref(), Some("wapforum.org"));
+    assert_eq!(access_control.path.as_deref(), Some("/cbb"));
+    assert_eq!(deck.cards.len(), 1, "head must not be mistaken for a card");
+}
+
+#[test]
+fn parse_wml_deck_without_head_has_no_access_control() {
+    let xml = r#"<wml><card id="home"><p>Hi</p></card></wml>"#;
+
+    let deck = parse_wml(xml).expect("deck should parse");
+    assert_eq!(deck.access_control, None);
+}
+
+#[test]
+fn parse_wml_propagates_duplicate_access_element_error() {
+    let xml = r#"
+        <wml>
+          <head>
+            <access domain="a.com"/>
+            <access domain="b.com"/>
+          </head>
+          <card id="home"><p>Hi</p></card>
+        </wml>
+        "#;
+
+    let err = parse_wml(xml).expect_err("duplicate <access> must be rejected");
+    assert!(
+        err.contains("more than one <access>"),
+        "unexpected error message: {err}"
+    );
+}
+
+#[test]
+fn parse_wml_honors_only_first_head_when_deck_has_more_than_one() {
+    let xml = r#"
+        <wml>
+          <head><access domain="first.com"/></head>
+          <head><access domain="second.com"/></head>
+          <card id="home"><p>Hi</p></card>
+        </wml>
+        "#;
+
+    let deck = parse_wml(xml).expect("deck should parse");
+    let access_control = deck
+        .access_control
+        .expect("access control should be present");
+    assert_eq!(access_control.domain.as_deref(), Some("first.com"));
+}

--- a/engine-wasm/engine/src/runtime/deck.rs
+++ b/engine-wasm/engine/src/runtime/deck.rs
@@ -1,20 +1,35 @@
 use crate::runtime::card::Card;
 use std::collections::HashMap;
 
+/// Deck-level access control from a WML `<head><access domain=".." path=".."/></head>`
+/// element (WML-C-21, section 11.3.1). Values are stored exactly as authored; resolving
+/// the domain/path defaults against the deck's own URL and enforcing the suffix/prefix
+/// match against a referring URI is a host-boundary concern, not a parser concern.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct DeckAccessControl {
+    pub domain: Option<String>,
+    pub path: Option<String>,
+}
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Deck {
     pub cards: Vec<Card>,
+    pub access_control: Option<DeckAccessControl>,
     id_index: HashMap<String, usize>,
 }
 
 impl Deck {
-    pub fn new(cards: Vec<Card>) -> Deck {
+    pub fn new(cards: Vec<Card>, access_control: Option<DeckAccessControl>) -> Deck {
         let mut id_index = HashMap::new();
         for (idx, card) in cards.iter().enumerate() {
             // First card wins for duplicate ids to keep navigation deterministic.
             id_index.entry(card.id.clone()).or_insert(idx);
         }
-        Deck { cards, id_index }
+        Deck {
+            cards,
+            access_control,
+            id_index,
+        }
     }
 
     pub fn card_index(&self, id: &str) -> Option<usize> {
@@ -29,41 +44,47 @@ mod tests {
 
     #[test]
     fn first_duplicate_card_id_wins_in_index() {
-        let deck = Deck::new(vec![
-            Card {
-                id: "dup".to_string(),
-                nodes: vec![],
-                accept_action: None,
-                onenterforward_action: None,
-                onenterbackward_action: None,
-                ontimer_action: None,
-                timer_value_ds: None,
-            },
-            Card {
-                id: "dup".to_string(),
-                nodes: vec![],
-                accept_action: None,
-                onenterforward_action: None,
-                onenterbackward_action: None,
-                ontimer_action: None,
-                timer_value_ds: None,
-            },
-        ]);
+        let deck = Deck::new(
+            vec![
+                Card {
+                    id: "dup".to_string(),
+                    nodes: vec![],
+                    accept_action: None,
+                    onenterforward_action: None,
+                    onenterbackward_action: None,
+                    ontimer_action: None,
+                    timer_value_ds: None,
+                },
+                Card {
+                    id: "dup".to_string(),
+                    nodes: vec![],
+                    accept_action: None,
+                    onenterforward_action: None,
+                    onenterbackward_action: None,
+                    ontimer_action: None,
+                    timer_value_ds: None,
+                },
+            ],
+            None,
+        );
 
         assert_eq!(deck.card_index("dup"), Some(0));
     }
 
     #[test]
     fn card_index_returns_none_for_unknown_id() {
-        let deck = Deck::new(vec![Card {
-            id: "home".to_string(),
-            nodes: vec![],
-            accept_action: None,
-            onenterforward_action: None,
-            onenterbackward_action: None,
-            ontimer_action: None,
-            timer_value_ds: None,
-        }]);
+        let deck = Deck::new(
+            vec![Card {
+                id: "home".to_string(),
+                nodes: vec![],
+                accept_action: None,
+                onenterforward_action: None,
+                onenterbackward_action: None,
+                ontimer_action: None,
+                timer_value_ds: None,
+            }],
+            None,
+        );
 
         assert_eq!(deck.card_index("missing"), None);
     }

--- a/scripts/check-requirement-status-drift.mjs
+++ b/scripts/check-requirement-status-drift.mjs
@@ -26,7 +26,7 @@ const familyDefinitions = [
     expectedRows: 76,
     expectedSelected: 39,
     expectedClauses: 174,
-    expectedStatus: { implemented: 2, partial: 23, missing: 14 },
+    expectedStatus: { implemented: 3, partial: 24, missing: 12 },
     activeDoc: 'docs/waves/WAP_1_2_1_WML_SCR_LEDGER.md'
   },
   {
@@ -320,7 +320,7 @@ if (
   aggregateSelected !== 201 ||
   aggregateClauses !== 781 ||
   JSON.stringify(aggregateStatus) !==
-    JSON.stringify({ implemented: 7, partial: 84, missing: 110 })
+    JSON.stringify({ implemented: 8, partial: 85, missing: 108 })
 ) {
   failures.push('selected-profile aggregate planning/status drift');
 }

--- a/scripts/check-wap-conformance-ledger.mjs
+++ b/scripts/check-wap-conformance-ledger.mjs
@@ -374,7 +374,7 @@ if (
 }
 if (
   JSON.stringify(sortedMandatoryStatusCounts) !==
-  JSON.stringify({ implemented: 2, missing: 22, partial: 23 })
+  JSON.stringify({ implemented: 3, missing: 20, partial: 24 })
 ) {
   failures.push(
     `mandatory implementation audit drift: ${JSON.stringify(sortedMandatoryStatusCounts)}`
@@ -622,7 +622,7 @@ if (aggregateRowCount !== 712 || aggregateSelectedCount !== 201) {
 }
 if (
   JSON.stringify(aggregateStatusCounts) !==
-  JSON.stringify({ implemented: 7, partial: 84, missing: 110 })
+  JSON.stringify({ implemented: 8, partial: 85, missing: 108 })
 ) {
   aggregateFailures.push(
     `selected-profile status aggregate drift: ${JSON.stringify(aggregateStatusCounts)}`

--- a/spec-processing/CLAUDE.md
+++ b/spec-processing/CLAUDE.md
@@ -1,0 +1,6 @@
+# Claude steering (spec-processing)
+
+Import-only pointer so Claude Code picks up this subproject's Codex steering automatically —
+see `../CLAUDE.md` for why this pattern exists. Do not duplicate content here.
+
+@AGENTS.md

--- a/spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json
+++ b/spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json
@@ -50,7 +50,7 @@
       "family": "wml",
       "status": "nested-clauses-anchored-fixtures-planned",
       "parentLedger": "spec-processing/source-manifests/wap-1.2.1-wml-scr.json",
-      "parentLedgerSha256": "d4933b7f72b0244fe30a6f02da5adb32265d05de425375e5312c3e1d61304200",
+      "parentLedgerSha256": "c175886342f055e2732e6e5d0c4ca20732505952bc509181b93366388f36f09e",
       "effectiveSequence": [
         "WAP-191-WML",
         "WAP-191_102-WML",
@@ -484,7 +484,7 @@
             "staticConformanceSection": "15.1.5",
             "changeSection": null
           },
-          "implementationStatus": "missing",
+          "implementationStatus": "partial",
           "ownerLayers": [
             "engine-wasm"
           ],
@@ -637,7 +637,7 @@
             "staticConformanceSection": "15.1.5",
             "changeSection": null
           },
-          "implementationStatus": "missing",
+          "implementationStatus": "implemented",
           "ownerLayers": [
             "engine-wasm"
           ],
@@ -3047,7 +3047,7 @@
             ],
             "parentImplementationSnapshot": {
               "WML-C-14": "missing",
-              "WML-C-21": "missing"
+              "WML-C-21": "partial"
             },
             "clauseImplementationStatus": "not-assessed",
             "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented."
@@ -3086,7 +3086,7 @@
               "RQ-RMK-001"
             ],
             "parentImplementationSnapshot": {
-              "WML-C-21": "missing"
+              "WML-C-21": "partial"
             },
             "clauseImplementationStatus": "not-assessed",
             "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented."
@@ -3125,7 +3125,7 @@
               "RQ-RMK-001"
             ],
             "parentImplementationSnapshot": {
-              "WML-C-21": "missing"
+              "WML-C-21": "partial"
             },
             "clauseImplementationStatus": "not-assessed",
             "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented."
@@ -3164,7 +3164,7 @@
               "RQ-RMK-001"
             ],
             "parentImplementationSnapshot": {
-              "WML-C-21": "missing"
+              "WML-C-21": "partial"
             },
             "clauseImplementationStatus": "not-assessed",
             "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented."
@@ -3203,7 +3203,7 @@
               "RQ-RMK-001"
             ],
             "parentImplementationSnapshot": {
-              "WML-C-21": "missing"
+              "WML-C-21": "partial"
             },
             "clauseImplementationStatus": "not-assessed",
             "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented."
@@ -3242,7 +3242,7 @@
               "RQ-RMK-001"
             ],
             "parentImplementationSnapshot": {
-              "WML-C-21": "missing"
+              "WML-C-21": "partial"
             },
             "clauseImplementationStatus": "not-assessed",
             "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented."
@@ -3281,7 +3281,7 @@
               "RQ-RMK-001"
             ],
             "parentImplementationSnapshot": {
-              "WML-C-21": "missing"
+              "WML-C-21": "partial"
             },
             "clauseImplementationStatus": "not-assessed",
             "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented."
@@ -3320,7 +3320,7 @@
               "RQ-RMK-001"
             ],
             "parentImplementationSnapshot": {
-              "WML-C-21": "missing"
+              "WML-C-21": "partial"
             },
             "clauseImplementationStatus": "not-assessed",
             "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented."
@@ -5751,7 +5751,7 @@
               "RQ-RMK-001"
             ],
             "parentImplementationSnapshot": {
-              "WML-C-30": "missing"
+              "WML-C-30": "implemented"
             },
             "clauseImplementationStatus": "not-assessed",
             "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented."
@@ -5790,7 +5790,7 @@
               "RQ-RMK-001"
             ],
             "parentImplementationSnapshot": {
-              "WML-C-30": "missing"
+              "WML-C-30": "implemented"
             },
             "clauseImplementationStatus": "not-assessed",
             "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented."

--- a/spec-processing/source-manifests/wap-1.2.1-wml-2-knowledge-graph.json
+++ b/spec-processing/source-manifests/wap-1.2.1-wml-2-knowledge-graph.json
@@ -25,7 +25,7 @@
         "sha256": "654284270a068b427ab05166247cb8e0644a99cf6af511f9b9c477d18ea36faa"
       },
       "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json": {
-        "sha256": "d15b8f0828ade4c360f16de427ba6794d839360b40785d045c1b93de651a4502"
+        "sha256": "9d95cfdfe37c5f89656e5f1fadff88ea8172662dd1b010f8c3e78d3d9ef7dc0f"
       }
     },
     "policy": "Canonical manifests remain authoritative; this graph and its Obsidian/context projections are generated views."

--- a/spec-processing/source-manifests/wap-1.2.1-wml-scr.json
+++ b/spec-processing/source-manifests/wap-1.2.1-wml-scr.json
@@ -61,11 +61,11 @@
       "wbxml-encoding-and-validation": 4,
       "wml-document-validation": 11
     },
-    "testEvidenceLinkedCount": 25,
+    "testEvidenceLinkedCount": 27,
     "mandatoryImplementationStatus": {
-      "implemented": 2,
-      "missing": 22,
-      "partial": 23
+      "implemented": 3,
+      "missing": 20,
+      "partial": 24
     }
   },
   "obligations": [
@@ -1059,11 +1059,31 @@
           "R0-01",
           "R0-04"
         ],
-        "implementationStatus": "missing",
-        "assessmentNote": "The access element is not retained and no deck access-control policy is enforced.",
-        "implementationEvidence": [],
-        "testEvidence": [],
-        "evidenceState": "gap-work-item-mapped"
+        "implementationStatus": "partial",
+        "assessmentNote": "The access element's domain/path attributes are now parsed and retained on the deck model (engine-wasm). Enforcement of the access-control policy (suffix/prefix matching against a referring URI) is a host-boundary concern and remains R0-07's scope; this obligation is partial until that lands.",
+        "implementationEvidence": [
+          {
+            "path": "engine-wasm/engine/src/parser/wml_parser/head.rs",
+            "symbol": "parse_deck_access_control"
+          },
+          {
+            "path": "engine-wasm/engine/src/runtime/deck.rs",
+            "symbol": "DeckAccessControl"
+          }
+        ],
+        "testEvidence": [
+          {
+            "path": "engine-wasm/engine/src/parser/wml_parser/tests.rs",
+            "test": "parse_wml_populates_deck_access_control_from_head",
+            "command": "cd engine-wasm/engine && cargo test parse_wml_populates_deck_access_control_from_head"
+          },
+          {
+            "path": "engine-wasm/engine/src/parser/wml_parser/head.rs",
+            "test": "more_than_one_access_element_is_a_parse_error",
+            "command": "cd engine-wasm/engine && cargo test more_than_one_access_element_is_a_parse_error"
+          }
+        ],
+        "evidenceState": "direct-test-linked"
       }
     },
     {
@@ -1479,11 +1499,27 @@
           "R0-01",
           "R0-04"
         ],
-        "implementationStatus": "missing",
-        "assessmentNote": "The head element and its metadata/access contents are not retained in the runtime deck.",
-        "implementationEvidence": [],
-        "testEvidence": [],
-        "evidenceState": "gap-work-item-mapped"
+        "implementationStatus": "implemented",
+        "assessmentNote": "The head element is recognized at the deck level (not mistaken for a card) and its access child is extracted onto the deck model. The meta child (WML-C-34, optional) is not yet represented and is tolerated as an unimplemented-optional element, consistent with this parser's existing handling of other unsupported optional constructs.",
+        "implementationEvidence": [
+          {
+            "path": "engine-wasm/engine/src/parser/wml_parser/mod.rs",
+            "symbol": "parse_wml"
+          }
+        ],
+        "testEvidence": [
+          {
+            "path": "engine-wasm/engine/src/parser/wml_parser/tests.rs",
+            "test": "parse_wml_populates_deck_access_control_from_head",
+            "command": "cd engine-wasm/engine && cargo test parse_wml_populates_deck_access_control_from_head"
+          },
+          {
+            "path": "engine-wasm/engine/src/parser/wml_parser/tests.rs",
+            "test": "parse_wml_honors_only_first_head_when_deck_has_more_than_one",
+            "command": "cd engine-wasm/engine && cargo test parse_wml_honors_only_first_head_when_deck_has_more_than_one"
+          }
+        ],
+        "evidenceState": "direct-test-linked"
       }
     },
     {


### PR DESCRIPTION
## Summary

First execution slice of the WAP compliance rebase's stated priority: "start `WML-2` parser/deck/validation fixture work." Also wires Claude Code into this repo's existing Codex steering files (`AGENTS.md` + `docs/agents/*.md`), which it doesn't auto-load on its own.

### Steering
Adds thin import-only `CLAUDE.md` files (root + `spec-processing/`) so Claude Code reads the same steering Codex already does, without duplicating any content.

### `head`/`access` element parsing (R0-04 slice)
The parser previously dropped any non-`<card>` top-level element silently — a deck's `<head><access domain="..." path="..."/></head>` was completely invisible; the deck model had no concept of deck-level access control at all (confirmed via `grep`, zero hits for `"head"`/`"access"` anywhere in the parser).

Adds `DeckAccessControl` (domain/path, stored exactly as authored) to the `Deck` model, and recognizes `<head>` as a distinct deck-level element rather than being silently skipped. Per section 11.3.1, "It is an error for a deck to contain more than one access element" is explicit spec text — that case is now rejected. A malformed deck with more than one `<head>` is tolerated, honoring only the first, consistent with this parser's existing first-wins handling of other duplicate structures.

**Deliberately scoped to parse-and-store only, not enforcement.** While researching this, `<template>` (`WML-C-47`, also in `R0-04`'s original scope) turned out to be spec-inseparable from card/deck task shadowing (`WML-C-08`, section 9.6) — implementing it correctly needs a real named `do[name]`/`onevent[type]` binding model this codebase doesn't have (the `Card` struct today only has four special-cased single actions). That's split out to a new `R0-12` ticket rather than folded in here, and rather than reopening `R0-02` (already `done`, but its coverage turns out not to include the shadowing rule) — per the backlog lifecycle policy in `docs/agents/AGENT_STANDARDS.md`, a `done` ticket found incomplete gets a scoped follow-up, not a reopen.

### Compliance ledger bookkeeping
`WML-C-30` moves to `implemented`; `WML-C-21` moves to `partial` (not `implemented`) — parsing/storage is done, but enforcing the access-control policy against a referring URI is `R0-07`'s host-boundary scope, so marking it fully implemented would overclaim. Updates:
- Obligation records in `spec-processing/source-manifests/wap-1.2.1-wml-scr.json` (status, evidence, assessment notes, summary counts).
- Parent-status mirrors + pinned parent-ledger SHA256 in `wap-1.2.1-selected-normative-clauses.json` (per-clause `clauseImplementationStatus` intentionally left `not-assessed` — that granularity isn't activated by the validator yet).
- Three separate hardcoded drift-guard snapshots across `scripts/check-wap-conformance-ledger.mjs` and `scripts/check-requirement-status-drift.mjs`.
- Human-readable prose in `WAP_1_2_1_WML_SCR_LEDGER.md`, `WAP_1_2_1_COMPLIANCE_PROGRAM.md`, `WML_191_FULL_STACK_COMPLIANCE_AUDIT.md`.
- `R0-04` moved to `in-progress` with a notes entry; new `R0-12` ticket added for `template`/shadowing.

## Test plan
- [x] `cargo test` — engine-wasm/engine: 218/218 passing
- [x] `cargo fmt --check` / `cargo clippy --all-targets -- -D warnings`: clean
- [x] `node scripts/check-wap-conformance-ledger.mjs`: all green (WML, WAE, WBXML, caching, transport, selected-normative-clauses, selected Class C aggregate)
- [x] `node scripts/check-requirement-status-drift.mjs`: green
- [x] `node scripts/check-wap-compliance-program.mjs`: green
- [x] Full local pre-push hook suite: all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)