### PR TITLE
docs(agents): document GitHub PR authentication flow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,6 +102,8 @@ Prefer work that improves:
   - suggested branch name
   - suggested PR title/message
 - Also include a concise commit message recommendation when the change is ready to land.
+- For GitHub authentication, duplicate-PR checks, and PR creation fallback behavior, follow
+  `docs/agents/AGENT_STANDARDS.md` under **GitHub Authentication and PR Publishing**.
 
 ## Repo conventions
 

--- a/docs/agents/AGENT_STANDARDS.md
+++ b/docs/agents/AGENT_STANDARDS.md
@@ -96,6 +96,49 @@ Agents MUST NOT:
 - introduce broad cross-layer refactors without explicit request
 - use branch-name collisions as justification for committing directly on `main`/`gh-pages`
 
+## GitHub Authentication and PR Publishing
+
+Treat these as three independent authentication paths:
+
+1. local Git credentials used by `git fetch` and `git push`
+2. local GitHub CLI credentials used by `gh`
+3. the Codex GitHub connector installation and its repository permissions
+
+A successful push does not prove that the connector can create a pull request, and a connector
+`403 Resource not accessible by integration` does not prove that local `gh` authentication is
+invalid.
+
+For local interactive development on macOS:
+
+- Prefer `gh auth login -h github.com -p https -w` so the OAuth credential is stored in the
+  system keyring.
+- Run `gh auth setup-git` when Git operations should use the same keyring-backed credential.
+- Keep `GH_TOKEN` and `GITHUB_TOKEN` unset unless an explicit headless workflow requires one;
+  either variable overrides stored `gh` credentials.
+- Never place token values in repository files, shell startup files, logs, comments, or agent
+  responses.
+
+Before declaring GitHub authentication invalid:
+
+1. Ensure the command has outbound access to `api.github.com`; request the required sandbox or
+   network permission when necessary.
+2. Run `gh auth status -h github.com`.
+3. Confirm API access with `gh api user --jq .login`.
+4. Check only whether token environment variables are present; never print their values.
+
+Do not treat a sandboxed network failure as token revocation. If the connector cannot create a
+pull request but local `gh` is valid, use `gh` as the fallback.
+
+Before creating a pull request:
+
+1. Resolve the repository, base branch, and current head branch from local Git.
+2. Check for an existing pull request for the head branch with
+   `gh pr list --repo <owner/repo> --head <branch> --state all`.
+3. Create a draft pull request by default unless the user explicitly requests ready-for-review
+   status.
+4. Use a body file with real Markdown newlines for CLI-created pull requests.
+5. Report the resulting pull request URL and whether it is draft or ready for review.
+
 ## Backlog Lifecycle Policy
 
 - Do not change the status of an existing `done` ticket to `todo`/`in-progress` during later audits.


### PR DESCRIPTION
## Summary

- Document the repository-standard GitHub authentication and PR publishing workflow for agents.
- Prevent sandboxed network failures from being misdiagnosed as revoked GitHub credentials.
- Establish the keyring-backed `gh` CLI as the fallback when the Codex GitHub connector lacks PR-write permission.

## What Changed

- Link the GitHub authentication procedure from the root `AGENTS.md`.
- Distinguish local Git, local GitHub CLI, and Codex GitHub connector authentication.
- Require network-enabled `gh auth status` and `gh api user` verification before declaring authentication invalid.
- Document safe handling of `GH_TOKEN` and `GITHUB_TOKEN` overrides without exposing token values.
- Require duplicate-PR checks, draft-by-default creation, Markdown body files, and final PR URL/status reporting.

## Why

PR creation repeatedly failed because connector permissions and sandboxed API access were conflated with local `gh` credential validity. The new steering makes those authentication paths and fallback behavior explicit.

## Validation

- `git diff --check`
- repository pre-commit staged-file checks
- repository pre-push checks
- Rust formatting and Clippy checks for engine, browser, and transport
- 218 engine tests

## Scope Notes

- Documentation-only change.
- No credentials or token values are stored in the repository.
- No runtime, transport, browser, or protocol behavior changes.
