### PR TITLE
test(browser): add story-driven Waves browser E2E lane

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,8 @@ jobs:
               - "engine-wasm/engine/**"
               - "engine-wasm/examples/**"
               - "engine-wasm/pkg/**"
+              - "browser/frontend/**"
+              - "browser/contracts/**"
             marketing_site:
               - "marketing-site/**"
             docs_portal:
@@ -299,7 +301,10 @@ jobs:
         run: pnpm --dir engine-wasm/host-sample exec playwright install --with-deps chromium
 
       - name: Host-sample executable stories
-        run: pnpm test:story all
+        run: pnpm test:story host-sample
+
+      - name: Waves browser executable stories
+        run: pnpm test:story:waves
 
       - name: Upload story failure evidence
         if: failure()

--- a/browser/README.md
+++ b/browser/README.md
@@ -19,6 +19,8 @@ Implemented now:
   - generator: `scripts/generate-contract-wrappers.mjs`
   - output: `contracts/generated/tauri-host-client.ts`
 - Frontend basic smoke harness under `frontend/` (load/render/key loop)
+- Ordinary-browser Waves story entry backed by the real WaveNav WASM engine and deterministic
+  canonical fixture fetching (`pnpm test:story:waves`)
 - Browser-style shell UI (address bar + back/reload/go + viewport-first layout)
 - App identity baseline (`Waves Browser` title/product metadata and bundled icon set)
 - Native app menu baseline with About metadata (`WAP/WML based browser 1.x`)

--- a/browser/frontend/README.md
+++ b/browser/frontend/README.md
@@ -10,6 +10,11 @@ Current responsibilities:
 - local/network mode orchestration
 - integration glue to invoke Tauri host commands
 
+The production entry remains `src/main.ts`, which composes the shell with the generated Tauri host
+client. `browser-story.html` is a separate test-only entry that uses the same controller, presenter,
+and DOM shell with a WASM-backed host client. Only that entry installs
+`window.__WAVENAV_STORY_EVIDENCE__`; production builds do not expose the observation bridge.
+
 Current backend harness commands are available in Tauri (`src-tauri/src/lib.rs`) for
 frontend integration:
 
@@ -96,7 +101,23 @@ pnpm --dir browser/frontend lint
 pnpm --dir browser/frontend typecheck
 pnpm --dir browser/frontend test
 pnpm --dir browser/frontend test:coverage
+pnpm --dir browser/frontend build
 ```
+
+Fast ordinary-browser story lane from the repository root:
+
+```bash
+cd engine-wasm/engine
+wasm-pack build --target web --out-dir ../pkg
+cd ../..
+pnpm test:story:waves
+```
+
+The lane drives the real Waves controls with softkey clicks and browser keyboard events. Its
+primary oracle is the test-only semantic bridge: runtime snapshots, engine traces, host session
+state, and render-list text. Playwright screenshots and traces are retained only for failed-flow
+debugging. Network-mode stories use an in-memory fixture adapter restricted to canonical
+`engine-wasm/examples` decks; they do not exercise native Tauri or Rust transport behavior.
 
 Run from `browser/`:
 

--- a/browser/frontend/browser-story.html
+++ b/browser/frontend/browser-story.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="description" content="Waves browser story test entry." />
+    <title>Waves Browser Story</title>
+    <script type="module" src="/src/browser-test-main.ts"></script>
+  </head>
+  <body data-boot-phase="booting">
+    <div id="app"></div>
+  </body>
+</html>

--- a/browser/frontend/src/app/browser-application.ts
+++ b/browser/frontend/src/app/browser-application.ts
@@ -1,0 +1,65 @@
+import type { HostSessionState } from '../../../contracts/transport';
+import type { TauriHostClient } from '../../../contracts/generated/tauri-host-client';
+import { BrowserController } from './browser-controller';
+import { BrowserPresenter } from './browser-presenter';
+import { mountBrowserShell, type BrowserShellRefs } from './browser-shell-template';
+import { defaultRunMode, defaultStartUrl } from './defaults';
+import { WAVES_CONFIG } from './waves-config';
+import { WAVES_COPY } from './waves-copy';
+import { registerBrowserComponents } from '../components';
+
+const SAMPLE_WML = `<wml>
+  <card id="home">
+    <p>${WAVES_COPY.sampleDeck.intro}</p>
+    <a href="#next">${WAVES_COPY.sampleDeck.next}</a>
+    <a href="https://example.org/">${WAVES_COPY.sampleDeck.external}</a>
+  </card>
+  <card id="next">
+    <p>${WAVES_COPY.sampleDeck.nextCard}</p>
+    <a href="#home">${WAVES_COPY.sampleDeck.home}</a>
+  </card>
+</wml>`;
+
+export interface BrowserApplication {
+  controller: BrowserController;
+  presenter: BrowserPresenter;
+  refs: BrowserShellRefs;
+}
+
+export interface BrowserApplicationOptions {
+  startUrl?: string;
+  runMode?: 'local' | 'network';
+}
+
+export const composeBrowserApplication = (
+  hostClient: TauriHostClient,
+  options: BrowserApplicationOptions = {}
+): BrowserApplication => {
+  document.body.setAttribute('data-boot-phase', 'booting');
+  document.title = WAVES_CONFIG.appName;
+  const descriptionMeta = document.querySelector<HTMLMetaElement>('meta[name="description"]');
+  if (descriptionMeta) {
+    descriptionMeta.content = WAVES_COPY.app.description;
+  }
+
+  registerBrowserComponents();
+
+  const startUrl = options.startUrl ?? defaultStartUrl();
+  const runMode = options.runMode ?? defaultRunMode(undefined, startUrl);
+  const refs = mountBrowserShell(startUrl, runMode);
+  const initialSession: HostSessionState = {
+    runMode,
+    navigationStatus: 'idle',
+    requestedUrl: refs.fetchUrlInput.value
+  };
+  const presenter = new BrowserPresenter(refs, initialSession, WAVES_CONFIG.maxTimelineEvents);
+  const controller = new BrowserController(hostClient, presenter, refs);
+
+  return { controller, presenter, refs };
+};
+
+export const initializeBrowserApplication = async (
+  application: BrowserApplication
+): Promise<void> => {
+  await application.controller.init(SAMPLE_WML);
+};

--- a/browser/frontend/src/app/browser-presenter.ts
+++ b/browser/frontend/src/app/browser-presenter.ts
@@ -48,6 +48,8 @@ export class BrowserPresenter {
   private timelineText = '';
   private snapshotText = '';
   private transportResponseText = '';
+  private statusText = '';
+  private latestRenderList: RenderList | null = null;
   private sessionStateDirty = true;
   private timelineDirty = true;
   private snapshotDirty = true;
@@ -139,9 +141,14 @@ export class BrowserPresenter {
   }
 
   setStatus(message: string): void {
+    this.statusText = message;
     const tone = inferStatusTone(message);
     this.refs.statusEl.setStatus(message, tone);
     uiEvents.emit('status', { message, tone });
+  }
+
+  getStatus(): string {
+    return this.statusText;
   }
 
   setBootPhase(phase: BootPhase): void {
@@ -300,6 +307,9 @@ export class BrowserPresenter {
   }
 
   drawRenderList(renderList: RenderList): void {
+    this.latestRenderList = {
+      draw: renderList.draw.map((command) => ({ ...command }))
+    };
     this.hasRenderedContent = true;
     // Real content just landed -- cancel any pending delayed in-progress
     // indicator so it can't appear after the fact (see beginNavigationProgress).
@@ -309,6 +319,15 @@ export class BrowserPresenter {
     }
     this.setViewportSkeleton(false);
     this.refs.viewportEl.innerHTML = renderWmlViewportHtml(renderList);
+  }
+
+  getRenderList(): RenderList | null {
+    if (!this.latestRenderList) {
+      return null;
+    }
+    return {
+      draw: this.latestRenderList.draw.map((command) => ({ ...command }))
+    };
   }
 
   exportTimeline(): void {

--- a/browser/frontend/src/app/keyboard-intent-router.test.ts
+++ b/browser/frontend/src/app/keyboard-intent-router.test.ts
@@ -95,8 +95,20 @@ describe('KeyboardIntentRouter', () => {
     expect(deps.setStatus).toHaveBeenCalledTimes(1);
   });
 
-  it('routes a plain Backspace through the focused-control-edit check first', async () => {
+  it('falls through to back navigation when the control-edit check does not handle Backspace', async () => {
     const deps = createDeps();
+    const router = new KeyboardIntentRouter(deps);
+
+    router.handleWindowKeydown(new KeyboardEvent('keydown', { key: 'Backspace' }));
+    await flushAsyncWork();
+
+    expect(deps.applyFocusedControlEditKey).toHaveBeenCalledWith('Backspace');
+    expect(deps.navigateBackWithFallback).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not navigate back when focused input editing handles Backspace', async () => {
+    const deps = createDeps();
+    deps.applyFocusedControlEditKey.mockResolvedValue('handled');
     const router = new KeyboardIntentRouter(deps);
 
     router.handleWindowKeydown(new KeyboardEvent('keydown', { key: 'Backspace' }));

--- a/browser/frontend/src/app/keyboard-intent-router.ts
+++ b/browser/frontend/src/app/keyboard-intent-router.ts
@@ -57,7 +57,7 @@ export class KeyboardIntentRouter {
         this.enqueueAction(async () => {
           await this.deps.runAction('keyboard-control-edit', async () => {
             const handled = await this.deps.applyFocusedControlEditKey(event.key);
-            if (handled) {
+            if (handled !== 'unhandled') {
               this.deps.setStatus(WAVES_COPY.status.keyboard(event.key));
             }
           })();
@@ -101,7 +101,7 @@ export class KeyboardIntentRouter {
         await this.deps.runAction('keyboard-backspace', async () => {
           if (this.shouldRouteKeyToControlEdit(event)) {
             const handled = await this.deps.applyFocusedControlEditKey(event.key);
-            if (handled) {
+            if (handled !== 'unhandled') {
               this.deps.setStatus(WAVES_COPY.status.keyboard(event.key));
               return;
             }

--- a/browser/frontend/src/browser-test-main.ts
+++ b/browser/frontend/src/browser-test-main.ts
@@ -1,0 +1,25 @@
+import './styles.css';
+import { composeBrowserApplication, initializeBrowserApplication } from './app/browser-application';
+import { createWasmBrowserTestHost } from './test-support/wasm-browser-test-host';
+import { installWavesStoryObservationBridge } from './test-support/waves-story-observation';
+
+const main = async (): Promise<void> => {
+  const host = await createWasmBrowserTestHost();
+  const application = composeBrowserApplication(host.client, {
+    startUrl: 'http://local.test/examples/basic.wml',
+    runMode: 'local'
+  });
+  await initializeBrowserApplication(application);
+  installWavesStoryObservationBridge(application, host.diagnostics);
+  document.body.setAttribute('data-story-target', 'waves-browser');
+};
+
+void main().catch((error: unknown) => {
+  const message = error instanceof Error ? error.message : String(error);
+  document.body.setAttribute('data-boot-phase', 'boot-error');
+  const banner = document.createElement('div');
+  banner.setAttribute('data-boot-error', 'true');
+  banner.setAttribute('role', 'alert');
+  banner.textContent = `Waves browser-test boot error: ${message}`;
+  (document.querySelector('#app') ?? document.body).prepend(banner);
+});

--- a/browser/frontend/src/main.ts
+++ b/browser/frontend/src/main.ts
@@ -1,62 +1,23 @@
 import { invoke } from '@tauri-apps/api/core';
-import type { HostSessionState } from '../../contracts/transport';
 import { createTauriHostClient } from '../../contracts/generated/tauri-host-client';
 import './styles.css';
-import { BrowserController } from './app/browser-controller';
-import { BrowserPresenter } from './app/browser-presenter';
-import { mountBrowserShell } from './app/browser-shell-template';
-import { defaultRunMode, defaultStartUrl } from './app/defaults';
+import {
+  composeBrowserApplication,
+  initializeBrowserApplication,
+  type BrowserApplication
+} from './app/browser-application';
 import { createGuardedTauriInvoke } from './app/tauri-invoke-guard';
-import { WAVES_CONFIG } from './app/waves-config';
 import { WAVES_COPY } from './app/waves-copy';
-import { registerBrowserComponents } from './components';
 
-const SAMPLE_WML = `<wml>
-  <card id="home">
-    <p>${WAVES_COPY.sampleDeck.intro}</p>
-    <a href="#next">${WAVES_COPY.sampleDeck.next}</a>
-    <a href="https://example.org/">${WAVES_COPY.sampleDeck.external}</a>
-  </card>
-  <card id="next">
-    <p>${WAVES_COPY.sampleDeck.nextCard}</p>
-    <a href="#home">${WAVES_COPY.sampleDeck.home}</a>
-  </card>
-</wml>`;
-
-let activeController: BrowserController | undefined;
-let activePresenter: BrowserPresenter | undefined;
+let activeApplication: BrowserApplication | undefined;
 
 const bootstrap = async (): Promise<void> => {
-  document.body.setAttribute('data-boot-phase', 'booting');
-  activeController?.dispose();
-  activeController = undefined;
-  activePresenter = undefined;
-
-  document.title = WAVES_CONFIG.appName;
-  const descriptionMeta = document.querySelector<HTMLMetaElement>('meta[name="description"]');
-  if (descriptionMeta) {
-    descriptionMeta.content = WAVES_COPY.app.description;
-  }
-
-  registerBrowserComponents();
-
-  const startUrl = defaultStartUrl();
-  const runMode = defaultRunMode(undefined, startUrl);
-  const refs = mountBrowserShell(startUrl, runMode);
+  activeApplication?.controller.dispose();
+  activeApplication = undefined;
   const hostClient = createTauriHostClient(createGuardedTauriInvoke(invoke));
-
-  const initialSession: HostSessionState = {
-    runMode,
-    navigationStatus: 'idle',
-    requestedUrl: refs.fetchUrlInput.value
-  };
-
-  const presenter = new BrowserPresenter(refs, initialSession, WAVES_CONFIG.maxTimelineEvents);
-  activePresenter = presenter;
-  const controller = new BrowserController(hostClient, presenter, refs);
-  activeController = controller;
-
-  await controller.init(SAMPLE_WML);
+  const application = composeBrowserApplication(hostClient);
+  activeApplication = application;
+  await initializeBrowserApplication(application);
 };
 
 /**
@@ -70,11 +31,14 @@ const reportBootFailure = (error: unknown): void => {
   const message = error instanceof Error ? error.message : String(error);
   document.body.setAttribute('data-boot-phase', 'boot-error');
 
-  if (activePresenter) {
-    activePresenter.patchSessionState({ navigationStatus: 'error', lastError: message });
-    activePresenter.setStatus(WAVES_COPY.status.error(message));
-    activePresenter.showToast(WAVES_COPY.status.error(message), 'error');
-    activePresenter.recordTimeline('bootstrap', 'error', { message });
+  if (activeApplication) {
+    activeApplication.presenter.patchSessionState({
+      navigationStatus: 'error',
+      lastError: message
+    });
+    activeApplication.presenter.setStatus(WAVES_COPY.status.error(message));
+    activeApplication.presenter.showToast(WAVES_COPY.status.error(message), 'error');
+    activeApplication.presenter.recordTimeline('bootstrap', 'error', { message });
     return;
   }
 
@@ -90,7 +54,7 @@ void bootstrap().catch(reportBootFailure);
 
 if (import.meta.hot) {
   import.meta.hot.dispose(() => {
-    activeController?.dispose();
-    activeController = undefined;
+    activeApplication?.controller.dispose();
+    activeApplication = undefined;
   });
 }

--- a/browser/frontend/src/test-support/deterministic-fixture-fetch.test.ts
+++ b/browser/frontend/src/test-support/deterministic-fixture-fetch.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import type { HostExample } from '../../../../engine-wasm/examples/generated/examples';
+import {
+  createDeterministicFixtureFetch,
+  fixtureUrlForExample
+} from './deterministic-fixture-fetch';
+
+const example: HostExample = {
+  key: 'navigationFixture',
+  label: 'Navigation fixture',
+  description: 'Fixture',
+  goal: 'Fixture',
+  workItems: ['A2-01'],
+  specItems: ['WML-R-006'],
+  testingAc: ['Loads'],
+  wml: '<wml><card id="home"><p>Fixture</p></card></wml>'
+};
+
+describe('deterministic browser fixture fetch', () => {
+  it('returns a transport-shaped response without performing network I/O', async () => {
+    const fetchFixture = createDeterministicFixtureFetch([example]);
+    const url = fixtureUrlForExample(example.key);
+
+    await expect(fetchFixture({ url })).resolves.toMatchObject({
+      ok: true,
+      status: 200,
+      finalUrl: url,
+      contentType: 'text/vnd.wap.wml',
+      engineDeckInput: {
+        wmlXml: example.wml,
+        baseUrl: url,
+        contentType: 'text/vnd.wap.wml'
+      }
+    });
+  });
+
+  it('rejects unknown and non-fixture URLs deterministically', async () => {
+    const fetchFixture = createDeterministicFixtureFetch([example]);
+
+    await expect(fetchFixture({ url: 'https://example.com/deck.wml' })).resolves.toMatchObject({
+      ok: false,
+      status: 404,
+      error: {
+        code: 'INVALID_REQUEST'
+      }
+    });
+    await expect(
+      fetchFixture({ url: 'http://fixtures.test/examples/%ZZ.wml' })
+    ).resolves.toMatchObject({
+      ok: false,
+      status: 404
+    });
+  });
+});

--- a/browser/frontend/src/test-support/deterministic-fixture-fetch.ts
+++ b/browser/frontend/src/test-support/deterministic-fixture-fetch.ts
@@ -1,0 +1,75 @@
+import type {
+  FetchDeckRequest,
+  FetchDeckResponse
+} from '../../../contracts/generated/transport-host';
+import { EXAMPLES, type HostExample } from '../../../../engine-wasm/examples/generated/examples';
+
+const FIXTURE_ORIGINS = new Set(['http://fixtures.test', 'http://local.test']);
+const WML_CONTENT_TYPE = 'text/vnd.wap.wml';
+
+export const fixtureUrlForExample = (exampleKey: string): string =>
+  `http://fixtures.test/examples/${encodeURIComponent(exampleKey)}.wml`;
+
+export const createDeterministicFixtureFetch = (
+  examples: readonly HostExample[] = EXAMPLES
+): ((request: FetchDeckRequest) => Promise<FetchDeckResponse>) => {
+  const examplesByKey = new Map(examples.map((example) => [example.key, example]));
+
+  return async (request) => {
+    const fixture = resolveFixture(request.url, examplesByKey);
+    if (!fixture) {
+      return {
+        ok: false,
+        status: 404,
+        finalUrl: request.url,
+        contentType: 'text/plain',
+        error: {
+          code: 'INVALID_REQUEST',
+          message: `No deterministic Waves fixture is registered for ${request.url}`
+        },
+        timingMs: { encode: 0, udpRtt: 0, decode: 0 }
+      };
+    }
+
+    return {
+      ok: true,
+      status: 200,
+      finalUrl: fixture.url,
+      contentType: WML_CONTENT_TYPE,
+      wml: fixture.example.wml,
+      timingMs: { encode: 0, udpRtt: 0, decode: 0 },
+      engineDeckInput: {
+        wmlXml: fixture.example.wml,
+        baseUrl: fixture.url,
+        contentType: WML_CONTENT_TYPE
+      }
+    };
+  };
+};
+
+const resolveFixture = (
+  candidate: string,
+  examplesByKey: ReadonlyMap<string, HostExample>
+): { example: HostExample; url: string } | null => {
+  let parsed: URL;
+  try {
+    parsed = new URL(candidate);
+  } catch {
+    return null;
+  }
+  if (!FIXTURE_ORIGINS.has(parsed.origin) || parsed.search || parsed.hash) {
+    return null;
+  }
+  const match = parsed.pathname.match(/^\/examples\/([^/]+)\.wml$/);
+  if (!match) {
+    return null;
+  }
+  let key: string;
+  try {
+    key = decodeURIComponent(match[1] ?? '');
+  } catch {
+    return null;
+  }
+  const example = examplesByKey.get(key);
+  return example ? { example, url: parsed.toString() } : null;
+};

--- a/browser/frontend/src/test-support/wasm-browser-test-host.ts
+++ b/browser/frontend/src/test-support/wasm-browser-test-host.ts
@@ -1,0 +1,197 @@
+import init, { WmlEngine } from '../../../../engine-wasm/pkg/wavenav_engine.js';
+import type { EngineFrame, EngineRuntimeSnapshot, RenderList } from '../../../contracts/engine';
+import type { TauriHostClient } from '../../../contracts/generated/tauri-host-client';
+import type { EngineTraceEntry, WmlEngineWasm } from '../../../../engine-wasm/contracts/wml-engine';
+import { createDeterministicFixtureFetch } from './deterministic-fixture-fetch';
+
+export interface BrowserTestHostDiagnostics {
+  traceEntries(): EngineTraceEntry[];
+}
+
+export interface BrowserTestHost {
+  client: TauriHostClient;
+  diagnostics: BrowserTestHostDiagnostics;
+}
+
+export const createWasmBrowserTestHost = async (): Promise<BrowserTestHost> => {
+  await init();
+  const engine = new WmlEngine() as unknown as WmlEngineWasm;
+  const fetchDeck = createDeterministicFixtureFetch();
+
+  const snapshot = (): EngineRuntimeSnapshot => ({
+    activeCardId: readActiveCardId(engine),
+    focusedLinkIndex: engine.focusedLinkIndex(),
+    focusedInputEditName: engine.focusedInputEditName(),
+    focusedInputEditValue: engine.focusedInputEditValue(),
+    focusedSelectEditName: engine.focusedSelectEditName(),
+    focusedSelectEditValue: engine.focusedSelectEditValue(),
+    baseUrl: engine.baseUrl(),
+    contentType: engine.contentType(),
+    externalNavigationIntent: engine.externalNavigationIntent(),
+    externalNavigationRequestPolicy: engine.externalNavigationRequestPolicy(),
+    lastScriptExecutionOk: engine.lastScriptExecutionOk(),
+    lastScriptExecutionTrap: engine.lastScriptExecutionTrap(),
+    lastScriptExecutionErrorClass: engine.lastScriptExecutionErrorClass(),
+    lastScriptExecutionErrorCategory: engine.lastScriptExecutionErrorCategory(),
+    lastScriptRequiresRefresh: engine.lastScriptRequiresRefresh(),
+    lastScriptDialogRequests: engine.lastScriptDialogRequests(),
+    lastScriptTimerRequests: engine.lastScriptTimerRequests()
+  });
+  const render = (): RenderList => engine.render();
+  const frame = (): EngineFrame => ({ snapshot: snapshot(), render: render() });
+
+  const client: TauriHostClient = {
+    health: async () => 'waves-browser-test-host:ok',
+    fetchDeck,
+    engineLoadDeck: async ({ wmlXml }) => {
+      engine.loadDeck(wmlXml);
+      return snapshot();
+    },
+    engineLoadDeckContext: async (request) => {
+      loadDeckContext(engine, request);
+      return snapshot();
+    },
+    engineLoadDeckContextFrame: async (request) => {
+      loadDeckContext(engine, request);
+      return frame();
+    },
+    engineRender: async () => render(),
+    engineRenderFrame: async () => frame(),
+    engineHandleKey: async ({ key }) => {
+      engine.handleKey(key);
+      return snapshot();
+    },
+    engineHandleKeyFrame: async ({ key }) => {
+      engine.handleKey(key);
+      return frame();
+    },
+    engineNavigateToCard: async ({ cardId }) => {
+      engine.navigateToCard(cardId);
+      return snapshot();
+    },
+    engineNavigateToCardFrame: async ({ cardId }) => {
+      engine.navigateToCard(cardId);
+      return frame();
+    },
+    engineNavigateBack: async () => {
+      engine.navigateBack();
+      return snapshot();
+    },
+    engineNavigateBackFrame: async () => {
+      engine.navigateBack();
+      return frame();
+    },
+    engineSetViewportCols: async ({ cols }) => {
+      engine.setViewportCols(cols);
+      return snapshot();
+    },
+    engineAdvanceTimeMs: async ({ deltaMs }) => {
+      engine.advanceTimeMs(deltaMs);
+      return snapshot();
+    },
+    engineAdvanceTimeMsFrame: async ({ deltaMs }) => {
+      engine.advanceTimeMs(deltaMs);
+      return frame();
+    },
+    engineSnapshot: async () => snapshot(),
+    engineClearExternalNavigationIntent: async () => {
+      engine.clearExternalNavigationIntent();
+      return snapshot();
+    },
+    engineClearExternalNavigationIntentFrame: async () => {
+      engine.clearExternalNavigationIntent();
+      return frame();
+    },
+    engineBeginFocusedInputEdit: async () => {
+      engine.beginFocusedInputEdit();
+      return snapshot();
+    },
+    engineBeginFocusedInputEditFrame: async () => {
+      engine.beginFocusedInputEdit();
+      return frame();
+    },
+    engineSetFocusedInputEditDraft: async ({ value }) => {
+      engine.setFocusedInputEditDraft(value);
+      return snapshot();
+    },
+    engineSetFocusedInputEditDraftFrame: async ({ value }) => {
+      engine.setFocusedInputEditDraft(value);
+      return frame();
+    },
+    engineCommitFocusedInputEdit: async () => {
+      engine.commitFocusedInputEdit();
+      return snapshot();
+    },
+    engineCommitFocusedInputEditFrame: async () => {
+      engine.commitFocusedInputEdit();
+      return frame();
+    },
+    engineCancelFocusedInputEdit: async () => {
+      engine.cancelFocusedInputEdit();
+      return snapshot();
+    },
+    engineCancelFocusedInputEditFrame: async () => {
+      engine.cancelFocusedInputEdit();
+      return frame();
+    },
+    engineBeginFocusedSelectEdit: async () => {
+      engine.beginFocusedSelectEdit();
+      return snapshot();
+    },
+    engineBeginFocusedSelectEditFrame: async () => {
+      engine.beginFocusedSelectEdit();
+      return frame();
+    },
+    engineMoveFocusedSelectEdit: async ({ delta }) => {
+      engine.moveFocusedSelectEdit(delta);
+      return snapshot();
+    },
+    engineMoveFocusedSelectEditFrame: async ({ delta }) => {
+      engine.moveFocusedSelectEdit(delta);
+      return frame();
+    },
+    engineCommitFocusedSelectEdit: async () => {
+      engine.commitFocusedSelectEdit();
+      return snapshot();
+    },
+    engineCommitFocusedSelectEditFrame: async () => {
+      engine.commitFocusedSelectEdit();
+      return frame();
+    },
+    engineCancelFocusedSelectEdit: async () => {
+      engine.cancelFocusedSelectEdit();
+      return snapshot();
+    },
+    engineCancelFocusedSelectEditFrame: async () => {
+      engine.cancelFocusedSelectEdit();
+      return frame();
+    }
+  };
+
+  return {
+    client,
+    diagnostics: {
+      traceEntries: () => engine.traceEntries().map((entry) => ({ ...entry }))
+    }
+  };
+};
+
+const loadDeckContext = (
+  engine: WmlEngineWasm,
+  request: Parameters<TauriHostClient['engineLoadDeckContext']>[0]
+): void => {
+  engine.loadDeckContext(
+    request.wmlXml,
+    request.baseUrl,
+    request.contentType,
+    request.rawBytesBase64
+  );
+};
+
+const readActiveCardId = (engine: WmlEngineWasm): string | undefined => {
+  try {
+    return engine.activeCardId();
+  } catch {
+    return undefined;
+  }
+};

--- a/browser/frontend/src/test-support/waves-story-observation.ts
+++ b/browser/frontend/src/test-support/waves-story-observation.ts
@@ -1,0 +1,36 @@
+import type { EngineTraceEntry } from '../../../../engine-wasm/contracts/wml-engine';
+import type { BrowserApplication } from '../app/browser-application';
+import type { BrowserTestHostDiagnostics } from './wasm-browser-test-host';
+
+export interface WavesStoryEvidence {
+  activeExampleKey: string;
+  snapshot: ReturnType<BrowserApplication['presenter']['getSnapshot']>;
+  traceEntries: EngineTraceEntry[];
+  status: string;
+  session: ReturnType<BrowserApplication['presenter']['getSessionState']>;
+  render: ReturnType<BrowserApplication['presenter']['getRenderList']>;
+}
+
+declare global {
+  interface Window {
+    __WAVENAV_STORY_EVIDENCE__?: {
+      collect(): WavesStoryEvidence;
+    };
+  }
+}
+
+export const installWavesStoryObservationBridge = (
+  application: BrowserApplication,
+  diagnostics: BrowserTestHostDiagnostics
+): void => {
+  window.__WAVENAV_STORY_EVIDENCE__ = {
+    collect: () => ({
+      activeExampleKey: application.refs.localExampleSelectEl.value,
+      snapshot: application.presenter.getSnapshot(),
+      traceEntries: diagnostics.traceEntries(),
+      status: application.presenter.getStatus(),
+      session: application.presenter.getSessionState(),
+      render: application.presenter.getRenderList()
+    })
+  };
+};

--- a/browser/frontend/vite.config.ts
+++ b/browser/frontend/vite.config.ts
@@ -1,0 +1,19 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { defineConfig } from 'vite';
+
+const dirname = path.dirname(fileURLToPath(import.meta.url));
+
+export default defineConfig({
+  build: {
+    // The vendored Win95 stylesheet contains legacy WebKit scrollbar selectors
+    // that Lightning CSS rejects even though browsers safely ignore them.
+    cssMinify: 'esbuild'
+  },
+  server: {
+    fs: {
+      // Local examples and the browser-test WASM package live outside frontend/.
+      allow: [path.resolve(dirname, '../..')]
+    }
+  }
+});

--- a/docs/wml-engine/test-strategy.md
+++ b/docs/wml-engine/test-strategy.md
@@ -53,12 +53,15 @@ Use `engine-wasm/host-sample` for manual or story-driven automated smoke:
 
 Executable acceptance flows are optional `engine-wasm/examples/source/*.flow.json` companions to
 the canonical WML examples. Run `pnpm test:story <work-item-or-spec-id>` from the repository root,
-or use `list`/`all`. The runner owns its production Vite server lifecycle, uses an ephemeral port,
-asserts structured runtime state and ordered trace evidence, and writes failure artifacts under
+or use `list`, `host-sample`, `waves`, or `all`. The runner owns each production Vite server
+lifecycle, uses ephemeral ports and unique temporary build directories, asserts structured runtime
+state and ordered trace evidence, and writes failure artifacts under
 `engine-wasm/host-sample/test-results/story/`.
 
-This lane currently covers representative fragment/external-intent, history-back, and immediate
-timer flows. It does not yet replay transport or native Tauri behavior.
+The Waves target composes the real frontend with the real WASM engine in an ordinary browser. It
+covers representative fragment/external-intent, history-back/error, and merged input/select
+behavior using semantic render/runtime evidence. Network-mode stories use deterministic canonical
+fixture fetching; native Tauri behavior and the Rust transport stack remain outside this lane.
 
 ## 4. Definition of Done for Each Ticket
 

--- a/engine-wasm/examples/generated/examples.ts
+++ b/engine-wasm/examples/generated/examples.ts
@@ -5,17 +5,37 @@
 export interface StoryStateExpectation {
   activeCardId?: string;
   focusedLinkIndex?: number;
+  focusedInputEditName?: string | null;
+  focusedInputEditValue?: string | null;
+  focusedSelectEditName?: string | null;
+  focusedSelectEditValue?: string | null;
   externalNavigationIntent?: string | null;
   nextCardVar?: string | null;
+}
+
+export interface StorySessionExpectation {
+  runMode?: 'local' | 'network';
+  navigationStatus?: string;
+  requestedUrl?: string | null;
+  finalUrl?: string | null;
+  activeCardId?: string | null;
+  focusedLinkIndex?: number;
+  externalNavigationIntent?: string | null;
+  lastError?: string | null;
 }
 
 export interface StoryExpectation {
   state: StoryStateExpectation;
   traceKinds?: string[];
+  session?: StorySessionExpectation;
+  statusIncludes?: string;
+  render?: { textIncludes: string[] };
 }
 
 export type StoryAction =
   | { type: 'key'; key: 'up' | 'down' | 'enter' }
+  | { type: 'keyboard'; key: 'ArrowUp' | 'ArrowDown' | 'Enter' | 'Backspace' | 'Escape' }
+  | { type: 'type-text'; text: string }
   | { type: 'back' }
   | { type: 'tick'; ms: 100 | 1000 }
   | { type: 'clear-intent' };
@@ -28,6 +48,8 @@ export interface StoryStep {
 export interface ExecutableStoryFlow {
   id: string;
   title: string;
+  target: 'host-sample' | 'waves-browser';
+  setup?: { runMode: 'local' | 'network' };
   workItems: string[];
   specItems: string[];
   initial: StoryExpectation;
@@ -189,6 +211,7 @@ export const EXAMPLES: HostExample[] = [
       {
         "id": "fragment-and-external-intent",
         "title": "Fragment navigation and external intent stay separate",
+        "target": "host-sample",
         "workItems": [
           "A2-01",
           "A2-02"
@@ -252,6 +275,103 @@ export const EXAMPLES: HostExample[] = [
             "action": {
               "type": "key",
               "key": "enter"
+            },
+            "expect": {
+              "state": {
+                "activeCardId": "home",
+                "focusedLinkIndex": 1,
+                "externalNavigationIntent": "http://example.com/other.wml"
+              },
+              "traceKinds": [
+                "ACTION_EXTERNAL"
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "id": "waves-fragment-and-external-intent",
+        "title": "Waves UI drives fragment navigation and captures external intent",
+        "target": "waves-browser",
+        "setup": {
+          "runMode": "local"
+        },
+        "workItems": [
+          "A2-01",
+          "A2-02"
+        ],
+        "specItems": [
+          "WML-R-006",
+          "WML-R-007"
+        ],
+        "initial": {
+          "state": {
+            "activeCardId": "home",
+            "focusedLinkIndex": 0,
+            "externalNavigationIntent": null
+          },
+          "session": {
+            "runMode": "local",
+            "navigationStatus": "loaded"
+          },
+          "render": {
+            "textIncludes": [
+              "WaveNav Host Harness",
+              "Go to next card"
+            ]
+          }
+        },
+        "steps": [
+          {
+            "action": {
+              "type": "key",
+              "key": "enter"
+            },
+            "expect": {
+              "state": {
+                "activeCardId": "next",
+                "focusedLinkIndex": 0
+              },
+              "traceKinds": [
+                "KEY",
+                "ACTION_FRAGMENT"
+              ],
+              "render": {
+                "textIncludes": [
+                  "Second card loaded.",
+                  "Return home"
+                ]
+              }
+            }
+          },
+          {
+            "action": {
+              "type": "key",
+              "key": "enter"
+            },
+            "expect": {
+              "state": {
+                "activeCardId": "home",
+                "focusedLinkIndex": 0
+              }
+            }
+          },
+          {
+            "action": {
+              "type": "keyboard",
+              "key": "ArrowDown"
+            },
+            "expect": {
+              "state": {
+                "activeCardId": "home",
+                "focusedLinkIndex": 1
+              }
+            }
+          },
+          {
+            "action": {
+              "type": "keyboard",
+              "key": "Enter"
             },
             "expect": {
               "state": {
@@ -370,6 +490,147 @@ export const EXAMPLES: HostExample[] = [
       "Re-enter Country edit, change the draft option, then press Escape and confirm the original committed option remains visible.",
       "Submit the card and confirm Waves captures the local-mode external intent without fetching."
     ],
+    "flows": [
+      {
+        "id": "waves-merged-select-and-input-edit",
+        "title": "Waves combines softkey focus with keyboard select and input editing",
+        "target": "waves-browser",
+        "setup": {
+          "runMode": "local"
+        },
+        "workItems": [
+          "A5-05",
+          "A5-06"
+        ],
+        "specItems": [
+          "WML-R-019",
+          "RQ-RMK-003",
+          "RQ-RMK-008"
+        ],
+        "initial": {
+          "state": {
+            "activeCardId": "profile",
+            "focusedLinkIndex": 0,
+            "focusedInputEditName": null,
+            "focusedSelectEditName": null
+          },
+          "render": {
+            "textIncludes": [
+              "Help",
+              "Jordan",
+              "PIN:",
+              "Review"
+            ]
+          }
+        },
+        "steps": [
+          {
+            "action": {
+              "type": "key",
+              "key": "down"
+            },
+            "expect": {
+              "state": {
+                "focusedLinkIndex": 1
+              }
+            }
+          },
+          {
+            "action": {
+              "type": "keyboard",
+              "key": "Enter"
+            },
+            "expect": {
+              "state": {
+                "focusedLinkIndex": 1,
+                "focusedSelectEditName": "Country",
+                "focusedSelectEditValue": "Jordan"
+              }
+            }
+          },
+          {
+            "action": {
+              "type": "keyboard",
+              "key": "ArrowDown"
+            },
+            "expect": {
+              "state": {
+                "focusedSelectEditName": "Country",
+                "focusedSelectEditValue": "France"
+              },
+              "render": {
+                "textIncludes": [
+                  "France"
+                ]
+              }
+            }
+          },
+          {
+            "action": {
+              "type": "keyboard",
+              "key": "Enter"
+            },
+            "expect": {
+              "state": {
+                "focusedLinkIndex": 1,
+                "focusedSelectEditName": null,
+                "focusedSelectEditValue": null
+              },
+              "render": {
+                "textIncludes": [
+                  "France"
+                ]
+              }
+            }
+          },
+          {
+            "action": {
+              "type": "key",
+              "key": "down"
+            },
+            "expect": {
+              "state": {
+                "focusedLinkIndex": 2
+              }
+            }
+          },
+          {
+            "action": {
+              "type": "type-text",
+              "text": "12"
+            },
+            "expect": {
+              "state": {
+                "focusedInputEditName": "pin",
+                "focusedInputEditValue": "12"
+              },
+              "render": {
+                "textIncludes": [
+                  "**"
+                ]
+              }
+            }
+          },
+          {
+            "action": {
+              "type": "keyboard",
+              "key": "Enter"
+            },
+            "expect": {
+              "state": {
+                "focusedInputEditName": null,
+                "focusedInputEditValue": null
+              },
+              "render": {
+                "textIncludes": [
+                  "**"
+                ]
+              }
+            }
+          }
+        ]
+      }
+    ],
     "wml": "<wml>\n  <card id=\"profile\" title=\"Select Navigation\">\n    <p><a href=\"#help\">Help</a></p>\n    <p>\n      Country:\n      <select name=\"Country\" title=\"Country\">\n        <option value=\"Jordan\">Jordan</option>\n        <option value=\"France\">France</option>\n        <option value=\"Germany\">Germany</option>\n        <option value=\"Japan\">Japan</option>\n      </select>\n    </p>\n    <p>PIN: <input name=\"pin\" value=\"\" type=\"password\"/></p>\n    <p><a href=\"#review\">Review</a></p>\n    <do type=\"accept\">\n      <go method=\"post\" href=\"/profile\">\n        <postfield name=\"Country\" value=\"$(Country)\"/>\n        <postfield name=\"pin\" value=\"$(pin)\"/>\n      </go>\n    </do>\n  </card>\n  <card id=\"help\" title=\"Help\">\n    <p>Use Enter to begin or commit select edit.</p>\n    <p>Use Escape to cancel select edit.</p>\n    <p><a href=\"#profile\">Back</a></p>\n  </card>\n  <card id=\"review\" title=\"Review\">\n    <p>Review card reached through normal focus navigation.</p>\n    <p><a href=\"#profile\">Back</a></p>\n  </card>\n</wml>\n"
   },
   {
@@ -435,6 +696,7 @@ export const EXAMPLES: HostExample[] = [
       {
         "id": "fragment-back-and-empty-history",
         "title": "Fragment history pops once and then reports empty",
+        "target": "host-sample",
         "workItems": [
           "A2-03"
         ],
@@ -495,6 +757,82 @@ export const EXAMPLES: HostExample[] = [
             }
           }
         ]
+      },
+      {
+        "id": "waves-fragment-back-and-empty-history",
+        "title": "Waves keyboard back pops fragment history and reports empty history",
+        "target": "waves-browser",
+        "setup": {
+          "runMode": "local"
+        },
+        "workItems": [
+          "A2-03"
+        ],
+        "specItems": [
+          "WML-R-008"
+        ],
+        "initial": {
+          "state": {
+            "activeCardId": "home",
+            "focusedLinkIndex": 0
+          },
+          "render": {
+            "textIncludes": [
+              "History baseline demo.",
+              "Go to next"
+            ]
+          }
+        },
+        "steps": [
+          {
+            "action": {
+              "type": "key",
+              "key": "enter"
+            },
+            "expect": {
+              "state": {
+                "activeCardId": "next",
+                "focusedLinkIndex": 0
+              },
+              "render": {
+                "textIncludes": [
+                  "Second card reached by fragment navigation."
+                ]
+              }
+            }
+          },
+          {
+            "action": {
+              "type": "back"
+            },
+            "expect": {
+              "state": {
+                "activeCardId": "home",
+                "focusedLinkIndex": 0
+              },
+              "traceKinds": [
+                "ACTION_BACK"
+              ],
+              "statusIncludes": "engine history"
+            }
+          },
+          {
+            "action": {
+              "type": "back"
+            },
+            "expect": {
+              "state": {
+                "activeCardId": "home",
+                "focusedLinkIndex": 0
+              },
+              "traceKinds": [
+                "ACTION_BACK",
+                "ACTION_BACK_EMPTY"
+              ],
+              "statusIncludes": "no back history"
+            }
+          }
+        ]
       }
     ],
     "wml": "<wml>\n  <card id=\"home\">\n    <p>History baseline demo.</p>\n    <a href=\"#next\">Go to next</a>\n  </card>\n  <card id=\"next\">\n    <p>Second card reached by fragment navigation.</p>\n    <a href=\"#home\">Return home via link</a>\n  </card>\n</wml>\n"
@@ -515,6 +853,65 @@ export const EXAMPLES: HostExample[] = [
       "Press Enter on \"Broken target\".",
       "Confirm status shows a key error and activeCardId remains home.",
       "Confirm focusedLinkIndex remains stable after the failed navigation."
+    ],
+    "flows": [
+      {
+        "id": "waves-network-missing-fragment-error",
+        "title": "Waves fixture fetch preserves state when fragment navigation fails",
+        "target": "waves-browser",
+        "setup": {
+          "runMode": "network"
+        },
+        "workItems": [
+          "A2-01"
+        ],
+        "specItems": [
+          "WML-R-006"
+        ],
+        "initial": {
+          "state": {
+            "activeCardId": "home",
+            "focusedLinkIndex": 0
+          },
+          "session": {
+            "runMode": "network",
+            "navigationStatus": "loaded",
+            "finalUrl": "http://fixtures.test/examples/missingFragment.wml"
+          },
+          "render": {
+            "textIncludes": [
+              "Missing fragment test",
+              "Broken target"
+            ]
+          }
+        },
+        "steps": [
+          {
+            "action": {
+              "type": "key",
+              "key": "enter"
+            },
+            "expect": {
+              "state": {
+                "activeCardId": "home",
+                "focusedLinkIndex": 0
+              },
+              "traceKinds": [
+                "KEY"
+              ],
+              "session": {
+                "navigationStatus": "error"
+              },
+              "statusIncludes": "Error:",
+              "render": {
+                "textIncludes": [
+                  "Broken target"
+                ]
+              }
+            }
+          }
+        ]
+      }
     ],
     "wml": "<wml>\n  <card id=\"home\">\n    <p>Missing fragment test</p>\n    <a href=\"#missing\">Broken target</a>\n  </card>\n</wml>\n"
   },
@@ -615,6 +1012,7 @@ export const EXAMPLES: HostExample[] = [
       {
         "id": "zero-timer-dispatch",
         "title": "Zero-value timer dispatches ontimer during card entry",
+        "target": "host-sample",
         "workItems": [
           "A5-03"
         ],

--- a/engine-wasm/examples/source/basic.flow.json
+++ b/engine-wasm/examples/source/basic.flow.json
@@ -58,6 +58,72 @@
           }
         }
       ]
+    },
+    {
+      "id": "waves-fragment-and-external-intent",
+      "title": "Waves UI drives fragment navigation and captures external intent",
+      "target": "waves-browser",
+      "setup": { "runMode": "local" },
+      "workItems": ["A2-01", "A2-02"],
+      "specItems": ["WML-R-006", "WML-R-007"],
+      "initial": {
+        "state": {
+          "activeCardId": "home",
+          "focusedLinkIndex": 0,
+          "externalNavigationIntent": null
+        },
+        "session": {
+          "runMode": "local",
+          "navigationStatus": "loaded"
+        },
+        "render": {
+          "textIncludes": ["WaveNav Host Harness", "Go to next card"]
+        }
+      },
+      "steps": [
+        {
+          "action": { "type": "key", "key": "enter" },
+          "expect": {
+            "state": {
+              "activeCardId": "next",
+              "focusedLinkIndex": 0
+            },
+            "render": {
+              "textIncludes": ["Second card loaded.", "Return home"]
+            },
+            "traceKinds": ["KEY", "ACTION_FRAGMENT"]
+          }
+        },
+        {
+          "action": { "type": "key", "key": "enter" },
+          "expect": {
+            "state": {
+              "activeCardId": "home",
+              "focusedLinkIndex": 0
+            }
+          }
+        },
+        {
+          "action": { "type": "keyboard", "key": "ArrowDown" },
+          "expect": {
+            "state": {
+              "activeCardId": "home",
+              "focusedLinkIndex": 1
+            }
+          }
+        },
+        {
+          "action": { "type": "keyboard", "key": "Enter" },
+          "expect": {
+            "state": {
+              "activeCardId": "home",
+              "focusedLinkIndex": 1,
+              "externalNavigationIntent": "http://example.com/other.wml"
+            },
+            "traceKinds": ["ACTION_EXTERNAL"]
+          }
+        }
+      ]
     }
   ]
 }

--- a/engine-wasm/examples/source/forms-select-navigation-local.flow.json
+++ b/engine-wasm/examples/source/forms-select-navigation-local.flow.json
@@ -1,0 +1,102 @@
+{
+  "version": 1,
+  "example": "formsSelectNavigationLocal",
+  "flows": [
+    {
+      "id": "waves-merged-select-and-input-edit",
+      "title": "Waves combines softkey focus with keyboard select and input editing",
+      "target": "waves-browser",
+      "setup": { "runMode": "local" },
+      "workItems": ["A5-05", "A5-06"],
+      "specItems": ["WML-R-019", "RQ-RMK-003", "RQ-RMK-008"],
+      "initial": {
+        "state": {
+          "activeCardId": "profile",
+          "focusedLinkIndex": 0,
+          "focusedInputEditName": null,
+          "focusedSelectEditName": null
+        },
+        "render": {
+          "textIncludes": ["Help", "Jordan", "PIN:", "Review"]
+        }
+      },
+      "steps": [
+        {
+          "action": { "type": "key", "key": "down" },
+          "expect": {
+            "state": {
+              "focusedLinkIndex": 1
+            }
+          }
+        },
+        {
+          "action": { "type": "keyboard", "key": "Enter" },
+          "expect": {
+            "state": {
+              "focusedLinkIndex": 1,
+              "focusedSelectEditName": "Country",
+              "focusedSelectEditValue": "Jordan"
+            }
+          }
+        },
+        {
+          "action": { "type": "keyboard", "key": "ArrowDown" },
+          "expect": {
+            "state": {
+              "focusedSelectEditName": "Country",
+              "focusedSelectEditValue": "France"
+            },
+            "render": {
+              "textIncludes": ["France"]
+            }
+          }
+        },
+        {
+          "action": { "type": "keyboard", "key": "Enter" },
+          "expect": {
+            "state": {
+              "focusedLinkIndex": 1,
+              "focusedSelectEditName": null,
+              "focusedSelectEditValue": null
+            },
+            "render": {
+              "textIncludes": ["France"]
+            }
+          }
+        },
+        {
+          "action": { "type": "key", "key": "down" },
+          "expect": {
+            "state": {
+              "focusedLinkIndex": 2
+            }
+          }
+        },
+        {
+          "action": { "type": "type-text", "text": "12" },
+          "expect": {
+            "state": {
+              "focusedInputEditName": "pin",
+              "focusedInputEditValue": "12"
+            },
+            "render": {
+              "textIncludes": ["**"]
+            }
+          }
+        },
+        {
+          "action": { "type": "keyboard", "key": "Enter" },
+          "expect": {
+            "state": {
+              "focusedInputEditName": null,
+              "focusedInputEditValue": null
+            },
+            "render": {
+              "textIncludes": ["**"]
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/engine-wasm/examples/source/history-back-stack.flow.json
+++ b/engine-wasm/examples/source/history-back-stack.flow.json
@@ -46,6 +46,59 @@
           }
         }
       ]
+    },
+    {
+      "id": "waves-fragment-back-and-empty-history",
+      "title": "Waves keyboard back pops fragment history and reports empty history",
+      "target": "waves-browser",
+      "setup": { "runMode": "local" },
+      "workItems": ["A2-03"],
+      "specItems": ["WML-R-008"],
+      "initial": {
+        "state": {
+          "activeCardId": "home",
+          "focusedLinkIndex": 0
+        },
+        "render": {
+          "textIncludes": ["History baseline demo.", "Go to next"]
+        }
+      },
+      "steps": [
+        {
+          "action": { "type": "key", "key": "enter" },
+          "expect": {
+            "state": {
+              "activeCardId": "next",
+              "focusedLinkIndex": 0
+            },
+            "render": {
+              "textIncludes": ["Second card reached by fragment navigation."]
+            }
+          }
+        },
+        {
+          "action": { "type": "back" },
+          "expect": {
+            "state": {
+              "activeCardId": "home",
+              "focusedLinkIndex": 0
+            },
+            "statusIncludes": "engine history",
+            "traceKinds": ["ACTION_BACK"]
+          }
+        },
+        {
+          "action": { "type": "back" },
+          "expect": {
+            "state": {
+              "activeCardId": "home",
+              "focusedLinkIndex": 0
+            },
+            "statusIncludes": "no back history",
+            "traceKinds": ["ACTION_BACK", "ACTION_BACK_EMPTY"]
+          }
+        }
+      ]
     }
   ]
 }

--- a/engine-wasm/examples/source/missing-fragment.flow.json
+++ b/engine-wasm/examples/source/missing-fragment.flow.json
@@ -1,0 +1,47 @@
+{
+  "version": 1,
+  "example": "missingFragment",
+  "flows": [
+    {
+      "id": "waves-network-missing-fragment-error",
+      "title": "Waves fixture fetch preserves state when fragment navigation fails",
+      "target": "waves-browser",
+      "setup": { "runMode": "network" },
+      "workItems": ["A2-01"],
+      "specItems": ["WML-R-006"],
+      "initial": {
+        "state": {
+          "activeCardId": "home",
+          "focusedLinkIndex": 0
+        },
+        "session": {
+          "runMode": "network",
+          "navigationStatus": "loaded",
+          "finalUrl": "http://fixtures.test/examples/missingFragment.wml"
+        },
+        "render": {
+          "textIncludes": ["Missing fragment test", "Broken target"]
+        }
+      },
+      "steps": [
+        {
+          "action": { "type": "key", "key": "enter" },
+          "expect": {
+            "state": {
+              "activeCardId": "home",
+              "focusedLinkIndex": 0
+            },
+            "session": {
+              "navigationStatus": "error"
+            },
+            "statusIncludes": "Error:",
+            "render": {
+              "textIncludes": ["Broken target"]
+            },
+            "traceKinds": ["KEY"]
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/engine-wasm/host-sample/README.md
+++ b/engine-wasm/host-sample/README.md
@@ -55,12 +55,15 @@ companion into `examples.ts`. A version 1 companion contains:
 
 - `example`: the generated example key (`basic`, `historyBackStack`, and so on)
 - one or more lower-kebab-case `flows`
+- optional `target`: `host-sample` (default) or `waves-browser`
+- optional Waves-only `setup.runMode`: `local` or `network`
 - exact `workItems` and `specItems` mappings; the union across flows must match the WML metadata
 - an `initial` expectation and one or more action/expectation steps
 - actions: `key` (`up`, `down`, `enter`), `back`, `tick` (`100` or `1000` ms), and
-  `clear-intent`
-- state assertions: `activeCardId`, `focusedLinkIndex`, `externalNavigationIntent`, and
-  `nextCardVar`
+  `clear-intent`; Waves flows can also use real `keyboard` presses and `type-text`
+- runtime state assertions including card/focus, focused input/select edit state, external intent,
+  and `nextCardVar`
+- Waves-only semantic `session`, `statusIncludes`, and rendered `textIncludes` assertions
 - optional `traceKinds`, matched as an ordered subsequence of engine trace entries
 
 Unknown example references/actions, malformed values, missing mappings, extra mappings, and stale
@@ -85,18 +88,27 @@ pnpm --dir engine-wasm/host-sample exec playwright install chromium
 pnpm test:story list
 pnpm test:story WML-R-007
 pnpm test:story A2-03
+pnpm test:story host-sample
+pnpm test:story:waves
 pnpm test:story all
 ```
 
-The command generates/validates the shared manifest, builds the production host sample, reserves an
-ephemeral localhost port, manages the Vite preview lifecycle, and drives the real WASM host through
-Playwright. No manual server setup is required.
+The command generates/validates the shared manifest and builds only the targets selected by the
+flow. `host-sample` drives the production engine sample. `waves-browser` builds a dedicated
+ordinary-browser entry that composes the real Waves frontend with the real WaveNav WASM engine and
+an in-memory deterministic fixture fetch adapter. Production Tauri startup still uses the generated
+Tauri host client.
+
+Each selected target receives an ephemeral localhost port and a unique temporary build directory,
+so concurrent worktrees and CI jobs do not share servers or build output. No manual server setup is
+required.
 
 Every run writes a stable summary under
 `engine-wasm/host-sample/test-results/story/<selector>/summary.json`. Failed flows also receive
-`failure.png`, `trace.zip`, and structured `evidence.json` containing runtime snapshots, engine
-trace entries, host events, and browser diagnostics. Override the root with
-`WAVES_STORY_OUTPUT_DIR`.
+`failure.png`, `trace.zip`, and structured `evidence.json` containing runtime snapshots, semantic
+render output, engine trace entries, host session state, and browser diagnostics. Override the root
+with a per-job `WAVES_STORY_OUTPUT_DIR` when intentionally running concurrent selectors in the same
+checkout.
 
 Exit codes are `0` for pass/list, `1` for assertion failures, `2` for usage or environment errors,
 and `3` when the requested ID has no executable coverage.

--- a/engine-wasm/host-sample/scripts/generate-example-manifest.mjs
+++ b/engine-wasm/host-sample/scripts/generate-example-manifest.mjs
@@ -13,11 +13,28 @@ const ID_PATTERN = /^[A-Z][A-Z0-9]*(?:-[A-Z0-9]+)+$/;
 const STATE_KEYS = new Set([
   'activeCardId',
   'focusedLinkIndex',
+  'focusedInputEditName',
+  'focusedInputEditValue',
+  'focusedSelectEditName',
+  'focusedSelectEditValue',
   'externalNavigationIntent',
   'nextCardVar'
 ]);
-const ACTION_TYPES = new Set(['key', 'back', 'tick', 'clear-intent']);
+const SESSION_KEYS = new Set([
+  'runMode',
+  'navigationStatus',
+  'requestedUrl',
+  'finalUrl',
+  'activeCardId',
+  'focusedLinkIndex',
+  'externalNavigationIntent',
+  'lastError'
+]);
+const ACTION_TYPES = new Set(['key', 'keyboard', 'type-text', 'back', 'tick', 'clear-intent']);
 const KEY_NAMES = new Set(['up', 'down', 'enter']);
+const KEYBOARD_NAMES = new Set(['ArrowUp', 'ArrowDown', 'Enter', 'Backspace', 'Escape']);
+const STORY_TARGETS = new Set(['host-sample', 'waves-browser']);
+const WAVES_RUN_MODES = new Set(['local', 'network']);
 
 function toCamelCase(value) {
   return value.replace(/[-_]+([a-zA-Z0-9])/g, (_, c) => c.toUpperCase());
@@ -175,10 +192,49 @@ function parseExpectedState(value, filename, location) {
   return state;
 }
 
+function parseExpectedSession(value, filename, location) {
+  const session = requireRecord(value, filename, location);
+  validateKeys(session, SESSION_KEYS, filename, location);
+  if (Object.keys(session).length === 0) {
+    throw new Error(`${filename}: ${location} needs at least one session assertion`);
+  }
+  for (const [key, expected] of Object.entries(session)) {
+    if (key === 'focusedLinkIndex') {
+      if (!Number.isInteger(expected) || expected < 0) {
+        throw new Error(`${filename}: ${location}.${key} must be a non-negative integer`);
+      }
+      continue;
+    }
+    if (expected !== null && typeof expected !== 'string') {
+      throw new Error(`${filename}: ${location}.${key} must be a string or null`);
+    }
+  }
+  return session;
+}
+
+function parseRenderExpectation(value, filename, location) {
+  const render = requireRecord(value, filename, location);
+  validateKeys(render, new Set(['textIncludes']), filename, location);
+  if (
+    !Array.isArray(render.textIncludes) ||
+    render.textIncludes.length === 0 ||
+    render.textIncludes.some((text) => typeof text !== 'string' || !text)
+  ) {
+    throw new Error(`${filename}: ${location}.textIncludes must be non-empty strings`);
+  }
+  return { textIncludes: render.textIncludes };
+}
+
 function parseExpectation(value, filename, location) {
   const expectation = requireRecord(value, filename, location);
-  validateKeys(expectation, new Set(['state', 'traceKinds']), filename, location);
+  validateKeys(
+    expectation,
+    new Set(['state', 'traceKinds', 'session', 'statusIncludes', 'render']),
+    filename,
+    location
+  );
   const state = parseExpectedState(expectation.state, filename, `${location}.state`);
+  const parsed = { state };
   let traceKinds;
   if (expectation.traceKinds !== undefined) {
     if (
@@ -189,13 +245,27 @@ function parseExpectation(value, filename, location) {
       throw new Error(`${filename}: ${location}.traceKinds must be non-empty trace kind strings`);
     }
     traceKinds = expectation.traceKinds.map((kind) => kind.trim());
+    parsed.traceKinds = traceKinds;
   }
-  return traceKinds ? { state, traceKinds } : { state };
+  if (expectation.session !== undefined) {
+    parsed.session = parseExpectedSession(expectation.session, filename, `${location}.session`);
+  }
+  if (expectation.statusIncludes !== undefined) {
+    parsed.statusIncludes = requireString(
+      expectation.statusIncludes,
+      filename,
+      `${location}.statusIncludes`
+    );
+  }
+  if (expectation.render !== undefined) {
+    parsed.render = parseRenderExpectation(expectation.render, filename, `${location}.render`);
+  }
+  return parsed;
 }
 
 function parseAction(value, filename, location) {
   const action = requireRecord(value, filename, location);
-  validateKeys(action, new Set(['type', 'key', 'ms']), filename, location);
+  validateKeys(action, new Set(['type', 'key', 'ms', 'text']), filename, location);
   if (!ACTION_TYPES.has(action.type)) {
     throw new Error(`${filename}: ${location}.type has unknown action "${String(action.type)}"`);
   }
@@ -204,14 +274,34 @@ function parseAction(value, filename, location) {
     if (!KEY_NAMES.has(action.key)) {
       throw new Error(`${filename}: ${location}.key must be up, down, or enter`);
     }
-    if (action.ms !== undefined) {
-      throw new Error(`${filename}: ${location}.ms is only valid for tick actions`);
+    if (action.ms !== undefined || action.text !== undefined) {
+      throw new Error(`${filename}: ${location} key actions only accept type and key`);
     }
     return { type: action.type, key: action.key };
   }
 
-  if (action.key !== undefined) {
-    throw new Error(`${filename}: ${location}.key is only valid for key actions`);
+  if (action.type === 'keyboard') {
+    if (!KEYBOARD_NAMES.has(action.key)) {
+      throw new Error(
+        `${filename}: ${location}.key must be ArrowUp, ArrowDown, Enter, Backspace, or Escape`
+      );
+    }
+    if (action.ms !== undefined || action.text !== undefined) {
+      throw new Error(`${filename}: ${location} keyboard actions only accept type and key`);
+    }
+    return { type: action.type, key: action.key };
+  }
+
+  if (action.type === 'type-text') {
+    const text = requireString(action.text, filename, `${location}.text`);
+    if (action.key !== undefined || action.ms !== undefined) {
+      throw new Error(`${filename}: ${location} type-text actions only accept type and text`);
+    }
+    return { type: action.type, text };
+  }
+
+  if (action.key !== undefined || action.text !== undefined) {
+    throw new Error(`${filename}: ${location} only key/keyboard/type-text actions accept input`);
   }
   if (action.type === 'tick') {
     if (action.ms !== 100 && action.ms !== 1000) {
@@ -223,6 +313,21 @@ function parseAction(value, filename, location) {
     throw new Error(`${filename}: ${location}.ms is only valid for tick actions`);
   }
   return { type: action.type };
+}
+
+function parseStorySetup(value, target, filename, location) {
+  if (value === undefined) {
+    return undefined;
+  }
+  const setup = requireRecord(value, filename, location);
+  validateKeys(setup, new Set(['runMode']), filename, location);
+  if (target !== 'waves-browser') {
+    throw new Error(`${filename}: ${location} is only valid for waves-browser flows`);
+  }
+  if (!WAVES_RUN_MODES.has(setup.runMode)) {
+    throw new Error(`${filename}: ${location}.runMode must be local or network`);
+  }
+  return { runMode: setup.runMode };
 }
 
 export function parseExecutableFlow(source, filename, expectedExampleKey) {
@@ -253,7 +358,7 @@ export function parseExecutableFlow(source, filename, expectedExampleKey) {
     const flow = requireRecord(rawFlow, filename, location);
     validateKeys(
       flow,
-      new Set(['id', 'title', 'workItems', 'specItems', 'initial', 'steps']),
+      new Set(['id', 'title', 'target', 'setup', 'workItems', 'specItems', 'initial', 'steps']),
       filename,
       location
     );
@@ -266,6 +371,11 @@ export function parseExecutableFlow(source, filename, expectedExampleKey) {
     }
     seenFlowIds.add(id);
     const title = requireString(flow.title, filename, `${location}.title`);
+    const target = flow.target ?? 'host-sample';
+    if (!STORY_TARGETS.has(target)) {
+      throw new Error(`${filename}: ${location}.target must be host-sample or waves-browser`);
+    }
+    const setup = parseStorySetup(flow.setup, target, filename, `${location}.setup`);
     const workItems = validateIdList(flow.workItems, filename, `${location}.workItems`);
     const specItems = validateIdList(flow.specItems, filename, `${location}.specItems`);
     const initial = parseExpectation(flow.initial, filename, `${location}.initial`);
@@ -281,7 +391,7 @@ export function parseExecutableFlow(source, filename, expectedExampleKey) {
         expect: parseExpectation(step.expect, filename, `${stepLocation}.expect`)
       };
     });
-    return { id, title, workItems, specItems, initial, steps };
+    return { id, title, target, ...(setup ? { setup } : {}), workItems, specItems, initial, steps };
   });
 
   return { version: 1, example, flows };
@@ -369,17 +479,37 @@ export function renderManifest(records) {
 export interface StoryStateExpectation {
   activeCardId?: string;
   focusedLinkIndex?: number;
+  focusedInputEditName?: string | null;
+  focusedInputEditValue?: string | null;
+  focusedSelectEditName?: string | null;
+  focusedSelectEditValue?: string | null;
   externalNavigationIntent?: string | null;
   nextCardVar?: string | null;
+}
+
+export interface StorySessionExpectation {
+  runMode?: 'local' | 'network';
+  navigationStatus?: string;
+  requestedUrl?: string | null;
+  finalUrl?: string | null;
+  activeCardId?: string | null;
+  focusedLinkIndex?: number;
+  externalNavigationIntent?: string | null;
+  lastError?: string | null;
 }
 
 export interface StoryExpectation {
   state: StoryStateExpectation;
   traceKinds?: string[];
+  session?: StorySessionExpectation;
+  statusIncludes?: string;
+  render?: { textIncludes: string[] };
 }
 
 export type StoryAction =
   | { type: 'key'; key: 'up' | 'down' | 'enter' }
+  | { type: 'keyboard'; key: 'ArrowUp' | 'ArrowDown' | 'Enter' | 'Backspace' | 'Escape' }
+  | { type: 'type-text'; text: string }
   | { type: 'back' }
   | { type: 'tick'; ms: 100 | 1000 }
   | { type: 'clear-intent' };
@@ -392,6 +522,8 @@ export interface StoryStep {
 export interface ExecutableStoryFlow {
   id: string;
   title: string;
+  target: 'host-sample' | 'waves-browser';
+  setup?: { runMode: 'local' | 'network' };
   workItems: string[];
   specItems: string[];
   initial: StoryExpectation;

--- a/engine-wasm/host-sample/scripts/story-runner-lib.mjs
+++ b/engine-wasm/host-sample/scripts/story-runner-lib.mjs
@@ -17,6 +17,12 @@ export function selectExecutableStories(records, selector) {
   if (selector === 'all') {
     return stories;
   }
+  if (selector === 'waves' || selector === 'waves-browser') {
+    return stories.filter((story) => story.flow.target === 'waves-browser');
+  }
+  if (selector === 'host-sample') {
+    return stories.filter((story) => (story.flow.target ?? 'host-sample') === 'host-sample');
+  }
 
   const normalized = selector.toUpperCase();
   const selected = stories.filter((story) =>
@@ -51,6 +57,7 @@ export function traceContainsSubsequence(actualKinds, expectedKinds) {
 }
 
 export function assertStoryExpectation(evidence, expectation, label) {
+  assert.ok(evidence.snapshot, `${label}: runtime snapshot is unavailable`);
   for (const [key, expected] of Object.entries(expectation.state)) {
     const actual = evidence.snapshot[key] ?? null;
     assert.deepEqual(actual, expected, `${label}: snapshot.${key}`);
@@ -62,6 +69,31 @@ export function assertStoryExpectation(evidence, expectation, label) {
       `${label}: expected trace subsequence ${expectation.traceKinds.join(' -> ')}, got ${actualKinds.join(' -> ')}`
     );
   }
+  if (expectation.session) {
+    assert.ok(evidence.session, `${label}: host session evidence is unavailable`);
+    for (const [key, expected] of Object.entries(expectation.session)) {
+      const actual = evidence.session[key] ?? null;
+      assert.deepEqual(actual, expected, `${label}: session.${key}`);
+    }
+  }
+  if (expectation.statusIncludes) {
+    assert.match(
+      evidence.status ?? '',
+      new RegExp(escapeRegExp(expectation.statusIncludes)),
+      `${label}: status`
+    );
+  }
+  if (expectation.render) {
+    assert.ok(evidence.render, `${label}: semantic render evidence is unavailable`);
+    const actualText = normalizeRenderText(evidence.render.draw.map((command) => command.text));
+    for (const expectedText of expectation.render.textIncludes) {
+      const normalizedExpected = normalizeRenderText([expectedText]);
+      assert.ok(
+        actualText.includes(normalizedExpected),
+        `${label}: expected render text to include "${expectedText}", got "${actualText}"`
+      );
+    }
+  }
 }
 
 export function storyListLines(records) {
@@ -71,6 +103,9 @@ export function storyListLines(records) {
   }
   return stories.map(
     ({ example, flow }) =>
-      `${example.key}/${flow.id} | ${[...flow.workItems, ...flow.specItems].join(', ')} | ${flow.title}`
+      `${example.key}/${flow.id} [${flow.target ?? 'host-sample'}] | ${[...flow.workItems, ...flow.specItems].join(', ')} | ${flow.title}`
   );
 }
+
+const escapeRegExp = (value) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+const normalizeRenderText = (parts) => parts.join(' ').replace(/\s+/g, ' ').trim();

--- a/engine-wasm/host-sample/scripts/test-story.mjs
+++ b/engine-wasm/host-sample/scripts/test-story.mjs
@@ -1,4 +1,4 @@
-import { mkdir, rm, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { createServer as createNetServer } from 'node:net';
 import os from 'node:os';
 import path from 'node:path';
@@ -17,14 +17,28 @@ const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
 const HOST_SAMPLE_DIR = path.resolve(SCRIPT_DIR, '..');
 const ENGINE_WASM_DIR = path.resolve(HOST_SAMPLE_DIR, '..');
 const REPO_ROOT = path.resolve(ENGINE_WASM_DIR, '..');
+const BROWSER_FRONTEND_DIR = path.join(REPO_ROOT, 'browser', 'frontend');
 const DEFAULT_OUTPUT_ROOT = path.join(HOST_SAMPLE_DIR, 'test-results', 'story');
-const STORY_DIST_DIR = path.join(HOST_SAMPLE_DIR, '.generated', 'story-dist');
 const FAILURE_STATUS_PATTERN = /^(Boot|Load|Key|Tick|Auto tick) error:/i;
+const STORY_TARGETS = {
+  'host-sample': {
+    root: HOST_SAMPLE_DIR,
+    configFile: path.join(HOST_SAMPLE_DIR, 'vite.config.ts'),
+    entry: 'index.html'
+  },
+  'waves-browser': {
+    root: BROWSER_FRONTEND_DIR,
+    configFile: path.join(BROWSER_FRONTEND_DIR, 'vite.config.ts'),
+    entry: 'browser-story.html'
+  }
+};
 
 function usage() {
   console.log(`Usage:
   pnpm test:story list
   pnpm test:story all
+  pnpm test:story host-sample
+  pnpm test:story waves
   pnpm test:story <work-item-or-spec-id>
 
 Exit codes: 0 pass/list, 1 flow failure, 2 usage/configuration error, 3 no executable coverage.`);
@@ -59,7 +73,9 @@ function deterministicEvidence(evidence) {
     activeExampleKey: evidence.activeExampleKey,
     snapshot: evidence.snapshot,
     traceEntries: evidence.traceEntries,
-    status: evidence.status
+    status: evidence.status,
+    session: evidence.session,
+    render: evidence.render
   };
 }
 
@@ -72,13 +88,32 @@ async function collectEvidence(page) {
   });
 }
 
-async function applyAction(page, action) {
+async function applyAction(page, action, target) {
   if (action.type === 'key') {
-    await page.locator(`#press-${action.key}`).click();
+    const selector =
+      target === 'waves-browser'
+        ? `#btn-${action.key === 'enter' ? 'enter' : action.key}`
+        : `#press-${action.key}`;
+    await page.locator(selector).click();
+    return;
+  }
+  if (action.type === 'keyboard') {
+    await page.locator(target === 'waves-browser' ? '#viewport' : 'body').focus();
+    await page.keyboard.press(action.key);
+    return;
+  }
+  if (action.type === 'type-text') {
+    await page.locator(target === 'waves-browser' ? '#viewport' : 'body').focus();
+    await page.keyboard.type(action.text);
     return;
   }
   if (action.type === 'back') {
-    await page.locator('#press-back').click();
+    if (target === 'waves-browser') {
+      await page.locator('#viewport').focus();
+      await page.keyboard.press('Backspace');
+    } else {
+      await page.locator('#press-back').click();
+    }
     return;
   }
   if (action.type === 'tick') {
@@ -92,11 +127,72 @@ async function applyAction(page, action) {
     }
     throw new Error(`Host controls do not expose a deterministic ${action.ms}ms tick`);
   }
-  await page.locator('#clear-intent').click();
+  await page.locator(target === 'waves-browser' ? '#btn-clear-intent' : '#clear-intent').click();
+}
+
+async function assertExpectationEventually(page, expectation, label) {
+  const deadline = Date.now() + 5_000;
+  let lastError;
+  let evidence;
+  while (Date.now() < deadline) {
+    evidence = await collectEvidence(page);
+    try {
+      assertStoryExpectation(evidence, expectation, label);
+      return evidence;
+    } catch (error) {
+      lastError = error;
+      await new Promise((resolve) => {
+        setTimeout(resolve, 20);
+      });
+    }
+  }
+  throw lastError ?? new Error(`${label}: expectation did not settle`);
+}
+
+async function prepareStory(page, story) {
+  const target = story.flow.target ?? 'host-sample';
+  if (target === 'host-sample') {
+    await page.locator('#example-select').selectOption(story.example.key);
+    return;
+  }
+
+  await page.locator('#local-example').selectOption(story.example.key);
+  const localBaseUrl = `http://local.test/examples/${story.example.key}.wml`;
+  await waitForWavesDeck(page, story.example.key, localBaseUrl);
+
+  if (story.flow.setup?.runMode === 'network') {
+    await page.locator('#run-mode').selectOption('network');
+    const fixtureUrl = `http://fixtures.test/examples/${encodeURIComponent(story.example.key)}.wml`;
+    await page.locator('#fetch-url').fill(fixtureUrl);
+    await page.locator('#btn-fetch-url').click();
+    await waitForWavesDeck(page, story.example.key, fixtureUrl);
+  }
+
+  await page.locator('#viewport').focus();
+}
+
+async function waitForWavesDeck(page, exampleKey, expectedBaseUrl) {
+  await page.waitForFunction(
+    ({ key, baseUrl }) => {
+      const bridge = window.__WAVENAV_STORY_EVIDENCE__;
+      if (!bridge) {
+        return false;
+      }
+      const evidence = bridge.collect();
+      return (
+        evidence.activeExampleKey === key &&
+        evidence.snapshot?.baseUrl === baseUrl &&
+        evidence.session?.navigationStatus === 'loaded'
+      );
+    },
+    { key: exampleKey, baseUrl: expectedBaseUrl },
+    { timeout: 10_000 }
+  );
 }
 
 async function runStory(browser, baseUrl, story, artifactRoot) {
   const storyName = `${story.example.key}--${story.flow.id}`;
+  const target = story.flow.target ?? 'host-sample';
   const storyDir = path.join(artifactRoot, storyName);
   const browserSignals = [];
   const context = await browser.newContext({ viewport: { width: 1280, height: 900 } });
@@ -129,6 +225,7 @@ async function runStory(browser, baseUrl, story, artifactRoot) {
     example: story.example.key,
     flow: story.flow.id,
     title: story.flow.title,
+    target,
     workItems: story.flow.workItems,
     specItems: story.flow.specItems,
     status: 'passed',
@@ -140,19 +237,25 @@ async function runStory(browser, baseUrl, story, artifactRoot) {
     await page.waitForFunction(() => window.__WAVENAV_STORY_EVIDENCE__ !== undefined, null, {
       timeout: 10_000
     });
-    await page.locator('#example-select').selectOption(story.example.key);
+    await prepareStory(page, story);
 
-    let evidence = await collectEvidence(page);
-    assertStoryExpectation(evidence, story.flow.initial, `${storyName} initial`);
+    let evidence = await assertExpectationEventually(
+      page,
+      story.flow.initial,
+      `${storyName} initial`
+    );
     result.steps.push({ index: 0, phase: 'initial', evidence: deterministicEvidence(evidence) });
 
     for (const [index, step] of story.flow.steps.entries()) {
-      await applyAction(page, step.action);
-      evidence = await collectEvidence(page);
-      if (FAILURE_STATUS_PATTERN.test(evidence.status)) {
+      await applyAction(page, step.action, target);
+      evidence = await assertExpectationEventually(
+        page,
+        step.expect,
+        `${storyName} step ${index + 1}`
+      );
+      if (target === 'host-sample' && FAILURE_STATUS_PATTERN.test(evidence.status)) {
         throw new Error(`${storyName} step ${index + 1}: host reported "${evidence.status}"`);
       }
-      assertStoryExpectation(evidence, step.expect, `${storyName} step ${index + 1}`);
       result.steps.push({
         index: index + 1,
         action: step.action,
@@ -192,8 +295,8 @@ async function runStory(browser, baseUrl, story, artifactRoot) {
   }
 }
 
-async function startHostServer() {
-  const port = await new Promise((resolve, reject) => {
+async function reservePort() {
+  return new Promise((resolve, reject) => {
     const reservation = createNetServer();
     reservation.once('error', reject);
     reservation.listen(0, '127.0.0.1', () => {
@@ -212,22 +315,33 @@ async function startHostServer() {
       });
     });
   });
+}
+
+async function startTargetServer(target, tempRoot) {
+  const config = STORY_TARGETS[target];
+  if (!config) {
+    throw new Error(`Unknown story target: ${target}`);
+  }
+  const port = await reservePort();
+  const outDir = path.join(tempRoot, target);
+  const build = {
+    outDir,
+    emptyOutDir: true,
+    ...(target === 'waves-browser'
+      ? { rollupOptions: { input: path.join(config.root, config.entry) } }
+      : {})
+  };
   await buildVite({
-    root: HOST_SAMPLE_DIR,
-    configFile: path.join(HOST_SAMPLE_DIR, 'vite.config.ts'),
+    root: config.root,
+    configFile: config.configFile,
     logLevel: 'error',
-    build: {
-      outDir: STORY_DIST_DIR,
-      emptyOutDir: true
-    }
+    build
   });
   const server = await previewVite({
-    root: HOST_SAMPLE_DIR,
-    configFile: path.join(HOST_SAMPLE_DIR, 'vite.config.ts'),
+    root: config.root,
+    configFile: config.configFile,
     logLevel: 'error',
-    build: {
-      outDir: STORY_DIST_DIR
-    },
+    build: { outDir },
     preview: {
       host: '127.0.0.1',
       port,
@@ -237,9 +351,37 @@ async function startHostServer() {
   const address = server.httpServer?.address();
   if (!address || typeof address === 'string') {
     await server.close();
-    throw new Error('Vite preview did not expose a local TCP address');
+    throw new Error(`Vite preview did not expose a local TCP address for ${target}`);
   }
-  return { server, baseUrl: `http://127.0.0.1:${address.port}/` };
+  return {
+    server,
+    baseUrl: `http://127.0.0.1:${address.port}/${target === 'waves-browser' ? config.entry : ''}`
+  };
+}
+
+async function startTargetServers(stories) {
+  const tempRoot = await mkdtemp(path.join(os.tmpdir(), 'waves-story-build-'));
+  const targets = [...new Set(stories.map((story) => story.flow.target ?? 'host-sample'))];
+  const servers = new Map();
+  try {
+    for (const target of targets) {
+      servers.set(target, await startTargetServer(target, tempRoot));
+    }
+  } catch (error) {
+    for (const { server } of servers.values()) {
+      await server.close();
+    }
+    await rm(tempRoot, { recursive: true, force: true });
+    throw error;
+  }
+  return { servers, tempRoot };
+}
+
+async function closeTargetServers(servers, tempRoot) {
+  for (const { server } of servers.values()) {
+    await server.close();
+  }
+  await rm(tempRoot, { recursive: true, force: true });
 }
 
 async function main() {
@@ -282,17 +424,22 @@ async function main() {
   await rm(outputRoot, { recursive: true, force: true });
   await mkdir(outputRoot, { recursive: true });
 
-  const { server, baseUrl } = await startHostServer();
+  const { servers, tempRoot } = await startTargetServers(stories);
   let browser;
   const results = [];
   try {
     browser = await chromium.launch({ headless: true });
     for (const story of stories) {
-      results.push(await runStory(browser, baseUrl, story, outputRoot));
+      const target = story.flow.target ?? 'host-sample';
+      const targetServer = servers.get(target);
+      if (!targetServer) {
+        throw new Error(`No running story server for ${target}`);
+      }
+      results.push(await runStory(browser, targetServer.baseUrl, story, outputRoot));
     }
   } finally {
     await browser?.close();
-    await server.close();
+    await closeTargetServers(servers, tempRoot);
   }
 
   const failed = results.filter((result) => result.status === 'failed');

--- a/engine-wasm/host-sample/scripts/tests/generate-example-manifest.test.mjs
+++ b/engine-wasm/host-sample/scripts/tests/generate-example-manifest.test.mjs
@@ -64,6 +64,36 @@ test('rejects unknown executable actions deterministically', () => {
   );
 });
 
+test('parses waves-browser target setup, keyboard actions, and semantic expectations', () => {
+  const document = validFlow({
+    target: 'waves-browser',
+    setup: { runMode: 'network' },
+    initial: {
+      state: { activeCardId: 'home' },
+      session: { navigationStatus: 'loaded' },
+      render: { textIncludes: ['Home'] }
+    },
+    steps: [
+      {
+        action: { type: 'keyboard', key: 'Enter' },
+        expect: {
+          state: { activeCardId: 'home' },
+          statusIncludes: 'loaded'
+        }
+      }
+    ]
+  });
+
+  const parsed = parseExecutableFlow(
+    JSON.stringify(document),
+    'test-example.flow.json',
+    'testExample'
+  );
+  assert.equal(parsed.flows[0].target, 'waves-browser');
+  assert.deepEqual(parsed.flows[0].setup, { runMode: 'network' });
+  assert.deepEqual(parsed.flows[0].initial.render, { textIncludes: ['Home'] });
+});
+
 test('rejects flow companions for examples that do not exist', async () => {
   const examplesDir = await mkdtemp(path.join(os.tmpdir(), 'wavenav-examples-'));
   await writeFile(path.join(examplesDir, 'unknown.flow.json'), JSON.stringify(validFlow()), 'utf8');

--- a/engine-wasm/host-sample/scripts/tests/story-runner-lib.test.mjs
+++ b/engine-wasm/host-sample/scripts/tests/story-runner-lib.test.mjs
@@ -15,6 +15,13 @@ const records = [
     flows: [
       {
         id: 'smoke',
+        target: 'host-sample',
+        workItems: ['R0-10'],
+        specItems: ['WML-R-007']
+      },
+      {
+        id: 'waves-smoke',
+        target: 'waves-browser',
         workItems: ['R0-10'],
         specItems: ['WML-R-007']
       }
@@ -28,8 +35,13 @@ const records = [
 ];
 
 test('selects executable stories by work item or spec item, case-insensitively', () => {
-  assert.equal(selectExecutableStories(records, 'r0-10').length, 1);
-  assert.equal(selectExecutableStories(records, 'WML-R-007').length, 1);
+  assert.equal(selectExecutableStories(records, 'r0-10').length, 2);
+  assert.equal(selectExecutableStories(records, 'WML-R-007').length, 2);
+});
+
+test('selects fast target-specific story lanes', () => {
+  assert.equal(selectExecutableStories(records, 'host-sample').length, 1);
+  assert.equal(selectExecutableStories(records, 'waves').length, 1);
 });
 
 test('reports an explicit metadata-only coverage gap', () => {
@@ -76,5 +88,36 @@ test('asserts structured runtime state and trace evidence', () => {
   assert.throws(
     () => assertStoryExpectation(evidence, { state: { activeCardId: 'home' } }, 'test'),
     /snapshot.activeCardId/
+  );
+});
+
+test('asserts Waves host session, status, and semantic render evidence', () => {
+  const evidence = {
+    snapshot: {
+      activeCardId: 'home',
+      focusedLinkIndex: 0
+    },
+    traceEntries: [],
+    session: {
+      runMode: 'network',
+      navigationStatus: 'error'
+    },
+    status: 'Error: card not found',
+    render: {
+      draw: [{ type: 'link', x: 0, y: 0, text: 'Broken target', focused: true, href: '#missing' }]
+    }
+  };
+
+  assert.doesNotThrow(() =>
+    assertStoryExpectation(
+      evidence,
+      {
+        state: { activeCardId: 'home' },
+        session: { navigationStatus: 'error' },
+        statusIncludes: 'card not found',
+        render: { textIncludes: ['Broken target'] }
+      },
+      'waves'
+    )
   );
 });

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "version:set": "node scripts/set-release-version.mjs",
     "test:node": "pnpm -r --if-present run test",
     "test:story": "pnpm --dir engine-wasm/host-sample run test:story",
+    "test:story:waves": "pnpm test:story waves",
     "build:node": "pnpm -r --if-present run build",
     "typecheck:node": "pnpm -r --if-present run typecheck"
   },


### PR DESCRIPTION
## Summary

- add ordinary-browser story testing for the real Waves frontend
- preserve production Tauri startup and runtime-layer boundaries
- provide a fast, deterministic CI lane with semantic runtime and render assertions

## What Changed

- extract an injectable frontend composition root and add a WASM-backed browser test host
- add deterministic canonical fixture fetching and a test-only observation bridge
- extend executable flows with target, keyboard, form, session, status, render, and trace assertions
- add navigation, back/error, and merged-control Waves flows
- isolate target builds with ephemeral ports and unique temporary output
- fix unhandled Backspace routing through focused-control editing

## Validation

- `wasm-pack build --target web --out-dir ../pkg`
- `pnpm test:node`
- `pnpm typecheck:node`
- `pnpm lint:node`
- `pnpm build:node`
- `pnpm format:check:node`
- `pnpm --dir engine-wasm/host-sample run examples:check`
- `pnpm test:story host-sample` (3 passed)
- `pnpm test:story:waves` (4 passed)
- `pnpm test:story all` (7 passed)

## Scope Notes

- production Tauri startup still uses the generated Tauri host client
- the semantic observation bridge exists only in the browser-test entry
- deterministic network-mode stories do not replace native Tauri or Rust transport integration coverage
- no native WebdriverIO/Tauri plugin or transport behavior was added
