### PR TITLE
R0-10/R0-11: add story-driven WASM host acceptance runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,7 @@ jobs:
             host_sample:
               - "engine-wasm/host-sample/**"
               - "engine-wasm/engine/**"
+              - "engine-wasm/examples/**"
               - "engine-wasm/pkg/**"
             marketing_site:
               - "marketing-site/**"
@@ -290,8 +291,29 @@ jobs:
       - name: Install host-sample deps
         run: pnpm install --frozen-lockfile --ignore-scripts
 
+      - name: Host-sample story schema tests
+        run: pnpm --dir engine-wasm/host-sample run test:story:unit
+
+      - name: Host-sample example manifest drift check
+        run: pnpm --dir engine-wasm/host-sample run examples:check
+
       - name: Build host-sample
         run: pnpm --dir engine-wasm/host-sample run build
+
+      - name: Install Playwright Chromium
+        run: pnpm --dir engine-wasm/host-sample exec playwright install --with-deps chromium
+
+      - name: Host-sample executable stories
+        run: pnpm test:story all
+
+      - name: Upload story failure evidence
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: host-sample-story-evidence
+          path: engine-wasm/host-sample/test-results/story
+          if-no-files-found: ignore
+          retention-days: 14
 
       - name: Host-sample typecheck
         run: pnpm --dir engine-wasm/host-sample run typecheck

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,6 +108,13 @@ Prefer work that improves:
 - Follow `.editorconfig` for whitespace and indentation.
 - Update docs when interfaces, setup steps, or commands change.
 - Add tests for parser/runtime behavior changes when toolchain is available.
+- For stable host-visible engine/runtime behavior, add or update the canonical
+  `engine-wasm/examples/source/*.wml` example and its optional adjacent `*.flow.json`
+  executable story when the acceptance path is deterministic. Run
+  `pnpm test:story <work-item-or-spec-id>` (or `all`) before handoff.
+- Do not treat exploratory/manual-only examples as executable coverage. If a stable example
+  intentionally has no story flow, leave that gap explicit rather than inferring coverage from
+  prose `testing-ac`.
 - Avoid committing generated artifacts unless explicitly requested.
 
 ## Useful commands

--- a/docs/agents/AGENT_STANDARDS.md
+++ b/docs/agents/AGENT_STANDARDS.md
@@ -71,6 +71,12 @@ Target-specific glue is allowed only at serialization/binding boundaries.
 - Add/adjust unit tests in the layer where behavior changed.
 - Add integration/E2E coverage for cross-layer flows (`fetch_deck` -> `loadDeckContext` -> render).
 - Preserve deterministic outputs for fixtures and error paths.
+- For stable host-visible engine/runtime behavior, check the shared
+  `engine-wasm/examples/source` corpus and add or update an adjacent executable `*.flow.json`
+  story when the acceptance path is deterministic.
+- Validate executable stories by work-item/spec ID with
+  `pnpm test:story <work-item-or-spec-id>` (or `all`). Prose `testing-ac` alone remains manual
+  evidence and must not be reported as executable coverage.
 
 ## Security and Robustness Notes
 

--- a/docs/ci/CI_SETUP.md
+++ b/docs/ci/CI_SETUP.md
@@ -48,6 +48,9 @@ Jobs:
   - coverage gate with `cargo llvm-cov`
 - `WaveNav Host Sample Build`
   - builds WASM package and host-sample app
+  - validates executable-flow schema and exact ticket/spec mappings
+  - installs Playwright Chromium and runs all story-driven WASM host flows
+  - uploads screenshots, traces, and structured evidence when a story fails
   - host-sample typecheck/lint/format checks
 - `Marketing Site Build`
   - builds marketing site (required/optional per branch-protection policy)

--- a/docs/waves/SPEC_TEST_COVERAGE.md
+++ b/docs/waves/SPEC_TEST_COVERAGE.md
@@ -27,7 +27,7 @@ Legend:
 | `RQ-WMLS-004..006` function/local/conversion semantics | `partial` | engine WaveScript VM tests in `engine-wasm/engine/src/wavescript/vm.rs` + `vm_tests.rs` and invocation tests in `engine-wasm/engine/src/engine_tests.rs`; broader spec parity closure tracked in `W1-04` |
 | `RQ-WMLS-008..010` bytecode format/verification/error model | `partial` | decoder/VM tests under `engine-wasm/engine/src/wavescript/` prove only the project-specific nine-opcode safety skeleton; they are provisional evidence and do not decode WAP-193 headers, pools, multi-byte fields, or instruction encoding; direct source-derived `.wmlsc` fixtures remain in `W1-02` |
 | `RQ-WMLS-011` WMLScript content-type routing | `planned` | Target files: `transport-rust/src/responses.rs`, `transport-rust/tests/fixtures/transport/`, `browser/src-tauri/src/lib.rs`; command: `cd transport-rust && cargo test --lib` then `cd browser/src-tauri && cargo test`; tracked in `W1-01` |
-| `RQ-WMLS-017..022` WMLBrowser/dialog/timer/refresh semantics | `partial` | `engine-wasm/engine/src/wavescript/stdlib/wmlbrowser.rs` + `wmlbrowser_tests.rs` and runtime effect tests in `engine-wasm/engine/src/engine_tests.rs`, including `m1_02_script_invocation_public_outcome_regression`, `wmlbrowser_get_current_card_returns_fragment_when_context_exists`, `wmlbrowser_get_current_card_returns_invalid_without_context`, and `wmlbrowser_new_context_clears_vars_and_history_and_prev_has_no_effect`; host/browser local example `examples/wmlbrowser-context-fidelity.wml` exercises `newContext/getCurrentCard`; remaining closure is centered on `refresh` optionality and dialog/timer breadth |
+| `RQ-WMLS-017..022` WMLBrowser/dialog/timer/refresh semantics | `partial` | `engine-wasm/engine/src/wavescript/stdlib/wmlbrowser.rs` + `wmlbrowser_tests.rs` and runtime effect tests in `engine-wasm/engine/src/engine_tests.rs`, including `m1_02_script_invocation_public_outcome_regression`, `wmlbrowser_get_current_card_returns_fragment_when_context_exists`, `wmlbrowser_get_current_card_returns_invalid_without_context`, and `wmlbrowser_new_context_clears_vars_and_history_and_prev_has_no_effect`; host/browser local example `engine-wasm/examples/source/wmlbrowser-context-fidelity.wml` exercises `newContext/getCurrentCard`; remaining closure is centered on `refresh` optionality and dialog/timer breadth |
 | WAP-191 section `11` text/layout semantics (`p`, `br`, `table`, `pre`, `img`) | `planned` | Target files: `engine-wasm/engine/src/render/flow_layout.rs`, `engine-wasm/engine/tests/fixtures/phase-a/`; command: `cd engine-wasm/engine && cargo test`; tickets `B5-02`, `B5-03`, `C5-01`, `C5-02` |
 | WAP-191 section `12.5` inter-card process ordering (`go/prev/refresh/noop`) | `covered` | engine runtime + parser coverage in `engine-wasm/engine/src/engine_tests.rs` (`fixture_accept_*_trace_order_is_deterministic`, `enter_accept_noop_action_keeps_current_card_and_history`, `onenterforward_noop_keeps_deterministic_navigation_state`) and parser action tests in `engine-wasm/engine/src/parser/wml_parser/tests.rs`; browser host-flow assertions in `browser/frontend/src/app/navigation-state.test.ts` (`emits deterministic state-event order for host-history back fallback`, `keeps host history pointer stable when history-back transport load fails`, `replays host back using stored request method and request policy`, header-aware host history replay) plus Tauri host integration path `browser/src-tauri/src/lib.rs` (`tauri_apply_accept_noop_refresh_prev_and_error_paths_are_deterministic`) confirm deterministic forward/back/refresh/noop/error behavior and request-policy handoff evidence |
 | Effective WAP-191 section `15` + SIN 105 conformance ID closure (76 actor-specific IDs) | `partial` | SCR ledger: `spec-processing/source-manifests/wap-1.2.1-wml-scr.json`; clause ledger: `spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json`; commands: `node scripts/check-wap-conformance-ledger.mjs` and `node scripts/check-wap-selected-normative-clauses.mjs`; all 39 selected rows expand into 174 anchored clauses and planned direct fixtures; clause status remains not assessed; optional capability pass remains in `R0-01` |
@@ -41,14 +41,15 @@ Legend:
 
 | Coverage Focus | Status | Example / Verification |
 |---|---|---|
-| Basic card navigation | `covered` | `examples/basic.wml` |
-| History back-stack baseline | `covered` | `examples/history-back-stack.wml` + Back control in host harness |
-| Missing-fragment error path | `covered` | `examples/missing-fragment.wml` |
-| External navigation intent | `covered` | `examples/external-navigation-intent.wml` |
-| Field/openwave realism baseline | `partial` | `examples/field-openwave-2011-navigation.wml` |
-| Wrap/layout stress | `covered` | `examples/wrap-stress.wml` |
-| Parser robustness | `covered` | `examples/parser-robustness.wml` |
-| WMLBrowser context reset/current-card semantics | `covered` | `examples/wmlbrowser-context-fidelity.wml` (`newContext` + `getCurrentCard`) |
+| Basic card navigation | `covered` | `examples/source/basic.wml` |
+| History back-stack baseline | `covered` | `examples/source/history-back-stack.wml` + Back control in host harness |
+| Missing-fragment error path | `covered` | `examples/source/missing-fragment.wml` |
+| External navigation intent | `covered` | `examples/source/external-navigation-intent.wml` |
+| Field/openwave realism baseline | `partial` | `examples/source/field-openwave-2011-navigation.wml` |
+| Wrap/layout stress | `covered` | `examples/source/wrap-stress.wml` |
+| Parser robustness | `covered` | `examples/source/parser-robustness.wml` |
+| WMLBrowser context reset/current-card semantics | `covered` | `examples/source/wmlbrowser-context-fidelity.wml` (`newContext` + `getCurrentCard`) |
+| Story-driven browser replay | `partial` | `pnpm test:story all` executes typed companion flows for basic fragment/external intent, history back/empty history, and zero-timer dispatch against the production WASM host; transport and native Tauri replay remain open |
 
 ## Transport (`transport-rust`)
 
@@ -107,6 +108,6 @@ Transport error taxonomy progress:
 1. [x] Create a minimal contract parity check between:
    - `transport-rust` request/response model tests
    - `browser/contracts/transport.ts`
-2. [ ] Add a CI check that verifies example metadata (`work-items`, `spec-items`, `testing-ac`) for each host-sample fixture.
+2. [x] Add a CI check that verifies example metadata (`work-items`, `spec-items`, `testing-ac`) and optional executable-flow schema/mappings for each shared host-sample fixture.
 3. [x] Add engine fixture test harness expansion (`A4-02`) and map fixture IDs back to `RQ-RMK-*` groups.
 4. [ ] Extend the 25-row direct evidence set through nested clause, optional-capability, parity, and strict release gates (`R0-01`; source and mandatory first-pass audit complete).

--- a/docs/waves/WORK_ITEMS.md
+++ b/docs/waves/WORK_ITEMS.md
@@ -230,6 +230,8 @@ When a PR changes spec interpretation, requirement mapping, or contract behavior
 - For any host-visible engine/runtime behavior change, add or update at least one example under `engine-wasm/examples/source/*.wml` in the same PR.
 - Regenerate `engine-wasm/examples/generated/examples.ts` via `pnpm --dir engine-wasm/host-sample run examples:generate` in the same PR.
 - New/updated examples must include metadata (`work-items` or `spec-items`, `goal`, and `testing-ac`) to keep host-sample and Waves tester verification aligned.
+- Stable acceptance paths should add an optional adjacent `*.flow.json` companion and verify it
+  with `pnpm test:story <work-item-or-spec-id>`.
 
 ## Initial Backlog (Prepared)
 
@@ -1949,7 +1951,7 @@ Reference:
 
 ### R0-10 Cross-layer acceptance fixture ledger
 
-1. `Status`: `todo`
+1. `Status`: `in-progress`
 2. `Depends On`: `R0-02`, `R0-03`, `R0-06`, `W1-06`
 3. `Files`:
 - `docs/waves/SPEC_TEST_COVERAGE.md`
@@ -1967,10 +1969,16 @@ Reference:
 - Ticket closure decisions can be made from one cross-layer fixture map without ad hoc test discovery.
 7. `Spec`:
 - Aggregated IDs from `WML-191`, `RQ-WAE-*`, `RQ-TRN-*`, and `RQ-WMLS-*` lanes linked by mapped tickets.
+8. `Progress`:
+- The shared WML example corpus now accepts validated executable-flow companions whose work-item
+  and spec-item mappings must exactly match example metadata. `pnpm test:story list` exposes this
+  first machine-readable host-sample ledger slice.
+- Full `R0`/`T0`/`W1` cross-layer asset enumeration and implemented/partial/missing acceptance
+  lanes remain open; this slice does not close the ticket.
 
 ### R0-11 Deterministic cross-layer replay runner
 
-1. `Status`: `todo`
+1. `Status`: `in-progress`
 2. `Depends On`: `R0-10`, `T0-04`, `R0-03`
 3. `Files`:
 - `transport-rust/tests/fixtures/transport/*`
@@ -1988,6 +1996,13 @@ Reference:
 - Cross-layer behavioral regressions are detectable in one reproducible replay lane with stable fixture outputs.
 7. `Spec`:
 - `WML-07`, `WML-18`, `RQ-WAE-008`, `RQ-WAE-016`, `RQ-TRN-004`
+8. `Progress`:
+- `pnpm test:story <id|all>` now provides deterministic Playwright replay against the production
+  WASM host sample with automatic Vite lifecycle, semantic state/trace assertions, and structured
+  failure artifacts.
+- Representative fragment/external-intent, history-back, and timer flows are executable. The
+  required transport-to-engine-to-native-browser replay and request-policy lane remain open; this
+  slice does not close the ticket.
 
 ### R0-12 Template element and card/deck task shadowing (`WML-C-47`, `WML-C-08`)
 

--- a/docs/wml-engine/test-strategy.md
+++ b/docs/wml-engine/test-strategy.md
@@ -45,11 +45,20 @@ Each fixture stores expected:
 
 ## 3. End-to-End Harness Validation
 
-Use `engine-wasm/host-sample` for manual/automated smoke:
+Use `engine-wasm/host-sample` for manual or story-driven automated smoke:
 
 1. Load fixture text.
 2. Execute key sequence.
 3. Verify screen output and status.
+
+Executable acceptance flows are optional `engine-wasm/examples/source/*.flow.json` companions to
+the canonical WML examples. Run `pnpm test:story <work-item-or-spec-id>` from the repository root,
+or use `list`/`all`. The runner owns its production Vite server lifecycle, uses an ephemeral port,
+asserts structured runtime state and ordered trace evidence, and writes failure artifacts under
+`engine-wasm/host-sample/test-results/story/`.
+
+This lane currently covers representative fragment/external-intent, history-back, and immediate
+timer flows. It does not yet replay transport or native Tauri behavior.
 
 ## 4. Definition of Done for Each Ticket
 

--- a/docs/wml-engine/work-items.md
+++ b/docs/wml-engine/work-items.md
@@ -58,8 +58,8 @@ Execution plan reference:
 
 For any newly implemented, demoable feature:
 
-- add a new `engine-wasm/host-sample/examples/*.wml` fixture, or
-- update an existing host-sample example that directly exercises the new behavior.
+- add a new `engine-wasm/examples/source/*.wml` fixture, or
+- update an existing shared example that directly exercises the new behavior.
 
 Every completed ticket with host-visible behavior should note which example covers it.
 Each example metadata block must include:
@@ -67,6 +67,9 @@ Each example metadata block must include:
 - work item and/or spec IDs (`work-items`, `spec-items`)
 - brief `description` and `goal`
 - `testing-ac` checklist steps for deterministic manual verification
+
+When behavior is stable enough for automated browser replay, add an optional adjacent
+`*.flow.json` companion and validate it with `pnpm test:story <work-item-or-spec-id>`.
 
 ## Ticket Template
 

--- a/engine-wasm/examples/generated/examples.ts
+++ b/engine-wasm/examples/generated/examples.ts
@@ -1,6 +1,38 @@
 /* eslint-disable */
 // AUTO-GENERATED FILE. DO NOT EDIT DIRECTLY.
-// Source: engine-wasm/examples/source/*.wml
+// Sources: engine-wasm/examples/source/*.wml and optional *.flow.json companions
+
+export interface StoryStateExpectation {
+  activeCardId?: string;
+  focusedLinkIndex?: number;
+  externalNavigationIntent?: string | null;
+  nextCardVar?: string | null;
+}
+
+export interface StoryExpectation {
+  state: StoryStateExpectation;
+  traceKinds?: string[];
+}
+
+export type StoryAction =
+  | { type: 'key'; key: 'up' | 'down' | 'enter' }
+  | { type: 'back' }
+  | { type: 'tick'; ms: 100 | 1000 }
+  | { type: 'clear-intent' };
+
+export interface StoryStep {
+  action: StoryAction;
+  expect: StoryExpectation;
+}
+
+export interface ExecutableStoryFlow {
+  id: string;
+  title: string;
+  workItems: string[];
+  specItems: string[];
+  initial: StoryExpectation;
+  steps: StoryStep[];
+}
 
 export interface HostExample {
   key: string;
@@ -10,6 +42,7 @@ export interface HostExample {
   workItems: string[];
   specItems: string[];
   testingAc: string[];
+  flows?: ExecutableStoryFlow[];
   wml: string;
 }
 
@@ -151,6 +184,88 @@ export const EXAMPLES: HostExample[] = [
       "Press Enter on \"Return home\"; activeCardId should become home.",
       "Move focus to \"External link\" and press Enter; activeCardId should remain home.",
       "Confirm runtime-state shows externalNavigationIntent as http://example.com/other.wml."
+    ],
+    "flows": [
+      {
+        "id": "fragment-and-external-intent",
+        "title": "Fragment navigation and external intent stay separate",
+        "workItems": [
+          "A2-01",
+          "A2-02"
+        ],
+        "specItems": [
+          "WML-R-006",
+          "WML-R-007"
+        ],
+        "initial": {
+          "state": {
+            "activeCardId": "home",
+            "focusedLinkIndex": 0,
+            "externalNavigationIntent": null
+          }
+        },
+        "steps": [
+          {
+            "action": {
+              "type": "key",
+              "key": "enter"
+            },
+            "expect": {
+              "state": {
+                "activeCardId": "next",
+                "focusedLinkIndex": 0,
+                "externalNavigationIntent": null
+              },
+              "traceKinds": [
+                "KEY",
+                "ACTION_FRAGMENT"
+              ]
+            }
+          },
+          {
+            "action": {
+              "type": "key",
+              "key": "enter"
+            },
+            "expect": {
+              "state": {
+                "activeCardId": "home",
+                "focusedLinkIndex": 0,
+                "externalNavigationIntent": null
+              }
+            }
+          },
+          {
+            "action": {
+              "type": "key",
+              "key": "down"
+            },
+            "expect": {
+              "state": {
+                "activeCardId": "home",
+                "focusedLinkIndex": 1,
+                "externalNavigationIntent": null
+              }
+            }
+          },
+          {
+            "action": {
+              "type": "key",
+              "key": "enter"
+            },
+            "expect": {
+              "state": {
+                "activeCardId": "home",
+                "focusedLinkIndex": 1,
+                "externalNavigationIntent": "http://example.com/other.wml"
+              },
+              "traceKinds": [
+                "ACTION_EXTERNAL"
+              ]
+            }
+          }
+        ]
+      }
     ],
     "wml": "<wml>\n  <card id=\"home\">\n    <p>WaveNav Host Harness</p>\n    <p>Use ArrowUp / ArrowDown / Enter.</p>\n    <a href=\"#next\">Go to next card</a>\n    <br/>\n    <a href=\"http://example.com/other.wml\">External link (emits host intent)</a>\n  </card>\n  <card id=\"next\">\n    <p>Second card loaded.</p>\n    <a href=\"#home\">Return home</a>\n  </card>\n</wml>\n"
   },
@@ -316,6 +431,72 @@ export const EXAMPLES: HostExample[] = [
       "Press Back; activeCardId should return to home.",
       "Press Back again and confirm status reports history empty with activeCardId still home."
     ],
+    "flows": [
+      {
+        "id": "fragment-back-and-empty-history",
+        "title": "Fragment history pops once and then reports empty",
+        "workItems": [
+          "A2-03"
+        ],
+        "specItems": [
+          "WML-R-008"
+        ],
+        "initial": {
+          "state": {
+            "activeCardId": "home",
+            "focusedLinkIndex": 0,
+            "externalNavigationIntent": null
+          }
+        },
+        "steps": [
+          {
+            "action": {
+              "type": "key",
+              "key": "enter"
+            },
+            "expect": {
+              "state": {
+                "activeCardId": "next",
+                "focusedLinkIndex": 0
+              },
+              "traceKinds": [
+                "KEY",
+                "ACTION_FRAGMENT"
+              ]
+            }
+          },
+          {
+            "action": {
+              "type": "back"
+            },
+            "expect": {
+              "state": {
+                "activeCardId": "home",
+                "focusedLinkIndex": 0
+              },
+              "traceKinds": [
+                "ACTION_BACK"
+              ]
+            }
+          },
+          {
+            "action": {
+              "type": "back"
+            },
+            "expect": {
+              "state": {
+                "activeCardId": "home",
+                "focusedLinkIndex": 0
+              },
+              "traceKinds": [
+                "ACTION_BACK",
+                "ACTION_BACK_EMPTY"
+              ]
+            }
+          }
+        ]
+      }
+    ],
     "wml": "<wml>\n  <card id=\"home\">\n    <p>History baseline demo.</p>\n    <a href=\"#next\">Go to next</a>\n  </card>\n  <card id=\"next\">\n    <p>Second card reached by fragment navigation.</p>\n    <a href=\"#home\">Return home via link</a>\n  </card>\n</wml>\n"
   },
   {
@@ -429,6 +610,46 @@ export const EXAMPLES: HostExample[] = [
       "Press Enter on \"To timed\" from home.",
       "Confirm activeCardId becomes next immediately (timed card should not remain active).",
       "Confirm trace includes TIMER_START and ACTION_ONTIMER before the final ACTION_FRAGMENT to next."
+    ],
+    "flows": [
+      {
+        "id": "zero-timer-dispatch",
+        "title": "Zero-value timer dispatches ontimer during card entry",
+        "workItems": [
+          "A5-03"
+        ],
+        "specItems": [
+          "WML-R-014"
+        ],
+        "initial": {
+          "state": {
+            "activeCardId": "home",
+            "focusedLinkIndex": 0,
+            "externalNavigationIntent": null
+          }
+        },
+        "steps": [
+          {
+            "action": {
+              "type": "key",
+              "key": "enter"
+            },
+            "expect": {
+              "state": {
+                "activeCardId": "next",
+                "focusedLinkIndex": 0,
+                "externalNavigationIntent": null
+              },
+              "traceKinds": [
+                "ACTION_FRAGMENT",
+                "TIMER_START",
+                "ACTION_ONTIMER",
+                "ACTION_FRAGMENT"
+              ]
+            }
+          }
+        ]
+      }
     ],
     "wml": "<wml>\n  <card id=\"home\">\n    <a href=\"#timed\">To timed</a>\n  </card>\n  <card id=\"timed\">\n    <timer value=\"0\"/>\n    <onevent type=\"ontimer\"><go href=\"#next\"/></onevent>\n    <p>Timed card should auto-advance.</p>\n  </card>\n  <card id=\"next\">\n    <p>Reached via ontimer dispatch.</p>\n  </card>\n</wml>\n"
   },

--- a/engine-wasm/examples/source/basic.flow.json
+++ b/engine-wasm/examples/source/basic.flow.json
@@ -1,0 +1,63 @@
+{
+  "version": 1,
+  "example": "basic",
+  "flows": [
+    {
+      "id": "fragment-and-external-intent",
+      "title": "Fragment navigation and external intent stay separate",
+      "workItems": ["A2-01", "A2-02"],
+      "specItems": ["WML-R-006", "WML-R-007"],
+      "initial": {
+        "state": {
+          "activeCardId": "home",
+          "focusedLinkIndex": 0,
+          "externalNavigationIntent": null
+        }
+      },
+      "steps": [
+        {
+          "action": { "type": "key", "key": "enter" },
+          "expect": {
+            "state": {
+              "activeCardId": "next",
+              "focusedLinkIndex": 0,
+              "externalNavigationIntent": null
+            },
+            "traceKinds": ["KEY", "ACTION_FRAGMENT"]
+          }
+        },
+        {
+          "action": { "type": "key", "key": "enter" },
+          "expect": {
+            "state": {
+              "activeCardId": "home",
+              "focusedLinkIndex": 0,
+              "externalNavigationIntent": null
+            }
+          }
+        },
+        {
+          "action": { "type": "key", "key": "down" },
+          "expect": {
+            "state": {
+              "activeCardId": "home",
+              "focusedLinkIndex": 1,
+              "externalNavigationIntent": null
+            }
+          }
+        },
+        {
+          "action": { "type": "key", "key": "enter" },
+          "expect": {
+            "state": {
+              "activeCardId": "home",
+              "focusedLinkIndex": 1,
+              "externalNavigationIntent": "http://example.com/other.wml"
+            },
+            "traceKinds": ["ACTION_EXTERNAL"]
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/engine-wasm/examples/source/history-back-stack.flow.json
+++ b/engine-wasm/examples/source/history-back-stack.flow.json
@@ -1,0 +1,51 @@
+{
+  "version": 1,
+  "example": "historyBackStack",
+  "flows": [
+    {
+      "id": "fragment-back-and-empty-history",
+      "title": "Fragment history pops once and then reports empty",
+      "workItems": ["A2-03"],
+      "specItems": ["WML-R-008"],
+      "initial": {
+        "state": {
+          "activeCardId": "home",
+          "focusedLinkIndex": 0,
+          "externalNavigationIntent": null
+        }
+      },
+      "steps": [
+        {
+          "action": { "type": "key", "key": "enter" },
+          "expect": {
+            "state": {
+              "activeCardId": "next",
+              "focusedLinkIndex": 0
+            },
+            "traceKinds": ["KEY", "ACTION_FRAGMENT"]
+          }
+        },
+        {
+          "action": { "type": "back" },
+          "expect": {
+            "state": {
+              "activeCardId": "home",
+              "focusedLinkIndex": 0
+            },
+            "traceKinds": ["ACTION_BACK"]
+          }
+        },
+        {
+          "action": { "type": "back" },
+          "expect": {
+            "state": {
+              "activeCardId": "home",
+              "focusedLinkIndex": 0
+            },
+            "traceKinds": ["ACTION_BACK", "ACTION_BACK_EMPTY"]
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/engine-wasm/examples/source/timer-ontimer-immediate.flow.json
+++ b/engine-wasm/examples/source/timer-ontimer-immediate.flow.json
@@ -1,0 +1,32 @@
+{
+  "version": 1,
+  "example": "timerOntimerImmediate",
+  "flows": [
+    {
+      "id": "zero-timer-dispatch",
+      "title": "Zero-value timer dispatches ontimer during card entry",
+      "workItems": ["A5-03"],
+      "specItems": ["WML-R-014"],
+      "initial": {
+        "state": {
+          "activeCardId": "home",
+          "focusedLinkIndex": 0,
+          "externalNavigationIntent": null
+        }
+      },
+      "steps": [
+        {
+          "action": { "type": "key", "key": "enter" },
+          "expect": {
+            "state": {
+              "activeCardId": "next",
+              "focusedLinkIndex": 0,
+              "externalNavigationIntent": null
+            },
+            "traceKinds": ["ACTION_FRAGMENT", "TIMER_START", "ACTION_ONTIMER", "ACTION_FRAGMENT"]
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/engine-wasm/host-sample/.gitignore
+++ b/engine-wasm/host-sample/.gitignore
@@ -1,1 +1,2 @@
 .generated/
+test-results/

--- a/engine-wasm/host-sample/README.md
+++ b/engine-wasm/host-sample/README.md
@@ -43,6 +43,64 @@ testing-ac:
 <wml>...</wml>
 ```
 
+Executable story flows are optional companion files next to the canonical deck:
+
+```text
+engine-wasm/examples/source/basic.wml
+engine-wasm/examples/source/basic.flow.json
+```
+
+The WML remains the only deck corpus. The existing manifest generator validates and merges the
+companion into `examples.ts`. A version 1 companion contains:
+
+- `example`: the generated example key (`basic`, `historyBackStack`, and so on)
+- one or more lower-kebab-case `flows`
+- exact `workItems` and `specItems` mappings; the union across flows must match the WML metadata
+- an `initial` expectation and one or more action/expectation steps
+- actions: `key` (`up`, `down`, `enter`), `back`, `tick` (`100` or `1000` ms), and
+  `clear-intent`
+- state assertions: `activeCardId`, `focusedLinkIndex`, `externalNavigationIntent`, and
+  `nextCardVar`
+- optional `traceKinds`, matched as an ordered subsequence of engine trace entries
+
+Unknown example references/actions, malformed values, missing mappings, extra mappings, and stale
+generated output fail deterministically:
+
+```bash
+pnpm --dir engine-wasm/host-sample run examples:check
+pnpm --dir engine-wasm/host-sample run test:story:unit
+```
+
+## Executable stories
+
+Build the WASM package once, install Playwright Chromium once, then run stories from the repository
+root:
+
+```bash
+cd engine-wasm/engine
+wasm-pack build --target web --out-dir ../pkg
+cd ../..
+pnpm --dir engine-wasm/host-sample exec playwright install chromium
+
+pnpm test:story list
+pnpm test:story WML-R-007
+pnpm test:story A2-03
+pnpm test:story all
+```
+
+The command generates/validates the shared manifest, builds the production host sample, reserves an
+ephemeral localhost port, manages the Vite preview lifecycle, and drives the real WASM host through
+Playwright. No manual server setup is required.
+
+Every run writes a stable summary under
+`engine-wasm/host-sample/test-results/story/<selector>/summary.json`. Failed flows also receive
+`failure.png`, `trace.zip`, and structured `evidence.json` containing runtime snapshots, engine
+trace entries, host events, and browser diagnostics. Override the root with
+`WAVES_STORY_OUTPUT_DIR`.
+
+Exit codes are `0` for pass/list, `1` for assertion failures, `2` for usage or environment errors,
+and `3` when the requested ID has no executable coverage.
+
 Main files:
 
 - `host-sample/index.html`

--- a/engine-wasm/host-sample/main.ts
+++ b/engine-wasm/host-sample/main.ts
@@ -9,6 +9,23 @@ import { renderExampleMetadata } from './ui/example-metadata';
 import { downloadFile } from './services/download';
 import './ui/runtime-inspector-panel';
 import type { RuntimeInspectorPanel } from './ui/runtime-inspector-panel';
+import type { EngineTraceEntry } from '../contracts/wml-engine';
+
+interface StoryEvidence {
+  activeExampleKey: string;
+  snapshot: EngineSnapshot;
+  traceEntries: EngineTraceEntry[];
+  status: string;
+  eventLog: string;
+}
+
+declare global {
+  interface Window {
+    __WAVENAV_STORY_EVIDENCE__?: {
+      collect(): StoryEvidence;
+    };
+  }
+}
 
 const LIVE_RELOAD_DEBOUNCE_MS = 250;
 const AUTO_TICK_DEFAULT_MS = 100;
@@ -179,6 +196,16 @@ async function main() {
 
   const appendEvent = (action: string, snapshot?: EngineSnapshot) =>
     eventLogService.append(action, snapshot);
+
+  window.__WAVENAV_STORY_EVIDENCE__ = {
+    collect: () => ({
+      activeExampleKey,
+      snapshot: host.snapshot(),
+      traceEntries: host.traceEntries(),
+      status: status.textContent ?? '',
+      eventLog: eventLog.textContent ?? ''
+    })
+  };
 
   const reloadFromEditor = (prefix: string, reason: string) => {
     try {

--- a/engine-wasm/host-sample/package.json
+++ b/engine-wasm/host-sample/package.json
@@ -7,17 +7,22 @@
   "type": "module",
   "scripts": {
     "examples:generate": "node ./scripts/generate-example-manifest.mjs",
+    "examples:check": "node ./scripts/generate-example-manifest.mjs --check",
     "predev": "pnpm run examples:generate",
     "dev": "vite",
     "prebuild": "pnpm run examples:generate",
     "build": "vite build",
     "preview": "vite preview",
+    "test": "pnpm run test:story:unit",
+    "test:story": "node ./scripts/test-story.mjs",
+    "test:story:unit": "node --test ./scripts/tests/*.test.mjs",
     "typecheck": "tsc --noEmit",
     "lint": "eslint \"**/*.ts\"",
     "format": "prettier --ignore-path ../../.prettierignore --write \"**/*.{ts,css,html}\"",
     "format:check": "prettier --ignore-path ../../.prettierignore --check \"**/*.{ts,css,html}\""
   },
   "devDependencies": {
+    "@playwright/test": "^1.58.2",
     "@types/node": "catalog:",
     "@typescript-eslint/eslint-plugin": "catalog:",
     "@typescript-eslint/parser": "catalog:",

--- a/engine-wasm/host-sample/scripts/generate-example-manifest.mjs
+++ b/engine-wasm/host-sample/scripts/generate-example-manifest.mjs
@@ -6,39 +6,85 @@ const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
 const HOST_SAMPLE_DIR = path.resolve(SCRIPT_DIR, '..');
 const ENGINE_WASM_DIR = path.resolve(HOST_SAMPLE_DIR, '..');
 const ROOT = HOST_SAMPLE_DIR;
-const EXAMPLES_DIR = path.join(ENGINE_WASM_DIR, 'examples', 'source');
-const OUTPUT_DIR = path.join(ENGINE_WASM_DIR, 'examples', 'generated');
-const OUTPUT_FILE = path.join(OUTPUT_DIR, 'examples.ts');
-
-function toTitleCase(value) {
-  return value
-    .replace(/[-_]+/g, ' ')
-    .replace(/\b\w/g, (m) => m.toUpperCase());
-}
+const DEFAULT_EXAMPLES_DIR = path.join(ENGINE_WASM_DIR, 'examples', 'source');
+const DEFAULT_OUTPUT_FILE = path.join(ENGINE_WASM_DIR, 'examples', 'generated', 'examples.ts');
+const FLOW_SUFFIX = '.flow.json';
+const ID_PATTERN = /^[A-Z][A-Z0-9]*(?:-[A-Z0-9]+)+$/;
+const STATE_KEYS = new Set([
+  'activeCardId',
+  'focusedLinkIndex',
+  'externalNavigationIntent',
+  'nextCardVar'
+]);
+const ACTION_TYPES = new Set(['key', 'back', 'tick', 'clear-intent']);
+const KEY_NAMES = new Set(['up', 'down', 'enter']);
 
 function toCamelCase(value) {
   return value.replace(/[-_]+([a-zA-Z0-9])/g, (_, c) => c.toUpperCase());
 }
 
-function parseIdList(value) {
-  return value
+function parseIdList(value, filename, field) {
+  const ids = value
     .split(',')
     .map((item) => item.trim())
     .filter(Boolean);
+  validateIdList(ids, filename, field, { allowEmpty: true });
+  return ids;
 }
 
-function parseExampleMetadata(source, filename) {
+function isRecord(value) {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function requireRecord(value, filename, location) {
+  if (!isRecord(value)) {
+    throw new Error(`${filename}: ${location} must be an object`);
+  }
+  return value;
+}
+
+function validateKeys(record, allowedKeys, filename, location) {
+  for (const key of Object.keys(record)) {
+    if (!allowedKeys.has(key)) {
+      throw new Error(`${filename}: unknown ${location} key "${key}"`);
+    }
+  }
+}
+
+function requireString(value, filename, location) {
+  if (typeof value !== 'string' || !value.trim()) {
+    throw new Error(`${filename}: ${location} must be a non-empty string`);
+  }
+  return value.trim();
+}
+
+function validateIdList(ids, filename, field, { allowEmpty = false } = {}) {
+  if (!Array.isArray(ids) || ids.some((id) => typeof id !== 'string')) {
+    throw new Error(`${filename}: ${field} must be an array of ids`);
+  }
+  if (!allowEmpty && ids.length === 0) {
+    throw new Error(`${filename}: ${field} needs at least one id`);
+  }
+  const normalized = ids.map((id) => id.trim());
+  for (const id of normalized) {
+    if (!ID_PATTERN.test(id)) {
+      throw new Error(`${filename}: ${field} contains invalid id "${id}"`);
+    }
+  }
+  if (new Set(normalized).size !== normalized.length) {
+    throw new Error(`${filename}: ${field} contains duplicate ids`);
+  }
+  return normalized;
+}
+
+export function parseExampleMetadata(source, filename) {
   const blockMatch = source.match(/^\s*<!--([\s\S]*?)-->/);
   if (!blockMatch) {
     throw new Error(`${filename}: missing metadata comment block at top of file`);
   }
 
   const lines = blockMatch[1].split(/\r?\n/).map((line) => line.trim());
-  let label = '';
-  let description = '';
-  let goal = '';
-  let rawWorkItems = '';
-  let rawSpecItems = '';
+  const values = new Map();
   const testingAc = [];
   let currentKey = null;
 
@@ -65,39 +111,24 @@ function parseExampleMetadata(source, filename) {
     const key = keyRaw.trim().toLowerCase();
     const value = valueParts.join(':').trim();
     currentKey = key;
-
-    if (key === 'label') {
-      label = value;
-      continue;
+    if (!['label', 'description', 'goal', 'work-items', 'spec-items', 'testing-ac'].includes(key)) {
+      throw new Error(`${filename}: unknown metadata key "${key}"`);
     }
-    if (key === 'description') {
-      description = value;
-      continue;
+    if (values.has(key)) {
+      throw new Error(`${filename}: duplicate metadata key "${key}"`);
     }
-    if (key === 'goal') {
-      goal = value;
-      continue;
+    values.set(key, value);
+    if (key === 'testing-ac' && value) {
+      testingAc.push(value);
     }
-    if (key === 'work-items') {
-      rawWorkItems = value;
-      continue;
-    }
-    if (key === 'spec-items') {
-      rawSpecItems = value;
-      continue;
-    }
-    if (key === 'testing-ac') {
-      if (value) {
-        testingAc.push(value);
-      }
-      continue;
-    }
-
-    throw new Error(`${filename}: unknown metadata key "${key}"`);
   }
 
-  const workItems = parseIdList(rawWorkItems);
-  const specItems = parseIdList(rawSpecItems);
+  const label = values.get('label') ?? '';
+  const description = values.get('description') ?? '';
+  const goal = values.get('goal') ?? '';
+  const workItems = parseIdList(values.get('work-items') ?? '', filename, 'work-items');
+  const specItems = parseIdList(values.get('spec-items') ?? '', filename, 'spec-items');
+
   if (!label) {
     throw new Error(`${filename}: metadata field "label" is required`);
   }
@@ -118,36 +149,254 @@ function parseExampleMetadata(source, filename) {
   return { label, description, goal, workItems, specItems, testingAc, wml };
 }
 
-async function main() {
-  const entries = await fs.readdir(EXAMPLES_DIR, { withFileTypes: true });
-  const files = entries
+function parseExpectedState(value, filename, location) {
+  const state = requireRecord(value, filename, location);
+  validateKeys(state, STATE_KEYS, filename, location);
+  if (Object.keys(state).length === 0) {
+    throw new Error(`${filename}: ${location} needs at least one state assertion`);
+  }
+  for (const [key, expected] of Object.entries(state)) {
+    if (key === 'focusedLinkIndex') {
+      if (!Number.isInteger(expected) || expected < 0) {
+        throw new Error(`${filename}: ${location}.${key} must be a non-negative integer`);
+      }
+      continue;
+    }
+    if (key === 'activeCardId') {
+      if (typeof expected !== 'string' || !expected) {
+        throw new Error(`${filename}: ${location}.${key} must be a non-empty string`);
+      }
+      continue;
+    }
+    if (expected !== null && typeof expected !== 'string') {
+      throw new Error(`${filename}: ${location}.${key} must be a string or null`);
+    }
+  }
+  return state;
+}
+
+function parseExpectation(value, filename, location) {
+  const expectation = requireRecord(value, filename, location);
+  validateKeys(expectation, new Set(['state', 'traceKinds']), filename, location);
+  const state = parseExpectedState(expectation.state, filename, `${location}.state`);
+  let traceKinds;
+  if (expectation.traceKinds !== undefined) {
+    if (
+      !Array.isArray(expectation.traceKinds) ||
+      expectation.traceKinds.length === 0 ||
+      expectation.traceKinds.some((kind) => typeof kind !== 'string' || !kind.trim())
+    ) {
+      throw new Error(`${filename}: ${location}.traceKinds must be non-empty trace kind strings`);
+    }
+    traceKinds = expectation.traceKinds.map((kind) => kind.trim());
+  }
+  return traceKinds ? { state, traceKinds } : { state };
+}
+
+function parseAction(value, filename, location) {
+  const action = requireRecord(value, filename, location);
+  validateKeys(action, new Set(['type', 'key', 'ms']), filename, location);
+  if (!ACTION_TYPES.has(action.type)) {
+    throw new Error(`${filename}: ${location}.type has unknown action "${String(action.type)}"`);
+  }
+
+  if (action.type === 'key') {
+    if (!KEY_NAMES.has(action.key)) {
+      throw new Error(`${filename}: ${location}.key must be up, down, or enter`);
+    }
+    if (action.ms !== undefined) {
+      throw new Error(`${filename}: ${location}.ms is only valid for tick actions`);
+    }
+    return { type: action.type, key: action.key };
+  }
+
+  if (action.key !== undefined) {
+    throw new Error(`${filename}: ${location}.key is only valid for key actions`);
+  }
+  if (action.type === 'tick') {
+    if (action.ms !== 100 && action.ms !== 1000) {
+      throw new Error(`${filename}: ${location}.ms must match a host tick control (100 or 1000)`);
+    }
+    return { type: action.type, ms: action.ms };
+  }
+  if (action.ms !== undefined) {
+    throw new Error(`${filename}: ${location}.ms is only valid for tick actions`);
+  }
+  return { type: action.type };
+}
+
+export function parseExecutableFlow(source, filename, expectedExampleKey) {
+  let raw;
+  try {
+    raw = JSON.parse(source);
+  } catch (error) {
+    throw new Error(`${filename}: invalid JSON (${error.message})`);
+  }
+  const document = requireRecord(raw, filename, 'flow document');
+  validateKeys(document, new Set(['version', 'example', 'flows']), filename, 'flow document');
+  if (document.version !== 1) {
+    throw new Error(`${filename}: version must be 1`);
+  }
+  const example = requireString(document.example, filename, 'example');
+  if (example !== expectedExampleKey) {
+    throw new Error(
+      `${filename}: example "${example}" does not match companion example "${expectedExampleKey}"`
+    );
+  }
+  if (!Array.isArray(document.flows) || document.flows.length === 0) {
+    throw new Error(`${filename}: flows needs at least one executable flow`);
+  }
+
+  const seenFlowIds = new Set();
+  const flows = document.flows.map((rawFlow, flowIndex) => {
+    const location = `flows[${flowIndex}]`;
+    const flow = requireRecord(rawFlow, filename, location);
+    validateKeys(
+      flow,
+      new Set(['id', 'title', 'workItems', 'specItems', 'initial', 'steps']),
+      filename,
+      location
+    );
+    const id = requireString(flow.id, filename, `${location}.id`);
+    if (!/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(id)) {
+      throw new Error(`${filename}: ${location}.id must be lower-kebab-case`);
+    }
+    if (seenFlowIds.has(id)) {
+      throw new Error(`${filename}: duplicate flow id "${id}"`);
+    }
+    seenFlowIds.add(id);
+    const title = requireString(flow.title, filename, `${location}.title`);
+    const workItems = validateIdList(flow.workItems, filename, `${location}.workItems`);
+    const specItems = validateIdList(flow.specItems, filename, `${location}.specItems`);
+    const initial = parseExpectation(flow.initial, filename, `${location}.initial`);
+    if (!Array.isArray(flow.steps) || flow.steps.length === 0) {
+      throw new Error(`${filename}: ${location}.steps needs at least one step`);
+    }
+    const steps = flow.steps.map((rawStep, stepIndex) => {
+      const stepLocation = `${location}.steps[${stepIndex}]`;
+      const step = requireRecord(rawStep, filename, stepLocation);
+      validateKeys(step, new Set(['action', 'expect']), filename, stepLocation);
+      return {
+        action: parseAction(step.action, filename, `${stepLocation}.action`),
+        expect: parseExpectation(step.expect, filename, `${stepLocation}.expect`)
+      };
+    });
+    return { id, title, workItems, specItems, initial, steps };
+  });
+
+  return { version: 1, example, flows };
+}
+
+function assertExactCoverage(flowDocument, metadata, filename) {
+  const mappedWorkItems = new Set(flowDocument.flows.flatMap((flow) => flow.workItems));
+  const mappedSpecItems = new Set(flowDocument.flows.flatMap((flow) => flow.specItems));
+  const checks = [
+    ['work item', metadata.workItems, mappedWorkItems],
+    ['spec item', metadata.specItems, mappedSpecItems]
+  ];
+
+  for (const [label, metadataIds, mappedIds] of checks) {
+    const unknown = [...mappedIds].filter((id) => !metadataIds.includes(id));
+    if (unknown.length > 0) {
+      throw new Error(`${filename}: flow maps unknown ${label}(s): ${unknown.join(', ')}`);
+    }
+    const missing = metadataIds.filter((id) => !mappedIds.has(id));
+    if (missing.length > 0) {
+      throw new Error(`${filename}: flow is missing ${label} mapping(s): ${missing.join(', ')}`);
+    }
+  }
+}
+
+export async function loadExampleRecords({ examplesDir = DEFAULT_EXAMPLES_DIR } = {}) {
+  const entries = await fs.readdir(examplesDir, { withFileTypes: true });
+  const wmlFiles = entries
     .filter((entry) => entry.isFile() && entry.name.endsWith('.wml'))
     .map((entry) => entry.name)
     .sort();
+  const flowFiles = entries
+    .filter((entry) => entry.isFile() && entry.name.endsWith(FLOW_SUFFIX))
+    .map((entry) => entry.name)
+    .sort();
+  const wmlBases = new Set(wmlFiles.map((filename) => filename.replace(/\.wml$/i, '')));
+
+  for (const flowFilename of flowFiles) {
+    const base = flowFilename.slice(0, -FLOW_SUFFIX.length);
+    if (!wmlBases.has(base)) {
+      throw new Error(`${flowFilename}: executable flow references unknown example "${base}"`);
+    }
+  }
 
   const records = [];
-  for (const filename of files) {
-    const filepath = path.join(EXAMPLES_DIR, filename);
+  for (const filename of wmlFiles) {
+    const filepath = path.join(examplesDir, filename);
     const source = await fs.readFile(filepath, 'utf8');
     const base = filename.replace(/\.wml$/i, '');
     const key = toCamelCase(base);
-    const fallbackLabel = toTitleCase(base);
     const metadata = parseExampleMetadata(source, filename);
+    const flowFilename = `${base}${FLOW_SUFFIX}`;
+    let flows;
+    try {
+      const flowSource = await fs.readFile(path.join(examplesDir, flowFilename), 'utf8');
+      const flowDocument = parseExecutableFlow(flowSource, flowFilename, key);
+      assertExactCoverage(flowDocument, metadata, flowFilename);
+      flows = flowDocument.flows;
+    } catch (error) {
+      if (error.code !== 'ENOENT') {
+        throw error;
+      }
+    }
+
     records.push({
       key,
-      label: metadata.label || fallbackLabel,
+      label: metadata.label,
       description: metadata.description,
       goal: metadata.goal,
       workItems: metadata.workItems,
       specItems: metadata.specItems,
       testingAc: metadata.testingAc,
+      ...(flows ? { flows } : {}),
       wml: metadata.wml
     });
   }
+  return records;
+}
 
-const content = `/* eslint-disable */
+export function renderManifest(records) {
+  return `/* eslint-disable */
 // AUTO-GENERATED FILE. DO NOT EDIT DIRECTLY.
-// Source: engine-wasm/examples/source/*.wml
+// Sources: engine-wasm/examples/source/*.wml and optional *.flow.json companions
+
+export interface StoryStateExpectation {
+  activeCardId?: string;
+  focusedLinkIndex?: number;
+  externalNavigationIntent?: string | null;
+  nextCardVar?: string | null;
+}
+
+export interface StoryExpectation {
+  state: StoryStateExpectation;
+  traceKinds?: string[];
+}
+
+export type StoryAction =
+  | { type: 'key'; key: 'up' | 'down' | 'enter' }
+  | { type: 'back' }
+  | { type: 'tick'; ms: 100 | 1000 }
+  | { type: 'clear-intent' };
+
+export interface StoryStep {
+  action: StoryAction;
+  expect: StoryExpectation;
+}
+
+export interface ExecutableStoryFlow {
+  id: string;
+  title: string;
+  workItems: string[];
+  specItems: string[];
+  initial: StoryExpectation;
+  steps: StoryStep[];
+}
 
 export interface HostExample {
   key: string;
@@ -157,18 +406,58 @@ export interface HostExample {
   workItems: string[];
   specItems: string[];
   testingAc: string[];
+  flows?: ExecutableStoryFlow[];
   wml: string;
 }
 
 export const EXAMPLES: HostExample[] = ${JSON.stringify(records, null, 2)};
 `;
-
-  await fs.mkdir(OUTPUT_DIR, { recursive: true });
-  await fs.writeFile(OUTPUT_FILE, content, 'utf8');
-  console.log(`generated ${path.relative(ROOT, OUTPUT_FILE)} (${records.length} examples)`);
 }
 
-main().catch((error) => {
-  console.error(error);
-  process.exit(1);
-});
+export async function generateExamples({
+  examplesDir = DEFAULT_EXAMPLES_DIR,
+  outputFile = DEFAULT_OUTPUT_FILE,
+  check = false
+} = {}) {
+  const records = await loadExampleRecords({ examplesDir });
+  const content = renderManifest(records);
+  if (check) {
+    let current;
+    try {
+      current = await fs.readFile(outputFile, 'utf8');
+    } catch (error) {
+      if (error.code === 'ENOENT') {
+        throw new Error(`${path.relative(ROOT, outputFile)} is missing; run examples:generate`);
+      }
+      throw error;
+    }
+    if (current !== content) {
+      throw new Error(
+        `${path.relative(ROOT, outputFile)} is stale; run pnpm --dir engine-wasm/host-sample run examples:generate`
+      );
+    }
+    console.log(`validated ${path.relative(ROOT, outputFile)} (${records.length} examples)`);
+    return records;
+  }
+
+  await fs.mkdir(path.dirname(outputFile), { recursive: true });
+  await fs.writeFile(outputFile, content, 'utf8');
+  console.log(`generated ${path.relative(ROOT, outputFile)} (${records.length} examples)`);
+  return records;
+}
+
+async function main() {
+  const unknownArgs = process.argv.slice(2).filter((arg) => arg !== '--check');
+  if (unknownArgs.length > 0) {
+    throw new Error(`unknown argument(s): ${unknownArgs.join(', ')}`);
+  }
+  await generateExamples({ check: process.argv.includes('--check') });
+}
+
+const isMain = process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+if (isMain) {
+  main().catch((error) => {
+    console.error(error.message ?? error);
+    process.exit(1);
+  });
+}

--- a/engine-wasm/host-sample/scripts/story-runner-lib.mjs
+++ b/engine-wasm/host-sample/scripts/story-runner-lib.mjs
@@ -1,0 +1,76 @@
+import assert from 'node:assert/strict';
+
+export class NoExecutableCoverageError extends Error {}
+
+export function collectExecutableStories(records) {
+  return records.flatMap((example) =>
+    (example.flows ?? []).map((flow) => ({
+      example,
+      flow,
+      selectors: new Set([...flow.workItems, ...flow.specItems])
+    }))
+  );
+}
+
+export function selectExecutableStories(records, selector) {
+  const stories = collectExecutableStories(records);
+  if (selector === 'all') {
+    return stories;
+  }
+
+  const normalized = selector.toUpperCase();
+  const selected = stories.filter((story) =>
+    [...story.selectors].some((id) => id.toUpperCase() === normalized)
+  );
+  if (selected.length > 0) {
+    return selected;
+  }
+
+  const knownMetadataIds = new Set(
+    records.flatMap((record) => [...record.workItems, ...record.specItems])
+  );
+  const suffix = [...knownMetadataIds].some((id) => id.toUpperCase() === normalized)
+    ? ' (the id exists in example metadata, but has no executable flow)'
+    : '';
+  throw new NoExecutableCoverageError(
+    `No executable story coverage found for "${selector}"${suffix}.`
+  );
+}
+
+export function traceContainsSubsequence(actualKinds, expectedKinds) {
+  let expectedIndex = 0;
+  for (const actual of actualKinds) {
+    if (actual === expectedKinds[expectedIndex]) {
+      expectedIndex += 1;
+      if (expectedIndex === expectedKinds.length) {
+        return true;
+      }
+    }
+  }
+  return expectedKinds.length === 0;
+}
+
+export function assertStoryExpectation(evidence, expectation, label) {
+  for (const [key, expected] of Object.entries(expectation.state)) {
+    const actual = evidence.snapshot[key] ?? null;
+    assert.deepEqual(actual, expected, `${label}: snapshot.${key}`);
+  }
+  if (expectation.traceKinds) {
+    const actualKinds = evidence.traceEntries.map((entry) => entry.kind);
+    assert.ok(
+      traceContainsSubsequence(actualKinds, expectation.traceKinds),
+      `${label}: expected trace subsequence ${expectation.traceKinds.join(' -> ')}, got ${actualKinds.join(' -> ')}`
+    );
+  }
+}
+
+export function storyListLines(records) {
+  const stories = collectExecutableStories(records);
+  if (stories.length === 0) {
+    return ['No executable story flows are defined.'];
+  }
+  return stories.map(
+    ({ example, flow }) =>
+      `${example.key}/${flow.id} | ${[...flow.workItems, ...flow.specItems].join(', ')} | ${flow.title}`
+  );
+}

--- a/engine-wasm/host-sample/scripts/test-story.mjs
+++ b/engine-wasm/host-sample/scripts/test-story.mjs
@@ -1,0 +1,318 @@
+import { mkdir, rm, writeFile } from 'node:fs/promises';
+import { createServer as createNetServer } from 'node:net';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { chromium } from '@playwright/test';
+import { build as buildVite, preview as previewVite } from 'vite';
+import { generateExamples } from './generate-example-manifest.mjs';
+import {
+  NoExecutableCoverageError,
+  assertStoryExpectation,
+  selectExecutableStories,
+  storyListLines
+} from './story-runner-lib.mjs';
+
+const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
+const HOST_SAMPLE_DIR = path.resolve(SCRIPT_DIR, '..');
+const ENGINE_WASM_DIR = path.resolve(HOST_SAMPLE_DIR, '..');
+const REPO_ROOT = path.resolve(ENGINE_WASM_DIR, '..');
+const DEFAULT_OUTPUT_ROOT = path.join(HOST_SAMPLE_DIR, 'test-results', 'story');
+const STORY_DIST_DIR = path.join(HOST_SAMPLE_DIR, '.generated', 'story-dist');
+const FAILURE_STATUS_PATTERN = /^(Boot|Load|Key|Tick|Auto tick) error:/i;
+
+function usage() {
+  console.log(`Usage:
+  pnpm test:story list
+  pnpm test:story all
+  pnpm test:story <work-item-or-spec-id>
+
+Exit codes: 0 pass/list, 1 flow failure, 2 usage/configuration error, 3 no executable coverage.`);
+}
+
+function slug(value) {
+  return (
+    value
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-|-$/g, '') || 'all'
+  );
+}
+
+function assertSafeOutputRoot(outputRoot) {
+  const forbidden = new Set([
+    path.parse(outputRoot).root,
+    os.homedir(),
+    os.tmpdir(),
+    REPO_ROOT,
+    ENGINE_WASM_DIR,
+    HOST_SAMPLE_DIR,
+    path.join(HOST_SAMPLE_DIR, 'test-results')
+  ]);
+  if (forbidden.has(outputRoot)) {
+    throw new Error(`Refusing to clear unsafe story output directory: ${outputRoot}`);
+  }
+}
+
+function deterministicEvidence(evidence) {
+  return {
+    activeExampleKey: evidence.activeExampleKey,
+    snapshot: evidence.snapshot,
+    traceEntries: evidence.traceEntries,
+    status: evidence.status
+  };
+}
+
+async function collectEvidence(page) {
+  return page.evaluate(() => {
+    if (!window.__WAVENAV_STORY_EVIDENCE__) {
+      throw new Error('WaveNav story evidence bridge is unavailable');
+    }
+    return window.__WAVENAV_STORY_EVIDENCE__.collect();
+  });
+}
+
+async function applyAction(page, action) {
+  if (action.type === 'key') {
+    await page.locator(`#press-${action.key}`).click();
+    return;
+  }
+  if (action.type === 'back') {
+    await page.locator('#press-back').click();
+    return;
+  }
+  if (action.type === 'tick') {
+    if (action.ms === 100) {
+      await page.locator('#tick-100ms').click();
+      return;
+    }
+    if (action.ms === 1000) {
+      await page.locator('#tick-1s').click();
+      return;
+    }
+    throw new Error(`Host controls do not expose a deterministic ${action.ms}ms tick`);
+  }
+  await page.locator('#clear-intent').click();
+}
+
+async function runStory(browser, baseUrl, story, artifactRoot) {
+  const storyName = `${story.example.key}--${story.flow.id}`;
+  const storyDir = path.join(artifactRoot, storyName);
+  const browserSignals = [];
+  const context = await browser.newContext({ viewport: { width: 1280, height: 900 } });
+  await context.tracing.start({ screenshots: true, snapshots: true, sources: true });
+  const page = await context.newPage();
+  page.on('console', (message) => {
+    if (message.type() === 'error' || message.type() === 'warning') {
+      browserSignals.push({ type: `console:${message.type()}`, text: message.text() });
+    }
+  });
+  page.on('pageerror', (error) => {
+    browserSignals.push({ type: 'pageerror', text: error.message });
+  });
+  page.on('requestfailed', (request) => {
+    browserSignals.push({
+      type: 'requestfailed',
+      text: `${request.method()} ${request.url()} ${request.failure()?.errorText ?? ''}`.trim()
+    });
+  });
+  page.on('response', (response) => {
+    if (response.status() >= 400) {
+      browserSignals.push({
+        type: 'response',
+        text: `${response.status()} ${response.request().method()} ${response.url()}`
+      });
+    }
+  });
+
+  const result = {
+    example: story.example.key,
+    flow: story.flow.id,
+    title: story.flow.title,
+    workItems: story.flow.workItems,
+    specItems: story.flow.specItems,
+    status: 'passed',
+    steps: []
+  };
+
+  try {
+    await page.goto(baseUrl, { waitUntil: 'networkidle' });
+    await page.waitForFunction(() => window.__WAVENAV_STORY_EVIDENCE__ !== undefined, null, {
+      timeout: 10_000
+    });
+    await page.locator('#example-select').selectOption(story.example.key);
+
+    let evidence = await collectEvidence(page);
+    assertStoryExpectation(evidence, story.flow.initial, `${storyName} initial`);
+    result.steps.push({ index: 0, phase: 'initial', evidence: deterministicEvidence(evidence) });
+
+    for (const [index, step] of story.flow.steps.entries()) {
+      await applyAction(page, step.action);
+      evidence = await collectEvidence(page);
+      if (FAILURE_STATUS_PATTERN.test(evidence.status)) {
+        throw new Error(`${storyName} step ${index + 1}: host reported "${evidence.status}"`);
+      }
+      assertStoryExpectation(evidence, step.expect, `${storyName} step ${index + 1}`);
+      result.steps.push({
+        index: index + 1,
+        action: step.action,
+        evidence: deterministicEvidence(evidence)
+      });
+    }
+
+    if (browserSignals.length > 0) {
+      throw new Error(
+        `${storyName}: browser emitted unexpected diagnostics: ${browserSignals
+          .map((signal) => `[${signal.type}] ${signal.text}`)
+          .join('; ')}`
+      );
+    }
+
+    await context.tracing.stop();
+    console.log(`PASS ${storyName}`);
+    return result;
+  } catch (error) {
+    result.status = 'failed';
+    result.error = error.message ?? String(error);
+    result.browserSignals = browserSignals;
+    await mkdir(storyDir, { recursive: true });
+    try {
+      result.failureEvidence = await collectEvidence(page);
+    } catch (evidenceError) {
+      result.evidenceError = evidenceError.message ?? String(evidenceError);
+    }
+    await page.screenshot({ path: path.join(storyDir, 'failure.png'), fullPage: true });
+    await writeFile(path.join(storyDir, 'evidence.json'), `${JSON.stringify(result, null, 2)}\n`);
+    await context.tracing.stop({ path: path.join(storyDir, 'trace.zip') });
+    console.error(`FAIL ${storyName}: ${result.error}`);
+    console.error(`  artifacts: ${storyDir}`);
+    return result;
+  } finally {
+    await context.close();
+  }
+}
+
+async function startHostServer() {
+  const port = await new Promise((resolve, reject) => {
+    const reservation = createNetServer();
+    reservation.once('error', reject);
+    reservation.listen(0, '127.0.0.1', () => {
+      const address = reservation.address();
+      if (!address || typeof address === 'string') {
+        reservation.close();
+        reject(new Error('Could not reserve an ephemeral localhost port'));
+        return;
+      }
+      reservation.close((error) => {
+        if (error) {
+          reject(error);
+          return;
+        }
+        resolve(address.port);
+      });
+    });
+  });
+  await buildVite({
+    root: HOST_SAMPLE_DIR,
+    configFile: path.join(HOST_SAMPLE_DIR, 'vite.config.ts'),
+    logLevel: 'error',
+    build: {
+      outDir: STORY_DIST_DIR,
+      emptyOutDir: true
+    }
+  });
+  const server = await previewVite({
+    root: HOST_SAMPLE_DIR,
+    configFile: path.join(HOST_SAMPLE_DIR, 'vite.config.ts'),
+    logLevel: 'error',
+    build: {
+      outDir: STORY_DIST_DIR
+    },
+    preview: {
+      host: '127.0.0.1',
+      port,
+      strictPort: true
+    }
+  });
+  const address = server.httpServer?.address();
+  if (!address || typeof address === 'string') {
+    await server.close();
+    throw new Error('Vite preview did not expose a local TCP address');
+  }
+  return { server, baseUrl: `http://127.0.0.1:${address.port}/` };
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  if (args.length !== 1 || args[0] === '--help' || args[0] === '-h') {
+    usage();
+    process.exitCode = args.includes('--help') || args.includes('-h') ? 0 : 2;
+    return;
+  }
+
+  const selector = args[0];
+  const records = await generateExamples();
+  if (selector === 'list' || selector === '--list') {
+    for (const line of storyListLines(records)) {
+      console.log(line);
+    }
+    return;
+  }
+
+  let stories;
+  try {
+    stories = selectExecutableStories(records, selector);
+  } catch (error) {
+    if (error instanceof NoExecutableCoverageError) {
+      console.error(error.message);
+      console.error('Run "pnpm test:story list" to see executable mappings.');
+      process.exitCode = 3;
+      return;
+    }
+    throw error;
+  }
+  if (stories.length === 0) {
+    throw new Error('No executable story flows are defined.');
+  }
+
+  const outputRoot = path.resolve(
+    process.env.WAVES_STORY_OUTPUT_DIR ?? path.join(DEFAULT_OUTPUT_ROOT, slug(selector))
+  );
+  assertSafeOutputRoot(outputRoot);
+  await rm(outputRoot, { recursive: true, force: true });
+  await mkdir(outputRoot, { recursive: true });
+
+  const { server, baseUrl } = await startHostServer();
+  let browser;
+  const results = [];
+  try {
+    browser = await chromium.launch({ headless: true });
+    for (const story of stories) {
+      results.push(await runStory(browser, baseUrl, story, outputRoot));
+    }
+  } finally {
+    await browser?.close();
+    await server.close();
+  }
+
+  const failed = results.filter((result) => result.status === 'failed');
+  const summary = {
+    selector,
+    baseUrl: 'ephemeral localhost Vite server',
+    passed: results.length - failed.length,
+    failed: failed.length,
+    results
+  };
+  const summaryPath = path.join(outputRoot, 'summary.json');
+  await writeFile(summaryPath, `${JSON.stringify(summary, null, 2)}\n`);
+  console.log(`RESULT ${summary.passed} passed, ${summary.failed} failed`);
+  console.log(`ARTIFACTS ${summaryPath}`);
+  if (failed.length > 0) {
+    process.exitCode = 1;
+  }
+}
+
+main().catch((error) => {
+  console.error(`Story runner configuration error: ${error.message ?? error}`);
+  process.exitCode = 2;
+});

--- a/engine-wasm/host-sample/scripts/tests/generate-example-manifest.test.mjs
+++ b/engine-wasm/host-sample/scripts/tests/generate-example-manifest.test.mjs
@@ -1,0 +1,120 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import {
+  loadExampleRecords,
+  parseExecutableFlow,
+  parseExampleMetadata
+} from '../generate-example-manifest.mjs';
+
+const METADATA = `<!--
+label: Test Example
+work-items: R0-10
+spec-items: WML-R-007
+description: Test description.
+goal: Test goal.
+testing-ac:
+- Verify behavior.
+-->
+<wml><card id="home"><p>Home</p></card></wml>
+`;
+
+const validFlow = (overrides = {}) => ({
+  version: 1,
+  example: 'testExample',
+  flows: [
+    {
+      id: 'smoke',
+      title: 'Smoke flow',
+      workItems: ['R0-10'],
+      specItems: ['WML-R-007'],
+      initial: { state: { activeCardId: 'home', externalNavigationIntent: null } },
+      steps: [
+        {
+          action: { type: 'key', key: 'enter' },
+          expect: { state: { activeCardId: 'home' } }
+        }
+      ],
+      ...overrides
+    }
+  ]
+});
+
+test('parses required WML metadata without embedding the comment in deck source', () => {
+  const metadata = parseExampleMetadata(METADATA, 'test-example.wml');
+  assert.deepEqual(metadata.workItems, ['R0-10']);
+  assert.deepEqual(metadata.specItems, ['WML-R-007']);
+  assert.match(metadata.wml, /^<wml>/);
+});
+
+test('rejects unknown executable actions deterministically', () => {
+  const document = validFlow({
+    steps: [
+      {
+        action: { type: 'teleport' },
+        expect: { state: { activeCardId: 'home' } }
+      }
+    ]
+  });
+  assert.throws(
+    () => parseExecutableFlow(JSON.stringify(document), 'test-example.flow.json', 'testExample'),
+    /unknown action "teleport"/
+  );
+});
+
+test('rejects flow companions for examples that do not exist', async () => {
+  const examplesDir = await mkdtemp(path.join(os.tmpdir(), 'wavenav-examples-'));
+  await writeFile(path.join(examplesDir, 'unknown.flow.json'), JSON.stringify(validFlow()), 'utf8');
+  await assert.rejects(
+    () => loadExampleRecords({ examplesDir }),
+    /references unknown example "unknown"/
+  );
+});
+
+test('rejects inconsistent extra ticket mappings in executable flows', async () => {
+  const examplesDir = await mkdtemp(path.join(os.tmpdir(), 'wavenav-examples-'));
+  await writeFile(path.join(examplesDir, 'test-example.wml'), METADATA, 'utf8');
+  await writeFile(
+    path.join(examplesDir, 'test-example.flow.json'),
+    JSON.stringify(validFlow({ workItems: ['R0-11'] })),
+    'utf8'
+  );
+  await assert.rejects(
+    () => loadExampleRecords({ examplesDir }),
+    /maps unknown work item\(s\): R0-11/
+  );
+});
+
+test('rejects ticket mappings that are present in metadata but missing from flows', async () => {
+  const examplesDir = await mkdtemp(path.join(os.tmpdir(), 'wavenav-examples-'));
+  await writeFile(
+    path.join(examplesDir, 'test-example.wml'),
+    METADATA.replace('work-items: R0-10', 'work-items: R0-10, R0-11'),
+    'utf8'
+  );
+  await writeFile(
+    path.join(examplesDir, 'test-example.flow.json'),
+    JSON.stringify(validFlow()),
+    'utf8'
+  );
+  await assert.rejects(
+    () => loadExampleRecords({ examplesDir }),
+    /flow is missing work item mapping\(s\): R0-11/
+  );
+});
+
+test('merges a valid companion into the canonical example record', async () => {
+  const examplesDir = await mkdtemp(path.join(os.tmpdir(), 'wavenav-examples-'));
+  await writeFile(path.join(examplesDir, 'test-example.wml'), METADATA, 'utf8');
+  await writeFile(
+    path.join(examplesDir, 'test-example.flow.json'),
+    JSON.stringify(validFlow()),
+    'utf8'
+  );
+  const records = await loadExampleRecords({ examplesDir });
+  assert.equal(records.length, 1);
+  assert.equal(records[0].key, 'testExample');
+  assert.equal(records[0].flows[0].id, 'smoke');
+});

--- a/engine-wasm/host-sample/scripts/tests/story-runner-lib.test.mjs
+++ b/engine-wasm/host-sample/scripts/tests/story-runner-lib.test.mjs
@@ -1,0 +1,80 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  NoExecutableCoverageError,
+  assertStoryExpectation,
+  selectExecutableStories,
+  traceContainsSubsequence
+} from '../story-runner-lib.mjs';
+
+const records = [
+  {
+    key: 'covered',
+    workItems: ['R0-10'],
+    specItems: ['WML-R-007'],
+    flows: [
+      {
+        id: 'smoke',
+        workItems: ['R0-10'],
+        specItems: ['WML-R-007']
+      }
+    ]
+  },
+  {
+    key: 'metadataOnly',
+    workItems: ['R0-11'],
+    specItems: ['WML-R-008']
+  }
+];
+
+test('selects executable stories by work item or spec item, case-insensitively', () => {
+  assert.equal(selectExecutableStories(records, 'r0-10').length, 1);
+  assert.equal(selectExecutableStories(records, 'WML-R-007').length, 1);
+});
+
+test('reports an explicit metadata-only coverage gap', () => {
+  assert.throws(
+    () => selectExecutableStories(records, 'R0-11'),
+    (error) =>
+      error instanceof NoExecutableCoverageError &&
+      error.message.includes('exists in example metadata')
+  );
+});
+
+test('checks ordered trace subsequences without requiring adjacent entries', () => {
+  assert.equal(
+    traceContainsSubsequence(
+      ['LOAD', 'ACTION_FRAGMENT', 'TIMER_START', 'KEY', 'ACTION_ONTIMER'],
+      ['ACTION_FRAGMENT', 'TIMER_START', 'ACTION_ONTIMER']
+    ),
+    true
+  );
+});
+
+test('asserts structured runtime state and trace evidence', () => {
+  const evidence = {
+    snapshot: {
+      activeCardId: 'next',
+      focusedLinkIndex: 0,
+      externalNavigationIntent: undefined
+    },
+    traceEntries: [{ kind: 'KEY' }, { kind: 'ACTION_FRAGMENT' }]
+  };
+  assert.doesNotThrow(() =>
+    assertStoryExpectation(
+      evidence,
+      {
+        state: {
+          activeCardId: 'next',
+          externalNavigationIntent: null
+        },
+        traceKinds: ['KEY', 'ACTION_FRAGMENT']
+      },
+      'test'
+    )
+  );
+  assert.throws(
+    () => assertStoryExpectation(evidence, { state: { activeCardId: 'home' } }, 'test'),
+    /snapshot.activeCardId/
+  );
+});

--- a/engine-wasm/host-sample/ui/runtime-inspector-panel.ts
+++ b/engine-wasm/host-sample/ui/runtime-inspector-panel.ts
@@ -114,15 +114,24 @@ export class RuntimeInspectorPanel extends LitElement {
     }
   `;
 
-  entries: EngineTraceEntry[] = [];
+  declare entries: EngineTraceEntry[];
 
-  private exportFormat: TraceExportFormat = 'txt';
+  declare private exportFormat: TraceExportFormat;
 
-  private kindFilter = '';
+  declare private kindFilter: string;
 
-  private cardFilter = '';
+  declare private cardFilter: string;
 
-  private trapsOnly = false;
+  declare private trapsOnly: boolean;
+
+  constructor() {
+    super();
+    this.entries = [];
+    this.exportFormat = 'txt';
+    this.kindFilter = '';
+    this.cardFilter = '';
+    this.trapsOnly = false;
+  }
 
   render() {
     const filteredEntries = this.getFilteredEntries();

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "version:check": "node scripts/check-release-version.mjs",
     "version:set": "node scripts/set-release-version.mjs",
     "test:node": "pnpm -r --if-present run test",
+    "test:story": "pnpm --dir engine-wasm/host-sample run test:story",
     "build:node": "pnpm -r --if-present run build",
     "typecheck:node": "pnpm -r --if-present run typecheck"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -136,6 +136,9 @@ importers:
         specifier: 'catalog:'
         version: 3.3.3
     devDependencies:
+      '@playwright/test':
+        specifier: ^1.58.2
+        version: 1.62.0
       '@types/node':
         specifier: 'catalog:'
         version: 26.1.1
@@ -824,6 +827,11 @@ packages:
 
   '@oxc-project/types@0.139.0':
     resolution: {integrity: sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==}
+
+  '@playwright/test@1.62.0':
+    resolution: {integrity: sha512-9zOJ6ZQRAena31MpOH9VSzIz8Ou3YJ/wtY/eQm5T2uhfhG7/U3COrMS8xOtUrZrp9OgdmzEnIYODye3nY1VqzA==}
+    engines: {node: '>=20'}
+    hasBin: true
 
   '@rolldown/binding-android-arm64@1.1.5':
     resolution: {integrity: sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==}
@@ -1593,6 +1601,11 @@ packages:
     resolution: {integrity: sha512-Wp1zXWPVUPBmfoa3Cqc9ctaKuzKAV6uLstRqlR56kSjplf5uAce+qeyYym7F+PHbGTk+tCEdkCW6RD7DX/gBZw==}
     engines: {node: '>=20'}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -2040,6 +2053,16 @@ packages:
   picomatch@4.0.5:
     resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
     engines: {node: '>=12'}
+
+  playwright-core@1.62.0:
+    resolution: {integrity: sha512-nsNRyq0r2zsG8AcRHWknc9QRA5XCueC7gWMrs+Gx2tlZn9hcl8zudfh00lhJPY1DE7NmZ6bDsT9g2yey8mXljA==}
+    engines: {node: '>=20'}
+    hasBin: true
+
+  playwright@1.62.0:
+    resolution: {integrity: sha512-Z14dG305dgaLu6foB1TXQagFiW8JfSUIUaUuPaKQ6NtBPKF1P/qXcqfh6c6K/icPqdy37JmjbiBXf6JNg6Sylw==}
+    engines: {node: '>=20'}
+    hasBin: true
 
   postcss@8.5.23:
     resolution: {integrity: sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==}
@@ -3254,6 +3277,10 @@ snapshots:
 
   '@oxc-project/types@0.139.0': {}
 
+  '@playwright/test@1.62.0':
+    dependencies:
+      playwright: 1.62.0
+
   '@rolldown/binding-android-arm64@1.1.5':
     optional: true
 
@@ -4145,6 +4172,9 @@ snapshots:
     dependencies:
       tiny-inflate: 1.0.3
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -4596,6 +4626,14 @@ snapshots:
   picomatch@2.3.2: {}
 
   picomatch@4.0.5: {}
+
+  playwright-core@1.62.0: {}
+
+  playwright@1.62.0:
+    dependencies:
+      playwright-core: 1.62.0
+    optionalDependencies:
+      fsevents: 2.3.2
 
   postcss@8.5.23:
     dependencies:


### PR DESCRIPTION
## Summary

- add optional typed `*.flow.json` companions beside the canonical shared WML examples and merge them through the existing manifest generator
- validate flow schema, example/action references, and exact work-item/spec mappings with deterministic errors and generated-output drift checks
- add `pnpm test:story list|all|<work-item-or-spec-id>` backed by Playwright against the production WASM host sample, with automatic Vite lifecycle and worktree-safe ports/output
- capture deterministic runtime snapshots and engine traces, plus failure-only screenshots, Playwright traces, event logs, and browser diagnostics
- add representative fragment/external-intent, history-back, and immediate timer stories
- wire schema tests, Chromium story replay, and failure artifact upload into CI
- update active coverage/status docs and repository agent steering so stable host-visible behavior uses executable stories when deterministic

## Why

The shared example corpus already carried ticket/spec mappings and prose acceptance checks, but developers and agents had no single deterministic command to select and replay those stories. This adds the first practical R0-10/R0-11 foundation without creating a second deck corpus or crossing into transport/native Tauri behavior.

The strict browser diagnostics pass also exposed Lit reactive class-field shadowing in the runtime inspector. The host fields now initialize through Lit's generated accessors so the production browser run remains clean.

## Developer impact

After the one-time WASM/Chromium prerequisites, contributors can run:

```bash
pnpm test:story list
pnpm test:story WML-R-007
pnpm test:story all
```

No manual Vite server setup is required. Missing executable coverage exits with code 3, while failed stories point directly to structured artifacts.

## Validation

- `pnpm test:story all` — 3/3 representative browser stories passed
- `pnpm test:node` — 145 browser frontend tests and 10 host-sample story tests passed
- `pnpm typecheck:node`
- `pnpm lint:node`
- `pnpm format:check:node`
- `pnpm --dir engine-wasm/host-sample run build`
- `pnpm --dir engine-wasm/host-sample run examples:check`
- repository pre-push hooks — engine fmt/clippy, 218 engine tests, browser Tauri fmt/clippy, transport fmt/clippy, and host-sample sanity passed
- `git diff --check`

## Remaining scope

R0-10 and R0-11 remain in progress. This slice does not yet enumerate every R0/T0/W1 fixture lane or replay transport-to-engine-to-native-browser/request-policy behavior. It intentionally adds no WebdriverIO or native Tauri automation.
