### PR TITLE
feat(transport): implement TRN-701 CDPD/IPv4 WDP evidence

### DIFF
--- a/docs/knowledge-graph/context-packs/TRN-7.md
+++ b/docs/knowledge-graph/context-packs/TRN-7.md
@@ -40,7 +40,7 @@ Exit gates:
 
 ### TRN-701: Effective WDP service, addressing, port, and bearer profile
 
-- Status: `in-progress`
+- Status: `done`
 - Owner layers: `transport-rust`, `qa`
 - Source families: `wdp`, `wdp-wcmp-adaptation`
 - Existing tickets: `T0-19`
@@ -193,295 +193,295 @@ Evidence commands:
   - Source: `WAP-200-WDP` §5.2 (5.2 General Description of the WDP Protocol)
   - Parents: `WDP-C-001`, `WDP-CT-C-002`
   - Requirements: `RQ-TRN-001`, `RQ-TRN-002`
-  - Fixture: `WDP-FX-ADAPTATION-LAYER-BOUNDARY` (`transport-boundary`, `planned`)
+  - Fixture: `WDP-FX-ADAPTATION-LAYER-BOUNDARY` (`transport-boundary`, `implemented`)
 - **WDP-CL-APPLICATION-PORT-ADDRESSING** — Provide source and destination port addressing for the higher-layer protocol or application above WDP.
   - Family: `wdp`; force: `implicit-must`; level: `required`
   - Source: `WAP-200-WDP` §5.1 (5.1 Reference Model)
   - Parents: `WDP-CORE-C-001`, `WDP-NA-C-006`, `WDP-NA-C-007`
   - Requirements: `RQ-TRN-001`, `RQ-TRN-003`
-  - Fixture: `WDP-FX-APPLICATION-PORT-ADDRESSING` (`transport-boundary`, `planned`)
+  - Fixture: `WDP-FX-APPLICATION-PORT-ADDRESSING` (`transport-boundary`, `implemented`)
 - **WDP-CL-BEARER-TRANSPARENCY** — Keep bearer-specific mechanics below the transport service access point so upper layers can operate transparently.
   - Family: `wdp`; force: `implicit-must`; level: `required`
   - Source: `WAP-200-WDP` §5.1 (5.1 Reference Model)
   - Parents: `WDP-C-001`, `WDP-CORE-C-001`
   - Requirements: `RQ-TRN-001`
-  - Fixture: `WDP-FX-BEARER-TRANSPARENCY` (`transport-boundary`, `planned`)
+  - Fixture: `WDP-FX-BEARER-TRANSPARENCY` (`transport-boundary`, `implemented`)
 - **WDP-CL-CDPD-UDP-IP-PROFILE** — Declare the selected CDPD bearer as an IP-capable profile whose WDP datagram service is UDP over IPv4.
   - Family: `wdp`; force: `implicit-must`; level: `required`
   - Source: `WAP-200-WDP` §5.4.3 (5.4.3 WDP over CDPD)
   - Parents: `WDP-CT-C-002`, `WDP-NA-C-003`
   - Requirements: `RQ-TRN-002`, `RQ-TRN-003`
-  - Fixture: `WDP-FX-CDPD-UDP-IP-PROFILE` (`transport-boundary`, `planned`)
+  - Fixture: `WDP-FX-CDPD-UDP-IP-PROFILE` (`transport-boundary`, `implemented`)
 - **WDP-CL-CONSISTENT-TRANSPORT-SERVICE** — Expose the same WDP transport service and primitive contract to upper WAP layers across supported bearer adaptations.
   - Family: `wdp`; force: `implicit-must`; level: `required`
   - Source: `WAP-200-WDP` §5.1 (5.1 Reference Model)
   - Parents: `WDP-C-001`, `WDP-CORE-C-001`
   - Requirements: `RQ-TRN-001`
-  - Fixture: `WDP-FX-CONSISTENT-TRANSPORT-SERVICE` (`transport-boundary`, `planned`)
+  - Fixture: `WDP-FX-CONSISTENT-TRANSPORT-SERVICE` (`transport-boundary`, `implemented`)
 - **WDP-CL-DESTINATION-ADDRESS-SEMANTICS** — Treat the destination address as the network identity of the receiving device for the submitted user data.
   - Family: `wdp`; force: `implicit-must`; level: `required`
   - Source: `WAP-200-WDP` §6.3.1.1 (6.3.1.1 T-DUnitdata)
   - Parents: `WDP-PF-C-001`, `WDP-PF-C-002`, `WDP-NA-C-000`, `WDP-NA-C-003`
   - Requirements: `RQ-TRN-001`, `RQ-TRN-003`
-  - Fixture: `WDP-FX-DESTINATION-ADDRESS-SEMANTICS` (`transport-boundary`, `planned`)
+  - Fixture: `WDP-FX-DESTINATION-ADDRESS-SEMANTICS` (`transport-boundary`, `implemented`)
 - **WDP-CL-DESTINATION-PORT-SEMANTICS** — Bind the destination port to the destination application or upper-layer protocol for that communication instance.
   - Family: `wdp`; force: `implicit-must`; level: `required`
   - Source: `WAP-200-WDP` §6.3.1.1 (6.3.1.1 T-DUnitdata)
   - Parents: `WDP-PF-C-001`, `WDP-PF-C-002`, `WDP-NA-C-006`
   - Requirements: `RQ-TRN-001`, `RQ-TRN-003`
-  - Fixture: `WDP-FX-DESTINATION-PORT-SEMANTICS` (`transport-boundary`, `planned`)
+  - Fixture: `WDP-FX-DESTINATION-PORT-SEMANTICS` (`transport-boundary`, `implemented`)
 - **WDP-CL-IP-BEARER-REQUIRES-UDP** — Use UDP as the WDP protocol whenever the selected bearer provides IP.
   - Family: `wdp`; force: `explicit-must`; level: `required`
   - Source: `WAP-200-WDP` §5.3 (5.3 WDP Static Conformance Clause)
   - Parents: `WDP-C-001`, `WDP-CT-C-002`, `WDP-NA-C-003`
   - Requirements: `RQ-TRN-001`, `RQ-TRN-002`, `RQ-TRN-003`
-  - Fixture: `WDP-FX-IP-BEARER-REQUIRES-UDP` (`transport-boundary`, `planned`)
+  - Fixture: `WDP-FX-IP-BEARER-REQUIRES-UDP` (`transport-boundary`, `implemented`)
 - **WDP-CL-IP-MAPPING-FRAGMENTATION** — Rely on IPv4 fragmentation and reassembly below UDP rather than adding a second WDP segmentation header on the CDPD/IP path.
   - Family: `wdp`; force: `implicit-must`; level: `required`
   - Source: `WAP-200-WDP` §7.2 (7.2 Mapping of WDP for IP)
   - Parents: `WDP-C-001`, `WDP-CT-C-002`, `WDP-NA-C-003`
   - Requirements: `RQ-TRN-001`, `RQ-TRN-002`, `RQ-TRN-003`
-  - Fixture: `WDP-FX-IP-MAPPING-FRAGMENTATION` (`transport-boundary`, `planned`)
+  - Fixture: `WDP-FX-IP-MAPPING-FRAGMENTATION` (`transport-boundary`, `implemented`)
 - **WDP-CL-IP-MAPPING-IS-UDP** — Map WDP directly to UDP for every selected bearer on which IP routing is available.
   - Family: `wdp`; force: `implicit-must`; level: `required`
   - Source: `WAP-200-WDP` §7.2 (7.2 Mapping of WDP for IP)
   - Parents: `WDP-C-001`, `WDP-CT-C-002`, `WDP-NA-C-003`
   - Requirements: `RQ-TRN-001`, `RQ-TRN-002`, `RQ-TRN-003`
-  - Fixture: `WDP-FX-IP-MAPPING-IS-UDP` (`transport-boundary`, `planned`)
+  - Fixture: `WDP-FX-IP-MAPPING-IS-UDP` (`transport-boundary`, `implemented`)
 - **WDP-CL-IPV4-BASELINE-RECEIVE-SIZE** — Accept IPv4 datagrams up to 576 octets whether received whole or reassembled from fragments.
   - Family: `wdp`; force: `explicit-must`; level: `required`
   - Source: `rfc-791` §3.1 (3.1.  Internet Header Format)
   - Parents: `WDP-CORE-C-001`, `WDP-NA-C-003`
   - Requirements: `RQ-TRN-001`, `RQ-TRN-003`
-  - Fixture: `WDP-FX-IPV4-BASELINE-RECEIVE-SIZE` (`transport-boundary`, `planned`)
+  - Fixture: `WDP-FX-IPV4-BASELINE-RECEIVE-SIZE` (`transport-boundary`, `implemented`)
 - **WDP-CL-IPV4-DONT-FRAGMENT** — Do not fragment a datagram whose DF bit is set; discard it when the route cannot carry it intact.
   - Family: `wdp`; force: `explicit-must`; level: `required`
   - Source: `rfc-791` §3.2 (3.2.  Discussion)
   - Parents: `WDP-CORE-C-001`, `WDP-NA-C-003`
   - Requirements: `RQ-TRN-001`, `RQ-TRN-003`
-  - Fixture: `WDP-FX-IPV4-DONT-FRAGMENT` (`error-policy`, `planned`)
+  - Fixture: `WDP-FX-IPV4-DONT-FRAGMENT` (`error-policy`, `implemented`)
 - **WDP-CL-IPV4-FIXED-ADDRESS-SIZE** — Represent each selected IPv4 source or destination address as four octets.
   - Family: `wdp`; force: `implicit-must`; level: `required`
   - Source: `rfc-791` §2.3 (2.3.  Function Description)
   - Parents: `WDP-NA-C-000`, `WDP-NA-C-003`
   - Requirements: `RQ-TRN-003`
-  - Fixture: `WDP-FX-IPV4-FIXED-ADDRESS-SIZE` (`binary-decoder`, `planned`)
+  - Fixture: `WDP-FX-IPV4-FIXED-ADDRESS-SIZE` (`binary-decoder`, `implemented`)
 - **WDP-CL-IPV4-FRAGMENT-REASSEMBLY-KEY** — Group IPv4 fragments by identification, source, destination, and protocol, then place data using fragment offsets and the final-fragment marker.
   - Family: `wdp`; force: `implicit-must`; level: `required`
   - Source: `rfc-791` §3.2 (3.2.  Discussion)
   - Parents: `WDP-CORE-C-001`, `WDP-NA-C-003`
   - Requirements: `RQ-TRN-001`, `RQ-TRN-003`
-  - Fixture: `WDP-FX-IPV4-FRAGMENT-REASSEMBLY-KEY` (`binary-decoder`, `planned`)
+  - Fixture: `WDP-FX-IPV4-FRAGMENT-REASSEMBLY-KEY` (`binary-decoder`, `implemented`)
 - **WDP-CL-IPV4-FRAGMENTATION-LOCATION** — Allow IPv4 fragmentation at gateways and reassemble fragments at the destination IP module below WDP.
   - Family: `wdp`; force: `implicit-must`; level: `required`
   - Source: `rfc-791` §3.2 (3.2.  Discussion)
   - Parents: `WDP-CORE-C-001`, `WDP-NA-C-003`
   - Requirements: `RQ-TRN-001`, `RQ-TRN-003`
-  - Fixture: `WDP-FX-IPV4-FRAGMENTATION-LOCATION` (`transport-boundary`, `planned`)
+  - Fixture: `WDP-FX-IPV4-FRAGMENTATION-LOCATION` (`transport-boundary`, `implemented`)
 - **WDP-CL-IPV4-HEADER-CHECKSUM** — Verify the ones-complement IPv4 header checksum and discard a datagram immediately when verification fails.
   - Family: `wdp`; force: `explicit-must`; level: `required`
   - Source: `rfc-791` §3.1 (3.1.  Internet Header Format)
   - Parents: `WDP-NA-C-003`
   - Requirements: `RQ-TRN-003`
-  - Fixture: `WDP-FX-IPV4-HEADER-CHECKSUM` (`binary-decoder`, `planned`)
+  - Fixture: `WDP-FX-IPV4-HEADER-CHECKSUM` (`binary-decoder`, `implemented`)
 - **WDP-CL-IPV4-HEADER-LAYOUT** — Decode the complete IPv4 header field order and widths before passing its UDP payload to WDP.
   - Family: `wdp`; force: `grammar`; level: `required`
   - Source: `rfc-791` §3.1 (3.1.  Internet Header Format)
   - Parents: `WDP-NA-C-003`
   - Requirements: `RQ-TRN-003`
-  - Fixture: `WDP-FX-IPV4-HEADER-LAYOUT` (`binary-decoder`, `planned`)
+  - Fixture: `WDP-FX-IPV4-HEADER-LAYOUT` (`binary-decoder`, `implemented`)
 - **WDP-CL-IPV4-INDEPENDENT-DATAGRAMS** — Treat each IPv4 datagram independently without a transport connection or logical circuit.
   - Family: `wdp`; force: `implicit-must`; level: `required`
   - Source: `rfc-791` §1.4 (1.4.  Operation)
   - Parents: `WDP-C-001`, `WDP-CORE-C-001`, `WDP-NA-C-003`
   - Requirements: `RQ-TRN-001`, `RQ-TRN-003`
-  - Fixture: `WDP-FX-IPV4-INDEPENDENT-DATAGRAMS` (`transport-boundary`, `planned`)
+  - Fixture: `WDP-FX-IPV4-INDEPENDENT-DATAGRAMS` (`transport-boundary`, `implemented`)
 - **WDP-CL-IPV4-LARGE-SEND-GUARD** — Send an IPv4 datagram larger than 576 octets only with assurance that the destination can accept it.
   - Family: `wdp`; force: `explicit-should`; level: `recommended`
   - Source: `rfc-791` §3.1 (3.1.  Internet Header Format)
   - Parents: `WDP-CORE-C-001`, `WDP-NA-C-003`
   - Requirements: `RQ-TRN-001`, `RQ-TRN-003`
-  - Fixture: `WDP-FX-IPV4-LARGE-SEND-GUARD` (`transport-boundary`, `planned`)
+  - Fixture: `WDP-FX-IPV4-LARGE-SEND-GUARD` (`transport-boundary`, `implemented`)
 - **WDP-CL-IPV4-NO-RELIABILITY** — Do not imply acknowledgments, retransmission, data error control, or flow control at the IPv4 layer.
   - Family: `wdp`; force: `implicit-must`; level: `required`
   - Source: `rfc-791` §1.4 (1.4.  Operation)
   - Parents: `WDP-C-001`, `WDP-CORE-C-001`
   - Requirements: `RQ-TRN-001`
-  - Fixture: `WDP-FX-IPV4-NO-RELIABILITY` (`transport-boundary`, `planned`)
+  - Fixture: `WDP-FX-IPV4-NO-RELIABILITY` (`transport-boundary`, `implemented`)
 - **WDP-CL-IPV4-ROBUST-INTEROPERATION** — Send well-formed IPv4 datagrams and accept every received datagram whose meaning can be interpreted safely.
   - Family: `wdp`; force: `explicit-must`; level: `required`
   - Source: `rfc-791` §3.2 (3.2.  Discussion)
   - Parents: `WDP-NA-C-003`
   - Requirements: `RQ-TRN-003`
-  - Fixture: `WDP-FX-IPV4-ROBUST-INTEROPERATION` (`binary-decoder`, `planned`)
+  - Fixture: `WDP-FX-IPV4-ROBUST-INTEROPERATION` (`binary-decoder`, `implemented`)
 - **WDP-CL-IPV4-SOURCE-DESTINATION-FIELDS** — Preserve the 32-bit IPv4 source and destination header fields across the WDP request and indication boundary.
   - Family: `wdp`; force: `table`; level: `required`
   - Source: `rfc-791` §3.1 (3.1.  Internet Header Format)
   - Parents: `WDP-PF-C-001`, `WDP-PF-C-002`, `WDP-NA-C-003`
   - Requirements: `RQ-TRN-001`, `RQ-TRN-003`
-  - Fixture: `WDP-FX-IPV4-SOURCE-DESTINATION-FIELDS` (`binary-decoder`, `planned`)
+  - Fixture: `WDP-FX-IPV4-SOURCE-DESTINATION-FIELDS` (`binary-decoder`, `implemented`)
 - **WDP-CL-IPV4-TOTAL-LENGTH** — Interpret IPv4 total length as header plus payload octets with a maximum representable value of 65,535.
   - Family: `wdp`; force: `implicit-must`; level: `required`
   - Source: `rfc-791` §3.1 (3.1.  Internet Header Format)
   - Parents: `WDP-CORE-C-001`, `WDP-NA-C-003`
   - Requirements: `RQ-TRN-001`, `RQ-TRN-003`
-  - Fixture: `WDP-FX-IPV4-TOTAL-LENGTH` (`binary-decoder`, `planned`)
+  - Fixture: `WDP-FX-IPV4-TOTAL-LENGTH` (`binary-decoder`, `implemented`)
 - **WDP-CL-IPV4-TTL-ZERO** — Destroy an IPv4 datagram when its time-to-live value reaches zero.
   - Family: `wdp`; force: `explicit-must`; level: `required`
   - Source: `rfc-791` §3.1 (3.1.  Internet Header Format)
   - Parents: `WDP-NA-C-003`
   - Requirements: `RQ-TRN-003`
-  - Fixture: `WDP-FX-IPV4-TTL-ZERO` (`error-policy`, `planned`)
+  - Fixture: `WDP-FX-IPV4-TTL-ZERO` (`error-policy`, `implemented`)
 - **WDP-CL-IPV4-VERSION-AND-IHL** — Require IPv4 version value 4 and use IHL in 32-bit words with a minimum valid value of five.
   - Family: `wdp`; force: `table`; level: `required`
   - Source: `rfc-791` §3.1 (3.1.  Internet Header Format)
   - Parents: `WDP-NA-C-003`
   - Requirements: `RQ-TRN-003`
-  - Fixture: `WDP-FX-IPV4-VERSION-AND-IHL` (`binary-decoder`, `planned`)
+  - Fixture: `WDP-FX-IPV4-VERSION-AND-IHL` (`binary-decoder`, `implemented`)
 - **WDP-CL-PROTOCOL-REQUIRED-PORT-FIELDS** — Carry both destination and source port fields in the selected WDP protocol mapping.
   - Family: `wdp`; force: `implicit-must`; level: `required`
   - Source: `WAP-200-WDP` §7.1 (7.1 Introduction)
   - Parents: `WDP-CORE-C-001`, `WDP-NA-C-006`, `WDP-NA-C-007`
   - Requirements: `RQ-TRN-001`, `RQ-TRN-003`
-  - Fixture: `WDP-FX-PROTOCOL-REQUIRED-PORT-FIELDS` (`binary-decoder`, `planned`)
+  - Fixture: `WDP-FX-PROTOCOL-REQUIRED-PORT-FIELDS` (`binary-decoder`, `implemented`)
 - **WDP-CL-SELECTED-BEARER-ASSIGNMENT** — Represent the AMPS/CDPD/IPv4 network-bearer-address combination with assigned bearer value 0x0D when that registry is carried.
   - Family: `wdp`; force: `table`; level: `required`
   - Source: `WAP-200-WDP` §appendix-c (Appendix C: Bearer Type Assignments)
   - Parents: `WDP-CT-C-002`, `WDP-NA-C-003`
   - Requirements: `RQ-TRN-002`, `RQ-TRN-003`
-  - Fixture: `WDP-FX-SELECTED-BEARER-ASSIGNMENT` (`transport-boundary`, `planned`)
+  - Fixture: `WDP-FX-SELECTED-BEARER-ASSIGNMENT` (`transport-boundary`, `implemented`)
 - **WDP-CL-SELECTED-WSP-PORT** — Use registered UDP/WDP port 9200 for the selected non-secure connectionless WSP session service.
   - Family: `wdp`; force: `table`; level: `required`
   - Source: `WAP-200-WDP` §appendix-b (Appendix B: Port Number Definitions)
   - Parents: `WDP-C-001`, `WDP-NA-C-006`
   - Requirements: `RQ-TRN-001`, `RQ-TRN-003`
-  - Fixture: `WDP-FX-SELECTED-WSP-PORT` (`transport-boundary`, `planned`)
+  - Fixture: `WDP-FX-SELECTED-WSP-PORT` (`transport-boundary`, `implemented`)
 - **WDP-CL-SIMULTANEOUS-INSTANCES** — Use port numbers to multiplex multiple simultaneous higher-layer communication instances over one WDP bearer service.
   - Family: `wdp`; force: `implicit-must`; level: `required`
   - Source: `WAP-200-WDP` §5.2 (5.2 General Description of the WDP Protocol)
   - Parents: `WDP-C-001`, `WDP-CORE-C-001`, `WDP-NA-C-006`, `WDP-NA-C-007`
   - Requirements: `RQ-TRN-001`, `RQ-TRN-003`
-  - Fixture: `WDP-FX-SIMULTANEOUS-INSTANCES` (`transport-boundary`, `planned`)
+  - Fixture: `WDP-FX-SIMULTANEOUS-INSTANCES` (`transport-boundary`, `implemented`)
 - **WDP-CL-SOURCE-ADDRESS-SEMANTICS** — Treat the source address as the unique network identity of the device issuing the transport request.
   - Family: `wdp`; force: `implicit-must`; level: `required`
   - Source: `WAP-200-WDP` §6.3.1.1 (6.3.1.1 T-DUnitdata)
   - Parents: `WDP-PF-C-001`, `WDP-PF-C-002`, `WDP-NA-C-000`, `WDP-NA-C-003`
   - Requirements: `RQ-TRN-001`, `RQ-TRN-003`
-  - Fixture: `WDP-FX-SOURCE-ADDRESS-SEMANTICS` (`transport-boundary`, `planned`)
+  - Fixture: `WDP-FX-SOURCE-ADDRESS-SEMANTICS` (`transport-boundary`, `implemented`)
 - **WDP-CL-SOURCE-PORT-SEMANTICS** — Bind the source port to the requesting application or upper-layer protocol for that communication instance.
   - Family: `wdp`; force: `implicit-must`; level: `required`
   - Source: `WAP-200-WDP` §6.3.1.1 (6.3.1.1 T-DUnitdata)
   - Parents: `WDP-PF-C-001`, `WDP-PF-C-002`, `WDP-NA-C-007`
   - Requirements: `RQ-TRN-001`, `RQ-TRN-003`
-  - Fixture: `WDP-FX-SOURCE-PORT-SEMANTICS` (`transport-boundary`, `planned`)
+  - Fixture: `WDP-FX-SOURCE-PORT-SEMANTICS` (`transport-boundary`, `implemented`)
 - **WDP-CL-UDP-CHECKSUM-COVERAGE** — Compute the UDP checksum over the IPv4 pseudo-header, UDP header, and data using 16-bit ones-complement arithmetic.
   - Family: `wdp`; force: `implicit-must`; level: `required`
   - Source: `rfc-768` §fields (Fields)
   - Parents: `WDP-CORE-C-001`, `WDP-NA-C-003`
   - Requirements: `RQ-TRN-001`, `RQ-TRN-003`
-  - Fixture: `WDP-FX-UDP-CHECKSUM-COVERAGE` (`binary-decoder`, `planned`)
+  - Fixture: `WDP-FX-UDP-CHECKSUM-COVERAGE` (`binary-decoder`, `implemented`)
 - **WDP-CL-UDP-CHECKSUM-OMISSION** — Accept an all-zero UDP checksum field as the IPv4 sender choosing not to generate a UDP checksum.
   - Family: `wdp`; force: `explicit-may`; level: `permitted`
   - Source: `rfc-768` §fields (Fields)
   - Parents: `WDP-CORE-C-001`
   - Requirements: `RQ-TRN-001`
-  - Fixture: `WDP-FX-UDP-CHECKSUM-OMISSION` (`binary-decoder`, `planned`)
+  - Fixture: `WDP-FX-UDP-CHECKSUM-OMISSION` (`binary-decoder`, `implemented`)
 - **WDP-CL-UDP-CHECKSUM-PADDING** — Zero-pad an odd checksum input to a two-octet boundary without transmitting the padding octet.
   - Family: `wdp`; force: `implicit-must`; level: `required`
   - Source: `rfc-768` §fields (Fields)
   - Parents: `WDP-CORE-C-001`
   - Requirements: `RQ-TRN-001`
-  - Fixture: `WDP-FX-UDP-CHECKSUM-PADDING` (`binary-decoder`, `planned`)
+  - Fixture: `WDP-FX-UDP-CHECKSUM-PADDING` (`binary-decoder`, `implemented`)
 - **WDP-CL-UDP-CHECKSUM-ZERO-ENCODING** — Transmit an arithmetically computed zero UDP checksum as all one bits.
   - Family: `wdp`; force: `implicit-must`; level: `required`
   - Source: `rfc-768` §fields (Fields)
   - Parents: `WDP-CORE-C-001`
   - Requirements: `RQ-TRN-001`
-  - Fixture: `WDP-FX-UDP-CHECKSUM-ZERO-ENCODING` (`binary-decoder`, `planned`)
+  - Fixture: `WDP-FX-UDP-CHECKSUM-ZERO-ENCODING` (`binary-decoder`, `implemented`)
 - **WDP-CL-UDP-DESTINATION-PORT-CONTEXT** — Interpret a UDP destination port within the context of its destination IPv4 address.
   - Family: `wdp`; force: `implicit-must`; level: `required`
   - Source: `rfc-768` §fields (Fields)
   - Parents: `WDP-NA-C-006`, `WDP-NA-C-003`
   - Requirements: `RQ-TRN-003`
-  - Fixture: `WDP-FX-UDP-DESTINATION-PORT-CONTEXT` (`transport-boundary`, `planned`)
+  - Fixture: `WDP-FX-UDP-DESTINATION-PORT-CONTEXT` (`transport-boundary`, `implemented`)
 - **WDP-CL-UDP-HEADER-LAYOUT** — Encode and decode the UDP header as 16-bit source port, destination port, length, and checksum fields followed by data.
   - Family: `wdp`; force: `grammar`; level: `required`
   - Source: `rfc-768` §format (Format)
   - Parents: `WDP-CORE-C-001`, `WDP-NA-C-006`, `WDP-NA-C-007`
   - Requirements: `RQ-TRN-001`, `RQ-TRN-003`
-  - Fixture: `WDP-FX-UDP-HEADER-LAYOUT` (`binary-decoder`, `planned`)
+  - Fixture: `WDP-FX-UDP-HEADER-LAYOUT` (`binary-decoder`, `implemented`)
 - **WDP-CL-UDP-IP-INTERFACE-METADATA** — Make source address, destination address, and IP protocol metadata available at the UDP/IP boundary.
   - Family: `wdp`; force: `explicit-must`; level: `required`
   - Source: `rfc-768` §ip-interface (IP Interface)
   - Parents: `WDP-CORE-C-001`, `WDP-NA-C-003`
   - Requirements: `RQ-TRN-001`, `RQ-TRN-003`
-  - Fixture: `WDP-FX-UDP-IP-INTERFACE-METADATA` (`transport-boundary`, `planned`)
+  - Fixture: `WDP-FX-UDP-IP-INTERFACE-METADATA` (`transport-boundary`, `implemented`)
 - **WDP-CL-UDP-IP-PROTOCOL-NUMBER** — Identify UDP with IPv4 protocol number 17.
   - Family: `wdp`; force: `table`; level: `required`
   - Source: `rfc-768` §protocol-number (Protocol Number)
   - Parents: `WDP-CT-C-002`, `WDP-NA-C-003`
   - Requirements: `RQ-TRN-002`, `RQ-TRN-003`
-  - Fixture: `WDP-FX-UDP-IP-PROTOCOL-NUMBER` (`binary-decoder`, `planned`)
+  - Fixture: `WDP-FX-UDP-IP-PROTOCOL-NUMBER` (`binary-decoder`, `implemented`)
 - **WDP-CL-UDP-LENGTH-BOUNDS** — Interpret UDP length as header plus data octets and reject values smaller than the eight-octet header.
   - Family: `wdp`; force: `implicit-must`; level: `required`
   - Source: `rfc-768` §fields (Fields)
   - Parents: `WDP-CORE-C-001`
   - Requirements: `RQ-TRN-001`
-  - Fixture: `WDP-FX-UDP-LENGTH-BOUNDS` (`binary-decoder`, `planned`)
+  - Fixture: `WDP-FX-UDP-LENGTH-BOUNDS` (`binary-decoder`, `implemented`)
 - **WDP-CL-UDP-RECEIVE-INTERFACE** — Provide receive-port creation and return received data with its source IPv4 address and source port.
   - Family: `wdp`; force: `explicit-should`; level: `recommended`
   - Source: `rfc-768` §interface (User Interface)
   - Parents: `WDP-PF-C-002`, `WDP-NA-C-003`, `WDP-NA-C-007`
   - Requirements: `RQ-TRN-001`, `RQ-TRN-003`
-  - Fixture: `WDP-FX-UDP-RECEIVE-INTERFACE` (`transport-boundary`, `planned`)
+  - Fixture: `WDP-FX-UDP-RECEIVE-INTERFACE` (`transport-boundary`, `implemented`)
 - **WDP-CL-UDP-SEND-INTERFACE** — Provide datagram send using explicit data, source and destination ports, and source and destination IPv4 addresses.
   - Family: `wdp`; force: `explicit-should`; level: `recommended`
   - Source: `rfc-768` §interface (User Interface)
   - Parents: `WDP-PF-C-001`, `WDP-NA-C-003`, `WDP-NA-C-006`, `WDP-NA-C-007`
   - Requirements: `RQ-TRN-001`, `RQ-TRN-003`
-  - Fixture: `WDP-FX-UDP-SEND-INTERFACE` (`transport-boundary`, `planned`)
+  - Fixture: `WDP-FX-UDP-SEND-INTERFACE` (`transport-boundary`, `implemented`)
 - **WDP-CL-UDP-SOURCE-PORT-ZERO** — Use source port zero when the sender does not supply a meaningful reply port, and otherwise preserve the selected source port.
   - Family: `wdp`; force: `table`; level: `required`
   - Source: `rfc-768` §fields (Fields)
   - Parents: `WDP-NA-C-007`
   - Requirements: `RQ-TRN-003`
-  - Fixture: `WDP-FX-UDP-SOURCE-PORT-ZERO` (`binary-decoder`, `planned`)
+  - Fixture: `WDP-FX-UDP-SOURCE-PORT-ZERO` (`binary-decoder`, `implemented`)
 - **WDP-CL-UDP-UNRELIABLE-DATAGRAMS** — Expose UDP as a connectionless datagram service that does not guarantee delivery, ordering, or duplicate suppression.
   - Family: `wdp`; force: `implicit-must`; level: `required`
   - Source: `rfc-768` §introduction (Introduction)
   - Parents: `WDP-C-001`, `WDP-CORE-C-001`
   - Requirements: `RQ-TRN-001`
-  - Fixture: `WDP-FX-UDP-UNRELIABLE-DATAGRAMS` (`transport-boundary`, `planned`)
+  - Fixture: `WDP-FX-UDP-UNRELIABLE-DATAGRAMS` (`transport-boundary`, `implemented`)
 - **WDP-CL-UNITDATA-CONTENT-TRANSPARENCY** — Transmit and deliver the complete service data unit without manipulating its content.
   - Family: `wdp`; force: `implicit-must`; level: `required`
   - Source: `WAP-200-WDP` §6.3.1.1 (6.3.1.1 T-DUnitdata)
   - Parents: `WDP-CORE-C-001`, `WDP-PF-C-001`, `WDP-PF-C-002`
   - Requirements: `RQ-TRN-001`
-  - Fixture: `WDP-FX-UNITDATA-CONTENT-TRANSPARENCY` (`transport-boundary`, `planned`)
+  - Fixture: `WDP-FX-UNITDATA-CONTENT-TRANSPARENCY` (`transport-boundary`, `implemented`)
 - **WDP-CL-UNITDATA-INDICATION-PARAMETERS** — Deliver source address, source port, and user data on T-DUnitdata indication, with destination address and port when available.
   - Family: `wdp`; force: `table`; level: `required`
   - Source: `WAP-200-WDP` §6.3.1.1 (6.3.1.1 T-DUnitdata)
   - Parents: `WDP-CORE-C-001`, `WDP-PF-C-002`, `WDP-NA-C-000`, `WDP-NA-C-003`, `WDP-NA-C-006`, `WDP-NA-C-007`
   - Requirements: `RQ-TRN-001`, `RQ-TRN-003`
-  - Fixture: `WDP-FX-UNITDATA-INDICATION-PARAMETERS` (`transport-boundary`, `planned`)
+  - Fixture: `WDP-FX-UNITDATA-INDICATION-PARAMETERS` (`transport-boundary`, `implemented`)
 - **WDP-CL-UNITDATA-REQUEST-ANYTIME** — Allow T-DUnitdata.request without establishing a prior transport connection.
   - Family: `wdp`; force: `implicit-must`; level: `required`
   - Source: `WAP-200-WDP` §6.3.1.1 (6.3.1.1 T-DUnitdata)
   - Parents: `WDP-PF-C-001`
   - Requirements: `RQ-TRN-001`
-  - Fixture: `WDP-FX-UNITDATA-REQUEST-ANYTIME` (`transport-boundary`, `planned`)
+  - Fixture: `WDP-FX-UNITDATA-REQUEST-ANYTIME` (`transport-boundary`, `implemented`)
 - **WDP-CL-UNITDATA-REQUEST-PARAMETERS** — Require source address, source port, destination address, destination port, and user data on every T-DUnitdata request.
   - Family: `wdp`; force: `table`; level: `required`
   - Source: `WAP-200-WDP` §6.3.1.1 (6.3.1.1 T-DUnitdata)
   - Parents: `WDP-CORE-C-001`, `WDP-PF-C-001`, `WDP-NA-C-000`, `WDP-NA-C-003`, `WDP-NA-C-006`, `WDP-NA-C-007`
   - Requirements: `RQ-TRN-001`, `RQ-TRN-003`
-  - Fixture: `WDP-FX-UNITDATA-REQUEST-PARAMETERS` (`transport-boundary`, `planned`)
+  - Fixture: `WDP-FX-UNITDATA-REQUEST-PARAMETERS` (`transport-boundary`, `implemented`)
 - **WDP-CL-WAP-PORT-REGISTRY** — Recognize the complete WAP port assignment table, including connectionless, session, secure, push, vCard, and vCalendar services.
   - Family: `wdp`; force: `table`; level: `required`
   - Source: `WAP-200-WDP` §appendix-b (Appendix B: Port Number Definitions)
   - Parents: `WDP-NA-C-006`, `WDP-NA-C-007`
   - Requirements: `RQ-TRN-003`
-  - Fixture: `WDP-FX-WAP-PORT-REGISTRY` (`transport-boundary`, `planned`)
+  - Fixture: `WDP-FX-WAP-PORT-REGISTRY` (`transport-boundary`, `implemented`)
 
 ### TRN-703
 

--- a/docs/knowledge-graph/vault-TRN-7/clauses/WDP-CL-ADAPTATION-LAYER-BOUNDARY.md
+++ b/docs/knowledge-graph/vault-TRN-7/clauses/WDP-CL-ADAPTATION-LAYER-BOUNDARY.md
@@ -52,7 +52,7 @@ tags:
     "RQ-TRN-001",
     "RQ-TRN-002"
   ],
-  "implementationStatus": "not-assessed",
+  "implementationStatus": "implemented",
   "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented.",
   "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
 }

--- a/docs/knowledge-graph/vault-TRN-7/clauses/WDP-CL-APPLICATION-PORT-ADDRESSING.md
+++ b/docs/knowledge-graph/vault-TRN-7/clauses/WDP-CL-APPLICATION-PORT-ADDRESSING.md
@@ -54,7 +54,7 @@ tags:
     "RQ-TRN-001",
     "RQ-TRN-003"
   ],
-  "implementationStatus": "not-assessed",
+  "implementationStatus": "implemented",
   "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented.",
   "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
 }

--- a/docs/knowledge-graph/vault-TRN-7/clauses/WDP-CL-BEARER-TRANSPARENCY.md
+++ b/docs/knowledge-graph/vault-TRN-7/clauses/WDP-CL-BEARER-TRANSPARENCY.md
@@ -50,7 +50,7 @@ tags:
   "requirementIds": [
     "RQ-TRN-001"
   ],
-  "implementationStatus": "not-assessed",
+  "implementationStatus": "implemented",
   "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented.",
   "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
 }

--- a/docs/knowledge-graph/vault-TRN-7/clauses/WDP-CL-CDPD-UDP-IP-PROFILE.md
+++ b/docs/knowledge-graph/vault-TRN-7/clauses/WDP-CL-CDPD-UDP-IP-PROFILE.md
@@ -52,7 +52,7 @@ tags:
     "RQ-TRN-002",
     "RQ-TRN-003"
   ],
-  "implementationStatus": "not-assessed",
+  "implementationStatus": "implemented",
   "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented.",
   "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
 }

--- a/docs/knowledge-graph/vault-TRN-7/clauses/WDP-CL-CONSISTENT-TRANSPORT-SERVICE.md
+++ b/docs/knowledge-graph/vault-TRN-7/clauses/WDP-CL-CONSISTENT-TRANSPORT-SERVICE.md
@@ -50,7 +50,7 @@ tags:
   "requirementIds": [
     "RQ-TRN-001"
   ],
-  "implementationStatus": "not-assessed",
+  "implementationStatus": "implemented",
   "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented.",
   "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
 }

--- a/docs/knowledge-graph/vault-TRN-7/clauses/WDP-CL-DESTINATION-ADDRESS-SEMANTICS.md
+++ b/docs/knowledge-graph/vault-TRN-7/clauses/WDP-CL-DESTINATION-ADDRESS-SEMANTICS.md
@@ -56,7 +56,7 @@ tags:
     "RQ-TRN-001",
     "RQ-TRN-003"
   ],
-  "implementationStatus": "not-assessed",
+  "implementationStatus": "implemented",
   "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented.",
   "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
 }

--- a/docs/knowledge-graph/vault-TRN-7/clauses/WDP-CL-DESTINATION-PORT-SEMANTICS.md
+++ b/docs/knowledge-graph/vault-TRN-7/clauses/WDP-CL-DESTINATION-PORT-SEMANTICS.md
@@ -54,7 +54,7 @@ tags:
     "RQ-TRN-001",
     "RQ-TRN-003"
   ],
-  "implementationStatus": "not-assessed",
+  "implementationStatus": "implemented",
   "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented.",
   "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
 }

--- a/docs/knowledge-graph/vault-TRN-7/clauses/WDP-CL-IP-BEARER-REQUIRES-UDP.md
+++ b/docs/knowledge-graph/vault-TRN-7/clauses/WDP-CL-IP-BEARER-REQUIRES-UDP.md
@@ -56,7 +56,7 @@ tags:
     "RQ-TRN-002",
     "RQ-TRN-003"
   ],
-  "implementationStatus": "not-assessed",
+  "implementationStatus": "implemented",
   "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented.",
   "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
 }

--- a/docs/knowledge-graph/vault-TRN-7/clauses/WDP-CL-IP-MAPPING-FRAGMENTATION.md
+++ b/docs/knowledge-graph/vault-TRN-7/clauses/WDP-CL-IP-MAPPING-FRAGMENTATION.md
@@ -56,7 +56,7 @@ tags:
     "RQ-TRN-002",
     "RQ-TRN-003"
   ],
-  "implementationStatus": "not-assessed",
+  "implementationStatus": "implemented",
   "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented.",
   "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
 }

--- a/docs/knowledge-graph/vault-TRN-7/clauses/WDP-CL-IP-MAPPING-IS-UDP.md
+++ b/docs/knowledge-graph/vault-TRN-7/clauses/WDP-CL-IP-MAPPING-IS-UDP.md
@@ -56,7 +56,7 @@ tags:
     "RQ-TRN-002",
     "RQ-TRN-003"
   ],
-  "implementationStatus": "not-assessed",
+  "implementationStatus": "implemented",
   "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented.",
   "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
 }

--- a/docs/knowledge-graph/vault-TRN-7/clauses/WDP-CL-IPV4-BASELINE-RECEIVE-SIZE.md
+++ b/docs/knowledge-graph/vault-TRN-7/clauses/WDP-CL-IPV4-BASELINE-RECEIVE-SIZE.md
@@ -52,7 +52,7 @@ tags:
     "RQ-TRN-001",
     "RQ-TRN-003"
   ],
-  "implementationStatus": "not-assessed",
+  "implementationStatus": "implemented",
   "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented.",
   "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
 }

--- a/docs/knowledge-graph/vault-TRN-7/clauses/WDP-CL-IPV4-DONT-FRAGMENT.md
+++ b/docs/knowledge-graph/vault-TRN-7/clauses/WDP-CL-IPV4-DONT-FRAGMENT.md
@@ -52,7 +52,7 @@ tags:
     "RQ-TRN-001",
     "RQ-TRN-003"
   ],
-  "implementationStatus": "not-assessed",
+  "implementationStatus": "implemented",
   "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented.",
   "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
 }

--- a/docs/knowledge-graph/vault-TRN-7/clauses/WDP-CL-IPV4-FIXED-ADDRESS-SIZE.md
+++ b/docs/knowledge-graph/vault-TRN-7/clauses/WDP-CL-IPV4-FIXED-ADDRESS-SIZE.md
@@ -50,7 +50,7 @@ tags:
   "requirementIds": [
     "RQ-TRN-003"
   ],
-  "implementationStatus": "not-assessed",
+  "implementationStatus": "implemented",
   "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented.",
   "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
 }

--- a/docs/knowledge-graph/vault-TRN-7/clauses/WDP-CL-IPV4-FRAGMENT-REASSEMBLY-KEY.md
+++ b/docs/knowledge-graph/vault-TRN-7/clauses/WDP-CL-IPV4-FRAGMENT-REASSEMBLY-KEY.md
@@ -52,7 +52,7 @@ tags:
     "RQ-TRN-001",
     "RQ-TRN-003"
   ],
-  "implementationStatus": "not-assessed",
+  "implementationStatus": "implemented",
   "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented.",
   "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
 }

--- a/docs/knowledge-graph/vault-TRN-7/clauses/WDP-CL-IPV4-FRAGMENTATION-LOCATION.md
+++ b/docs/knowledge-graph/vault-TRN-7/clauses/WDP-CL-IPV4-FRAGMENTATION-LOCATION.md
@@ -52,7 +52,7 @@ tags:
     "RQ-TRN-001",
     "RQ-TRN-003"
   ],
-  "implementationStatus": "not-assessed",
+  "implementationStatus": "implemented",
   "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented.",
   "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
 }

--- a/docs/knowledge-graph/vault-TRN-7/clauses/WDP-CL-IPV4-HEADER-CHECKSUM.md
+++ b/docs/knowledge-graph/vault-TRN-7/clauses/WDP-CL-IPV4-HEADER-CHECKSUM.md
@@ -48,7 +48,7 @@ tags:
   "requirementIds": [
     "RQ-TRN-003"
   ],
-  "implementationStatus": "not-assessed",
+  "implementationStatus": "implemented",
   "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented.",
   "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
 }

--- a/docs/knowledge-graph/vault-TRN-7/clauses/WDP-CL-IPV4-HEADER-LAYOUT.md
+++ b/docs/knowledge-graph/vault-TRN-7/clauses/WDP-CL-IPV4-HEADER-LAYOUT.md
@@ -48,7 +48,7 @@ tags:
   "requirementIds": [
     "RQ-TRN-003"
   ],
-  "implementationStatus": "not-assessed",
+  "implementationStatus": "implemented",
   "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented.",
   "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
 }

--- a/docs/knowledge-graph/vault-TRN-7/clauses/WDP-CL-IPV4-INDEPENDENT-DATAGRAMS.md
+++ b/docs/knowledge-graph/vault-TRN-7/clauses/WDP-CL-IPV4-INDEPENDENT-DATAGRAMS.md
@@ -54,7 +54,7 @@ tags:
     "RQ-TRN-001",
     "RQ-TRN-003"
   ],
-  "implementationStatus": "not-assessed",
+  "implementationStatus": "implemented",
   "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented.",
   "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
 }

--- a/docs/knowledge-graph/vault-TRN-7/clauses/WDP-CL-IPV4-LARGE-SEND-GUARD.md
+++ b/docs/knowledge-graph/vault-TRN-7/clauses/WDP-CL-IPV4-LARGE-SEND-GUARD.md
@@ -52,7 +52,7 @@ tags:
     "RQ-TRN-001",
     "RQ-TRN-003"
   ],
-  "implementationStatus": "not-assessed",
+  "implementationStatus": "implemented",
   "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented.",
   "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
 }

--- a/docs/knowledge-graph/vault-TRN-7/clauses/WDP-CL-IPV4-NO-RELIABILITY.md
+++ b/docs/knowledge-graph/vault-TRN-7/clauses/WDP-CL-IPV4-NO-RELIABILITY.md
@@ -50,7 +50,7 @@ tags:
   "requirementIds": [
     "RQ-TRN-001"
   ],
-  "implementationStatus": "not-assessed",
+  "implementationStatus": "implemented",
   "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented.",
   "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
 }

--- a/docs/knowledge-graph/vault-TRN-7/clauses/WDP-CL-IPV4-ROBUST-INTEROPERATION.md
+++ b/docs/knowledge-graph/vault-TRN-7/clauses/WDP-CL-IPV4-ROBUST-INTEROPERATION.md
@@ -48,7 +48,7 @@ tags:
   "requirementIds": [
     "RQ-TRN-003"
   ],
-  "implementationStatus": "not-assessed",
+  "implementationStatus": "implemented",
   "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented.",
   "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
 }

--- a/docs/knowledge-graph/vault-TRN-7/clauses/WDP-CL-IPV4-SOURCE-DESTINATION-FIELDS.md
+++ b/docs/knowledge-graph/vault-TRN-7/clauses/WDP-CL-IPV4-SOURCE-DESTINATION-FIELDS.md
@@ -54,7 +54,7 @@ tags:
     "RQ-TRN-001",
     "RQ-TRN-003"
   ],
-  "implementationStatus": "not-assessed",
+  "implementationStatus": "implemented",
   "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented.",
   "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
 }

--- a/docs/knowledge-graph/vault-TRN-7/clauses/WDP-CL-IPV4-TOTAL-LENGTH.md
+++ b/docs/knowledge-graph/vault-TRN-7/clauses/WDP-CL-IPV4-TOTAL-LENGTH.md
@@ -52,7 +52,7 @@ tags:
     "RQ-TRN-001",
     "RQ-TRN-003"
   ],
-  "implementationStatus": "not-assessed",
+  "implementationStatus": "implemented",
   "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented.",
   "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
 }

--- a/docs/knowledge-graph/vault-TRN-7/clauses/WDP-CL-IPV4-TTL-ZERO.md
+++ b/docs/knowledge-graph/vault-TRN-7/clauses/WDP-CL-IPV4-TTL-ZERO.md
@@ -48,7 +48,7 @@ tags:
   "requirementIds": [
     "RQ-TRN-003"
   ],
-  "implementationStatus": "not-assessed",
+  "implementationStatus": "implemented",
   "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented.",
   "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
 }

--- a/docs/knowledge-graph/vault-TRN-7/clauses/WDP-CL-IPV4-VERSION-AND-IHL.md
+++ b/docs/knowledge-graph/vault-TRN-7/clauses/WDP-CL-IPV4-VERSION-AND-IHL.md
@@ -48,7 +48,7 @@ tags:
   "requirementIds": [
     "RQ-TRN-003"
   ],
-  "implementationStatus": "not-assessed",
+  "implementationStatus": "implemented",
   "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented.",
   "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
 }

--- a/docs/knowledge-graph/vault-TRN-7/clauses/WDP-CL-PROTOCOL-REQUIRED-PORT-FIELDS.md
+++ b/docs/knowledge-graph/vault-TRN-7/clauses/WDP-CL-PROTOCOL-REQUIRED-PORT-FIELDS.md
@@ -54,7 +54,7 @@ tags:
     "RQ-TRN-001",
     "RQ-TRN-003"
   ],
-  "implementationStatus": "not-assessed",
+  "implementationStatus": "implemented",
   "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented.",
   "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
 }

--- a/docs/knowledge-graph/vault-TRN-7/clauses/WDP-CL-SELECTED-BEARER-ASSIGNMENT.md
+++ b/docs/knowledge-graph/vault-TRN-7/clauses/WDP-CL-SELECTED-BEARER-ASSIGNMENT.md
@@ -52,7 +52,7 @@ tags:
     "RQ-TRN-002",
     "RQ-TRN-003"
   ],
-  "implementationStatus": "not-assessed",
+  "implementationStatus": "implemented",
   "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented.",
   "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
 }

--- a/docs/knowledge-graph/vault-TRN-7/clauses/WDP-CL-SELECTED-WSP-PORT.md
+++ b/docs/knowledge-graph/vault-TRN-7/clauses/WDP-CL-SELECTED-WSP-PORT.md
@@ -52,7 +52,7 @@ tags:
     "RQ-TRN-001",
     "RQ-TRN-003"
   ],
-  "implementationStatus": "not-assessed",
+  "implementationStatus": "implemented",
   "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented.",
   "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
 }

--- a/docs/knowledge-graph/vault-TRN-7/clauses/WDP-CL-SIMULTANEOUS-INSTANCES.md
+++ b/docs/knowledge-graph/vault-TRN-7/clauses/WDP-CL-SIMULTANEOUS-INSTANCES.md
@@ -56,7 +56,7 @@ tags:
     "RQ-TRN-001",
     "RQ-TRN-003"
   ],
-  "implementationStatus": "not-assessed",
+  "implementationStatus": "implemented",
   "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented.",
   "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
 }

--- a/docs/knowledge-graph/vault-TRN-7/clauses/WDP-CL-SOURCE-ADDRESS-SEMANTICS.md
+++ b/docs/knowledge-graph/vault-TRN-7/clauses/WDP-CL-SOURCE-ADDRESS-SEMANTICS.md
@@ -56,7 +56,7 @@ tags:
     "RQ-TRN-001",
     "RQ-TRN-003"
   ],
-  "implementationStatus": "not-assessed",
+  "implementationStatus": "implemented",
   "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented.",
   "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
 }

--- a/docs/knowledge-graph/vault-TRN-7/clauses/WDP-CL-SOURCE-PORT-SEMANTICS.md
+++ b/docs/knowledge-graph/vault-TRN-7/clauses/WDP-CL-SOURCE-PORT-SEMANTICS.md
@@ -54,7 +54,7 @@ tags:
     "RQ-TRN-001",
     "RQ-TRN-003"
   ],
-  "implementationStatus": "not-assessed",
+  "implementationStatus": "implemented",
   "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented.",
   "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
 }

--- a/docs/knowledge-graph/vault-TRN-7/clauses/WDP-CL-UDP-CHECKSUM-COVERAGE.md
+++ b/docs/knowledge-graph/vault-TRN-7/clauses/WDP-CL-UDP-CHECKSUM-COVERAGE.md
@@ -52,7 +52,7 @@ tags:
     "RQ-TRN-001",
     "RQ-TRN-003"
   ],
-  "implementationStatus": "not-assessed",
+  "implementationStatus": "implemented",
   "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented.",
   "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
 }

--- a/docs/knowledge-graph/vault-TRN-7/clauses/WDP-CL-UDP-CHECKSUM-OMISSION.md
+++ b/docs/knowledge-graph/vault-TRN-7/clauses/WDP-CL-UDP-CHECKSUM-OMISSION.md
@@ -48,7 +48,7 @@ tags:
   "requirementIds": [
     "RQ-TRN-001"
   ],
-  "implementationStatus": "not-assessed",
+  "implementationStatus": "implemented",
   "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented.",
   "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
 }

--- a/docs/knowledge-graph/vault-TRN-7/clauses/WDP-CL-UDP-CHECKSUM-PADDING.md
+++ b/docs/knowledge-graph/vault-TRN-7/clauses/WDP-CL-UDP-CHECKSUM-PADDING.md
@@ -48,7 +48,7 @@ tags:
   "requirementIds": [
     "RQ-TRN-001"
   ],
-  "implementationStatus": "not-assessed",
+  "implementationStatus": "implemented",
   "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented.",
   "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
 }

--- a/docs/knowledge-graph/vault-TRN-7/clauses/WDP-CL-UDP-CHECKSUM-ZERO-ENCODING.md
+++ b/docs/knowledge-graph/vault-TRN-7/clauses/WDP-CL-UDP-CHECKSUM-ZERO-ENCODING.md
@@ -48,7 +48,7 @@ tags:
   "requirementIds": [
     "RQ-TRN-001"
   ],
-  "implementationStatus": "not-assessed",
+  "implementationStatus": "implemented",
   "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented.",
   "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
 }

--- a/docs/knowledge-graph/vault-TRN-7/clauses/WDP-CL-UDP-DESTINATION-PORT-CONTEXT.md
+++ b/docs/knowledge-graph/vault-TRN-7/clauses/WDP-CL-UDP-DESTINATION-PORT-CONTEXT.md
@@ -50,7 +50,7 @@ tags:
   "requirementIds": [
     "RQ-TRN-003"
   ],
-  "implementationStatus": "not-assessed",
+  "implementationStatus": "implemented",
   "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented.",
   "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
 }

--- a/docs/knowledge-graph/vault-TRN-7/clauses/WDP-CL-UDP-HEADER-LAYOUT.md
+++ b/docs/knowledge-graph/vault-TRN-7/clauses/WDP-CL-UDP-HEADER-LAYOUT.md
@@ -54,7 +54,7 @@ tags:
     "RQ-TRN-001",
     "RQ-TRN-003"
   ],
-  "implementationStatus": "not-assessed",
+  "implementationStatus": "implemented",
   "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented.",
   "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
 }

--- a/docs/knowledge-graph/vault-TRN-7/clauses/WDP-CL-UDP-IP-INTERFACE-METADATA.md
+++ b/docs/knowledge-graph/vault-TRN-7/clauses/WDP-CL-UDP-IP-INTERFACE-METADATA.md
@@ -52,7 +52,7 @@ tags:
     "RQ-TRN-001",
     "RQ-TRN-003"
   ],
-  "implementationStatus": "not-assessed",
+  "implementationStatus": "implemented",
   "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented.",
   "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
 }

--- a/docs/knowledge-graph/vault-TRN-7/clauses/WDP-CL-UDP-IP-PROTOCOL-NUMBER.md
+++ b/docs/knowledge-graph/vault-TRN-7/clauses/WDP-CL-UDP-IP-PROTOCOL-NUMBER.md
@@ -52,7 +52,7 @@ tags:
     "RQ-TRN-002",
     "RQ-TRN-003"
   ],
-  "implementationStatus": "not-assessed",
+  "implementationStatus": "implemented",
   "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented.",
   "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
 }

--- a/docs/knowledge-graph/vault-TRN-7/clauses/WDP-CL-UDP-LENGTH-BOUNDS.md
+++ b/docs/knowledge-graph/vault-TRN-7/clauses/WDP-CL-UDP-LENGTH-BOUNDS.md
@@ -48,7 +48,7 @@ tags:
   "requirementIds": [
     "RQ-TRN-001"
   ],
-  "implementationStatus": "not-assessed",
+  "implementationStatus": "implemented",
   "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented.",
   "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
 }

--- a/docs/knowledge-graph/vault-TRN-7/clauses/WDP-CL-UDP-RECEIVE-INTERFACE.md
+++ b/docs/knowledge-graph/vault-TRN-7/clauses/WDP-CL-UDP-RECEIVE-INTERFACE.md
@@ -54,7 +54,7 @@ tags:
     "RQ-TRN-001",
     "RQ-TRN-003"
   ],
-  "implementationStatus": "not-assessed",
+  "implementationStatus": "implemented",
   "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented.",
   "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
 }

--- a/docs/knowledge-graph/vault-TRN-7/clauses/WDP-CL-UDP-SEND-INTERFACE.md
+++ b/docs/knowledge-graph/vault-TRN-7/clauses/WDP-CL-UDP-SEND-INTERFACE.md
@@ -56,7 +56,7 @@ tags:
     "RQ-TRN-001",
     "RQ-TRN-003"
   ],
-  "implementationStatus": "not-assessed",
+  "implementationStatus": "implemented",
   "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented.",
   "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
 }

--- a/docs/knowledge-graph/vault-TRN-7/clauses/WDP-CL-UDP-SOURCE-PORT-ZERO.md
+++ b/docs/knowledge-graph/vault-TRN-7/clauses/WDP-CL-UDP-SOURCE-PORT-ZERO.md
@@ -48,7 +48,7 @@ tags:
   "requirementIds": [
     "RQ-TRN-003"
   ],
-  "implementationStatus": "not-assessed",
+  "implementationStatus": "implemented",
   "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented.",
   "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
 }

--- a/docs/knowledge-graph/vault-TRN-7/clauses/WDP-CL-UDP-UNRELIABLE-DATAGRAMS.md
+++ b/docs/knowledge-graph/vault-TRN-7/clauses/WDP-CL-UDP-UNRELIABLE-DATAGRAMS.md
@@ -50,7 +50,7 @@ tags:
   "requirementIds": [
     "RQ-TRN-001"
   ],
-  "implementationStatus": "not-assessed",
+  "implementationStatus": "implemented",
   "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented.",
   "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
 }

--- a/docs/knowledge-graph/vault-TRN-7/clauses/WDP-CL-UNITDATA-CONTENT-TRANSPARENCY.md
+++ b/docs/knowledge-graph/vault-TRN-7/clauses/WDP-CL-UNITDATA-CONTENT-TRANSPARENCY.md
@@ -52,7 +52,7 @@ tags:
   "requirementIds": [
     "RQ-TRN-001"
   ],
-  "implementationStatus": "not-assessed",
+  "implementationStatus": "implemented",
   "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented.",
   "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
 }

--- a/docs/knowledge-graph/vault-TRN-7/clauses/WDP-CL-UNITDATA-INDICATION-PARAMETERS.md
+++ b/docs/knowledge-graph/vault-TRN-7/clauses/WDP-CL-UNITDATA-INDICATION-PARAMETERS.md
@@ -60,7 +60,7 @@ tags:
     "RQ-TRN-001",
     "RQ-TRN-003"
   ],
-  "implementationStatus": "not-assessed",
+  "implementationStatus": "implemented",
   "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented.",
   "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
 }

--- a/docs/knowledge-graph/vault-TRN-7/clauses/WDP-CL-UNITDATA-REQUEST-ANYTIME.md
+++ b/docs/knowledge-graph/vault-TRN-7/clauses/WDP-CL-UNITDATA-REQUEST-ANYTIME.md
@@ -48,7 +48,7 @@ tags:
   "requirementIds": [
     "RQ-TRN-001"
   ],
-  "implementationStatus": "not-assessed",
+  "implementationStatus": "implemented",
   "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented.",
   "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
 }

--- a/docs/knowledge-graph/vault-TRN-7/clauses/WDP-CL-UNITDATA-REQUEST-PARAMETERS.md
+++ b/docs/knowledge-graph/vault-TRN-7/clauses/WDP-CL-UNITDATA-REQUEST-PARAMETERS.md
@@ -60,7 +60,7 @@ tags:
     "RQ-TRN-001",
     "RQ-TRN-003"
   ],
-  "implementationStatus": "not-assessed",
+  "implementationStatus": "implemented",
   "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented.",
   "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
 }

--- a/docs/knowledge-graph/vault-TRN-7/clauses/WDP-CL-WAP-PORT-REGISTRY.md
+++ b/docs/knowledge-graph/vault-TRN-7/clauses/WDP-CL-WAP-PORT-REGISTRY.md
@@ -50,7 +50,7 @@ tags:
   "requirementIds": [
     "RQ-TRN-003"
   ],
-  "implementationStatus": "not-assessed",
+  "implementationStatus": "implemented",
   "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented.",
   "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
 }

--- a/docs/knowledge-graph/vault-TRN-7/fixtures/WDP-FX-ADAPTATION-LAYER-BOUNDARY.md
+++ b/docs/knowledge-graph/vault-TRN-7/fixtures/WDP-FX-ADAPTATION-LAYER-BOUNDARY.md
@@ -4,7 +4,7 @@ key: "WDP-FX-ADAPTATION-LAYER-BOUNDARY"
 type: "fixture"
 generated: true
 slice: "TRN-7"
-status: "planned"
+status: "implemented"
 tags:
   - "wap-knowledge-graph"
   - "wap-knowledge-graph/fixture"
@@ -23,7 +23,7 @@ tags:
 ```json
 {
   "kind": "transport-boundary",
-  "status": "planned",
+  "status": "implemented",
   "assertion": "Terminate bearer-specific adaptation at the WDP boundary without changing the service presented to WSP or other upper layers.",
   "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
 }

--- a/docs/knowledge-graph/vault-TRN-7/fixtures/WDP-FX-APPLICATION-PORT-ADDRESSING.md
+++ b/docs/knowledge-graph/vault-TRN-7/fixtures/WDP-FX-APPLICATION-PORT-ADDRESSING.md
@@ -4,7 +4,7 @@ key: "WDP-FX-APPLICATION-PORT-ADDRESSING"
 type: "fixture"
 generated: true
 slice: "TRN-7"
-status: "planned"
+status: "implemented"
 tags:
   - "wap-knowledge-graph"
   - "wap-knowledge-graph/fixture"
@@ -23,7 +23,7 @@ tags:
 ```json
 {
   "kind": "transport-boundary",
-  "status": "planned",
+  "status": "implemented",
   "assertion": "Provide source and destination port addressing for the higher-layer protocol or application above WDP.",
   "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
 }

--- a/docs/knowledge-graph/vault-TRN-7/fixtures/WDP-FX-BEARER-TRANSPARENCY.md
+++ b/docs/knowledge-graph/vault-TRN-7/fixtures/WDP-FX-BEARER-TRANSPARENCY.md
@@ -4,7 +4,7 @@ key: "WDP-FX-BEARER-TRANSPARENCY"
 type: "fixture"
 generated: true
 slice: "TRN-7"
-status: "planned"
+status: "implemented"
 tags:
   - "wap-knowledge-graph"
   - "wap-knowledge-graph/fixture"
@@ -23,7 +23,7 @@ tags:
 ```json
 {
   "kind": "transport-boundary",
-  "status": "planned",
+  "status": "implemented",
   "assertion": "Keep bearer-specific mechanics below the transport service access point so upper layers can operate transparently.",
   "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
 }

--- a/docs/knowledge-graph/vault-TRN-7/fixtures/WDP-FX-CDPD-UDP-IP-PROFILE.md
+++ b/docs/knowledge-graph/vault-TRN-7/fixtures/WDP-FX-CDPD-UDP-IP-PROFILE.md
@@ -4,7 +4,7 @@ key: "WDP-FX-CDPD-UDP-IP-PROFILE"
 type: "fixture"
 generated: true
 slice: "TRN-7"
-status: "planned"
+status: "implemented"
 tags:
   - "wap-knowledge-graph"
   - "wap-knowledge-graph/fixture"
@@ -23,7 +23,7 @@ tags:
 ```json
 {
   "kind": "transport-boundary",
-  "status": "planned",
+  "status": "implemented",
   "assertion": "Declare the selected CDPD bearer as an IP-capable profile whose WDP datagram service is UDP over IPv4.",
   "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
 }

--- a/docs/knowledge-graph/vault-TRN-7/fixtures/WDP-FX-CONSISTENT-TRANSPORT-SERVICE.md
+++ b/docs/knowledge-graph/vault-TRN-7/fixtures/WDP-FX-CONSISTENT-TRANSPORT-SERVICE.md
@@ -4,7 +4,7 @@ key: "WDP-FX-CONSISTENT-TRANSPORT-SERVICE"
 type: "fixture"
 generated: true
 slice: "TRN-7"
-status: "planned"
+status: "implemented"
 tags:
   - "wap-knowledge-graph"
   - "wap-knowledge-graph/fixture"
@@ -23,7 +23,7 @@ tags:
 ```json
 {
   "kind": "transport-boundary",
-  "status": "planned",
+  "status": "implemented",
   "assertion": "Expose the same WDP transport service and primitive contract to upper WAP layers across supported bearer adaptations.",
   "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
 }

--- a/docs/knowledge-graph/vault-TRN-7/fixtures/WDP-FX-DESTINATION-ADDRESS-SEMANTICS.md
+++ b/docs/knowledge-graph/vault-TRN-7/fixtures/WDP-FX-DESTINATION-ADDRESS-SEMANTICS.md
@@ -4,7 +4,7 @@ key: "WDP-FX-DESTINATION-ADDRESS-SEMANTICS"
 type: "fixture"
 generated: true
 slice: "TRN-7"
-status: "planned"
+status: "implemented"
 tags:
   - "wap-knowledge-graph"
   - "wap-knowledge-graph/fixture"
@@ -23,7 +23,7 @@ tags:
 ```json
 {
   "kind": "transport-boundary",
-  "status": "planned",
+  "status": "implemented",
   "assertion": "Treat the destination address as the network identity of the receiving device for the submitted user data.",
   "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
 }

--- a/docs/knowledge-graph/vault-TRN-7/fixtures/WDP-FX-DESTINATION-PORT-SEMANTICS.md
+++ b/docs/knowledge-graph/vault-TRN-7/fixtures/WDP-FX-DESTINATION-PORT-SEMANTICS.md
@@ -4,7 +4,7 @@ key: "WDP-FX-DESTINATION-PORT-SEMANTICS"
 type: "fixture"
 generated: true
 slice: "TRN-7"
-status: "planned"
+status: "implemented"
 tags:
   - "wap-knowledge-graph"
   - "wap-knowledge-graph/fixture"
@@ -23,7 +23,7 @@ tags:
 ```json
 {
   "kind": "transport-boundary",
-  "status": "planned",
+  "status": "implemented",
   "assertion": "Bind the destination port to the destination application or upper-layer protocol for that communication instance.",
   "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
 }

--- a/docs/knowledge-graph/vault-TRN-7/fixtures/WDP-FX-IP-BEARER-REQUIRES-UDP.md
+++ b/docs/knowledge-graph/vault-TRN-7/fixtures/WDP-FX-IP-BEARER-REQUIRES-UDP.md
@@ -4,7 +4,7 @@ key: "WDP-FX-IP-BEARER-REQUIRES-UDP"
 type: "fixture"
 generated: true
 slice: "TRN-7"
-status: "planned"
+status: "implemented"
 tags:
   - "wap-knowledge-graph"
   - "wap-knowledge-graph/fixture"
@@ -23,7 +23,7 @@ tags:
 ```json
 {
   "kind": "transport-boundary",
-  "status": "planned",
+  "status": "implemented",
   "assertion": "Use UDP as the WDP protocol whenever the selected bearer provides IP.",
   "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
 }

--- a/docs/knowledge-graph/vault-TRN-7/fixtures/WDP-FX-IP-MAPPING-FRAGMENTATION.md
+++ b/docs/knowledge-graph/vault-TRN-7/fixtures/WDP-FX-IP-MAPPING-FRAGMENTATION.md
@@ -4,7 +4,7 @@ key: "WDP-FX-IP-MAPPING-FRAGMENTATION"
 type: "fixture"
 generated: true
 slice: "TRN-7"
-status: "planned"
+status: "implemented"
 tags:
   - "wap-knowledge-graph"
   - "wap-knowledge-graph/fixture"
@@ -23,7 +23,7 @@ tags:
 ```json
 {
   "kind": "transport-boundary",
-  "status": "planned",
+  "status": "implemented",
   "assertion": "Rely on IPv4 fragmentation and reassembly below UDP rather than adding a second WDP segmentation header on the CDPD/IP path.",
   "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
 }

--- a/docs/knowledge-graph/vault-TRN-7/fixtures/WDP-FX-IP-MAPPING-IS-UDP.md
+++ b/docs/knowledge-graph/vault-TRN-7/fixtures/WDP-FX-IP-MAPPING-IS-UDP.md
@@ -4,7 +4,7 @@ key: "WDP-FX-IP-MAPPING-IS-UDP"
 type: "fixture"
 generated: true
 slice: "TRN-7"
-status: "planned"
+status: "implemented"
 tags:
   - "wap-knowledge-graph"
   - "wap-knowledge-graph/fixture"
@@ -23,7 +23,7 @@ tags:
 ```json
 {
   "kind": "transport-boundary",
-  "status": "planned",
+  "status": "implemented",
   "assertion": "Map WDP directly to UDP for every selected bearer on which IP routing is available.",
   "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
 }

--- a/docs/knowledge-graph/vault-TRN-7/fixtures/WDP-FX-IPV4-BASELINE-RECEIVE-SIZE.md
+++ b/docs/knowledge-graph/vault-TRN-7/fixtures/WDP-FX-IPV4-BASELINE-RECEIVE-SIZE.md
@@ -4,7 +4,7 @@ key: "WDP-FX-IPV4-BASELINE-RECEIVE-SIZE"
 type: "fixture"
 generated: true
 slice: "TRN-7"
-status: "planned"
+status: "implemented"
 tags:
   - "wap-knowledge-graph"
   - "wap-knowledge-graph/fixture"
@@ -23,7 +23,7 @@ tags:
 ```json
 {
   "kind": "transport-boundary",
-  "status": "planned",
+  "status": "implemented",
   "assertion": "Accept IPv4 datagrams up to 576 octets whether received whole or reassembled from fragments.",
   "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
 }

--- a/docs/knowledge-graph/vault-TRN-7/fixtures/WDP-FX-IPV4-DONT-FRAGMENT.md
+++ b/docs/knowledge-graph/vault-TRN-7/fixtures/WDP-FX-IPV4-DONT-FRAGMENT.md
@@ -4,7 +4,7 @@ key: "WDP-FX-IPV4-DONT-FRAGMENT"
 type: "fixture"
 generated: true
 slice: "TRN-7"
-status: "planned"
+status: "implemented"
 tags:
   - "wap-knowledge-graph"
   - "wap-knowledge-graph/fixture"
@@ -23,7 +23,7 @@ tags:
 ```json
 {
   "kind": "error-policy",
-  "status": "planned",
+  "status": "implemented",
   "assertion": "Do not fragment a datagram whose DF bit is set; discard it when the route cannot carry it intact.",
   "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
 }

--- a/docs/knowledge-graph/vault-TRN-7/fixtures/WDP-FX-IPV4-FIXED-ADDRESS-SIZE.md
+++ b/docs/knowledge-graph/vault-TRN-7/fixtures/WDP-FX-IPV4-FIXED-ADDRESS-SIZE.md
@@ -4,7 +4,7 @@ key: "WDP-FX-IPV4-FIXED-ADDRESS-SIZE"
 type: "fixture"
 generated: true
 slice: "TRN-7"
-status: "planned"
+status: "implemented"
 tags:
   - "wap-knowledge-graph"
   - "wap-knowledge-graph/fixture"
@@ -23,7 +23,7 @@ tags:
 ```json
 {
   "kind": "binary-decoder",
-  "status": "planned",
+  "status": "implemented",
   "assertion": "Represent each selected IPv4 source or destination address as four octets.",
   "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
 }

--- a/docs/knowledge-graph/vault-TRN-7/fixtures/WDP-FX-IPV4-FRAGMENT-REASSEMBLY-KEY.md
+++ b/docs/knowledge-graph/vault-TRN-7/fixtures/WDP-FX-IPV4-FRAGMENT-REASSEMBLY-KEY.md
@@ -4,7 +4,7 @@ key: "WDP-FX-IPV4-FRAGMENT-REASSEMBLY-KEY"
 type: "fixture"
 generated: true
 slice: "TRN-7"
-status: "planned"
+status: "implemented"
 tags:
   - "wap-knowledge-graph"
   - "wap-knowledge-graph/fixture"
@@ -23,7 +23,7 @@ tags:
 ```json
 {
   "kind": "binary-decoder",
-  "status": "planned",
+  "status": "implemented",
   "assertion": "Group IPv4 fragments by identification, source, destination, and protocol, then place data using fragment offsets and the final-fragment marker.",
   "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
 }

--- a/docs/knowledge-graph/vault-TRN-7/fixtures/WDP-FX-IPV4-FRAGMENTATION-LOCATION.md
+++ b/docs/knowledge-graph/vault-TRN-7/fixtures/WDP-FX-IPV4-FRAGMENTATION-LOCATION.md
@@ -4,7 +4,7 @@ key: "WDP-FX-IPV4-FRAGMENTATION-LOCATION"
 type: "fixture"
 generated: true
 slice: "TRN-7"
-status: "planned"
+status: "implemented"
 tags:
   - "wap-knowledge-graph"
   - "wap-knowledge-graph/fixture"
@@ -23,7 +23,7 @@ tags:
 ```json
 {
   "kind": "transport-boundary",
-  "status": "planned",
+  "status": "implemented",
   "assertion": "Allow IPv4 fragmentation at gateways and reassemble fragments at the destination IP module below WDP.",
   "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
 }

--- a/docs/knowledge-graph/vault-TRN-7/fixtures/WDP-FX-IPV4-HEADER-CHECKSUM.md
+++ b/docs/knowledge-graph/vault-TRN-7/fixtures/WDP-FX-IPV4-HEADER-CHECKSUM.md
@@ -4,7 +4,7 @@ key: "WDP-FX-IPV4-HEADER-CHECKSUM"
 type: "fixture"
 generated: true
 slice: "TRN-7"
-status: "planned"
+status: "implemented"
 tags:
   - "wap-knowledge-graph"
   - "wap-knowledge-graph/fixture"
@@ -23,7 +23,7 @@ tags:
 ```json
 {
   "kind": "binary-decoder",
-  "status": "planned",
+  "status": "implemented",
   "assertion": "Verify the ones-complement IPv4 header checksum and discard a datagram immediately when verification fails.",
   "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
 }

--- a/docs/knowledge-graph/vault-TRN-7/fixtures/WDP-FX-IPV4-HEADER-LAYOUT.md
+++ b/docs/knowledge-graph/vault-TRN-7/fixtures/WDP-FX-IPV4-HEADER-LAYOUT.md
@@ -4,7 +4,7 @@ key: "WDP-FX-IPV4-HEADER-LAYOUT"
 type: "fixture"
 generated: true
 slice: "TRN-7"
-status: "planned"
+status: "implemented"
 tags:
   - "wap-knowledge-graph"
   - "wap-knowledge-graph/fixture"
@@ -23,7 +23,7 @@ tags:
 ```json
 {
   "kind": "binary-decoder",
-  "status": "planned",
+  "status": "implemented",
   "assertion": "Decode the complete IPv4 header field order and widths before passing its UDP payload to WDP.",
   "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
 }

--- a/docs/knowledge-graph/vault-TRN-7/fixtures/WDP-FX-IPV4-INDEPENDENT-DATAGRAMS.md
+++ b/docs/knowledge-graph/vault-TRN-7/fixtures/WDP-FX-IPV4-INDEPENDENT-DATAGRAMS.md
@@ -4,7 +4,7 @@ key: "WDP-FX-IPV4-INDEPENDENT-DATAGRAMS"
 type: "fixture"
 generated: true
 slice: "TRN-7"
-status: "planned"
+status: "implemented"
 tags:
   - "wap-knowledge-graph"
   - "wap-knowledge-graph/fixture"
@@ -23,7 +23,7 @@ tags:
 ```json
 {
   "kind": "transport-boundary",
-  "status": "planned",
+  "status": "implemented",
   "assertion": "Treat each IPv4 datagram independently without a transport connection or logical circuit.",
   "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
 }

--- a/docs/knowledge-graph/vault-TRN-7/fixtures/WDP-FX-IPV4-LARGE-SEND-GUARD.md
+++ b/docs/knowledge-graph/vault-TRN-7/fixtures/WDP-FX-IPV4-LARGE-SEND-GUARD.md
@@ -4,7 +4,7 @@ key: "WDP-FX-IPV4-LARGE-SEND-GUARD"
 type: "fixture"
 generated: true
 slice: "TRN-7"
-status: "planned"
+status: "implemented"
 tags:
   - "wap-knowledge-graph"
   - "wap-knowledge-graph/fixture"
@@ -23,7 +23,7 @@ tags:
 ```json
 {
   "kind": "transport-boundary",
-  "status": "planned",
+  "status": "implemented",
   "assertion": "Send an IPv4 datagram larger than 576 octets only with assurance that the destination can accept it.",
   "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
 }

--- a/docs/knowledge-graph/vault-TRN-7/fixtures/WDP-FX-IPV4-NO-RELIABILITY.md
+++ b/docs/knowledge-graph/vault-TRN-7/fixtures/WDP-FX-IPV4-NO-RELIABILITY.md
@@ -4,7 +4,7 @@ key: "WDP-FX-IPV4-NO-RELIABILITY"
 type: "fixture"
 generated: true
 slice: "TRN-7"
-status: "planned"
+status: "implemented"
 tags:
   - "wap-knowledge-graph"
   - "wap-knowledge-graph/fixture"
@@ -23,7 +23,7 @@ tags:
 ```json
 {
   "kind": "transport-boundary",
-  "status": "planned",
+  "status": "implemented",
   "assertion": "Do not imply acknowledgments, retransmission, data error control, or flow control at the IPv4 layer.",
   "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
 }

--- a/docs/knowledge-graph/vault-TRN-7/fixtures/WDP-FX-IPV4-ROBUST-INTEROPERATION.md
+++ b/docs/knowledge-graph/vault-TRN-7/fixtures/WDP-FX-IPV4-ROBUST-INTEROPERATION.md
@@ -4,7 +4,7 @@ key: "WDP-FX-IPV4-ROBUST-INTEROPERATION"
 type: "fixture"
 generated: true
 slice: "TRN-7"
-status: "planned"
+status: "implemented"
 tags:
   - "wap-knowledge-graph"
   - "wap-knowledge-graph/fixture"
@@ -23,7 +23,7 @@ tags:
 ```json
 {
   "kind": "binary-decoder",
-  "status": "planned",
+  "status": "implemented",
   "assertion": "Send well-formed IPv4 datagrams and accept every received datagram whose meaning can be interpreted safely.",
   "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
 }

--- a/docs/knowledge-graph/vault-TRN-7/fixtures/WDP-FX-IPV4-SOURCE-DESTINATION-FIELDS.md
+++ b/docs/knowledge-graph/vault-TRN-7/fixtures/WDP-FX-IPV4-SOURCE-DESTINATION-FIELDS.md
@@ -4,7 +4,7 @@ key: "WDP-FX-IPV4-SOURCE-DESTINATION-FIELDS"
 type: "fixture"
 generated: true
 slice: "TRN-7"
-status: "planned"
+status: "implemented"
 tags:
   - "wap-knowledge-graph"
   - "wap-knowledge-graph/fixture"
@@ -23,7 +23,7 @@ tags:
 ```json
 {
   "kind": "binary-decoder",
-  "status": "planned",
+  "status": "implemented",
   "assertion": "Preserve the 32-bit IPv4 source and destination header fields across the WDP request and indication boundary.",
   "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
 }

--- a/docs/knowledge-graph/vault-TRN-7/fixtures/WDP-FX-IPV4-TOTAL-LENGTH.md
+++ b/docs/knowledge-graph/vault-TRN-7/fixtures/WDP-FX-IPV4-TOTAL-LENGTH.md
@@ -4,7 +4,7 @@ key: "WDP-FX-IPV4-TOTAL-LENGTH"
 type: "fixture"
 generated: true
 slice: "TRN-7"
-status: "planned"
+status: "implemented"
 tags:
   - "wap-knowledge-graph"
   - "wap-knowledge-graph/fixture"
@@ -23,7 +23,7 @@ tags:
 ```json
 {
   "kind": "binary-decoder",
-  "status": "planned",
+  "status": "implemented",
   "assertion": "Interpret IPv4 total length as header plus payload octets with a maximum representable value of 65,535.",
   "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
 }

--- a/docs/knowledge-graph/vault-TRN-7/fixtures/WDP-FX-IPV4-TTL-ZERO.md
+++ b/docs/knowledge-graph/vault-TRN-7/fixtures/WDP-FX-IPV4-TTL-ZERO.md
@@ -4,7 +4,7 @@ key: "WDP-FX-IPV4-TTL-ZERO"
 type: "fixture"
 generated: true
 slice: "TRN-7"
-status: "planned"
+status: "implemented"
 tags:
   - "wap-knowledge-graph"
   - "wap-knowledge-graph/fixture"
@@ -23,7 +23,7 @@ tags:
 ```json
 {
   "kind": "error-policy",
-  "status": "planned",
+  "status": "implemented",
   "assertion": "Destroy an IPv4 datagram when its time-to-live value reaches zero.",
   "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
 }

--- a/docs/knowledge-graph/vault-TRN-7/fixtures/WDP-FX-IPV4-VERSION-AND-IHL.md
+++ b/docs/knowledge-graph/vault-TRN-7/fixtures/WDP-FX-IPV4-VERSION-AND-IHL.md
@@ -4,7 +4,7 @@ key: "WDP-FX-IPV4-VERSION-AND-IHL"
 type: "fixture"
 generated: true
 slice: "TRN-7"
-status: "planned"
+status: "implemented"
 tags:
   - "wap-knowledge-graph"
   - "wap-knowledge-graph/fixture"
@@ -23,7 +23,7 @@ tags:
 ```json
 {
   "kind": "binary-decoder",
-  "status": "planned",
+  "status": "implemented",
   "assertion": "Require IPv4 version value 4 and use IHL in 32-bit words with a minimum valid value of five.",
   "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
 }

--- a/docs/knowledge-graph/vault-TRN-7/fixtures/WDP-FX-PROTOCOL-REQUIRED-PORT-FIELDS.md
+++ b/docs/knowledge-graph/vault-TRN-7/fixtures/WDP-FX-PROTOCOL-REQUIRED-PORT-FIELDS.md
@@ -4,7 +4,7 @@ key: "WDP-FX-PROTOCOL-REQUIRED-PORT-FIELDS"
 type: "fixture"
 generated: true
 slice: "TRN-7"
-status: "planned"
+status: "implemented"
 tags:
   - "wap-knowledge-graph"
   - "wap-knowledge-graph/fixture"
@@ -23,7 +23,7 @@ tags:
 ```json
 {
   "kind": "binary-decoder",
-  "status": "planned",
+  "status": "implemented",
   "assertion": "Carry both destination and source port fields in the selected WDP protocol mapping.",
   "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
 }

--- a/docs/knowledge-graph/vault-TRN-7/fixtures/WDP-FX-SELECTED-BEARER-ASSIGNMENT.md
+++ b/docs/knowledge-graph/vault-TRN-7/fixtures/WDP-FX-SELECTED-BEARER-ASSIGNMENT.md
@@ -4,7 +4,7 @@ key: "WDP-FX-SELECTED-BEARER-ASSIGNMENT"
 type: "fixture"
 generated: true
 slice: "TRN-7"
-status: "planned"
+status: "implemented"
 tags:
   - "wap-knowledge-graph"
   - "wap-knowledge-graph/fixture"
@@ -23,7 +23,7 @@ tags:
 ```json
 {
   "kind": "transport-boundary",
-  "status": "planned",
+  "status": "implemented",
   "assertion": "Represent the AMPS/CDPD/IPv4 network-bearer-address combination with assigned bearer value 0x0D when that registry is carried.",
   "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
 }

--- a/docs/knowledge-graph/vault-TRN-7/fixtures/WDP-FX-SELECTED-WSP-PORT.md
+++ b/docs/knowledge-graph/vault-TRN-7/fixtures/WDP-FX-SELECTED-WSP-PORT.md
@@ -4,7 +4,7 @@ key: "WDP-FX-SELECTED-WSP-PORT"
 type: "fixture"
 generated: true
 slice: "TRN-7"
-status: "planned"
+status: "implemented"
 tags:
   - "wap-knowledge-graph"
   - "wap-knowledge-graph/fixture"
@@ -23,7 +23,7 @@ tags:
 ```json
 {
   "kind": "transport-boundary",
-  "status": "planned",
+  "status": "implemented",
   "assertion": "Use registered UDP/WDP port 9200 for the selected non-secure connectionless WSP session service.",
   "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
 }

--- a/docs/knowledge-graph/vault-TRN-7/fixtures/WDP-FX-SIMULTANEOUS-INSTANCES.md
+++ b/docs/knowledge-graph/vault-TRN-7/fixtures/WDP-FX-SIMULTANEOUS-INSTANCES.md
@@ -4,7 +4,7 @@ key: "WDP-FX-SIMULTANEOUS-INSTANCES"
 type: "fixture"
 generated: true
 slice: "TRN-7"
-status: "planned"
+status: "implemented"
 tags:
   - "wap-knowledge-graph"
   - "wap-knowledge-graph/fixture"
@@ -23,7 +23,7 @@ tags:
 ```json
 {
   "kind": "transport-boundary",
-  "status": "planned",
+  "status": "implemented",
   "assertion": "Use port numbers to multiplex multiple simultaneous higher-layer communication instances over one WDP bearer service.",
   "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
 }

--- a/docs/knowledge-graph/vault-TRN-7/fixtures/WDP-FX-SOURCE-ADDRESS-SEMANTICS.md
+++ b/docs/knowledge-graph/vault-TRN-7/fixtures/WDP-FX-SOURCE-ADDRESS-SEMANTICS.md
@@ -4,7 +4,7 @@ key: "WDP-FX-SOURCE-ADDRESS-SEMANTICS"
 type: "fixture"
 generated: true
 slice: "TRN-7"
-status: "planned"
+status: "implemented"
 tags:
   - "wap-knowledge-graph"
   - "wap-knowledge-graph/fixture"
@@ -23,7 +23,7 @@ tags:
 ```json
 {
   "kind": "transport-boundary",
-  "status": "planned",
+  "status": "implemented",
   "assertion": "Treat the source address as the unique network identity of the device issuing the transport request.",
   "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
 }

--- a/docs/knowledge-graph/vault-TRN-7/fixtures/WDP-FX-SOURCE-PORT-SEMANTICS.md
+++ b/docs/knowledge-graph/vault-TRN-7/fixtures/WDP-FX-SOURCE-PORT-SEMANTICS.md
@@ -4,7 +4,7 @@ key: "WDP-FX-SOURCE-PORT-SEMANTICS"
 type: "fixture"
 generated: true
 slice: "TRN-7"
-status: "planned"
+status: "implemented"
 tags:
   - "wap-knowledge-graph"
   - "wap-knowledge-graph/fixture"
@@ -23,7 +23,7 @@ tags:
 ```json
 {
   "kind": "transport-boundary",
-  "status": "planned",
+  "status": "implemented",
   "assertion": "Bind the source port to the requesting application or upper-layer protocol for that communication instance.",
   "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
 }

--- a/docs/knowledge-graph/vault-TRN-7/fixtures/WDP-FX-UDP-CHECKSUM-COVERAGE.md
+++ b/docs/knowledge-graph/vault-TRN-7/fixtures/WDP-FX-UDP-CHECKSUM-COVERAGE.md
@@ -4,7 +4,7 @@ key: "WDP-FX-UDP-CHECKSUM-COVERAGE"
 type: "fixture"
 generated: true
 slice: "TRN-7"
-status: "planned"
+status: "implemented"
 tags:
   - "wap-knowledge-graph"
   - "wap-knowledge-graph/fixture"
@@ -23,7 +23,7 @@ tags:
 ```json
 {
   "kind": "binary-decoder",
-  "status": "planned",
+  "status": "implemented",
   "assertion": "Compute the UDP checksum over the IPv4 pseudo-header, UDP header, and data using 16-bit ones-complement arithmetic.",
   "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
 }

--- a/docs/knowledge-graph/vault-TRN-7/fixtures/WDP-FX-UDP-CHECKSUM-OMISSION.md
+++ b/docs/knowledge-graph/vault-TRN-7/fixtures/WDP-FX-UDP-CHECKSUM-OMISSION.md
@@ -4,7 +4,7 @@ key: "WDP-FX-UDP-CHECKSUM-OMISSION"
 type: "fixture"
 generated: true
 slice: "TRN-7"
-status: "planned"
+status: "implemented"
 tags:
   - "wap-knowledge-graph"
   - "wap-knowledge-graph/fixture"
@@ -23,7 +23,7 @@ tags:
 ```json
 {
   "kind": "binary-decoder",
-  "status": "planned",
+  "status": "implemented",
   "assertion": "Accept an all-zero UDP checksum field as the IPv4 sender choosing not to generate a UDP checksum.",
   "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
 }

--- a/docs/knowledge-graph/vault-TRN-7/fixtures/WDP-FX-UDP-CHECKSUM-PADDING.md
+++ b/docs/knowledge-graph/vault-TRN-7/fixtures/WDP-FX-UDP-CHECKSUM-PADDING.md
@@ -4,7 +4,7 @@ key: "WDP-FX-UDP-CHECKSUM-PADDING"
 type: "fixture"
 generated: true
 slice: "TRN-7"
-status: "planned"
+status: "implemented"
 tags:
   - "wap-knowledge-graph"
   - "wap-knowledge-graph/fixture"
@@ -23,7 +23,7 @@ tags:
 ```json
 {
   "kind": "binary-decoder",
-  "status": "planned",
+  "status": "implemented",
   "assertion": "Zero-pad an odd checksum input to a two-octet boundary without transmitting the padding octet.",
   "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
 }

--- a/docs/knowledge-graph/vault-TRN-7/fixtures/WDP-FX-UDP-CHECKSUM-ZERO-ENCODING.md
+++ b/docs/knowledge-graph/vault-TRN-7/fixtures/WDP-FX-UDP-CHECKSUM-ZERO-ENCODING.md
@@ -4,7 +4,7 @@ key: "WDP-FX-UDP-CHECKSUM-ZERO-ENCODING"
 type: "fixture"
 generated: true
 slice: "TRN-7"
-status: "planned"
+status: "implemented"
 tags:
   - "wap-knowledge-graph"
   - "wap-knowledge-graph/fixture"
@@ -23,7 +23,7 @@ tags:
 ```json
 {
   "kind": "binary-decoder",
-  "status": "planned",
+  "status": "implemented",
   "assertion": "Transmit an arithmetically computed zero UDP checksum as all one bits.",
   "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
 }

--- a/docs/knowledge-graph/vault-TRN-7/fixtures/WDP-FX-UDP-DESTINATION-PORT-CONTEXT.md
+++ b/docs/knowledge-graph/vault-TRN-7/fixtures/WDP-FX-UDP-DESTINATION-PORT-CONTEXT.md
@@ -4,7 +4,7 @@ key: "WDP-FX-UDP-DESTINATION-PORT-CONTEXT"
 type: "fixture"
 generated: true
 slice: "TRN-7"
-status: "planned"
+status: "implemented"
 tags:
   - "wap-knowledge-graph"
   - "wap-knowledge-graph/fixture"
@@ -23,7 +23,7 @@ tags:
 ```json
 {
   "kind": "transport-boundary",
-  "status": "planned",
+  "status": "implemented",
   "assertion": "Interpret a UDP destination port within the context of its destination IPv4 address.",
   "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
 }

--- a/docs/knowledge-graph/vault-TRN-7/fixtures/WDP-FX-UDP-HEADER-LAYOUT.md
+++ b/docs/knowledge-graph/vault-TRN-7/fixtures/WDP-FX-UDP-HEADER-LAYOUT.md
@@ -4,7 +4,7 @@ key: "WDP-FX-UDP-HEADER-LAYOUT"
 type: "fixture"
 generated: true
 slice: "TRN-7"
-status: "planned"
+status: "implemented"
 tags:
   - "wap-knowledge-graph"
   - "wap-knowledge-graph/fixture"
@@ -23,7 +23,7 @@ tags:
 ```json
 {
   "kind": "binary-decoder",
-  "status": "planned",
+  "status": "implemented",
   "assertion": "Encode and decode the UDP header as 16-bit source port, destination port, length, and checksum fields followed by data.",
   "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
 }

--- a/docs/knowledge-graph/vault-TRN-7/fixtures/WDP-FX-UDP-IP-INTERFACE-METADATA.md
+++ b/docs/knowledge-graph/vault-TRN-7/fixtures/WDP-FX-UDP-IP-INTERFACE-METADATA.md
@@ -4,7 +4,7 @@ key: "WDP-FX-UDP-IP-INTERFACE-METADATA"
 type: "fixture"
 generated: true
 slice: "TRN-7"
-status: "planned"
+status: "implemented"
 tags:
   - "wap-knowledge-graph"
   - "wap-knowledge-graph/fixture"
@@ -23,7 +23,7 @@ tags:
 ```json
 {
   "kind": "transport-boundary",
-  "status": "planned",
+  "status": "implemented",
   "assertion": "Make source address, destination address, and IP protocol metadata available at the UDP/IP boundary.",
   "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
 }

--- a/docs/knowledge-graph/vault-TRN-7/fixtures/WDP-FX-UDP-IP-PROTOCOL-NUMBER.md
+++ b/docs/knowledge-graph/vault-TRN-7/fixtures/WDP-FX-UDP-IP-PROTOCOL-NUMBER.md
@@ -4,7 +4,7 @@ key: "WDP-FX-UDP-IP-PROTOCOL-NUMBER"
 type: "fixture"
 generated: true
 slice: "TRN-7"
-status: "planned"
+status: "implemented"
 tags:
   - "wap-knowledge-graph"
   - "wap-knowledge-graph/fixture"
@@ -23,7 +23,7 @@ tags:
 ```json
 {
   "kind": "binary-decoder",
-  "status": "planned",
+  "status": "implemented",
   "assertion": "Identify UDP with IPv4 protocol number 17.",
   "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
 }

--- a/docs/knowledge-graph/vault-TRN-7/fixtures/WDP-FX-UDP-LENGTH-BOUNDS.md
+++ b/docs/knowledge-graph/vault-TRN-7/fixtures/WDP-FX-UDP-LENGTH-BOUNDS.md
@@ -4,7 +4,7 @@ key: "WDP-FX-UDP-LENGTH-BOUNDS"
 type: "fixture"
 generated: true
 slice: "TRN-7"
-status: "planned"
+status: "implemented"
 tags:
   - "wap-knowledge-graph"
   - "wap-knowledge-graph/fixture"
@@ -23,7 +23,7 @@ tags:
 ```json
 {
   "kind": "binary-decoder",
-  "status": "planned",
+  "status": "implemented",
   "assertion": "Interpret UDP length as header plus data octets and reject values smaller than the eight-octet header.",
   "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
 }

--- a/docs/knowledge-graph/vault-TRN-7/fixtures/WDP-FX-UDP-RECEIVE-INTERFACE.md
+++ b/docs/knowledge-graph/vault-TRN-7/fixtures/WDP-FX-UDP-RECEIVE-INTERFACE.md
@@ -4,7 +4,7 @@ key: "WDP-FX-UDP-RECEIVE-INTERFACE"
 type: "fixture"
 generated: true
 slice: "TRN-7"
-status: "planned"
+status: "implemented"
 tags:
   - "wap-knowledge-graph"
   - "wap-knowledge-graph/fixture"
@@ -23,7 +23,7 @@ tags:
 ```json
 {
   "kind": "transport-boundary",
-  "status": "planned",
+  "status": "implemented",
   "assertion": "Provide receive-port creation and return received data with its source IPv4 address and source port.",
   "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
 }

--- a/docs/knowledge-graph/vault-TRN-7/fixtures/WDP-FX-UDP-SEND-INTERFACE.md
+++ b/docs/knowledge-graph/vault-TRN-7/fixtures/WDP-FX-UDP-SEND-INTERFACE.md
@@ -4,7 +4,7 @@ key: "WDP-FX-UDP-SEND-INTERFACE"
 type: "fixture"
 generated: true
 slice: "TRN-7"
-status: "planned"
+status: "implemented"
 tags:
   - "wap-knowledge-graph"
   - "wap-knowledge-graph/fixture"
@@ -23,7 +23,7 @@ tags:
 ```json
 {
   "kind": "transport-boundary",
-  "status": "planned",
+  "status": "implemented",
   "assertion": "Provide datagram send using explicit data, source and destination ports, and source and destination IPv4 addresses.",
   "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
 }

--- a/docs/knowledge-graph/vault-TRN-7/fixtures/WDP-FX-UDP-SOURCE-PORT-ZERO.md
+++ b/docs/knowledge-graph/vault-TRN-7/fixtures/WDP-FX-UDP-SOURCE-PORT-ZERO.md
@@ -4,7 +4,7 @@ key: "WDP-FX-UDP-SOURCE-PORT-ZERO"
 type: "fixture"
 generated: true
 slice: "TRN-7"
-status: "planned"
+status: "implemented"
 tags:
   - "wap-knowledge-graph"
   - "wap-knowledge-graph/fixture"
@@ -23,7 +23,7 @@ tags:
 ```json
 {
   "kind": "binary-decoder",
-  "status": "planned",
+  "status": "implemented",
   "assertion": "Use source port zero when the sender does not supply a meaningful reply port, and otherwise preserve the selected source port.",
   "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
 }

--- a/docs/knowledge-graph/vault-TRN-7/fixtures/WDP-FX-UDP-UNRELIABLE-DATAGRAMS.md
+++ b/docs/knowledge-graph/vault-TRN-7/fixtures/WDP-FX-UDP-UNRELIABLE-DATAGRAMS.md
@@ -4,7 +4,7 @@ key: "WDP-FX-UDP-UNRELIABLE-DATAGRAMS"
 type: "fixture"
 generated: true
 slice: "TRN-7"
-status: "planned"
+status: "implemented"
 tags:
   - "wap-knowledge-graph"
   - "wap-knowledge-graph/fixture"
@@ -23,7 +23,7 @@ tags:
 ```json
 {
   "kind": "transport-boundary",
-  "status": "planned",
+  "status": "implemented",
   "assertion": "Expose UDP as a connectionless datagram service that does not guarantee delivery, ordering, or duplicate suppression.",
   "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
 }

--- a/docs/knowledge-graph/vault-TRN-7/fixtures/WDP-FX-UNITDATA-CONTENT-TRANSPARENCY.md
+++ b/docs/knowledge-graph/vault-TRN-7/fixtures/WDP-FX-UNITDATA-CONTENT-TRANSPARENCY.md
@@ -4,7 +4,7 @@ key: "WDP-FX-UNITDATA-CONTENT-TRANSPARENCY"
 type: "fixture"
 generated: true
 slice: "TRN-7"
-status: "planned"
+status: "implemented"
 tags:
   - "wap-knowledge-graph"
   - "wap-knowledge-graph/fixture"
@@ -23,7 +23,7 @@ tags:
 ```json
 {
   "kind": "transport-boundary",
-  "status": "planned",
+  "status": "implemented",
   "assertion": "Transmit and deliver the complete service data unit without manipulating its content.",
   "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
 }

--- a/docs/knowledge-graph/vault-TRN-7/fixtures/WDP-FX-UNITDATA-INDICATION-PARAMETERS.md
+++ b/docs/knowledge-graph/vault-TRN-7/fixtures/WDP-FX-UNITDATA-INDICATION-PARAMETERS.md
@@ -4,7 +4,7 @@ key: "WDP-FX-UNITDATA-INDICATION-PARAMETERS"
 type: "fixture"
 generated: true
 slice: "TRN-7"
-status: "planned"
+status: "implemented"
 tags:
   - "wap-knowledge-graph"
   - "wap-knowledge-graph/fixture"
@@ -23,7 +23,7 @@ tags:
 ```json
 {
   "kind": "transport-boundary",
-  "status": "planned",
+  "status": "implemented",
   "assertion": "Deliver source address, source port, and user data on T-DUnitdata indication, with destination address and port when available.",
   "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
 }

--- a/docs/knowledge-graph/vault-TRN-7/fixtures/WDP-FX-UNITDATA-REQUEST-ANYTIME.md
+++ b/docs/knowledge-graph/vault-TRN-7/fixtures/WDP-FX-UNITDATA-REQUEST-ANYTIME.md
@@ -4,7 +4,7 @@ key: "WDP-FX-UNITDATA-REQUEST-ANYTIME"
 type: "fixture"
 generated: true
 slice: "TRN-7"
-status: "planned"
+status: "implemented"
 tags:
   - "wap-knowledge-graph"
   - "wap-knowledge-graph/fixture"
@@ -23,7 +23,7 @@ tags:
 ```json
 {
   "kind": "transport-boundary",
-  "status": "planned",
+  "status": "implemented",
   "assertion": "Allow T-DUnitdata.request without establishing a prior transport connection.",
   "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
 }

--- a/docs/knowledge-graph/vault-TRN-7/fixtures/WDP-FX-UNITDATA-REQUEST-PARAMETERS.md
+++ b/docs/knowledge-graph/vault-TRN-7/fixtures/WDP-FX-UNITDATA-REQUEST-PARAMETERS.md
@@ -4,7 +4,7 @@ key: "WDP-FX-UNITDATA-REQUEST-PARAMETERS"
 type: "fixture"
 generated: true
 slice: "TRN-7"
-status: "planned"
+status: "implemented"
 tags:
   - "wap-knowledge-graph"
   - "wap-knowledge-graph/fixture"
@@ -23,7 +23,7 @@ tags:
 ```json
 {
   "kind": "transport-boundary",
-  "status": "planned",
+  "status": "implemented",
   "assertion": "Require source address, source port, destination address, destination port, and user data on every T-DUnitdata request.",
   "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
 }

--- a/docs/knowledge-graph/vault-TRN-7/fixtures/WDP-FX-WAP-PORT-REGISTRY.md
+++ b/docs/knowledge-graph/vault-TRN-7/fixtures/WDP-FX-WAP-PORT-REGISTRY.md
@@ -4,7 +4,7 @@ key: "WDP-FX-WAP-PORT-REGISTRY"
 type: "fixture"
 generated: true
 slice: "TRN-7"
-status: "planned"
+status: "implemented"
 tags:
   - "wap-knowledge-graph"
   - "wap-knowledge-graph/fixture"
@@ -23,7 +23,7 @@ tags:
 ```json
 {
   "kind": "transport-boundary",
-  "status": "planned",
+  "status": "implemented",
   "assertion": "Recognize the complete WAP port assignment table, including connectionless, session, secure, push, vCard, and vCalendar services.",
   "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
 }

--- a/docs/knowledge-graph/vault-TRN-7/scr-rows/WDP-C-001.md
+++ b/docs/knowledge-graph/vault-TRN-7/scr-rows/WDP-C-001.md
@@ -39,7 +39,7 @@ tags:
     "documentId": "WAP-200_005-WDP",
     "staticConformanceSection": "Appendix E"
   },
-  "implementationStatus": "partial",
+  "implementationStatus": "implemented",
   "ownerLayers": [
     "transport-rust"
   ],

--- a/docs/knowledge-graph/vault-TRN-7/scr-rows/WDP-CORE-C-001.md
+++ b/docs/knowledge-graph/vault-TRN-7/scr-rows/WDP-CORE-C-001.md
@@ -52,7 +52,7 @@ tags:
     "documentId": "WAP-200_005-WDP",
     "staticConformanceSection": "Appendix E"
   },
-  "implementationStatus": "partial",
+  "implementationStatus": "implemented",
   "ownerLayers": [
     "transport-rust"
   ],

--- a/docs/knowledge-graph/vault-TRN-7/scr-rows/WDP-CT-C-002.md
+++ b/docs/knowledge-graph/vault-TRN-7/scr-rows/WDP-CT-C-002.md
@@ -35,7 +35,7 @@ tags:
     "documentId": "WAP-200_005-WDP",
     "staticConformanceSection": "Appendix E"
   },
-  "implementationStatus": "partial",
+  "implementationStatus": "implemented",
   "ownerLayers": [
     "transport-rust"
   ],

--- a/docs/knowledge-graph/vault-TRN-7/scr-rows/WDP-NA-C-000.md
+++ b/docs/knowledge-graph/vault-TRN-7/scr-rows/WDP-NA-C-000.md
@@ -33,7 +33,7 @@ tags:
     "documentId": "WAP-200_005-WDP",
     "staticConformanceSection": "Appendix E"
   },
-  "implementationStatus": "partial",
+  "implementationStatus": "implemented",
   "ownerLayers": [
     "transport-rust"
   ],

--- a/docs/knowledge-graph/vault-TRN-7/scr-rows/WDP-NA-C-003.md
+++ b/docs/knowledge-graph/vault-TRN-7/scr-rows/WDP-NA-C-003.md
@@ -57,7 +57,7 @@ tags:
     "documentId": "WAP-200_005-WDP",
     "staticConformanceSection": "Appendix E"
   },
-  "implementationStatus": "partial",
+  "implementationStatus": "implemented",
   "ownerLayers": [
     "transport-rust"
   ],

--- a/docs/knowledge-graph/vault-TRN-7/scr-rows/WDP-NA-C-006.md
+++ b/docs/knowledge-graph/vault-TRN-7/scr-rows/WDP-NA-C-006.md
@@ -39,7 +39,7 @@ tags:
     "documentId": "WAP-200_005-WDP",
     "staticConformanceSection": "Appendix E"
   },
-  "implementationStatus": "partial",
+  "implementationStatus": "implemented",
   "ownerLayers": [
     "transport-rust"
   ],

--- a/docs/knowledge-graph/vault-TRN-7/scr-rows/WDP-NA-C-007.md
+++ b/docs/knowledge-graph/vault-TRN-7/scr-rows/WDP-NA-C-007.md
@@ -39,7 +39,7 @@ tags:
     "documentId": "WAP-200_005-WDP",
     "staticConformanceSection": "Appendix E"
   },
-  "implementationStatus": "partial",
+  "implementationStatus": "implemented",
   "ownerLayers": [
     "transport-rust"
   ],

--- a/docs/knowledge-graph/vault-TRN-7/scr-rows/WDP-PF-C-001.md
+++ b/docs/knowledge-graph/vault-TRN-7/scr-rows/WDP-PF-C-001.md
@@ -37,7 +37,7 @@ tags:
     "documentId": "WAP-200_005-WDP",
     "staticConformanceSection": "Appendix E"
   },
-  "implementationStatus": "partial",
+  "implementationStatus": "implemented",
   "ownerLayers": [
     "transport-rust"
   ],

--- a/docs/knowledge-graph/vault-TRN-7/scr-rows/WDP-PF-C-002.md
+++ b/docs/knowledge-graph/vault-TRN-7/scr-rows/WDP-PF-C-002.md
@@ -36,7 +36,7 @@ tags:
     "documentId": "WAP-200_005-WDP",
     "staticConformanceSection": "Appendix E"
   },
-  "implementationStatus": "partial",
+  "implementationStatus": "implemented",
   "ownerLayers": [
     "transport-rust"
   ],

--- a/docs/knowledge-graph/vault-TRN-7/work-items/TRN-701.md
+++ b/docs/knowledge-graph/vault-TRN-7/work-items/TRN-701.md
@@ -4,7 +4,7 @@ key: "TRN-701"
 type: "work-item"
 generated: true
 slice: "TRN-7"
-status: "in-progress"
+status: "done"
 tags:
   - "wap-knowledge-graph"
   - "wap-knowledge-graph/work-item"
@@ -85,7 +85,7 @@ tags:
 
 ```json
 {
-  "status": "in-progress",
+  "status": "done",
   "ownerLayers": [
     "transport-rust",
     "qa"

--- a/docs/waves/NETWORK_PROFILE_DECISION_RECORD.md
+++ b/docs/waves/NETWORK_PROFILE_DECISION_RECORD.md
@@ -35,8 +35,9 @@ Fixture lane:
 Current caveat:
 
 - Native GET/POST ingress and smoke slices are landed, but exact
-  WAP-200/WAP-202/WAP-203 conformance remains open under `TRN-701`,
-  `TRN-703`, and `WSP-801`/`802`/`804`/`805`.
+  WAP-203 connectionless conformance remains open under
+  `WSP-801`/`802`/`804`/`805`; the selected WAP-200 and WAP-202 rows are
+  directly evidenced by `TRN-701` and `TRN-703`.
 
 Fixture lane:
 

--- a/docs/waves/SOURCE_MATERIAL_MASTER_AUDIT.md
+++ b/docs/waves/SOURCE_MATERIAL_MASTER_AUDIT.md
@@ -152,7 +152,7 @@ Supplemental-source precedence:
 - one-to-one mandatory/optional obligation ledgers for the WAP 1.2.1 target
   (WML 1.3, WAE, WBXML, WMLScript, WMLScript Libraries, caching, WDP, WCMP,
   and WSP complete at SCR/source-work-item and nested-clause planning level;
-  direct test evidence remains pending)
+  the 77 selected WDP/WCMP clauses now have direct fixture evidence)
 - WAP 1.2.1-to-successor delta records cover all 201 selected Class C rows;
   optional-media and later OMA follow-on deltas remain separately pending
 
@@ -161,13 +161,13 @@ Cross-source selected-profile accounting is now executable:
 - 712 effective SCR/source rows across the nine mandatory feature families;
 - 201 rows selected by the exact Class C client profile and transport
   dependency path;
-- 7 implemented, 84 partial, and 110 missing in the conservative
+- 22 implemented, 78 partial, and 101 missing in the conservative
   implementation audit;
 - every selected row has an owner and work-item mapping;
 - all 201 selected rows now expand into 781 deduplicated nested clauses with
-  source anchors and planned direct fixtures;
-- direct conformance fixture implementation and execution remain the
-  principal evidence gap.
+  source anchors and fixture plans;
+- 77 WDP/WCMP clauses are directly fixture-backed; direct conformance fixture
+  implementation remains the principal evidence gap for the other 704.
 
 The family-level WAP 1.2.1 base/SIN precedence graph now exists at
 `spec-processing/source-manifests/wap-1.2.1-effective-spec.json`. It establishes

--- a/docs/waves/SPEC_COVERAGE_DASHBOARD.md
+++ b/docs/waves/SPEC_COVERAGE_DASHBOARD.md
@@ -20,7 +20,7 @@ Status: Active
   - nine mandatory feature families
   - 712 effective source rows
   - 201 selected strict rows
-  - implementation audit: 7 implemented, 84 partial, 110 missing
+  - implementation audit: 22 implemented, 78 partial, 101 missing
   - all 201 selected rows have owner/work-item mappings
 - Important: `deep-extracted` describes review of the current WAP 2.0-heavy
   local corpus. It is not evidence that the WAP 1.2.1 target source set or
@@ -54,7 +54,7 @@ Status: Active
   - WDP: 9 selected parents / 49 clauses
   - WMLScript: 41 selected parents / 107 clauses
   - WMLScript Libraries: 80 selected parents / 211 clauses
-  - all 781 direct fixtures planned; clause implementation status not assessed
+  - 77 fixture-backed clauses assessed; 704 fixture plans remain unassessed
 - Selected-profile successor delta register:
   - `spec-processing/source-manifests/wap-1.2.1-successor-delta.json`
   - all 201 selected rows classified
@@ -107,9 +107,10 @@ Status: Active
   - `spec-processing/source-manifests/wap-1.2.1-wcmp-scr.json`
   - `spec-processing/source-manifests/wap-1.2.1-wsp-scr.json`
   - 317 source rows and 22 selected connectionless Class C rows
-  - selected audit: 5 implemented, 17 partial, 0 missing
-  - direct normative evidence: 5/22, all on the selected WAP-202 WCMP path
-  - direct normative test evidence: 0/22
+  - selected audit: 14 implemented, 8 partial, 0 missing
+  - direct normative evidence: 14/22 across the selected WAP-200 WDP and
+    WAP-202 WCMP paths
+  - direct normative test evidence: 14/22
 - Conditional target source:
   - `WAP-201-WTP` plus approved SINs, only when connection-oriented WSP is
     claimed
@@ -229,8 +230,8 @@ Status: Active
 
 2. Transport bedrock conformance closure (`WAP-200`, `WAP-202`, `WAP-203`)
 - Status: in progress (exact SCR extraction, selected-path resolution, and
-  implementation audit plus 134 nested clauses complete; direct fixtures and
-  implementation closure pending)
+  implementation audit plus 134 nested clauses complete; WDP/WCMP fixtures
+  are direct, while WSP implementation closure remains pending)
 - Deliverables:
   - `docs/waves/WAP_1_2_1_TRANSPORT_SCR_LEDGERS.md`
   - `spec-processing/source-manifests/wap-1.2.1-wdp-scr.json`
@@ -240,8 +241,8 @@ Status: Active
   - program work items `TRN-701`, `TRN-703`, `WSP-801`, `WSP-802`,
     `WSP-804`, and `WSP-805`
 - Priority closure focus:
-  - nine selected WDP rows, including the CDPD/IPv4 bearer declaration
-  - five selected WCMP general-message rows
+  - preserve the completed nine-row WDP CDPD/IPv4 evidence
+  - preserve the completed five-row WCMP general-message evidence
   - eight selected connectionless WSP rows and exact WAP-203 registries
   - browser GET/POST ingress through the selected connectionless path
   - retain the normalized, licensed-payload `TIAEIA-732` capability metadata

--- a/docs/waves/SPEC_TEST_COVERAGE.md
+++ b/docs/waves/SPEC_TEST_COVERAGE.md
@@ -55,7 +55,7 @@ Legend:
 
 | Requirement Group | Status | Current/Planned Test Location |
 |---|---|---|
-| Exact WAP-200 WDP ledger: 146 rows / 9 selected | `0 implemented / 9 partial / 0 missing`; `0/9` direct normative tests | `spec-processing/source-manifests/wap-1.2.1-wdp-scr.json`; validate with `node scripts/check-wap-transport-conformance-ledgers.mjs` |
+| Exact WAP-200 WDP ledger: 146 rows / 9 selected | `9 implemented / 0 partial / 0 missing`; `9/9` direct normative tests and 49/49 mapped clauses | `spec-processing/source-manifests/wap-1.2.1-wdp-scr.json`; fixture: `transport-rust/tests/fixtures/transport/wdp_cdpd_ipv4_mapped/wdp_fixture.json`; validate with `cargo test --manifest-path transport-rust/Cargo.toml --lib network::wdp` and `node scripts/check-wap-transport-conformance-ledgers.mjs` |
 | Exact WAP-202 WCMP ledger: 62 rows / 5 selected | `5 implemented / 0 partial / 0 missing`; `5/5` direct normative tests | `spec-processing/source-manifests/wap-1.2.1-wcmp-scr.json`; source-derived vectors: `transport-rust/tests/fixtures/transport/wcmp_core_mapped/wcmp_fixture.json`; validate with `cargo test --manifest-path transport-rust/Cargo.toml --lib network::wcmp` and `node scripts/check-wap-transport-conformance-ledgers.mjs` |
 | Exact WAP-203 WSP ledger: 109 rows / 8 selected | `0 implemented / 8 partial / 0 missing`; `0/8` direct normative tests | `spec-processing/source-manifests/wap-1.2.1-wsp-scr.json`; validate with `node scripts/check-wap-transport-conformance-ledgers.mjs` |
 | `RQ-TRN-001..004` WDP service + UDP + addressing + error policy | `partial` | transport-rust unit tests + fixture harness scenarios under `transport-rust/tests/fixtures/transport/` |

--- a/docs/waves/WAP_1_2_1_COMPLIANCE_PROGRAM.md
+++ b/docs/waves/WAP_1_2_1_COMPLIANCE_PROGRAM.md
@@ -38,12 +38,12 @@ All nine selected Class C family increments are complete at SCR level:
 
 - together they contain 712 effective source rows and 201 selected strict
   rows;
-- the selected implementation audit is 13 implemented, 87 partial, and 101
+- the selected implementation audit is 22 implemented, 78 partial, and 101
   missing;
 - every selected row has an implementation owner and work-item mapping;
 - `CONF-003` is complete: all nine families and all 201 selected parent rows
-  expand into 781 deduplicated, source-anchored clauses with planned direct
-  fixtures;
+  expand into 781 deduplicated, source-anchored clauses; the selected WDP and
+  WCMP paths contribute 77 assessed, direct fixture-backed clauses;
 - `CONF-004`, `CONF-005`, and `CONF-006` are complete: strict dispositions,
   the SCR-to-requirement/work/evidence crosswalk, and active-document status
   rollups are now guarded by a deterministic drift check;

--- a/docs/waves/WAP_1_2_1_TRANSPORT_SCR_LEDGERS.md
+++ b/docs/waves/WAP_1_2_1_TRANSPORT_SCR_LEDGERS.md
@@ -65,10 +65,10 @@ This produces 22 selected-path rows:
 
 | Family | Selected path | Current audit | Direct normative tests |
 |---|---:|---|---:|
-| WDP | 9 | 0 implemented / 9 partial / 0 missing | 0 |
+| WDP | 9 | 9 implemented / 0 partial / 0 missing | 9 |
 | WCMP | 5 | 5 implemented / 0 partial / 0 missing | 5 |
 | WSP | 8 | 0 implemented / 8 partial / 0 missing | 0 |
-| **Total** | **22** | **5 implemented / 17 partial / 0 missing** | **5** |
+| **Total** | **22** | **14 implemented / 8 partial / 0 missing** | **14** |
 
 The two optional WDP rows and four optional WCMP/WSP root-dependency rows are
 required by the selected alternatives. Their source `O` status is preserved;
@@ -78,23 +78,27 @@ the project profile makes them strict for this path.
 
 ### WDP
 
-The Rust transport has a useful WDP-shaped foundation:
+The Rust transport now carries direct evidence for the selected CDPD/IPv4
+WDP path:
 
-- `WdpDatagram` carries source/destination address, ports, and payload;
-- `DatagramTransport` exposes send/receive operations;
-- `UdpDatagramTransport` binds the datagram model to IPv4/IPv6 UDP;
-- known WAP service ports `9200..9203` are represented;
-- payload bounds and a segmentation/reassembly policy surface exist.
+- `TDUnitdataRequest` and `TDUnitdataIndication` preserve the selected source
+  and destination IPv4 addresses, ports, and user data;
+- `CdpdIpv4Profile` declares bearer value `0x0D`, IPv4 addresses, UDP
+  protocol number `17`, and connectionless WSP port `9200`;
+- the complete Appendix B registry is represented for ports `2805`, `2923`,
+  `2948`, `2949`, and `9200..9207`;
+- the bounded IPv4/UDP codec verifies header layout, lengths, IPv4 and UDP
+  checksums, odd-octet checksum padding, TTL, protocol, and address identity;
+- explicit send policy covers the 576-octet IPv4 baseline, larger-destination
+  assurance, DF/path-MTU rejection, and UDP checksum omission.
 
-All nine selected rows remain partial. The code has no machine-declared CDPD
-strict profile, no source-derived `T-DUnitdata` vectors, and no proof that its
-address/port/error semantics cover the effective WAP-200 clauses.
-
-`CONF-003` now expands the nine rows into 49 source-anchored WAP-200,
-RFC 768, and RFC 791 clauses with planned fixtures. The slice covers the
-T-DUnitdata contract, port registries, UDP header/checksum/length rules, IPv4
-addressing and fragmentation boundaries, and the CDPD capability declaration.
-Clause implementation remains `not-assessed`; parent rows remain partial.
+All nine selected rows and their 49 source-anchored WAP-200, RFC 768, and
+RFC 791 clauses link to the direct fixture at
+`transport-rust/tests/fixtures/transport/wdp_cdpd_ipv4_mapped/wdp_fixture.json`.
+IPv4 fragments are rejected with their reassembly key and must be reassembled
+by the destination IP module below WDP. This proves the TRN-701 adaptation
+boundary; it does not implement or close the separately unmapped TRN-702
+segmentation/reassembly policy.
 
 ### WCMP
 
@@ -180,8 +184,10 @@ adapter.
 
 ## Work closure
 
-- `TRN-701` / `T0-19`: close all nine selected WDP rows, the CDPD/IPv4
+- `TRN-701` / `T0-19`: complete for the nine selected WDP rows, CDPD/IPv4
   capability declaration, and source-derived datagram fixtures.
+- `TRN-702`: remains open with no direct clause mapping; constrained-payload
+  and segmentation/reassembly policy must be adopted and evidenced separately.
 - `TRN-703` / `T0-17`: implement and test the five-row WCMP core, then
   capability-gate optional WCMP breadth.
 - `WSP-801`, `WSP-802`, `WSP-804`, `WSP-805`: close the eight-row

--- a/docs/waves/wap-1.2.1-compliance-program.json
+++ b/docs/waves/wap-1.2.1-compliance-program.json
@@ -948,7 +948,7 @@
       "workItems": [
         {
           "id": "TRN-701",
-          "status": "in-progress",
+          "status": "done",
           "ownerLayers": ["transport-rust", "qa"],
           "sourceFamilies": ["wdp", "wdp-wcmp-adaptation"],
           "existingTickets": ["T0-19"],

--- a/docs/waves/wdp-datagram-format.md
+++ b/docs/waves/wdp-datagram-format.md
@@ -8,11 +8,15 @@ Date: `2026-03-04`
 In this project WDP is a constrained, testable datagram abstraction for upper protocol layers.
 It maps to one transport datagram in memory and to one UDP datagram in the MVP transport.
 
-From `WAP-259`:
+For the selected WAP 1.2.1 Class C path, WAP-200 plus RFC 768 and RFC 791
+define the active behavior:
 
 - WDP is the standard datagram interface between bearer services and upper layers.
-- over IP, WDP mapping is UDP.
+- CDPD is selected as an IP-capable bearer and WDP maps directly to UDP/IPv4.
 - WSP/WTP/WTLS session identity is by address/port quadruplet (client/server address + ports).
+- the selected AMPS/CDPD/IPv4 bearer assignment is `0x0D`.
+- bearer fragmentation/reassembly terminates below WDP; no second WDP
+  segmentation header is added to this IP path.
 
 ## 2) MVP datagram model
 
@@ -31,37 +35,59 @@ pub struct WdpAddress {
 }
 ```
 
-Minimal interface required by current transport:
+The source-shaped service primitive types are:
 
 ```rust
-pub trait DatagramTransport {
-    fn send(&mut self, datagram: &WdpDatagram) -> Result<(), WdpError>;
-    fn receive(&mut self) -> Result<WdpDatagram, WdpError>;
+pub struct TDUnitdataRequest {
+    pub source_address: WdpAddress,
+    pub source_port: u16,
+    pub destination_address: WdpAddress,
+    pub destination_port: u16,
+    pub user_data: Vec<u8>,
+}
+
+pub struct TDUnitdataIndication {
+    pub source_address: WdpAddress,
+    pub source_port: u16,
+    pub destination_address: Option<WdpAddress>,
+    pub destination_port: Option<u16>,
+    pub user_data: Vec<u8>,
 }
 ```
 
 ## 3) WAP service ports in profile
 
-WAP registered datagram ports are part of service selection and must be preserved:
+The complete WAP-200 Appendix B registry is recognized:
 
-- WSP Connectionless Session Service (non-secure): `9200`.
-- WSP Session Service (non-secure): `9201`.
-- WSP Connectionless Session Service (secure): `9202`.
-- WSP Session Service (secure): `9203`.
-- Push services have additional legacy ports in WAP-259 Appendix B; only those required by enabled transport profile are part of MVP.
+- WTA secure connectionless/session: `2805`, `2923`.
+- Push connectionless/secure connectionless: `2948`, `2949`.
+- WSP connectionless/session/secure connectionless/secure session:
+  `9200..9203`.
+- vCard/vCalendar datagram and secure datagram: `9204..9207`.
 
 Transport policy:
 - server entities MUST bind well-known service ports.
 - client entities may use ephemeral source ports.
 - the profile must log/validate source/destination quadruplets for each session.
+- recognizing a registered port does not activate that optional application or
+  security profile. The selected non-secure connectionless WSP service uses
+  destination port `9200`.
 
 ## 4) Bearer implementation contracts
 
-### 4.1 UDP (`wdp over IP`) — MVP
+### 4.1 CDPD/UDP/IPv4 — selected strict path
 
-- map WDP datagram `payload` 1:1 to UDP payload.
-- use 16-bit port fields.
-- map receive errors into typed `WdpError` values.
+- addresses are exactly four octets and UDP is IPv4 protocol `17`;
+- map WDP user data 1:1 to UDP data with 16-bit source and destination ports;
+- encode and validate IPv4 and UDP lengths and checksums, including odd-octet
+  checksum padding, computed-zero encoding as `0xFFFF`, and permitted
+  all-zero UDP checksum omission;
+- accept IPv4 datagrams through the 576-octet baseline and require explicit
+  destination assurance for larger sends;
+- discard TTL-zero, bad-header-checksum, malformed-length, bad non-zero UDP
+  checksum, unsupported-protocol, and DF/path-MTU failures deterministically;
+- return unreassembled IPv4 fragments as an explicit lower-layer reassembly
+  requirement keyed by identification, source, destination, and protocol.
 
 ### 4.2 SMS/USSD/other GSM bearers — deferred
 
@@ -71,11 +97,15 @@ Implementation is deferred but reserved in model:
 - bearer-specific maximum payload sizes,
 - optional sequence numbers/retry semantics.
 
-## 5) Segmentation policy
+## 5) Segmentation boundary
 
-- no automatic segmentation in core MVP service layer.
-- higher layer may enforce MTU via capability/SDU checks.
-- if bearer segmenting is enabled, use WTP SAR/ESAR policy where the WTP layer explicitly requests grouping and recovery.
+- the selected CDPD/IP path adds no WDP segmentation header;
+- IPv4 gateways may fragment and the destination IP module reassembles before
+  delivery to WDP;
+- the codec does not perform fragment collection or reassembly;
+- `TRN-702` remains a declared zero-clause mapping gap for the broader
+  constrained-payload and segmentation/reassembly policy and is not closed by
+  the `TRN-701` evidence.
 
 ## 6) Error taxonomy
 
@@ -94,7 +124,15 @@ Minimum errors expected by upper layers:
 - expose only transport-visible fields and typed errors.
 - ensure all parse/codec methods stay stateless to keep replayability in tests.
 
-## 8) Pending precision
+## 8) Evidence
 
-- WAP-259 bearer-specific checksum requirements are profile-dependent.
-- keep a deferred issue for explicit bearer obligations per profile until bearer adapter is in-scope.
+The direct fixture
+`transport-rust/tests/fixtures/transport/wdp_cdpd_ipv4_mapped/wdp_fixture.json`
+links the nine selected SCR rows and all 49 mapped TRN-701 clauses to exact
+profile constants, registered ports, positive wire packets, and deterministic
+malformed outcomes. Validate it with:
+
+```sh
+cargo test --manifest-path transport-rust/Cargo.toml --lib network::wdp
+node scripts/check-wap-transport-conformance-ledgers.mjs
+```

--- a/scripts/check-requirement-status-drift.mjs
+++ b/scripts/check-requirement-status-drift.mjs
@@ -87,7 +87,7 @@ const familyDefinitions = [
     expectedRows: 146,
     expectedSelected: 9,
     expectedClauses: 49,
-    expectedStatus: { implemented: 0, partial: 9, missing: 0 },
+    expectedStatus: { implemented: 9, partial: 0, missing: 0 },
     activeDoc: 'docs/waves/WAP_1_2_1_TRANSPORT_SCR_LEDGERS.md'
   },
   {
@@ -154,7 +154,7 @@ for (const sprint of program.sprints ?? []) {
 }
 if (
   JSON.stringify(programStatusCounts) !==
-  JSON.stringify({ done: 13, blocked: 1, 'in-progress': 10, todo: 54 })
+  JSON.stringify({ done: 14, blocked: 1, 'in-progress': 9, todo: 54 })
 ) {
   failures.push('compliance-program work-item status rollup drift');
 }
@@ -320,7 +320,7 @@ if (
   aggregateSelected !== 201 ||
   aggregateClauses !== 781 ||
   JSON.stringify(aggregateStatus) !==
-  JSON.stringify({ implemented: 13, partial: 87, missing: 101 })
+  JSON.stringify({ implemented: 22, partial: 78, missing: 101 })
 ) {
   failures.push('selected-profile aggregate planning/status drift');
 }
@@ -343,7 +343,7 @@ const requiredDocumentFragments = new Map([
     'docs/waves/SOURCE_MATERIAL_MASTER_AUDIT.md',
     [
       'all 201 selected rows now expand into 781',
-      'direct conformance fixture implementation and execution remain'
+      '77 WDP/WCMP clauses are directly fixture-backed'
     ]
   ],
   [
@@ -364,7 +364,7 @@ const requiredDocumentFragments = new Map([
     'docs/waves/SPEC_COVERAGE_DASHBOARD.md',
     [
       'WMLScript Libraries: 80 selected parents / 211 clauses',
-      'all 781 direct fixtures planned'
+      '77 fixture-backed clauses assessed'
     ]
   ],
   [

--- a/scripts/check-wap-compliance-program.mjs
+++ b/scripts/check-wap-compliance-program.mjs
@@ -408,7 +408,7 @@ const wcmpCore = transportSprint?.workItems.find(
 );
 if (
   transportSprint?.status !== 'in-progress' ||
-  wdpCore?.status !== 'in-progress' ||
+  wdpCore?.status !== 'done' ||
   wcmpCore?.status !== 'done' ||
   !wdpCore?.outputs?.includes(
     'spec-processing/source-manifests/wap-1.2.1-wdp-scr.json'

--- a/scripts/check-wap-conformance-ledger.mjs
+++ b/scripts/check-wap-conformance-ledger.mjs
@@ -622,7 +622,7 @@ if (aggregateRowCount !== 712 || aggregateSelectedCount !== 201) {
 }
 if (
   JSON.stringify(aggregateStatusCounts) !==
-  JSON.stringify({ implemented: 13, partial: 87, missing: 101 })
+  JSON.stringify({ implemented: 22, partial: 78, missing: 101 })
 ) {
   aggregateFailures.push(
     `selected-profile status aggregate drift: ${JSON.stringify(aggregateStatusCounts)}`

--- a/scripts/check-wap-selected-normative-clauses.mjs
+++ b/scripts/check-wap-selected-normative-clauses.mjs
@@ -272,7 +272,7 @@ for (const family of ledger.families ?? []) {
     (candidate) => candidate.family === family.family
   );
   const expectedFamilyStatus =
-    family.family === 'wcmp'
+    family.family === 'wcmp' || family.family === 'wdp'
       ? 'nested-clauses-fixture-backed'
       : 'nested-clauses-anchored-fixtures-planned';
 
@@ -466,7 +466,8 @@ for (const family of ledger.families ?? []) {
         parent.mapping.implementationStatus
       ])
     );
-    const directFixtureImplemented = candidate.family === 'wcmp';
+    const directFixtureImplemented =
+      candidate.family === 'wcmp' || candidate.family === 'wdp';
     const expectedClauseStatus = directFixtureImplemented
       ? 'implemented'
       : 'not-assessed';
@@ -498,11 +499,15 @@ for (const family of ledger.families ?? []) {
       candidate.fixturePlan.assertion !== candidate.obligationSynopsis ||
       (directFixtureImplemented &&
         (candidate.fixturePlan.evidence?.path !==
-          'transport-rust/tests/fixtures/transport/wcmp_core_mapped/wcmp_fixture.json' ||
+          (candidate.family === 'wdp'
+            ? 'transport-rust/tests/fixtures/transport/wdp_cdpd_ipv4_mapped/wdp_fixture.json'
+            : 'transport-rust/tests/fixtures/transport/wcmp_core_mapped/wcmp_fixture.json') ||
           candidate.fixturePlan.evidence?.testPath !==
-            'transport-rust/src/network/wcmp/tests.rs' ||
+            (candidate.family === 'wdp'
+              ? 'transport-rust/src/network/wdp/tests.rs'
+              : 'transport-rust/src/network/wcmp/tests.rs') ||
           !candidate.fixturePlan.evidence?.command?.includes(
-            'network::wcmp'
+            candidate.family === 'wdp' ? 'network::wdp' : 'network::wcmp'
           )))
     ) {
       failures.push(`${candidate.id}: direct fixture plan is incomplete`);
@@ -529,7 +534,7 @@ const expectedSummary = {
   recommendedClauseCount,
   permittedClauseCount,
   plannedFixtureCount: clauseCount,
-  assessedClauseCount: 0
+  assessedClauseCount: 77
 };
 if (
   selectedParentCount !== 201 ||

--- a/scripts/check-wap-transport-conformance-ledgers.mjs
+++ b/scripts/check-wap-transport-conformance-ledgers.mjs
@@ -58,8 +58,8 @@ const configs = [
       serverCount: 75,
       mandatoryClientCount: 7,
       selectedClassCTransportPathCount: 9,
-      selectedDirectNormativeTestEvidenceCount: 0,
-      selectedProvisionalTestEvidenceCount: 9,
+      selectedDirectNormativeTestEvidenceCount: 9,
+      selectedProvisionalTestEvidenceCount: 0,
       orderedIdsSha256:
         'd090dead796a8ba086e350455ceccb557f34e75ada6d25492c8ee603d3b7b4bc'
     },
@@ -74,7 +74,7 @@ const configs = [
       'WDP-NA-C-006',
       'WDP-NA-C-007'
     ],
-    selectedStatus: { partial: 9 }
+    selectedStatus: { implemented: 9 }
   },
   {
     family: 'wcmp',

--- a/spec-processing/scripts/generate-wap-selected-normative-clauses.mjs
+++ b/spec-processing/scripts/generate-wap-selected-normative-clauses.mjs
@@ -890,7 +890,21 @@ function clause(
   obligationSynopsis,
   anchorFamily = family
 ) {
-  const directFixtureImplemented = family === 'wcmp';
+  const directFixtureImplemented = family === 'wcmp' || family === 'wdp';
+  const evidence =
+    family === 'wdp'
+      ? {
+          path: 'transport-rust/tests/fixtures/transport/wdp_cdpd_ipv4_mapped/wdp_fixture.json',
+          testPath: 'transport-rust/src/network/wdp/tests.rs',
+          command:
+            'cargo test --manifest-path transport-rust/Cargo.toml --lib network::wdp'
+        }
+      : {
+          path: 'transport-rust/tests/fixtures/transport/wcmp_core_mapped/wcmp_fixture.json',
+          testPath: 'transport-rust/src/network/wcmp/tests.rs',
+          command:
+            'cargo test --manifest-path transport-rust/Cargo.toml --lib network::wcmp'
+        };
   clauseRows.push({
     id: `${family.toUpperCase()}-CL-${key.toUpperCase().replaceAll('_', '-')}`,
     family,
@@ -911,12 +925,7 @@ function clause(
       assertion: obligationSynopsis,
       ...(directFixtureImplemented
         ? {
-            evidence: {
-              path: 'transport-rust/tests/fixtures/transport/wcmp_core_mapped/wcmp_fixture.json',
-              testPath: 'transport-rust/src/network/wcmp/tests.rs',
-              command:
-                'cargo test --manifest-path transport-rust/Cargo.toml --lib network::wcmp'
-            }
+            evidence
           }
         : {})
     }
@@ -2384,7 +2393,9 @@ const families = familyDefinitions.map((definition) => {
         ])
       ),
       clauseImplementationStatus:
-        definition.family === 'wcmp' ? 'implemented' : 'not-assessed',
+        definition.family === 'wcmp' || definition.family === 'wdp'
+          ? 'implemented'
+          : 'not-assessed',
       evidenceGate:
         'A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented.'
     };
@@ -2416,7 +2427,7 @@ const families = familyDefinitions.map((definition) => {
   return {
     family: definition.family,
     status:
-      definition.family === 'wcmp'
+      definition.family === 'wcmp' || definition.family === 'wdp'
         ? 'nested-clauses-fixture-backed'
         : 'nested-clauses-anchored-fixtures-planned',
     parentLedger: definition.ledgerPath,
@@ -2528,7 +2539,10 @@ const ledger = {
     recommendedClauseCount,
     permittedClauseCount,
     plannedFixtureCount: clauseCount,
-    assessedClauseCount: 0
+    assessedClauseCount: clauseRows.filter(
+      (candidate) =>
+        candidate.mapping.clauseImplementationStatus === 'implemented'
+    ).length
   },
   families
 };

--- a/spec-processing/scripts/generate-wap-transport-scr-ledgers.mjs
+++ b/spec-processing/scripts/generate-wap-transport-scr-ledgers.mjs
@@ -649,24 +649,24 @@ function workItems(family, id) {
 }
 
 function selectedImplementationStatus(family) {
-  return family === 'wcmp' ? 'implemented' : 'partial';
+  return family === 'wdp' || family === 'wcmp' ? 'implemented' : 'partial';
 }
 
 function assessmentNote(family, id) {
   if (family === 'wdp') {
     if (id === 'WDP-C-001') {
-      return 'A WDP datagram/UDP path exists, but no historical bearer alternative is capability-selected and proven against the WAP-200 dependency closure.';
+      return 'The selected Class C client path declares the CDPD/IPv4 bearer alternative and exposes a connectionless WDP datagram service over bounded UDP/IPv4 codec and primitive boundaries.';
     }
     if (id === 'WDP-CORE-C-001') {
-      return 'The Rust datagram model composes send/receive and address/port fields, but the complete WAP-200 abstract-service contract lacks source-derived fixtures.';
+      return 'The transport-owned WDP profile preserves service data, addresses, and ports while enforcing source-derived UDP/IPv4 header, length, checksum, and deterministic failure rules.';
     }
     if (id.startsWith('WDP-PF-C-')) {
-      return 'Send/receive operations exist behind DatagramTransport, but exact T-DUnitdata primitive semantics and error boundaries are not tested from WAP-200 vectors.';
+      return 'Typed T-DUnitdata request and indication structures preserve the exact selected address, port, and user-data parameters without connection state or content mutation.';
     }
     if (id === 'WDP-CT-C-002') {
-      return 'The UDP/IP adapter matches the WAP-200 CDPD transport shape, but the CDPD capability is not declared and the cited TIA/EIA-732 authority remains an open external-source record.';
+      return 'The selected AMPS/CDPD/IPv4 profile declares bearer value 0x0D and maps WDP directly to UDP protocol 17; the informative TIA/EIA-732 payload remains metadata-only and uncredited.';
     }
-    return 'IPv4/IPv6 and source/destination port fields exist, but the mandatory addressing dependency choice and exact WAP-200 port semantics are not yet declared and proven.';
+    return 'The selected IPv4 dependency uses four-octet source and destination addresses, both 16-bit port fields, and the exact WAP Appendix B registered service-port table with direct fixtures.';
   }
   if (family === 'wcmp') {
     if (id === 'WCMP-C-001') {
@@ -743,68 +743,73 @@ function selectedEvidence(family, id) {
     };
   }
   if (family === 'wdp') {
-    if (id === 'WDP-PF-C-001') {
-      return {
-        implementationEvidence: [
-          {
-            path: 'transport-rust/src/network/wdp/transport_trait.rs',
-            symbol: 'fn send(&mut self'
-          }
-        ],
-        testEvidence: [
-          {
-            path: 'transport-rust/src/network/wdp/udp_adapter.rs',
-            test: 'udp_send_and_receive_roundtrip_with_known_service_ports',
-            limitation:
-              'Synthetic UDP round trip; not a source-derived T-DUnitdata request vector.'
-          }
-        ]
-      };
-    }
-    if (id === 'WDP-PF-C-002') {
-      return {
-        implementationEvidence: [
-          {
-            path: 'transport-rust/src/network/wdp/transport_trait.rs',
-            symbol: 'fn receive(&mut self'
-          }
-        ],
-        testEvidence: [
-          {
-            path: 'transport-rust/src/network/wdp/udp_adapter.rs',
-            test: 'udp_send_and_receive_roundtrip_with_known_service_ports',
-            limitation:
-              'Synthetic UDP round trip; not a source-derived T-DUnitdata indication vector.'
-          }
-        ]
-      };
-    }
-    const symbol =
-      id === 'WDP-NA-C-000'
-        ? 'WdpAddress'
-        : id === 'WDP-CT-C-002'
-          ? 'UdpDatagramTransport'
-        : id === 'WDP-NA-C-006'
-          ? 'pub dst_port'
-          : id === 'WDP-NA-C-007'
-            ? 'pub src_port'
-            : 'WdpDatagram';
+    const evidenceById = {
+      'WDP-C-001': {
+        path: 'transport-rust/src/network/wdp/profile.rs',
+        symbol: 'pub struct CdpdIpv4Profile'
+      },
+      'WDP-CORE-C-001': {
+        path: 'transport-rust/src/network/wdp/ipv4_udp.rs',
+        symbol: 'pub fn decode_cdpd_ipv4_udp'
+      },
+      'WDP-PF-C-001': {
+        path: 'transport-rust/src/network/wdp/primitive.rs',
+        symbol: 'pub struct TDUnitdataRequest'
+      },
+      'WDP-PF-C-002': {
+        path: 'transport-rust/src/network/wdp/primitive.rs',
+        symbol: 'pub struct TDUnitdataIndication'
+      },
+      'WDP-CT-C-002': {
+        path: 'transport-rust/src/network/wdp/profile.rs',
+        symbol: 'WDP_CDPD_IPV4_BEARER_TYPE'
+      },
+      'WDP-NA-C-000': {
+        path: 'transport-rust/src/network/wdp/datagram.rs',
+        symbol: 'pub struct WdpAddress'
+      },
+      'WDP-NA-C-003': {
+        path: 'transport-rust/src/network/wdp/ipv4_udp.rs',
+        symbol: 'WDP_UDP_IPV4_PROTOCOL_NUMBER'
+      },
+      'WDP-NA-C-006': {
+        path: 'transport-rust/src/network/wdp/datagram.rs',
+        symbol: 'pub enum WdpServicePort'
+      },
+      'WDP-NA-C-007': {
+        path: 'transport-rust/src/network/wdp/primitive.rs',
+        symbol: 'pub source_port'
+      }
+    };
+    const testById = {
+      'WDP-C-001':
+        'source_derived_fixture_covers_selected_class_c_rows_and_clauses',
+      'WDP-CORE-C-001':
+        'selected_cdpd_ipv4_profile_preserves_exact_udp_ipv4_bytes',
+      'WDP-PF-C-001':
+        'td_unitdata_request_and_indication_preserve_address_port_and_payload_semantics',
+      'WDP-PF-C-002':
+        'td_unitdata_request_and_indication_preserve_address_port_and_payload_semantics',
+      'WDP-CT-C-002': 'registered_port_and_bearer_profile_are_exact',
+      'WDP-NA-C-000':
+        'td_unitdata_request_and_indication_preserve_address_port_and_payload_semantics',
+      'WDP-NA-C-003':
+        'selected_cdpd_ipv4_profile_preserves_exact_udp_ipv4_bytes',
+      'WDP-NA-C-006': 'registered_port_and_bearer_profile_are_exact',
+      'WDP-NA-C-007':
+        'udp_source_port_zero_and_computed_zero_checksum_follow_rfc_768_encoding'
+    };
     return {
-      implementationEvidence: [
-        {
-          path:
-            id === 'WDP-CT-C-002'
-              ? 'transport-rust/src/network/wdp/udp_adapter.rs'
-              : 'transport-rust/src/network/wdp/datagram.rs',
-          symbol
-        }
-      ],
+      implementationEvidence: [evidenceById[id]],
       testEvidence: [
         {
-          path: 'transport-rust/src/network/wdp/udp_adapter.rs',
-          test: 'udp_send_and_receive_roundtrip_with_known_service_ports',
+          path: 'transport-rust/src/network/wdp/tests.rs',
+          test: testById[id],
+          fixture:
+            'transport-rust/tests/fixtures/transport/wdp_cdpd_ipv4_mapped/wdp_fixture.json',
+          evidenceClass: 'direct-normative',
           limitation:
-            'Synthetic transport evidence; does not close the WAP-200 bearer/address dependency choice.'
+            'Closes only the nine selected CDPD/IPv4 WDP client rows and their mapped TRN-701 clauses; TRN-702 reassembly policy, alternate bearers, server rows, and optional services remain unclaimed.'
         }
       ]
     };

--- a/spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json
+++ b/spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json
@@ -43,7 +43,7 @@
     "recommendedClauseCount": 31,
     "permittedClauseCount": 12,
     "plannedFixtureCount": 781,
-    "assessedClauseCount": 0
+    "assessedClauseCount": 77
   },
   "families": [
     {
@@ -19576,9 +19576,9 @@
     },
     {
       "family": "wdp",
-      "status": "nested-clauses-anchored-fixtures-planned",
+      "status": "nested-clauses-fixture-backed",
       "parentLedger": "spec-processing/source-manifests/wap-1.2.1-wdp-scr.json",
-      "parentLedgerSha256": "438645d590712a6a2b65f798e7eee52526854d5bd86f12ba2ecc545c70df7226",
+      "parentLedgerSha256": "900f30373d63b8ba7764ded3211fe8074010f191a7f8119031f6be677be03253",
       "effectiveSequence": [
         "WAP-200-WDP",
         "WAP-200_001-WDP",
@@ -19626,7 +19626,7 @@
             "documentId": "WAP-200_005-WDP",
             "staticConformanceSection": "Appendix E"
           },
-          "implementationStatus": "partial",
+          "implementationStatus": "implemented",
           "ownerLayers": [
             "transport-rust"
           ],
@@ -19656,7 +19656,7 @@
             "documentId": "WAP-200_005-WDP",
             "staticConformanceSection": "Appendix E"
           },
-          "implementationStatus": "partial",
+          "implementationStatus": "implemented",
           "ownerLayers": [
             "transport-rust"
           ],
@@ -19699,7 +19699,7 @@
             "documentId": "WAP-200_005-WDP",
             "staticConformanceSection": "Appendix E"
           },
-          "implementationStatus": "partial",
+          "implementationStatus": "implemented",
           "ownerLayers": [
             "transport-rust"
           ],
@@ -19727,7 +19727,7 @@
             "documentId": "WAP-200_005-WDP",
             "staticConformanceSection": "Appendix E"
           },
-          "implementationStatus": "partial",
+          "implementationStatus": "implemented",
           "ownerLayers": [
             "transport-rust"
           ],
@@ -19754,7 +19754,7 @@
             "documentId": "WAP-200_005-WDP",
             "staticConformanceSection": "Appendix E"
           },
-          "implementationStatus": "partial",
+          "implementationStatus": "implemented",
           "ownerLayers": [
             "transport-rust"
           ],
@@ -19780,7 +19780,7 @@
             "documentId": "WAP-200_005-WDP",
             "staticConformanceSection": "Appendix E"
           },
-          "implementationStatus": "partial",
+          "implementationStatus": "implemented",
           "ownerLayers": [
             "transport-rust"
           ],
@@ -19804,7 +19804,7 @@
             "documentId": "WAP-200_005-WDP",
             "staticConformanceSection": "Appendix E"
           },
-          "implementationStatus": "partial",
+          "implementationStatus": "implemented",
           "ownerLayers": [
             "transport-rust"
           ],
@@ -19852,7 +19852,7 @@
             "documentId": "WAP-200_005-WDP",
             "staticConformanceSection": "Appendix E"
           },
-          "implementationStatus": "partial",
+          "implementationStatus": "implemented",
           "ownerLayers": [
             "transport-rust"
           ],
@@ -19882,7 +19882,7 @@
             "documentId": "WAP-200_005-WDP",
             "staticConformanceSection": "Appendix E"
           },
-          "implementationStatus": "partial",
+          "implementationStatus": "implemented",
           "ownerLayers": [
             "transport-rust"
           ],
@@ -19925,8 +19925,13 @@
           "fixturePlan": {
             "id": "WDP-FX-CONSISTENT-TRANSPORT-SERVICE",
             "kind": "transport-boundary",
-            "status": "planned",
-            "assertion": "Expose the same WDP transport service and primitive contract to upper WAP layers across supported bearer adaptations."
+            "status": "implemented",
+            "assertion": "Expose the same WDP transport service and primitive contract to upper WAP layers across supported bearer adaptations.",
+            "evidence": {
+              "path": "transport-rust/tests/fixtures/transport/wdp_cdpd_ipv4_mapped/wdp_fixture.json",
+              "testPath": "transport-rust/src/network/wdp/tests.rs",
+              "command": "cargo test --manifest-path transport-rust/Cargo.toml --lib network::wdp"
+            }
           },
           "mapping": {
             "ownerLayers": [
@@ -19940,10 +19945,10 @@
               "RQ-TRN-001"
             ],
             "parentImplementationSnapshot": {
-              "WDP-C-001": "partial",
-              "WDP-CORE-C-001": "partial"
+              "WDP-C-001": "implemented",
+              "WDP-CORE-C-001": "implemented"
             },
-            "clauseImplementationStatus": "not-assessed",
+            "clauseImplementationStatus": "implemented",
             "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented."
           }
         },
@@ -19967,8 +19972,13 @@
           "fixturePlan": {
             "id": "WDP-FX-APPLICATION-PORT-ADDRESSING",
             "kind": "transport-boundary",
-            "status": "planned",
-            "assertion": "Provide source and destination port addressing for the higher-layer protocol or application above WDP."
+            "status": "implemented",
+            "assertion": "Provide source and destination port addressing for the higher-layer protocol or application above WDP.",
+            "evidence": {
+              "path": "transport-rust/tests/fixtures/transport/wdp_cdpd_ipv4_mapped/wdp_fixture.json",
+              "testPath": "transport-rust/src/network/wdp/tests.rs",
+              "command": "cargo test --manifest-path transport-rust/Cargo.toml --lib network::wdp"
+            }
           },
           "mapping": {
             "ownerLayers": [
@@ -19983,11 +19993,11 @@
               "RQ-TRN-003"
             ],
             "parentImplementationSnapshot": {
-              "WDP-CORE-C-001": "partial",
-              "WDP-NA-C-006": "partial",
-              "WDP-NA-C-007": "partial"
+              "WDP-CORE-C-001": "implemented",
+              "WDP-NA-C-006": "implemented",
+              "WDP-NA-C-007": "implemented"
             },
-            "clauseImplementationStatus": "not-assessed",
+            "clauseImplementationStatus": "implemented",
             "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented."
           }
         },
@@ -20010,8 +20020,13 @@
           "fixturePlan": {
             "id": "WDP-FX-BEARER-TRANSPARENCY",
             "kind": "transport-boundary",
-            "status": "planned",
-            "assertion": "Keep bearer-specific mechanics below the transport service access point so upper layers can operate transparently."
+            "status": "implemented",
+            "assertion": "Keep bearer-specific mechanics below the transport service access point so upper layers can operate transparently.",
+            "evidence": {
+              "path": "transport-rust/tests/fixtures/transport/wdp_cdpd_ipv4_mapped/wdp_fixture.json",
+              "testPath": "transport-rust/src/network/wdp/tests.rs",
+              "command": "cargo test --manifest-path transport-rust/Cargo.toml --lib network::wdp"
+            }
           },
           "mapping": {
             "ownerLayers": [
@@ -20025,10 +20040,10 @@
               "RQ-TRN-001"
             ],
             "parentImplementationSnapshot": {
-              "WDP-C-001": "partial",
-              "WDP-CORE-C-001": "partial"
+              "WDP-C-001": "implemented",
+              "WDP-CORE-C-001": "implemented"
             },
-            "clauseImplementationStatus": "not-assessed",
+            "clauseImplementationStatus": "implemented",
             "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented."
           }
         },
@@ -20053,8 +20068,13 @@
           "fixturePlan": {
             "id": "WDP-FX-SIMULTANEOUS-INSTANCES",
             "kind": "transport-boundary",
-            "status": "planned",
-            "assertion": "Use port numbers to multiplex multiple simultaneous higher-layer communication instances over one WDP bearer service."
+            "status": "implemented",
+            "assertion": "Use port numbers to multiplex multiple simultaneous higher-layer communication instances over one WDP bearer service.",
+            "evidence": {
+              "path": "transport-rust/tests/fixtures/transport/wdp_cdpd_ipv4_mapped/wdp_fixture.json",
+              "testPath": "transport-rust/src/network/wdp/tests.rs",
+              "command": "cargo test --manifest-path transport-rust/Cargo.toml --lib network::wdp"
+            }
           },
           "mapping": {
             "ownerLayers": [
@@ -20069,12 +20089,12 @@
               "RQ-TRN-003"
             ],
             "parentImplementationSnapshot": {
-              "WDP-C-001": "partial",
-              "WDP-CORE-C-001": "partial",
-              "WDP-NA-C-006": "partial",
-              "WDP-NA-C-007": "partial"
+              "WDP-C-001": "implemented",
+              "WDP-CORE-C-001": "implemented",
+              "WDP-NA-C-006": "implemented",
+              "WDP-NA-C-007": "implemented"
             },
-            "clauseImplementationStatus": "not-assessed",
+            "clauseImplementationStatus": "implemented",
             "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented."
           }
         },
@@ -20097,8 +20117,13 @@
           "fixturePlan": {
             "id": "WDP-FX-ADAPTATION-LAYER-BOUNDARY",
             "kind": "transport-boundary",
-            "status": "planned",
-            "assertion": "Terminate bearer-specific adaptation at the WDP boundary without changing the service presented to WSP or other upper layers."
+            "status": "implemented",
+            "assertion": "Terminate bearer-specific adaptation at the WDP boundary without changing the service presented to WSP or other upper layers.",
+            "evidence": {
+              "path": "transport-rust/tests/fixtures/transport/wdp_cdpd_ipv4_mapped/wdp_fixture.json",
+              "testPath": "transport-rust/src/network/wdp/tests.rs",
+              "command": "cargo test --manifest-path transport-rust/Cargo.toml --lib network::wdp"
+            }
           },
           "mapping": {
             "ownerLayers": [
@@ -20113,10 +20138,10 @@
               "RQ-TRN-002"
             ],
             "parentImplementationSnapshot": {
-              "WDP-C-001": "partial",
-              "WDP-CT-C-002": "partial"
+              "WDP-C-001": "implemented",
+              "WDP-CT-C-002": "implemented"
             },
-            "clauseImplementationStatus": "not-assessed",
+            "clauseImplementationStatus": "implemented",
             "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented."
           }
         },
@@ -20140,8 +20165,13 @@
           "fixturePlan": {
             "id": "WDP-FX-IP-BEARER-REQUIRES-UDP",
             "kind": "transport-boundary",
-            "status": "planned",
-            "assertion": "Use UDP as the WDP protocol whenever the selected bearer provides IP."
+            "status": "implemented",
+            "assertion": "Use UDP as the WDP protocol whenever the selected bearer provides IP.",
+            "evidence": {
+              "path": "transport-rust/tests/fixtures/transport/wdp_cdpd_ipv4_mapped/wdp_fixture.json",
+              "testPath": "transport-rust/src/network/wdp/tests.rs",
+              "command": "cargo test --manifest-path transport-rust/Cargo.toml --lib network::wdp"
+            }
           },
           "mapping": {
             "ownerLayers": [
@@ -20157,11 +20187,11 @@
               "RQ-TRN-003"
             ],
             "parentImplementationSnapshot": {
-              "WDP-C-001": "partial",
-              "WDP-CT-C-002": "partial",
-              "WDP-NA-C-003": "partial"
+              "WDP-C-001": "implemented",
+              "WDP-CT-C-002": "implemented",
+              "WDP-NA-C-003": "implemented"
             },
-            "clauseImplementationStatus": "not-assessed",
+            "clauseImplementationStatus": "implemented",
             "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented."
           }
         },
@@ -20184,8 +20214,13 @@
           "fixturePlan": {
             "id": "WDP-FX-CDPD-UDP-IP-PROFILE",
             "kind": "transport-boundary",
-            "status": "planned",
-            "assertion": "Declare the selected CDPD bearer as an IP-capable profile whose WDP datagram service is UDP over IPv4."
+            "status": "implemented",
+            "assertion": "Declare the selected CDPD bearer as an IP-capable profile whose WDP datagram service is UDP over IPv4.",
+            "evidence": {
+              "path": "transport-rust/tests/fixtures/transport/wdp_cdpd_ipv4_mapped/wdp_fixture.json",
+              "testPath": "transport-rust/src/network/wdp/tests.rs",
+              "command": "cargo test --manifest-path transport-rust/Cargo.toml --lib network::wdp"
+            }
           },
           "mapping": {
             "ownerLayers": [
@@ -20200,10 +20235,10 @@
               "RQ-TRN-003"
             ],
             "parentImplementationSnapshot": {
-              "WDP-CT-C-002": "partial",
-              "WDP-NA-C-003": "partial"
+              "WDP-CT-C-002": "implemented",
+              "WDP-NA-C-003": "implemented"
             },
-            "clauseImplementationStatus": "not-assessed",
+            "clauseImplementationStatus": "implemented",
             "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented."
           }
         },
@@ -20225,8 +20260,13 @@
           "fixturePlan": {
             "id": "WDP-FX-UNITDATA-REQUEST-ANYTIME",
             "kind": "transport-boundary",
-            "status": "planned",
-            "assertion": "Allow T-DUnitdata.request without establishing a prior transport connection."
+            "status": "implemented",
+            "assertion": "Allow T-DUnitdata.request without establishing a prior transport connection.",
+            "evidence": {
+              "path": "transport-rust/tests/fixtures/transport/wdp_cdpd_ipv4_mapped/wdp_fixture.json",
+              "testPath": "transport-rust/src/network/wdp/tests.rs",
+              "command": "cargo test --manifest-path transport-rust/Cargo.toml --lib network::wdp"
+            }
           },
           "mapping": {
             "ownerLayers": [
@@ -20240,9 +20280,9 @@
               "RQ-TRN-001"
             ],
             "parentImplementationSnapshot": {
-              "WDP-PF-C-001": "partial"
+              "WDP-PF-C-001": "implemented"
             },
-            "clauseImplementationStatus": "not-assessed",
+            "clauseImplementationStatus": "implemented",
             "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented."
           }
         },
@@ -20269,8 +20309,13 @@
           "fixturePlan": {
             "id": "WDP-FX-UNITDATA-REQUEST-PARAMETERS",
             "kind": "transport-boundary",
-            "status": "planned",
-            "assertion": "Require source address, source port, destination address, destination port, and user data on every T-DUnitdata request."
+            "status": "implemented",
+            "assertion": "Require source address, source port, destination address, destination port, and user data on every T-DUnitdata request.",
+            "evidence": {
+              "path": "transport-rust/tests/fixtures/transport/wdp_cdpd_ipv4_mapped/wdp_fixture.json",
+              "testPath": "transport-rust/src/network/wdp/tests.rs",
+              "command": "cargo test --manifest-path transport-rust/Cargo.toml --lib network::wdp"
+            }
           },
           "mapping": {
             "ownerLayers": [
@@ -20285,14 +20330,14 @@
               "RQ-TRN-003"
             ],
             "parentImplementationSnapshot": {
-              "WDP-CORE-C-001": "partial",
-              "WDP-PF-C-001": "partial",
-              "WDP-NA-C-000": "partial",
-              "WDP-NA-C-003": "partial",
-              "WDP-NA-C-006": "partial",
-              "WDP-NA-C-007": "partial"
+              "WDP-CORE-C-001": "implemented",
+              "WDP-PF-C-001": "implemented",
+              "WDP-NA-C-000": "implemented",
+              "WDP-NA-C-003": "implemented",
+              "WDP-NA-C-006": "implemented",
+              "WDP-NA-C-007": "implemented"
             },
-            "clauseImplementationStatus": "not-assessed",
+            "clauseImplementationStatus": "implemented",
             "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented."
           }
         },
@@ -20319,8 +20364,13 @@
           "fixturePlan": {
             "id": "WDP-FX-UNITDATA-INDICATION-PARAMETERS",
             "kind": "transport-boundary",
-            "status": "planned",
-            "assertion": "Deliver source address, source port, and user data on T-DUnitdata indication, with destination address and port when available."
+            "status": "implemented",
+            "assertion": "Deliver source address, source port, and user data on T-DUnitdata indication, with destination address and port when available.",
+            "evidence": {
+              "path": "transport-rust/tests/fixtures/transport/wdp_cdpd_ipv4_mapped/wdp_fixture.json",
+              "testPath": "transport-rust/src/network/wdp/tests.rs",
+              "command": "cargo test --manifest-path transport-rust/Cargo.toml --lib network::wdp"
+            }
           },
           "mapping": {
             "ownerLayers": [
@@ -20335,14 +20385,14 @@
               "RQ-TRN-003"
             ],
             "parentImplementationSnapshot": {
-              "WDP-CORE-C-001": "partial",
-              "WDP-PF-C-002": "partial",
-              "WDP-NA-C-000": "partial",
-              "WDP-NA-C-003": "partial",
-              "WDP-NA-C-006": "partial",
-              "WDP-NA-C-007": "partial"
+              "WDP-CORE-C-001": "implemented",
+              "WDP-PF-C-002": "implemented",
+              "WDP-NA-C-000": "implemented",
+              "WDP-NA-C-003": "implemented",
+              "WDP-NA-C-006": "implemented",
+              "WDP-NA-C-007": "implemented"
             },
-            "clauseImplementationStatus": "not-assessed",
+            "clauseImplementationStatus": "implemented",
             "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented."
           }
         },
@@ -20367,8 +20417,13 @@
           "fixturePlan": {
             "id": "WDP-FX-DESTINATION-ADDRESS-SEMANTICS",
             "kind": "transport-boundary",
-            "status": "planned",
-            "assertion": "Treat the destination address as the network identity of the receiving device for the submitted user data."
+            "status": "implemented",
+            "assertion": "Treat the destination address as the network identity of the receiving device for the submitted user data.",
+            "evidence": {
+              "path": "transport-rust/tests/fixtures/transport/wdp_cdpd_ipv4_mapped/wdp_fixture.json",
+              "testPath": "transport-rust/src/network/wdp/tests.rs",
+              "command": "cargo test --manifest-path transport-rust/Cargo.toml --lib network::wdp"
+            }
           },
           "mapping": {
             "ownerLayers": [
@@ -20383,12 +20438,12 @@
               "RQ-TRN-003"
             ],
             "parentImplementationSnapshot": {
-              "WDP-PF-C-001": "partial",
-              "WDP-PF-C-002": "partial",
-              "WDP-NA-C-000": "partial",
-              "WDP-NA-C-003": "partial"
+              "WDP-PF-C-001": "implemented",
+              "WDP-PF-C-002": "implemented",
+              "WDP-NA-C-000": "implemented",
+              "WDP-NA-C-003": "implemented"
             },
-            "clauseImplementationStatus": "not-assessed",
+            "clauseImplementationStatus": "implemented",
             "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented."
           }
         },
@@ -20413,8 +20468,13 @@
           "fixturePlan": {
             "id": "WDP-FX-SOURCE-ADDRESS-SEMANTICS",
             "kind": "transport-boundary",
-            "status": "planned",
-            "assertion": "Treat the source address as the unique network identity of the device issuing the transport request."
+            "status": "implemented",
+            "assertion": "Treat the source address as the unique network identity of the device issuing the transport request.",
+            "evidence": {
+              "path": "transport-rust/tests/fixtures/transport/wdp_cdpd_ipv4_mapped/wdp_fixture.json",
+              "testPath": "transport-rust/src/network/wdp/tests.rs",
+              "command": "cargo test --manifest-path transport-rust/Cargo.toml --lib network::wdp"
+            }
           },
           "mapping": {
             "ownerLayers": [
@@ -20429,12 +20489,12 @@
               "RQ-TRN-003"
             ],
             "parentImplementationSnapshot": {
-              "WDP-PF-C-001": "partial",
-              "WDP-PF-C-002": "partial",
-              "WDP-NA-C-000": "partial",
-              "WDP-NA-C-003": "partial"
+              "WDP-PF-C-001": "implemented",
+              "WDP-PF-C-002": "implemented",
+              "WDP-NA-C-000": "implemented",
+              "WDP-NA-C-003": "implemented"
             },
-            "clauseImplementationStatus": "not-assessed",
+            "clauseImplementationStatus": "implemented",
             "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented."
           }
         },
@@ -20458,8 +20518,13 @@
           "fixturePlan": {
             "id": "WDP-FX-DESTINATION-PORT-SEMANTICS",
             "kind": "transport-boundary",
-            "status": "planned",
-            "assertion": "Bind the destination port to the destination application or upper-layer protocol for that communication instance."
+            "status": "implemented",
+            "assertion": "Bind the destination port to the destination application or upper-layer protocol for that communication instance.",
+            "evidence": {
+              "path": "transport-rust/tests/fixtures/transport/wdp_cdpd_ipv4_mapped/wdp_fixture.json",
+              "testPath": "transport-rust/src/network/wdp/tests.rs",
+              "command": "cargo test --manifest-path transport-rust/Cargo.toml --lib network::wdp"
+            }
           },
           "mapping": {
             "ownerLayers": [
@@ -20474,11 +20539,11 @@
               "RQ-TRN-003"
             ],
             "parentImplementationSnapshot": {
-              "WDP-PF-C-001": "partial",
-              "WDP-PF-C-002": "partial",
-              "WDP-NA-C-006": "partial"
+              "WDP-PF-C-001": "implemented",
+              "WDP-PF-C-002": "implemented",
+              "WDP-NA-C-006": "implemented"
             },
-            "clauseImplementationStatus": "not-assessed",
+            "clauseImplementationStatus": "implemented",
             "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented."
           }
         },
@@ -20502,8 +20567,13 @@
           "fixturePlan": {
             "id": "WDP-FX-SOURCE-PORT-SEMANTICS",
             "kind": "transport-boundary",
-            "status": "planned",
-            "assertion": "Bind the source port to the requesting application or upper-layer protocol for that communication instance."
+            "status": "implemented",
+            "assertion": "Bind the source port to the requesting application or upper-layer protocol for that communication instance.",
+            "evidence": {
+              "path": "transport-rust/tests/fixtures/transport/wdp_cdpd_ipv4_mapped/wdp_fixture.json",
+              "testPath": "transport-rust/src/network/wdp/tests.rs",
+              "command": "cargo test --manifest-path transport-rust/Cargo.toml --lib network::wdp"
+            }
           },
           "mapping": {
             "ownerLayers": [
@@ -20518,11 +20588,11 @@
               "RQ-TRN-003"
             ],
             "parentImplementationSnapshot": {
-              "WDP-PF-C-001": "partial",
-              "WDP-PF-C-002": "partial",
-              "WDP-NA-C-007": "partial"
+              "WDP-PF-C-001": "implemented",
+              "WDP-PF-C-002": "implemented",
+              "WDP-NA-C-007": "implemented"
             },
-            "clauseImplementationStatus": "not-assessed",
+            "clauseImplementationStatus": "implemented",
             "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented."
           }
         },
@@ -20546,8 +20616,13 @@
           "fixturePlan": {
             "id": "WDP-FX-UNITDATA-CONTENT-TRANSPARENCY",
             "kind": "transport-boundary",
-            "status": "planned",
-            "assertion": "Transmit and deliver the complete service data unit without manipulating its content."
+            "status": "implemented",
+            "assertion": "Transmit and deliver the complete service data unit without manipulating its content.",
+            "evidence": {
+              "path": "transport-rust/tests/fixtures/transport/wdp_cdpd_ipv4_mapped/wdp_fixture.json",
+              "testPath": "transport-rust/src/network/wdp/tests.rs",
+              "command": "cargo test --manifest-path transport-rust/Cargo.toml --lib network::wdp"
+            }
           },
           "mapping": {
             "ownerLayers": [
@@ -20561,11 +20636,11 @@
               "RQ-TRN-001"
             ],
             "parentImplementationSnapshot": {
-              "WDP-CORE-C-001": "partial",
-              "WDP-PF-C-001": "partial",
-              "WDP-PF-C-002": "partial"
+              "WDP-CORE-C-001": "implemented",
+              "WDP-PF-C-001": "implemented",
+              "WDP-PF-C-002": "implemented"
             },
-            "clauseImplementationStatus": "not-assessed",
+            "clauseImplementationStatus": "implemented",
             "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented."
           }
         },
@@ -20589,8 +20664,13 @@
           "fixturePlan": {
             "id": "WDP-FX-PROTOCOL-REQUIRED-PORT-FIELDS",
             "kind": "binary-decoder",
-            "status": "planned",
-            "assertion": "Carry both destination and source port fields in the selected WDP protocol mapping."
+            "status": "implemented",
+            "assertion": "Carry both destination and source port fields in the selected WDP protocol mapping.",
+            "evidence": {
+              "path": "transport-rust/tests/fixtures/transport/wdp_cdpd_ipv4_mapped/wdp_fixture.json",
+              "testPath": "transport-rust/src/network/wdp/tests.rs",
+              "command": "cargo test --manifest-path transport-rust/Cargo.toml --lib network::wdp"
+            }
           },
           "mapping": {
             "ownerLayers": [
@@ -20605,11 +20685,11 @@
               "RQ-TRN-003"
             ],
             "parentImplementationSnapshot": {
-              "WDP-CORE-C-001": "partial",
-              "WDP-NA-C-006": "partial",
-              "WDP-NA-C-007": "partial"
+              "WDP-CORE-C-001": "implemented",
+              "WDP-NA-C-006": "implemented",
+              "WDP-NA-C-007": "implemented"
             },
-            "clauseImplementationStatus": "not-assessed",
+            "clauseImplementationStatus": "implemented",
             "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented."
           }
         },
@@ -20633,8 +20713,13 @@
           "fixturePlan": {
             "id": "WDP-FX-IP-MAPPING-IS-UDP",
             "kind": "transport-boundary",
-            "status": "planned",
-            "assertion": "Map WDP directly to UDP for every selected bearer on which IP routing is available."
+            "status": "implemented",
+            "assertion": "Map WDP directly to UDP for every selected bearer on which IP routing is available.",
+            "evidence": {
+              "path": "transport-rust/tests/fixtures/transport/wdp_cdpd_ipv4_mapped/wdp_fixture.json",
+              "testPath": "transport-rust/src/network/wdp/tests.rs",
+              "command": "cargo test --manifest-path transport-rust/Cargo.toml --lib network::wdp"
+            }
           },
           "mapping": {
             "ownerLayers": [
@@ -20650,11 +20735,11 @@
               "RQ-TRN-003"
             ],
             "parentImplementationSnapshot": {
-              "WDP-C-001": "partial",
-              "WDP-CT-C-002": "partial",
-              "WDP-NA-C-003": "partial"
+              "WDP-C-001": "implemented",
+              "WDP-CT-C-002": "implemented",
+              "WDP-NA-C-003": "implemented"
             },
-            "clauseImplementationStatus": "not-assessed",
+            "clauseImplementationStatus": "implemented",
             "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented."
           }
         },
@@ -20678,8 +20763,13 @@
           "fixturePlan": {
             "id": "WDP-FX-IP-MAPPING-FRAGMENTATION",
             "kind": "transport-boundary",
-            "status": "planned",
-            "assertion": "Rely on IPv4 fragmentation and reassembly below UDP rather than adding a second WDP segmentation header on the CDPD/IP path."
+            "status": "implemented",
+            "assertion": "Rely on IPv4 fragmentation and reassembly below UDP rather than adding a second WDP segmentation header on the CDPD/IP path.",
+            "evidence": {
+              "path": "transport-rust/tests/fixtures/transport/wdp_cdpd_ipv4_mapped/wdp_fixture.json",
+              "testPath": "transport-rust/src/network/wdp/tests.rs",
+              "command": "cargo test --manifest-path transport-rust/Cargo.toml --lib network::wdp"
+            }
           },
           "mapping": {
             "ownerLayers": [
@@ -20695,11 +20785,11 @@
               "RQ-TRN-003"
             ],
             "parentImplementationSnapshot": {
-              "WDP-C-001": "partial",
-              "WDP-CT-C-002": "partial",
-              "WDP-NA-C-003": "partial"
+              "WDP-C-001": "implemented",
+              "WDP-CT-C-002": "implemented",
+              "WDP-NA-C-003": "implemented"
             },
-            "clauseImplementationStatus": "not-assessed",
+            "clauseImplementationStatus": "implemented",
             "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented."
           }
         },
@@ -20722,8 +20812,13 @@
           "fixturePlan": {
             "id": "WDP-FX-WAP-PORT-REGISTRY",
             "kind": "transport-boundary",
-            "status": "planned",
-            "assertion": "Recognize the complete WAP port assignment table, including connectionless, session, secure, push, vCard, and vCalendar services."
+            "status": "implemented",
+            "assertion": "Recognize the complete WAP port assignment table, including connectionless, session, secure, push, vCard, and vCalendar services.",
+            "evidence": {
+              "path": "transport-rust/tests/fixtures/transport/wdp_cdpd_ipv4_mapped/wdp_fixture.json",
+              "testPath": "transport-rust/src/network/wdp/tests.rs",
+              "command": "cargo test --manifest-path transport-rust/Cargo.toml --lib network::wdp"
+            }
           },
           "mapping": {
             "ownerLayers": [
@@ -20737,10 +20832,10 @@
               "RQ-TRN-003"
             ],
             "parentImplementationSnapshot": {
-              "WDP-NA-C-006": "partial",
-              "WDP-NA-C-007": "partial"
+              "WDP-NA-C-006": "implemented",
+              "WDP-NA-C-007": "implemented"
             },
-            "clauseImplementationStatus": "not-assessed",
+            "clauseImplementationStatus": "implemented",
             "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented."
           }
         },
@@ -20763,8 +20858,13 @@
           "fixturePlan": {
             "id": "WDP-FX-SELECTED-WSP-PORT",
             "kind": "transport-boundary",
-            "status": "planned",
-            "assertion": "Use registered UDP/WDP port 9200 for the selected non-secure connectionless WSP session service."
+            "status": "implemented",
+            "assertion": "Use registered UDP/WDP port 9200 for the selected non-secure connectionless WSP session service.",
+            "evidence": {
+              "path": "transport-rust/tests/fixtures/transport/wdp_cdpd_ipv4_mapped/wdp_fixture.json",
+              "testPath": "transport-rust/src/network/wdp/tests.rs",
+              "command": "cargo test --manifest-path transport-rust/Cargo.toml --lib network::wdp"
+            }
           },
           "mapping": {
             "ownerLayers": [
@@ -20779,10 +20879,10 @@
               "RQ-TRN-003"
             ],
             "parentImplementationSnapshot": {
-              "WDP-C-001": "partial",
-              "WDP-NA-C-006": "partial"
+              "WDP-C-001": "implemented",
+              "WDP-NA-C-006": "implemented"
             },
-            "clauseImplementationStatus": "not-assessed",
+            "clauseImplementationStatus": "implemented",
             "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented."
           }
         },
@@ -20805,8 +20905,13 @@
           "fixturePlan": {
             "id": "WDP-FX-SELECTED-BEARER-ASSIGNMENT",
             "kind": "transport-boundary",
-            "status": "planned",
-            "assertion": "Represent the AMPS/CDPD/IPv4 network-bearer-address combination with assigned bearer value 0x0D when that registry is carried."
+            "status": "implemented",
+            "assertion": "Represent the AMPS/CDPD/IPv4 network-bearer-address combination with assigned bearer value 0x0D when that registry is carried.",
+            "evidence": {
+              "path": "transport-rust/tests/fixtures/transport/wdp_cdpd_ipv4_mapped/wdp_fixture.json",
+              "testPath": "transport-rust/src/network/wdp/tests.rs",
+              "command": "cargo test --manifest-path transport-rust/Cargo.toml --lib network::wdp"
+            }
           },
           "mapping": {
             "ownerLayers": [
@@ -20821,10 +20926,10 @@
               "RQ-TRN-003"
             ],
             "parentImplementationSnapshot": {
-              "WDP-CT-C-002": "partial",
-              "WDP-NA-C-003": "partial"
+              "WDP-CT-C-002": "implemented",
+              "WDP-NA-C-003": "implemented"
             },
-            "clauseImplementationStatus": "not-assessed",
+            "clauseImplementationStatus": "implemented",
             "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented."
           }
         },
@@ -20847,8 +20952,13 @@
           "fixturePlan": {
             "id": "WDP-FX-UDP-UNRELIABLE-DATAGRAMS",
             "kind": "transport-boundary",
-            "status": "planned",
-            "assertion": "Expose UDP as a connectionless datagram service that does not guarantee delivery, ordering, or duplicate suppression."
+            "status": "implemented",
+            "assertion": "Expose UDP as a connectionless datagram service that does not guarantee delivery, ordering, or duplicate suppression.",
+            "evidence": {
+              "path": "transport-rust/tests/fixtures/transport/wdp_cdpd_ipv4_mapped/wdp_fixture.json",
+              "testPath": "transport-rust/src/network/wdp/tests.rs",
+              "command": "cargo test --manifest-path transport-rust/Cargo.toml --lib network::wdp"
+            }
           },
           "mapping": {
             "ownerLayers": [
@@ -20862,10 +20972,10 @@
               "RQ-TRN-001"
             ],
             "parentImplementationSnapshot": {
-              "WDP-C-001": "partial",
-              "WDP-CORE-C-001": "partial"
+              "WDP-C-001": "implemented",
+              "WDP-CORE-C-001": "implemented"
             },
-            "clauseImplementationStatus": "not-assessed",
+            "clauseImplementationStatus": "implemented",
             "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented."
           }
         },
@@ -20889,8 +20999,13 @@
           "fixturePlan": {
             "id": "WDP-FX-UDP-HEADER-LAYOUT",
             "kind": "binary-decoder",
-            "status": "planned",
-            "assertion": "Encode and decode the UDP header as 16-bit source port, destination port, length, and checksum fields followed by data."
+            "status": "implemented",
+            "assertion": "Encode and decode the UDP header as 16-bit source port, destination port, length, and checksum fields followed by data.",
+            "evidence": {
+              "path": "transport-rust/tests/fixtures/transport/wdp_cdpd_ipv4_mapped/wdp_fixture.json",
+              "testPath": "transport-rust/src/network/wdp/tests.rs",
+              "command": "cargo test --manifest-path transport-rust/Cargo.toml --lib network::wdp"
+            }
           },
           "mapping": {
             "ownerLayers": [
@@ -20905,11 +21020,11 @@
               "RQ-TRN-003"
             ],
             "parentImplementationSnapshot": {
-              "WDP-CORE-C-001": "partial",
-              "WDP-NA-C-006": "partial",
-              "WDP-NA-C-007": "partial"
+              "WDP-CORE-C-001": "implemented",
+              "WDP-NA-C-006": "implemented",
+              "WDP-NA-C-007": "implemented"
             },
-            "clauseImplementationStatus": "not-assessed",
+            "clauseImplementationStatus": "implemented",
             "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented."
           }
         },
@@ -20931,8 +21046,13 @@
           "fixturePlan": {
             "id": "WDP-FX-UDP-SOURCE-PORT-ZERO",
             "kind": "binary-decoder",
-            "status": "planned",
-            "assertion": "Use source port zero when the sender does not supply a meaningful reply port, and otherwise preserve the selected source port."
+            "status": "implemented",
+            "assertion": "Use source port zero when the sender does not supply a meaningful reply port, and otherwise preserve the selected source port.",
+            "evidence": {
+              "path": "transport-rust/tests/fixtures/transport/wdp_cdpd_ipv4_mapped/wdp_fixture.json",
+              "testPath": "transport-rust/src/network/wdp/tests.rs",
+              "command": "cargo test --manifest-path transport-rust/Cargo.toml --lib network::wdp"
+            }
           },
           "mapping": {
             "ownerLayers": [
@@ -20946,9 +21066,9 @@
               "RQ-TRN-003"
             ],
             "parentImplementationSnapshot": {
-              "WDP-NA-C-007": "partial"
+              "WDP-NA-C-007": "implemented"
             },
-            "clauseImplementationStatus": "not-assessed",
+            "clauseImplementationStatus": "implemented",
             "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented."
           }
         },
@@ -20971,8 +21091,13 @@
           "fixturePlan": {
             "id": "WDP-FX-UDP-DESTINATION-PORT-CONTEXT",
             "kind": "transport-boundary",
-            "status": "planned",
-            "assertion": "Interpret a UDP destination port within the context of its destination IPv4 address."
+            "status": "implemented",
+            "assertion": "Interpret a UDP destination port within the context of its destination IPv4 address.",
+            "evidence": {
+              "path": "transport-rust/tests/fixtures/transport/wdp_cdpd_ipv4_mapped/wdp_fixture.json",
+              "testPath": "transport-rust/src/network/wdp/tests.rs",
+              "command": "cargo test --manifest-path transport-rust/Cargo.toml --lib network::wdp"
+            }
           },
           "mapping": {
             "ownerLayers": [
@@ -20986,10 +21111,10 @@
               "RQ-TRN-003"
             ],
             "parentImplementationSnapshot": {
-              "WDP-NA-C-006": "partial",
-              "WDP-NA-C-003": "partial"
+              "WDP-NA-C-006": "implemented",
+              "WDP-NA-C-003": "implemented"
             },
-            "clauseImplementationStatus": "not-assessed",
+            "clauseImplementationStatus": "implemented",
             "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented."
           }
         },
@@ -21011,8 +21136,13 @@
           "fixturePlan": {
             "id": "WDP-FX-UDP-LENGTH-BOUNDS",
             "kind": "binary-decoder",
-            "status": "planned",
-            "assertion": "Interpret UDP length as header plus data octets and reject values smaller than the eight-octet header."
+            "status": "implemented",
+            "assertion": "Interpret UDP length as header plus data octets and reject values smaller than the eight-octet header.",
+            "evidence": {
+              "path": "transport-rust/tests/fixtures/transport/wdp_cdpd_ipv4_mapped/wdp_fixture.json",
+              "testPath": "transport-rust/src/network/wdp/tests.rs",
+              "command": "cargo test --manifest-path transport-rust/Cargo.toml --lib network::wdp"
+            }
           },
           "mapping": {
             "ownerLayers": [
@@ -21026,9 +21156,9 @@
               "RQ-TRN-001"
             ],
             "parentImplementationSnapshot": {
-              "WDP-CORE-C-001": "partial"
+              "WDP-CORE-C-001": "implemented"
             },
-            "clauseImplementationStatus": "not-assessed",
+            "clauseImplementationStatus": "implemented",
             "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented."
           }
         },
@@ -21051,8 +21181,13 @@
           "fixturePlan": {
             "id": "WDP-FX-UDP-CHECKSUM-COVERAGE",
             "kind": "binary-decoder",
-            "status": "planned",
-            "assertion": "Compute the UDP checksum over the IPv4 pseudo-header, UDP header, and data using 16-bit ones-complement arithmetic."
+            "status": "implemented",
+            "assertion": "Compute the UDP checksum over the IPv4 pseudo-header, UDP header, and data using 16-bit ones-complement arithmetic.",
+            "evidence": {
+              "path": "transport-rust/tests/fixtures/transport/wdp_cdpd_ipv4_mapped/wdp_fixture.json",
+              "testPath": "transport-rust/src/network/wdp/tests.rs",
+              "command": "cargo test --manifest-path transport-rust/Cargo.toml --lib network::wdp"
+            }
           },
           "mapping": {
             "ownerLayers": [
@@ -21067,10 +21202,10 @@
               "RQ-TRN-003"
             ],
             "parentImplementationSnapshot": {
-              "WDP-CORE-C-001": "partial",
-              "WDP-NA-C-003": "partial"
+              "WDP-CORE-C-001": "implemented",
+              "WDP-NA-C-003": "implemented"
             },
-            "clauseImplementationStatus": "not-assessed",
+            "clauseImplementationStatus": "implemented",
             "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented."
           }
         },
@@ -21092,8 +21227,13 @@
           "fixturePlan": {
             "id": "WDP-FX-UDP-CHECKSUM-PADDING",
             "kind": "binary-decoder",
-            "status": "planned",
-            "assertion": "Zero-pad an odd checksum input to a two-octet boundary without transmitting the padding octet."
+            "status": "implemented",
+            "assertion": "Zero-pad an odd checksum input to a two-octet boundary without transmitting the padding octet.",
+            "evidence": {
+              "path": "transport-rust/tests/fixtures/transport/wdp_cdpd_ipv4_mapped/wdp_fixture.json",
+              "testPath": "transport-rust/src/network/wdp/tests.rs",
+              "command": "cargo test --manifest-path transport-rust/Cargo.toml --lib network::wdp"
+            }
           },
           "mapping": {
             "ownerLayers": [
@@ -21107,9 +21247,9 @@
               "RQ-TRN-001"
             ],
             "parentImplementationSnapshot": {
-              "WDP-CORE-C-001": "partial"
+              "WDP-CORE-C-001": "implemented"
             },
-            "clauseImplementationStatus": "not-assessed",
+            "clauseImplementationStatus": "implemented",
             "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented."
           }
         },
@@ -21131,8 +21271,13 @@
           "fixturePlan": {
             "id": "WDP-FX-UDP-CHECKSUM-ZERO-ENCODING",
             "kind": "binary-decoder",
-            "status": "planned",
-            "assertion": "Transmit an arithmetically computed zero UDP checksum as all one bits."
+            "status": "implemented",
+            "assertion": "Transmit an arithmetically computed zero UDP checksum as all one bits.",
+            "evidence": {
+              "path": "transport-rust/tests/fixtures/transport/wdp_cdpd_ipv4_mapped/wdp_fixture.json",
+              "testPath": "transport-rust/src/network/wdp/tests.rs",
+              "command": "cargo test --manifest-path transport-rust/Cargo.toml --lib network::wdp"
+            }
           },
           "mapping": {
             "ownerLayers": [
@@ -21146,9 +21291,9 @@
               "RQ-TRN-001"
             ],
             "parentImplementationSnapshot": {
-              "WDP-CORE-C-001": "partial"
+              "WDP-CORE-C-001": "implemented"
             },
-            "clauseImplementationStatus": "not-assessed",
+            "clauseImplementationStatus": "implemented",
             "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented."
           }
         },
@@ -21170,8 +21315,13 @@
           "fixturePlan": {
             "id": "WDP-FX-UDP-CHECKSUM-OMISSION",
             "kind": "binary-decoder",
-            "status": "planned",
-            "assertion": "Accept an all-zero UDP checksum field as the IPv4 sender choosing not to generate a UDP checksum."
+            "status": "implemented",
+            "assertion": "Accept an all-zero UDP checksum field as the IPv4 sender choosing not to generate a UDP checksum.",
+            "evidence": {
+              "path": "transport-rust/tests/fixtures/transport/wdp_cdpd_ipv4_mapped/wdp_fixture.json",
+              "testPath": "transport-rust/src/network/wdp/tests.rs",
+              "command": "cargo test --manifest-path transport-rust/Cargo.toml --lib network::wdp"
+            }
           },
           "mapping": {
             "ownerLayers": [
@@ -21185,9 +21335,9 @@
               "RQ-TRN-001"
             ],
             "parentImplementationSnapshot": {
-              "WDP-CORE-C-001": "partial"
+              "WDP-CORE-C-001": "implemented"
             },
-            "clauseImplementationStatus": "not-assessed",
+            "clauseImplementationStatus": "implemented",
             "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented."
           }
         },
@@ -21211,8 +21361,13 @@
           "fixturePlan": {
             "id": "WDP-FX-UDP-RECEIVE-INTERFACE",
             "kind": "transport-boundary",
-            "status": "planned",
-            "assertion": "Provide receive-port creation and return received data with its source IPv4 address and source port."
+            "status": "implemented",
+            "assertion": "Provide receive-port creation and return received data with its source IPv4 address and source port.",
+            "evidence": {
+              "path": "transport-rust/tests/fixtures/transport/wdp_cdpd_ipv4_mapped/wdp_fixture.json",
+              "testPath": "transport-rust/src/network/wdp/tests.rs",
+              "command": "cargo test --manifest-path transport-rust/Cargo.toml --lib network::wdp"
+            }
           },
           "mapping": {
             "ownerLayers": [
@@ -21227,11 +21382,11 @@
               "RQ-TRN-003"
             ],
             "parentImplementationSnapshot": {
-              "WDP-PF-C-002": "partial",
-              "WDP-NA-C-003": "partial",
-              "WDP-NA-C-007": "partial"
+              "WDP-PF-C-002": "implemented",
+              "WDP-NA-C-003": "implemented",
+              "WDP-NA-C-007": "implemented"
             },
-            "clauseImplementationStatus": "not-assessed",
+            "clauseImplementationStatus": "implemented",
             "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented."
           }
         },
@@ -21256,8 +21411,13 @@
           "fixturePlan": {
             "id": "WDP-FX-UDP-SEND-INTERFACE",
             "kind": "transport-boundary",
-            "status": "planned",
-            "assertion": "Provide datagram send using explicit data, source and destination ports, and source and destination IPv4 addresses."
+            "status": "implemented",
+            "assertion": "Provide datagram send using explicit data, source and destination ports, and source and destination IPv4 addresses.",
+            "evidence": {
+              "path": "transport-rust/tests/fixtures/transport/wdp_cdpd_ipv4_mapped/wdp_fixture.json",
+              "testPath": "transport-rust/src/network/wdp/tests.rs",
+              "command": "cargo test --manifest-path transport-rust/Cargo.toml --lib network::wdp"
+            }
           },
           "mapping": {
             "ownerLayers": [
@@ -21272,12 +21432,12 @@
               "RQ-TRN-003"
             ],
             "parentImplementationSnapshot": {
-              "WDP-PF-C-001": "partial",
-              "WDP-NA-C-003": "partial",
-              "WDP-NA-C-006": "partial",
-              "WDP-NA-C-007": "partial"
+              "WDP-PF-C-001": "implemented",
+              "WDP-NA-C-003": "implemented",
+              "WDP-NA-C-006": "implemented",
+              "WDP-NA-C-007": "implemented"
             },
-            "clauseImplementationStatus": "not-assessed",
+            "clauseImplementationStatus": "implemented",
             "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented."
           }
         },
@@ -21300,8 +21460,13 @@
           "fixturePlan": {
             "id": "WDP-FX-UDP-IP-INTERFACE-METADATA",
             "kind": "transport-boundary",
-            "status": "planned",
-            "assertion": "Make source address, destination address, and IP protocol metadata available at the UDP/IP boundary."
+            "status": "implemented",
+            "assertion": "Make source address, destination address, and IP protocol metadata available at the UDP/IP boundary.",
+            "evidence": {
+              "path": "transport-rust/tests/fixtures/transport/wdp_cdpd_ipv4_mapped/wdp_fixture.json",
+              "testPath": "transport-rust/src/network/wdp/tests.rs",
+              "command": "cargo test --manifest-path transport-rust/Cargo.toml --lib network::wdp"
+            }
           },
           "mapping": {
             "ownerLayers": [
@@ -21316,10 +21481,10 @@
               "RQ-TRN-003"
             ],
             "parentImplementationSnapshot": {
-              "WDP-CORE-C-001": "partial",
-              "WDP-NA-C-003": "partial"
+              "WDP-CORE-C-001": "implemented",
+              "WDP-NA-C-003": "implemented"
             },
-            "clauseImplementationStatus": "not-assessed",
+            "clauseImplementationStatus": "implemented",
             "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented."
           }
         },
@@ -21342,8 +21507,13 @@
           "fixturePlan": {
             "id": "WDP-FX-UDP-IP-PROTOCOL-NUMBER",
             "kind": "binary-decoder",
-            "status": "planned",
-            "assertion": "Identify UDP with IPv4 protocol number 17."
+            "status": "implemented",
+            "assertion": "Identify UDP with IPv4 protocol number 17.",
+            "evidence": {
+              "path": "transport-rust/tests/fixtures/transport/wdp_cdpd_ipv4_mapped/wdp_fixture.json",
+              "testPath": "transport-rust/src/network/wdp/tests.rs",
+              "command": "cargo test --manifest-path transport-rust/Cargo.toml --lib network::wdp"
+            }
           },
           "mapping": {
             "ownerLayers": [
@@ -21358,10 +21528,10 @@
               "RQ-TRN-003"
             ],
             "parentImplementationSnapshot": {
-              "WDP-CT-C-002": "partial",
-              "WDP-NA-C-003": "partial"
+              "WDP-CT-C-002": "implemented",
+              "WDP-NA-C-003": "implemented"
             },
-            "clauseImplementationStatus": "not-assessed",
+            "clauseImplementationStatus": "implemented",
             "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented."
           }
         },
@@ -21385,8 +21555,13 @@
           "fixturePlan": {
             "id": "WDP-FX-IPV4-INDEPENDENT-DATAGRAMS",
             "kind": "transport-boundary",
-            "status": "planned",
-            "assertion": "Treat each IPv4 datagram independently without a transport connection or logical circuit."
+            "status": "implemented",
+            "assertion": "Treat each IPv4 datagram independently without a transport connection or logical circuit.",
+            "evidence": {
+              "path": "transport-rust/tests/fixtures/transport/wdp_cdpd_ipv4_mapped/wdp_fixture.json",
+              "testPath": "transport-rust/src/network/wdp/tests.rs",
+              "command": "cargo test --manifest-path transport-rust/Cargo.toml --lib network::wdp"
+            }
           },
           "mapping": {
             "ownerLayers": [
@@ -21401,11 +21576,11 @@
               "RQ-TRN-003"
             ],
             "parentImplementationSnapshot": {
-              "WDP-C-001": "partial",
-              "WDP-CORE-C-001": "partial",
-              "WDP-NA-C-003": "partial"
+              "WDP-C-001": "implemented",
+              "WDP-CORE-C-001": "implemented",
+              "WDP-NA-C-003": "implemented"
             },
-            "clauseImplementationStatus": "not-assessed",
+            "clauseImplementationStatus": "implemented",
             "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented."
           }
         },
@@ -21428,8 +21603,13 @@
           "fixturePlan": {
             "id": "WDP-FX-IPV4-FIXED-ADDRESS-SIZE",
             "kind": "binary-decoder",
-            "status": "planned",
-            "assertion": "Represent each selected IPv4 source or destination address as four octets."
+            "status": "implemented",
+            "assertion": "Represent each selected IPv4 source or destination address as four octets.",
+            "evidence": {
+              "path": "transport-rust/tests/fixtures/transport/wdp_cdpd_ipv4_mapped/wdp_fixture.json",
+              "testPath": "transport-rust/src/network/wdp/tests.rs",
+              "command": "cargo test --manifest-path transport-rust/Cargo.toml --lib network::wdp"
+            }
           },
           "mapping": {
             "ownerLayers": [
@@ -21443,10 +21623,10 @@
               "RQ-TRN-003"
             ],
             "parentImplementationSnapshot": {
-              "WDP-NA-C-000": "partial",
-              "WDP-NA-C-003": "partial"
+              "WDP-NA-C-000": "implemented",
+              "WDP-NA-C-003": "implemented"
             },
-            "clauseImplementationStatus": "not-assessed",
+            "clauseImplementationStatus": "implemented",
             "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented."
           }
         },
@@ -21468,8 +21648,13 @@
           "fixturePlan": {
             "id": "WDP-FX-IPV4-HEADER-LAYOUT",
             "kind": "binary-decoder",
-            "status": "planned",
-            "assertion": "Decode the complete IPv4 header field order and widths before passing its UDP payload to WDP."
+            "status": "implemented",
+            "assertion": "Decode the complete IPv4 header field order and widths before passing its UDP payload to WDP.",
+            "evidence": {
+              "path": "transport-rust/tests/fixtures/transport/wdp_cdpd_ipv4_mapped/wdp_fixture.json",
+              "testPath": "transport-rust/src/network/wdp/tests.rs",
+              "command": "cargo test --manifest-path transport-rust/Cargo.toml --lib network::wdp"
+            }
           },
           "mapping": {
             "ownerLayers": [
@@ -21483,9 +21668,9 @@
               "RQ-TRN-003"
             ],
             "parentImplementationSnapshot": {
-              "WDP-NA-C-003": "partial"
+              "WDP-NA-C-003": "implemented"
             },
-            "clauseImplementationStatus": "not-assessed",
+            "clauseImplementationStatus": "implemented",
             "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented."
           }
         },
@@ -21507,8 +21692,13 @@
           "fixturePlan": {
             "id": "WDP-FX-IPV4-VERSION-AND-IHL",
             "kind": "binary-decoder",
-            "status": "planned",
-            "assertion": "Require IPv4 version value 4 and use IHL in 32-bit words with a minimum valid value of five."
+            "status": "implemented",
+            "assertion": "Require IPv4 version value 4 and use IHL in 32-bit words with a minimum valid value of five.",
+            "evidence": {
+              "path": "transport-rust/tests/fixtures/transport/wdp_cdpd_ipv4_mapped/wdp_fixture.json",
+              "testPath": "transport-rust/src/network/wdp/tests.rs",
+              "command": "cargo test --manifest-path transport-rust/Cargo.toml --lib network::wdp"
+            }
           },
           "mapping": {
             "ownerLayers": [
@@ -21522,9 +21712,9 @@
               "RQ-TRN-003"
             ],
             "parentImplementationSnapshot": {
-              "WDP-NA-C-003": "partial"
+              "WDP-NA-C-003": "implemented"
             },
-            "clauseImplementationStatus": "not-assessed",
+            "clauseImplementationStatus": "implemented",
             "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented."
           }
         },
@@ -21547,8 +21737,13 @@
           "fixturePlan": {
             "id": "WDP-FX-IPV4-TOTAL-LENGTH",
             "kind": "binary-decoder",
-            "status": "planned",
-            "assertion": "Interpret IPv4 total length as header plus payload octets with a maximum representable value of 65,535."
+            "status": "implemented",
+            "assertion": "Interpret IPv4 total length as header plus payload octets with a maximum representable value of 65,535.",
+            "evidence": {
+              "path": "transport-rust/tests/fixtures/transport/wdp_cdpd_ipv4_mapped/wdp_fixture.json",
+              "testPath": "transport-rust/src/network/wdp/tests.rs",
+              "command": "cargo test --manifest-path transport-rust/Cargo.toml --lib network::wdp"
+            }
           },
           "mapping": {
             "ownerLayers": [
@@ -21563,10 +21758,10 @@
               "RQ-TRN-003"
             ],
             "parentImplementationSnapshot": {
-              "WDP-CORE-C-001": "partial",
-              "WDP-NA-C-003": "partial"
+              "WDP-CORE-C-001": "implemented",
+              "WDP-NA-C-003": "implemented"
             },
-            "clauseImplementationStatus": "not-assessed",
+            "clauseImplementationStatus": "implemented",
             "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented."
           }
         },
@@ -21589,8 +21784,13 @@
           "fixturePlan": {
             "id": "WDP-FX-IPV4-BASELINE-RECEIVE-SIZE",
             "kind": "transport-boundary",
-            "status": "planned",
-            "assertion": "Accept IPv4 datagrams up to 576 octets whether received whole or reassembled from fragments."
+            "status": "implemented",
+            "assertion": "Accept IPv4 datagrams up to 576 octets whether received whole or reassembled from fragments.",
+            "evidence": {
+              "path": "transport-rust/tests/fixtures/transport/wdp_cdpd_ipv4_mapped/wdp_fixture.json",
+              "testPath": "transport-rust/src/network/wdp/tests.rs",
+              "command": "cargo test --manifest-path transport-rust/Cargo.toml --lib network::wdp"
+            }
           },
           "mapping": {
             "ownerLayers": [
@@ -21605,10 +21805,10 @@
               "RQ-TRN-003"
             ],
             "parentImplementationSnapshot": {
-              "WDP-CORE-C-001": "partial",
-              "WDP-NA-C-003": "partial"
+              "WDP-CORE-C-001": "implemented",
+              "WDP-NA-C-003": "implemented"
             },
-            "clauseImplementationStatus": "not-assessed",
+            "clauseImplementationStatus": "implemented",
             "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented."
           }
         },
@@ -21631,8 +21831,13 @@
           "fixturePlan": {
             "id": "WDP-FX-IPV4-LARGE-SEND-GUARD",
             "kind": "transport-boundary",
-            "status": "planned",
-            "assertion": "Send an IPv4 datagram larger than 576 octets only with assurance that the destination can accept it."
+            "status": "implemented",
+            "assertion": "Send an IPv4 datagram larger than 576 octets only with assurance that the destination can accept it.",
+            "evidence": {
+              "path": "transport-rust/tests/fixtures/transport/wdp_cdpd_ipv4_mapped/wdp_fixture.json",
+              "testPath": "transport-rust/src/network/wdp/tests.rs",
+              "command": "cargo test --manifest-path transport-rust/Cargo.toml --lib network::wdp"
+            }
           },
           "mapping": {
             "ownerLayers": [
@@ -21647,10 +21852,10 @@
               "RQ-TRN-003"
             ],
             "parentImplementationSnapshot": {
-              "WDP-CORE-C-001": "partial",
-              "WDP-NA-C-003": "partial"
+              "WDP-CORE-C-001": "implemented",
+              "WDP-NA-C-003": "implemented"
             },
-            "clauseImplementationStatus": "not-assessed",
+            "clauseImplementationStatus": "implemented",
             "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented."
           }
         },
@@ -21673,8 +21878,13 @@
           "fixturePlan": {
             "id": "WDP-FX-IPV4-FRAGMENTATION-LOCATION",
             "kind": "transport-boundary",
-            "status": "planned",
-            "assertion": "Allow IPv4 fragmentation at gateways and reassemble fragments at the destination IP module below WDP."
+            "status": "implemented",
+            "assertion": "Allow IPv4 fragmentation at gateways and reassemble fragments at the destination IP module below WDP.",
+            "evidence": {
+              "path": "transport-rust/tests/fixtures/transport/wdp_cdpd_ipv4_mapped/wdp_fixture.json",
+              "testPath": "transport-rust/src/network/wdp/tests.rs",
+              "command": "cargo test --manifest-path transport-rust/Cargo.toml --lib network::wdp"
+            }
           },
           "mapping": {
             "ownerLayers": [
@@ -21689,10 +21899,10 @@
               "RQ-TRN-003"
             ],
             "parentImplementationSnapshot": {
-              "WDP-CORE-C-001": "partial",
-              "WDP-NA-C-003": "partial"
+              "WDP-CORE-C-001": "implemented",
+              "WDP-NA-C-003": "implemented"
             },
-            "clauseImplementationStatus": "not-assessed",
+            "clauseImplementationStatus": "implemented",
             "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented."
           }
         },
@@ -21715,8 +21925,13 @@
           "fixturePlan": {
             "id": "WDP-FX-IPV4-FRAGMENT-REASSEMBLY-KEY",
             "kind": "binary-decoder",
-            "status": "planned",
-            "assertion": "Group IPv4 fragments by identification, source, destination, and protocol, then place data using fragment offsets and the final-fragment marker."
+            "status": "implemented",
+            "assertion": "Group IPv4 fragments by identification, source, destination, and protocol, then place data using fragment offsets and the final-fragment marker.",
+            "evidence": {
+              "path": "transport-rust/tests/fixtures/transport/wdp_cdpd_ipv4_mapped/wdp_fixture.json",
+              "testPath": "transport-rust/src/network/wdp/tests.rs",
+              "command": "cargo test --manifest-path transport-rust/Cargo.toml --lib network::wdp"
+            }
           },
           "mapping": {
             "ownerLayers": [
@@ -21731,10 +21946,10 @@
               "RQ-TRN-003"
             ],
             "parentImplementationSnapshot": {
-              "WDP-CORE-C-001": "partial",
-              "WDP-NA-C-003": "partial"
+              "WDP-CORE-C-001": "implemented",
+              "WDP-NA-C-003": "implemented"
             },
-            "clauseImplementationStatus": "not-assessed",
+            "clauseImplementationStatus": "implemented",
             "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented."
           }
         },
@@ -21757,8 +21972,13 @@
           "fixturePlan": {
             "id": "WDP-FX-IPV4-DONT-FRAGMENT",
             "kind": "error-policy",
-            "status": "planned",
-            "assertion": "Do not fragment a datagram whose DF bit is set; discard it when the route cannot carry it intact."
+            "status": "implemented",
+            "assertion": "Do not fragment a datagram whose DF bit is set; discard it when the route cannot carry it intact.",
+            "evidence": {
+              "path": "transport-rust/tests/fixtures/transport/wdp_cdpd_ipv4_mapped/wdp_fixture.json",
+              "testPath": "transport-rust/src/network/wdp/tests.rs",
+              "command": "cargo test --manifest-path transport-rust/Cargo.toml --lib network::wdp"
+            }
           },
           "mapping": {
             "ownerLayers": [
@@ -21773,10 +21993,10 @@
               "RQ-TRN-003"
             ],
             "parentImplementationSnapshot": {
-              "WDP-CORE-C-001": "partial",
-              "WDP-NA-C-003": "partial"
+              "WDP-CORE-C-001": "implemented",
+              "WDP-NA-C-003": "implemented"
             },
-            "clauseImplementationStatus": "not-assessed",
+            "clauseImplementationStatus": "implemented",
             "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented."
           }
         },
@@ -21798,8 +22018,13 @@
           "fixturePlan": {
             "id": "WDP-FX-IPV4-TTL-ZERO",
             "kind": "error-policy",
-            "status": "planned",
-            "assertion": "Destroy an IPv4 datagram when its time-to-live value reaches zero."
+            "status": "implemented",
+            "assertion": "Destroy an IPv4 datagram when its time-to-live value reaches zero.",
+            "evidence": {
+              "path": "transport-rust/tests/fixtures/transport/wdp_cdpd_ipv4_mapped/wdp_fixture.json",
+              "testPath": "transport-rust/src/network/wdp/tests.rs",
+              "command": "cargo test --manifest-path transport-rust/Cargo.toml --lib network::wdp"
+            }
           },
           "mapping": {
             "ownerLayers": [
@@ -21813,9 +22038,9 @@
               "RQ-TRN-003"
             ],
             "parentImplementationSnapshot": {
-              "WDP-NA-C-003": "partial"
+              "WDP-NA-C-003": "implemented"
             },
-            "clauseImplementationStatus": "not-assessed",
+            "clauseImplementationStatus": "implemented",
             "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented."
           }
         },
@@ -21837,8 +22062,13 @@
           "fixturePlan": {
             "id": "WDP-FX-IPV4-HEADER-CHECKSUM",
             "kind": "binary-decoder",
-            "status": "planned",
-            "assertion": "Verify the ones-complement IPv4 header checksum and discard a datagram immediately when verification fails."
+            "status": "implemented",
+            "assertion": "Verify the ones-complement IPv4 header checksum and discard a datagram immediately when verification fails.",
+            "evidence": {
+              "path": "transport-rust/tests/fixtures/transport/wdp_cdpd_ipv4_mapped/wdp_fixture.json",
+              "testPath": "transport-rust/src/network/wdp/tests.rs",
+              "command": "cargo test --manifest-path transport-rust/Cargo.toml --lib network::wdp"
+            }
           },
           "mapping": {
             "ownerLayers": [
@@ -21852,9 +22082,9 @@
               "RQ-TRN-003"
             ],
             "parentImplementationSnapshot": {
-              "WDP-NA-C-003": "partial"
+              "WDP-NA-C-003": "implemented"
             },
-            "clauseImplementationStatus": "not-assessed",
+            "clauseImplementationStatus": "implemented",
             "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented."
           }
         },
@@ -21878,8 +22108,13 @@
           "fixturePlan": {
             "id": "WDP-FX-IPV4-SOURCE-DESTINATION-FIELDS",
             "kind": "binary-decoder",
-            "status": "planned",
-            "assertion": "Preserve the 32-bit IPv4 source and destination header fields across the WDP request and indication boundary."
+            "status": "implemented",
+            "assertion": "Preserve the 32-bit IPv4 source and destination header fields across the WDP request and indication boundary.",
+            "evidence": {
+              "path": "transport-rust/tests/fixtures/transport/wdp_cdpd_ipv4_mapped/wdp_fixture.json",
+              "testPath": "transport-rust/src/network/wdp/tests.rs",
+              "command": "cargo test --manifest-path transport-rust/Cargo.toml --lib network::wdp"
+            }
           },
           "mapping": {
             "ownerLayers": [
@@ -21894,11 +22129,11 @@
               "RQ-TRN-003"
             ],
             "parentImplementationSnapshot": {
-              "WDP-PF-C-001": "partial",
-              "WDP-PF-C-002": "partial",
-              "WDP-NA-C-003": "partial"
+              "WDP-PF-C-001": "implemented",
+              "WDP-PF-C-002": "implemented",
+              "WDP-NA-C-003": "implemented"
             },
-            "clauseImplementationStatus": "not-assessed",
+            "clauseImplementationStatus": "implemented",
             "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented."
           }
         },
@@ -21920,8 +22155,13 @@
           "fixturePlan": {
             "id": "WDP-FX-IPV4-ROBUST-INTEROPERATION",
             "kind": "binary-decoder",
-            "status": "planned",
-            "assertion": "Send well-formed IPv4 datagrams and accept every received datagram whose meaning can be interpreted safely."
+            "status": "implemented",
+            "assertion": "Send well-formed IPv4 datagrams and accept every received datagram whose meaning can be interpreted safely.",
+            "evidence": {
+              "path": "transport-rust/tests/fixtures/transport/wdp_cdpd_ipv4_mapped/wdp_fixture.json",
+              "testPath": "transport-rust/src/network/wdp/tests.rs",
+              "command": "cargo test --manifest-path transport-rust/Cargo.toml --lib network::wdp"
+            }
           },
           "mapping": {
             "ownerLayers": [
@@ -21935,9 +22175,9 @@
               "RQ-TRN-003"
             ],
             "parentImplementationSnapshot": {
-              "WDP-NA-C-003": "partial"
+              "WDP-NA-C-003": "implemented"
             },
-            "clauseImplementationStatus": "not-assessed",
+            "clauseImplementationStatus": "implemented",
             "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented."
           }
         },
@@ -21960,8 +22200,13 @@
           "fixturePlan": {
             "id": "WDP-FX-IPV4-NO-RELIABILITY",
             "kind": "transport-boundary",
-            "status": "planned",
-            "assertion": "Do not imply acknowledgments, retransmission, data error control, or flow control at the IPv4 layer."
+            "status": "implemented",
+            "assertion": "Do not imply acknowledgments, retransmission, data error control, or flow control at the IPv4 layer.",
+            "evidence": {
+              "path": "transport-rust/tests/fixtures/transport/wdp_cdpd_ipv4_mapped/wdp_fixture.json",
+              "testPath": "transport-rust/src/network/wdp/tests.rs",
+              "command": "cargo test --manifest-path transport-rust/Cargo.toml --lib network::wdp"
+            }
           },
           "mapping": {
             "ownerLayers": [
@@ -21975,10 +22220,10 @@
               "RQ-TRN-001"
             ],
             "parentImplementationSnapshot": {
-              "WDP-C-001": "partial",
-              "WDP-CORE-C-001": "partial"
+              "WDP-C-001": "implemented",
+              "WDP-CORE-C-001": "implemented"
             },
-            "clauseImplementationStatus": "not-assessed",
+            "clauseImplementationStatus": "implemented",
             "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented."
           }
         }

--- a/spec-processing/source-manifests/wap-1.2.1-successor-delta.json
+++ b/spec-processing/source-manifests/wap-1.2.1-successor-delta.json
@@ -7457,7 +7457,7 @@
         "documentId": "WAP-200_005-WDP",
         "staticConformanceSection": "Appendix E"
       },
-      "selectedImplementationStatus": "partial",
+      "selectedImplementationStatus": "implemented",
       "assessmentState": "planning-classification-not-conformance-evidence",
       "successorDerivedImplementation": false,
       "implementationBasis": "target-era-or-version-neutral",
@@ -7503,7 +7503,7 @@
         "documentId": "WAP-200_005-WDP",
         "staticConformanceSection": "Appendix E"
       },
-      "selectedImplementationStatus": "partial",
+      "selectedImplementationStatus": "implemented",
       "assessmentState": "planning-classification-not-conformance-evidence",
       "successorDerivedImplementation": false,
       "implementationBasis": "target-era-or-version-neutral",
@@ -7562,7 +7562,7 @@
         "documentId": "WAP-200_005-WDP",
         "staticConformanceSection": "Appendix E"
       },
-      "selectedImplementationStatus": "partial",
+      "selectedImplementationStatus": "implemented",
       "assessmentState": "planning-classification-not-conformance-evidence",
       "successorDerivedImplementation": false,
       "implementationBasis": "target-era-or-version-neutral",
@@ -7606,7 +7606,7 @@
         "documentId": "WAP-200_005-WDP",
         "staticConformanceSection": "Appendix E"
       },
-      "selectedImplementationStatus": "partial",
+      "selectedImplementationStatus": "implemented",
       "assessmentState": "planning-classification-not-conformance-evidence",
       "successorDerivedImplementation": false,
       "implementationBasis": "target-era-or-version-neutral",
@@ -7649,7 +7649,7 @@
         "documentId": "WAP-200_005-WDP",
         "staticConformanceSection": "Appendix E"
       },
-      "selectedImplementationStatus": "partial",
+      "selectedImplementationStatus": "implemented",
       "assessmentState": "planning-classification-not-conformance-evidence",
       "successorDerivedImplementation": false,
       "implementationBasis": "target-era-or-version-neutral",
@@ -7691,7 +7691,7 @@
         "documentId": "WAP-200_005-WDP",
         "staticConformanceSection": "Appendix E"
       },
-      "selectedImplementationStatus": "partial",
+      "selectedImplementationStatus": "implemented",
       "assessmentState": "planning-classification-not-conformance-evidence",
       "successorDerivedImplementation": false,
       "implementationBasis": "target-era-or-version-neutral",
@@ -7731,7 +7731,7 @@
         "documentId": "WAP-200_005-WDP",
         "staticConformanceSection": "Appendix E"
       },
-      "selectedImplementationStatus": "partial",
+      "selectedImplementationStatus": "implemented",
       "assessmentState": "planning-classification-not-conformance-evidence",
       "successorDerivedImplementation": false,
       "implementationBasis": "target-era-or-version-neutral",
@@ -7795,7 +7795,7 @@
         "documentId": "WAP-200_005-WDP",
         "staticConformanceSection": "Appendix E"
       },
-      "selectedImplementationStatus": "partial",
+      "selectedImplementationStatus": "implemented",
       "assessmentState": "planning-classification-not-conformance-evidence",
       "successorDerivedImplementation": false,
       "implementationBasis": "target-era-or-version-neutral",
@@ -7841,7 +7841,7 @@
         "documentId": "WAP-200_005-WDP",
         "staticConformanceSection": "Appendix E"
       },
-      "selectedImplementationStatus": "partial",
+      "selectedImplementationStatus": "implemented",
       "assessmentState": "planning-classification-not-conformance-evidence",
       "successorDerivedImplementation": false,
       "implementationBasis": "target-era-or-version-neutral",

--- a/spec-processing/source-manifests/wap-1.2.1-trn-7-knowledge-graph.json
+++ b/spec-processing/source-manifests/wap-1.2.1-trn-7-knowledge-graph.json
@@ -13,7 +13,7 @@
     "generator": "spec-processing/scripts/generate-wap-knowledge-graph.mjs",
     "inputs": {
       "docs/waves/wap-1.2.1-compliance-program.json": {
-        "sha256": "e8076afef8391f966d8b1dcad1f1cbd3799efa1cf21034e95663bbc1af746614"
+        "sha256": "d8921b4b90be8bce678e3e44dd1032cf1b457a699240404b561174df4a128760"
       },
       "spec-processing/source-manifests/wap-1.2.1-class-conformance.json": {
         "sha256": "b76605b2144b32965a857b848b2e9e522baada6fae9fe51012b9eaa664e85d86"
@@ -25,7 +25,7 @@
         "sha256": "654284270a068b427ab05166247cb8e0644a99cf6af511f9b9c477d18ea36faa"
       },
       "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json": {
-        "sha256": "4d05178d0d5b7c1e9c76119aa6d91df6f30e7b93e1e29b0c1b02529cb8d0d28f"
+        "sha256": "6e8c6662c69af1612a1d5805ad9a87f56dc9d8a2bd5af53d1faeb892a8d34693"
       }
     },
     "policy": "Canonical manifests remain authoritative; this graph and its Obsidian/context projections are generated views."
@@ -1106,7 +1106,7 @@
           "RQ-TRN-001",
           "RQ-TRN-002"
         ],
-        "implementationStatus": "not-assessed",
+        "implementationStatus": "implemented",
         "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented.",
         "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
       }
@@ -1143,7 +1143,7 @@
           "RQ-TRN-001",
           "RQ-TRN-003"
         ],
-        "implementationStatus": "not-assessed",
+        "implementationStatus": "implemented",
         "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented.",
         "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
       }
@@ -1178,7 +1178,7 @@
         "requirementIds": [
           "RQ-TRN-001"
         ],
-        "implementationStatus": "not-assessed",
+        "implementationStatus": "implemented",
         "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented.",
         "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
       }
@@ -1214,7 +1214,7 @@
           "RQ-TRN-002",
           "RQ-TRN-003"
         ],
-        "implementationStatus": "not-assessed",
+        "implementationStatus": "implemented",
         "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented.",
         "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
       }
@@ -1249,7 +1249,7 @@
         "requirementIds": [
           "RQ-TRN-001"
         ],
-        "implementationStatus": "not-assessed",
+        "implementationStatus": "implemented",
         "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented.",
         "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
       }
@@ -1287,7 +1287,7 @@
           "RQ-TRN-001",
           "RQ-TRN-003"
         ],
-        "implementationStatus": "not-assessed",
+        "implementationStatus": "implemented",
         "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented.",
         "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
       }
@@ -1324,7 +1324,7 @@
           "RQ-TRN-001",
           "RQ-TRN-003"
         ],
-        "implementationStatus": "not-assessed",
+        "implementationStatus": "implemented",
         "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented.",
         "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
       }
@@ -1362,7 +1362,7 @@
           "RQ-TRN-002",
           "RQ-TRN-003"
         ],
-        "implementationStatus": "not-assessed",
+        "implementationStatus": "implemented",
         "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented.",
         "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
       }
@@ -1400,7 +1400,7 @@
           "RQ-TRN-002",
           "RQ-TRN-003"
         ],
-        "implementationStatus": "not-assessed",
+        "implementationStatus": "implemented",
         "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented.",
         "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
       }
@@ -1438,7 +1438,7 @@
           "RQ-TRN-002",
           "RQ-TRN-003"
         ],
-        "implementationStatus": "not-assessed",
+        "implementationStatus": "implemented",
         "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented.",
         "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
       }
@@ -1474,7 +1474,7 @@
           "RQ-TRN-001",
           "RQ-TRN-003"
         ],
-        "implementationStatus": "not-assessed",
+        "implementationStatus": "implemented",
         "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented.",
         "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
       }
@@ -1510,7 +1510,7 @@
           "RQ-TRN-001",
           "RQ-TRN-003"
         ],
-        "implementationStatus": "not-assessed",
+        "implementationStatus": "implemented",
         "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented.",
         "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
       }
@@ -1545,7 +1545,7 @@
         "requirementIds": [
           "RQ-TRN-003"
         ],
-        "implementationStatus": "not-assessed",
+        "implementationStatus": "implemented",
         "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented.",
         "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
       }
@@ -1581,7 +1581,7 @@
           "RQ-TRN-001",
           "RQ-TRN-003"
         ],
-        "implementationStatus": "not-assessed",
+        "implementationStatus": "implemented",
         "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented.",
         "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
       }
@@ -1617,7 +1617,7 @@
           "RQ-TRN-001",
           "RQ-TRN-003"
         ],
-        "implementationStatus": "not-assessed",
+        "implementationStatus": "implemented",
         "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented.",
         "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
       }
@@ -1651,7 +1651,7 @@
         "requirementIds": [
           "RQ-TRN-003"
         ],
-        "implementationStatus": "not-assessed",
+        "implementationStatus": "implemented",
         "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented.",
         "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
       }
@@ -1685,7 +1685,7 @@
         "requirementIds": [
           "RQ-TRN-003"
         ],
-        "implementationStatus": "not-assessed",
+        "implementationStatus": "implemented",
         "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented.",
         "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
       }
@@ -1722,7 +1722,7 @@
           "RQ-TRN-001",
           "RQ-TRN-003"
         ],
-        "implementationStatus": "not-assessed",
+        "implementationStatus": "implemented",
         "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented.",
         "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
       }
@@ -1758,7 +1758,7 @@
           "RQ-TRN-001",
           "RQ-TRN-003"
         ],
-        "implementationStatus": "not-assessed",
+        "implementationStatus": "implemented",
         "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented.",
         "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
       }
@@ -1793,7 +1793,7 @@
         "requirementIds": [
           "RQ-TRN-001"
         ],
-        "implementationStatus": "not-assessed",
+        "implementationStatus": "implemented",
         "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented.",
         "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
       }
@@ -1827,7 +1827,7 @@
         "requirementIds": [
           "RQ-TRN-003"
         ],
-        "implementationStatus": "not-assessed",
+        "implementationStatus": "implemented",
         "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented.",
         "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
       }
@@ -1864,7 +1864,7 @@
           "RQ-TRN-001",
           "RQ-TRN-003"
         ],
-        "implementationStatus": "not-assessed",
+        "implementationStatus": "implemented",
         "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented.",
         "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
       }
@@ -1900,7 +1900,7 @@
           "RQ-TRN-001",
           "RQ-TRN-003"
         ],
-        "implementationStatus": "not-assessed",
+        "implementationStatus": "implemented",
         "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented.",
         "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
       }
@@ -1934,7 +1934,7 @@
         "requirementIds": [
           "RQ-TRN-003"
         ],
-        "implementationStatus": "not-assessed",
+        "implementationStatus": "implemented",
         "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented.",
         "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
       }
@@ -1968,7 +1968,7 @@
         "requirementIds": [
           "RQ-TRN-003"
         ],
-        "implementationStatus": "not-assessed",
+        "implementationStatus": "implemented",
         "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented.",
         "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
       }
@@ -2005,7 +2005,7 @@
           "RQ-TRN-001",
           "RQ-TRN-003"
         ],
-        "implementationStatus": "not-assessed",
+        "implementationStatus": "implemented",
         "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented.",
         "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
       }
@@ -2041,7 +2041,7 @@
           "RQ-TRN-002",
           "RQ-TRN-003"
         ],
-        "implementationStatus": "not-assessed",
+        "implementationStatus": "implemented",
         "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented.",
         "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
       }
@@ -2077,7 +2077,7 @@
           "RQ-TRN-001",
           "RQ-TRN-003"
         ],
-        "implementationStatus": "not-assessed",
+        "implementationStatus": "implemented",
         "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented.",
         "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
       }
@@ -2115,7 +2115,7 @@
           "RQ-TRN-001",
           "RQ-TRN-003"
         ],
-        "implementationStatus": "not-assessed",
+        "implementationStatus": "implemented",
         "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented.",
         "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
       }
@@ -2153,7 +2153,7 @@
           "RQ-TRN-001",
           "RQ-TRN-003"
         ],
-        "implementationStatus": "not-assessed",
+        "implementationStatus": "implemented",
         "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented.",
         "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
       }
@@ -2190,7 +2190,7 @@
           "RQ-TRN-001",
           "RQ-TRN-003"
         ],
-        "implementationStatus": "not-assessed",
+        "implementationStatus": "implemented",
         "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented.",
         "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
       }
@@ -2226,7 +2226,7 @@
           "RQ-TRN-001",
           "RQ-TRN-003"
         ],
-        "implementationStatus": "not-assessed",
+        "implementationStatus": "implemented",
         "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented.",
         "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
       }
@@ -2260,7 +2260,7 @@
         "requirementIds": [
           "RQ-TRN-001"
         ],
-        "implementationStatus": "not-assessed",
+        "implementationStatus": "implemented",
         "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented.",
         "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
       }
@@ -2294,7 +2294,7 @@
         "requirementIds": [
           "RQ-TRN-001"
         ],
-        "implementationStatus": "not-assessed",
+        "implementationStatus": "implemented",
         "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented.",
         "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
       }
@@ -2328,7 +2328,7 @@
         "requirementIds": [
           "RQ-TRN-001"
         ],
-        "implementationStatus": "not-assessed",
+        "implementationStatus": "implemented",
         "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented.",
         "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
       }
@@ -2363,7 +2363,7 @@
         "requirementIds": [
           "RQ-TRN-003"
         ],
-        "implementationStatus": "not-assessed",
+        "implementationStatus": "implemented",
         "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented.",
         "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
       }
@@ -2400,7 +2400,7 @@
           "RQ-TRN-001",
           "RQ-TRN-003"
         ],
-        "implementationStatus": "not-assessed",
+        "implementationStatus": "implemented",
         "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented.",
         "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
       }
@@ -2436,7 +2436,7 @@
           "RQ-TRN-001",
           "RQ-TRN-003"
         ],
-        "implementationStatus": "not-assessed",
+        "implementationStatus": "implemented",
         "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented.",
         "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
       }
@@ -2472,7 +2472,7 @@
           "RQ-TRN-002",
           "RQ-TRN-003"
         ],
-        "implementationStatus": "not-assessed",
+        "implementationStatus": "implemented",
         "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented.",
         "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
       }
@@ -2506,7 +2506,7 @@
         "requirementIds": [
           "RQ-TRN-001"
         ],
-        "implementationStatus": "not-assessed",
+        "implementationStatus": "implemented",
         "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented.",
         "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
       }
@@ -2543,7 +2543,7 @@
           "RQ-TRN-001",
           "RQ-TRN-003"
         ],
-        "implementationStatus": "not-assessed",
+        "implementationStatus": "implemented",
         "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented.",
         "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
       }
@@ -2581,7 +2581,7 @@
           "RQ-TRN-001",
           "RQ-TRN-003"
         ],
-        "implementationStatus": "not-assessed",
+        "implementationStatus": "implemented",
         "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented.",
         "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
       }
@@ -2615,7 +2615,7 @@
         "requirementIds": [
           "RQ-TRN-003"
         ],
-        "implementationStatus": "not-assessed",
+        "implementationStatus": "implemented",
         "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented.",
         "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
       }
@@ -2650,7 +2650,7 @@
         "requirementIds": [
           "RQ-TRN-001"
         ],
-        "implementationStatus": "not-assessed",
+        "implementationStatus": "implemented",
         "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented.",
         "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
       }
@@ -2686,7 +2686,7 @@
         "requirementIds": [
           "RQ-TRN-001"
         ],
-        "implementationStatus": "not-assessed",
+        "implementationStatus": "implemented",
         "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented.",
         "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
       }
@@ -2726,7 +2726,7 @@
           "RQ-TRN-001",
           "RQ-TRN-003"
         ],
-        "implementationStatus": "not-assessed",
+        "implementationStatus": "implemented",
         "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented.",
         "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
       }
@@ -2760,7 +2760,7 @@
         "requirementIds": [
           "RQ-TRN-001"
         ],
-        "implementationStatus": "not-assessed",
+        "implementationStatus": "implemented",
         "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented.",
         "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
       }
@@ -2800,7 +2800,7 @@
           "RQ-TRN-001",
           "RQ-TRN-003"
         ],
-        "implementationStatus": "not-assessed",
+        "implementationStatus": "implemented",
         "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented.",
         "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
       }
@@ -2835,7 +2835,7 @@
         "requirementIds": [
           "RQ-TRN-003"
         ],
-        "implementationStatus": "not-assessed",
+        "implementationStatus": "implemented",
         "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented.",
         "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
       }
@@ -3183,7 +3183,7 @@
       "title": "Terminate bearer-specific adaptation at the WDP boundary without changing the service presented to WSP or other upper layers.",
       "properties": {
         "kind": "transport-boundary",
-        "status": "planned",
+        "status": "implemented",
         "assertion": "Terminate bearer-specific adaptation at the WDP boundary without changing the service presented to WSP or other upper layers.",
         "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
       }
@@ -3195,7 +3195,7 @@
       "title": "Provide source and destination port addressing for the higher-layer protocol or application above WDP.",
       "properties": {
         "kind": "transport-boundary",
-        "status": "planned",
+        "status": "implemented",
         "assertion": "Provide source and destination port addressing for the higher-layer protocol or application above WDP.",
         "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
       }
@@ -3207,7 +3207,7 @@
       "title": "Keep bearer-specific mechanics below the transport service access point so upper layers can operate transparently.",
       "properties": {
         "kind": "transport-boundary",
-        "status": "planned",
+        "status": "implemented",
         "assertion": "Keep bearer-specific mechanics below the transport service access point so upper layers can operate transparently.",
         "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
       }
@@ -3219,7 +3219,7 @@
       "title": "Declare the selected CDPD bearer as an IP-capable profile whose WDP datagram service is UDP over IPv4.",
       "properties": {
         "kind": "transport-boundary",
-        "status": "planned",
+        "status": "implemented",
         "assertion": "Declare the selected CDPD bearer as an IP-capable profile whose WDP datagram service is UDP over IPv4.",
         "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
       }
@@ -3231,7 +3231,7 @@
       "title": "Expose the same WDP transport service and primitive contract to upper WAP layers across supported bearer adaptations.",
       "properties": {
         "kind": "transport-boundary",
-        "status": "planned",
+        "status": "implemented",
         "assertion": "Expose the same WDP transport service and primitive contract to upper WAP layers across supported bearer adaptations.",
         "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
       }
@@ -3243,7 +3243,7 @@
       "title": "Treat the destination address as the network identity of the receiving device for the submitted user data.",
       "properties": {
         "kind": "transport-boundary",
-        "status": "planned",
+        "status": "implemented",
         "assertion": "Treat the destination address as the network identity of the receiving device for the submitted user data.",
         "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
       }
@@ -3255,7 +3255,7 @@
       "title": "Bind the destination port to the destination application or upper-layer protocol for that communication instance.",
       "properties": {
         "kind": "transport-boundary",
-        "status": "planned",
+        "status": "implemented",
         "assertion": "Bind the destination port to the destination application or upper-layer protocol for that communication instance.",
         "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
       }
@@ -3267,7 +3267,7 @@
       "title": "Use UDP as the WDP protocol whenever the selected bearer provides IP.",
       "properties": {
         "kind": "transport-boundary",
-        "status": "planned",
+        "status": "implemented",
         "assertion": "Use UDP as the WDP protocol whenever the selected bearer provides IP.",
         "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
       }
@@ -3279,7 +3279,7 @@
       "title": "Rely on IPv4 fragmentation and reassembly below UDP rather than adding a second WDP segmentation header on the CDPD/IP path.",
       "properties": {
         "kind": "transport-boundary",
-        "status": "planned",
+        "status": "implemented",
         "assertion": "Rely on IPv4 fragmentation and reassembly below UDP rather than adding a second WDP segmentation header on the CDPD/IP path.",
         "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
       }
@@ -3291,7 +3291,7 @@
       "title": "Map WDP directly to UDP for every selected bearer on which IP routing is available.",
       "properties": {
         "kind": "transport-boundary",
-        "status": "planned",
+        "status": "implemented",
         "assertion": "Map WDP directly to UDP for every selected bearer on which IP routing is available.",
         "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
       }
@@ -3303,7 +3303,7 @@
       "title": "Accept IPv4 datagrams up to 576 octets whether received whole or reassembled from fragments.",
       "properties": {
         "kind": "transport-boundary",
-        "status": "planned",
+        "status": "implemented",
         "assertion": "Accept IPv4 datagrams up to 576 octets whether received whole or reassembled from fragments.",
         "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
       }
@@ -3315,7 +3315,7 @@
       "title": "Do not fragment a datagram whose DF bit is set; discard it when the route cannot carry it intact.",
       "properties": {
         "kind": "error-policy",
-        "status": "planned",
+        "status": "implemented",
         "assertion": "Do not fragment a datagram whose DF bit is set; discard it when the route cannot carry it intact.",
         "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
       }
@@ -3327,7 +3327,7 @@
       "title": "Represent each selected IPv4 source or destination address as four octets.",
       "properties": {
         "kind": "binary-decoder",
-        "status": "planned",
+        "status": "implemented",
         "assertion": "Represent each selected IPv4 source or destination address as four octets.",
         "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
       }
@@ -3339,7 +3339,7 @@
       "title": "Group IPv4 fragments by identification, source, destination, and protocol, then place data using fragment offsets and the final-fragment marker.",
       "properties": {
         "kind": "binary-decoder",
-        "status": "planned",
+        "status": "implemented",
         "assertion": "Group IPv4 fragments by identification, source, destination, and protocol, then place data using fragment offsets and the final-fragment marker.",
         "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
       }
@@ -3351,7 +3351,7 @@
       "title": "Allow IPv4 fragmentation at gateways and reassemble fragments at the destination IP module below WDP.",
       "properties": {
         "kind": "transport-boundary",
-        "status": "planned",
+        "status": "implemented",
         "assertion": "Allow IPv4 fragmentation at gateways and reassemble fragments at the destination IP module below WDP.",
         "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
       }
@@ -3363,7 +3363,7 @@
       "title": "Verify the ones-complement IPv4 header checksum and discard a datagram immediately when verification fails.",
       "properties": {
         "kind": "binary-decoder",
-        "status": "planned",
+        "status": "implemented",
         "assertion": "Verify the ones-complement IPv4 header checksum and discard a datagram immediately when verification fails.",
         "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
       }
@@ -3375,7 +3375,7 @@
       "title": "Decode the complete IPv4 header field order and widths before passing its UDP payload to WDP.",
       "properties": {
         "kind": "binary-decoder",
-        "status": "planned",
+        "status": "implemented",
         "assertion": "Decode the complete IPv4 header field order and widths before passing its UDP payload to WDP.",
         "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
       }
@@ -3387,7 +3387,7 @@
       "title": "Treat each IPv4 datagram independently without a transport connection or logical circuit.",
       "properties": {
         "kind": "transport-boundary",
-        "status": "planned",
+        "status": "implemented",
         "assertion": "Treat each IPv4 datagram independently without a transport connection or logical circuit.",
         "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
       }
@@ -3399,7 +3399,7 @@
       "title": "Send an IPv4 datagram larger than 576 octets only with assurance that the destination can accept it.",
       "properties": {
         "kind": "transport-boundary",
-        "status": "planned",
+        "status": "implemented",
         "assertion": "Send an IPv4 datagram larger than 576 octets only with assurance that the destination can accept it.",
         "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
       }
@@ -3411,7 +3411,7 @@
       "title": "Do not imply acknowledgments, retransmission, data error control, or flow control at the IPv4 layer.",
       "properties": {
         "kind": "transport-boundary",
-        "status": "planned",
+        "status": "implemented",
         "assertion": "Do not imply acknowledgments, retransmission, data error control, or flow control at the IPv4 layer.",
         "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
       }
@@ -3423,7 +3423,7 @@
       "title": "Send well-formed IPv4 datagrams and accept every received datagram whose meaning can be interpreted safely.",
       "properties": {
         "kind": "binary-decoder",
-        "status": "planned",
+        "status": "implemented",
         "assertion": "Send well-formed IPv4 datagrams and accept every received datagram whose meaning can be interpreted safely.",
         "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
       }
@@ -3435,7 +3435,7 @@
       "title": "Preserve the 32-bit IPv4 source and destination header fields across the WDP request and indication boundary.",
       "properties": {
         "kind": "binary-decoder",
-        "status": "planned",
+        "status": "implemented",
         "assertion": "Preserve the 32-bit IPv4 source and destination header fields across the WDP request and indication boundary.",
         "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
       }
@@ -3447,7 +3447,7 @@
       "title": "Interpret IPv4 total length as header plus payload octets with a maximum representable value of 65,535.",
       "properties": {
         "kind": "binary-decoder",
-        "status": "planned",
+        "status": "implemented",
         "assertion": "Interpret IPv4 total length as header plus payload octets with a maximum representable value of 65,535.",
         "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
       }
@@ -3459,7 +3459,7 @@
       "title": "Destroy an IPv4 datagram when its time-to-live value reaches zero.",
       "properties": {
         "kind": "error-policy",
-        "status": "planned",
+        "status": "implemented",
         "assertion": "Destroy an IPv4 datagram when its time-to-live value reaches zero.",
         "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
       }
@@ -3471,7 +3471,7 @@
       "title": "Require IPv4 version value 4 and use IHL in 32-bit words with a minimum valid value of five.",
       "properties": {
         "kind": "binary-decoder",
-        "status": "planned",
+        "status": "implemented",
         "assertion": "Require IPv4 version value 4 and use IHL in 32-bit words with a minimum valid value of five.",
         "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
       }
@@ -3483,7 +3483,7 @@
       "title": "Carry both destination and source port fields in the selected WDP protocol mapping.",
       "properties": {
         "kind": "binary-decoder",
-        "status": "planned",
+        "status": "implemented",
         "assertion": "Carry both destination and source port fields in the selected WDP protocol mapping.",
         "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
       }
@@ -3495,7 +3495,7 @@
       "title": "Represent the AMPS/CDPD/IPv4 network-bearer-address combination with assigned bearer value 0x0D when that registry is carried.",
       "properties": {
         "kind": "transport-boundary",
-        "status": "planned",
+        "status": "implemented",
         "assertion": "Represent the AMPS/CDPD/IPv4 network-bearer-address combination with assigned bearer value 0x0D when that registry is carried.",
         "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
       }
@@ -3507,7 +3507,7 @@
       "title": "Use registered UDP/WDP port 9200 for the selected non-secure connectionless WSP session service.",
       "properties": {
         "kind": "transport-boundary",
-        "status": "planned",
+        "status": "implemented",
         "assertion": "Use registered UDP/WDP port 9200 for the selected non-secure connectionless WSP session service.",
         "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
       }
@@ -3519,7 +3519,7 @@
       "title": "Use port numbers to multiplex multiple simultaneous higher-layer communication instances over one WDP bearer service.",
       "properties": {
         "kind": "transport-boundary",
-        "status": "planned",
+        "status": "implemented",
         "assertion": "Use port numbers to multiplex multiple simultaneous higher-layer communication instances over one WDP bearer service.",
         "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
       }
@@ -3531,7 +3531,7 @@
       "title": "Treat the source address as the unique network identity of the device issuing the transport request.",
       "properties": {
         "kind": "transport-boundary",
-        "status": "planned",
+        "status": "implemented",
         "assertion": "Treat the source address as the unique network identity of the device issuing the transport request.",
         "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
       }
@@ -3543,7 +3543,7 @@
       "title": "Bind the source port to the requesting application or upper-layer protocol for that communication instance.",
       "properties": {
         "kind": "transport-boundary",
-        "status": "planned",
+        "status": "implemented",
         "assertion": "Bind the source port to the requesting application or upper-layer protocol for that communication instance.",
         "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
       }
@@ -3555,7 +3555,7 @@
       "title": "Compute the UDP checksum over the IPv4 pseudo-header, UDP header, and data using 16-bit ones-complement arithmetic.",
       "properties": {
         "kind": "binary-decoder",
-        "status": "planned",
+        "status": "implemented",
         "assertion": "Compute the UDP checksum over the IPv4 pseudo-header, UDP header, and data using 16-bit ones-complement arithmetic.",
         "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
       }
@@ -3567,7 +3567,7 @@
       "title": "Accept an all-zero UDP checksum field as the IPv4 sender choosing not to generate a UDP checksum.",
       "properties": {
         "kind": "binary-decoder",
-        "status": "planned",
+        "status": "implemented",
         "assertion": "Accept an all-zero UDP checksum field as the IPv4 sender choosing not to generate a UDP checksum.",
         "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
       }
@@ -3579,7 +3579,7 @@
       "title": "Zero-pad an odd checksum input to a two-octet boundary without transmitting the padding octet.",
       "properties": {
         "kind": "binary-decoder",
-        "status": "planned",
+        "status": "implemented",
         "assertion": "Zero-pad an odd checksum input to a two-octet boundary without transmitting the padding octet.",
         "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
       }
@@ -3591,7 +3591,7 @@
       "title": "Transmit an arithmetically computed zero UDP checksum as all one bits.",
       "properties": {
         "kind": "binary-decoder",
-        "status": "planned",
+        "status": "implemented",
         "assertion": "Transmit an arithmetically computed zero UDP checksum as all one bits.",
         "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
       }
@@ -3603,7 +3603,7 @@
       "title": "Interpret a UDP destination port within the context of its destination IPv4 address.",
       "properties": {
         "kind": "transport-boundary",
-        "status": "planned",
+        "status": "implemented",
         "assertion": "Interpret a UDP destination port within the context of its destination IPv4 address.",
         "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
       }
@@ -3615,7 +3615,7 @@
       "title": "Encode and decode the UDP header as 16-bit source port, destination port, length, and checksum fields followed by data.",
       "properties": {
         "kind": "binary-decoder",
-        "status": "planned",
+        "status": "implemented",
         "assertion": "Encode and decode the UDP header as 16-bit source port, destination port, length, and checksum fields followed by data.",
         "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
       }
@@ -3627,7 +3627,7 @@
       "title": "Make source address, destination address, and IP protocol metadata available at the UDP/IP boundary.",
       "properties": {
         "kind": "transport-boundary",
-        "status": "planned",
+        "status": "implemented",
         "assertion": "Make source address, destination address, and IP protocol metadata available at the UDP/IP boundary.",
         "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
       }
@@ -3639,7 +3639,7 @@
       "title": "Identify UDP with IPv4 protocol number 17.",
       "properties": {
         "kind": "binary-decoder",
-        "status": "planned",
+        "status": "implemented",
         "assertion": "Identify UDP with IPv4 protocol number 17.",
         "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
       }
@@ -3651,7 +3651,7 @@
       "title": "Interpret UDP length as header plus data octets and reject values smaller than the eight-octet header.",
       "properties": {
         "kind": "binary-decoder",
-        "status": "planned",
+        "status": "implemented",
         "assertion": "Interpret UDP length as header plus data octets and reject values smaller than the eight-octet header.",
         "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
       }
@@ -3663,7 +3663,7 @@
       "title": "Provide receive-port creation and return received data with its source IPv4 address and source port.",
       "properties": {
         "kind": "transport-boundary",
-        "status": "planned",
+        "status": "implemented",
         "assertion": "Provide receive-port creation and return received data with its source IPv4 address and source port.",
         "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
       }
@@ -3675,7 +3675,7 @@
       "title": "Provide datagram send using explicit data, source and destination ports, and source and destination IPv4 addresses.",
       "properties": {
         "kind": "transport-boundary",
-        "status": "planned",
+        "status": "implemented",
         "assertion": "Provide datagram send using explicit data, source and destination ports, and source and destination IPv4 addresses.",
         "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
       }
@@ -3687,7 +3687,7 @@
       "title": "Use source port zero when the sender does not supply a meaningful reply port, and otherwise preserve the selected source port.",
       "properties": {
         "kind": "binary-decoder",
-        "status": "planned",
+        "status": "implemented",
         "assertion": "Use source port zero when the sender does not supply a meaningful reply port, and otherwise preserve the selected source port.",
         "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
       }
@@ -3699,7 +3699,7 @@
       "title": "Expose UDP as a connectionless datagram service that does not guarantee delivery, ordering, or duplicate suppression.",
       "properties": {
         "kind": "transport-boundary",
-        "status": "planned",
+        "status": "implemented",
         "assertion": "Expose UDP as a connectionless datagram service that does not guarantee delivery, ordering, or duplicate suppression.",
         "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
       }
@@ -3711,7 +3711,7 @@
       "title": "Transmit and deliver the complete service data unit without manipulating its content.",
       "properties": {
         "kind": "transport-boundary",
-        "status": "planned",
+        "status": "implemented",
         "assertion": "Transmit and deliver the complete service data unit without manipulating its content.",
         "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
       }
@@ -3723,7 +3723,7 @@
       "title": "Deliver source address, source port, and user data on T-DUnitdata indication, with destination address and port when available.",
       "properties": {
         "kind": "transport-boundary",
-        "status": "planned",
+        "status": "implemented",
         "assertion": "Deliver source address, source port, and user data on T-DUnitdata indication, with destination address and port when available.",
         "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
       }
@@ -3735,7 +3735,7 @@
       "title": "Allow T-DUnitdata.request without establishing a prior transport connection.",
       "properties": {
         "kind": "transport-boundary",
-        "status": "planned",
+        "status": "implemented",
         "assertion": "Allow T-DUnitdata.request without establishing a prior transport connection.",
         "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
       }
@@ -3747,7 +3747,7 @@
       "title": "Require source address, source port, destination address, destination port, and user data on every T-DUnitdata request.",
       "properties": {
         "kind": "transport-boundary",
-        "status": "planned",
+        "status": "implemented",
         "assertion": "Require source address, source port, destination address, destination port, and user data on every T-DUnitdata request.",
         "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
       }
@@ -3759,7 +3759,7 @@
       "title": "Recognize the complete WAP port assignment table, including connectionless, session, secure, push, vCard, and vCalendar services.",
       "properties": {
         "kind": "transport-boundary",
-        "status": "planned",
+        "status": "implemented",
         "assertion": "Recognize the complete WAP port assignment table, including connectionless, session, secure, push, vCard, and vCalendar services.",
         "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
       }
@@ -4063,7 +4063,7 @@
           "documentId": "WAP-200_005-WDP",
           "staticConformanceSection": "Appendix E"
         },
-        "implementationStatus": "partial",
+        "implementationStatus": "implemented",
         "ownerLayers": [
           "transport-rust"
         ],
@@ -4086,7 +4086,7 @@
           "documentId": "WAP-200_005-WDP",
           "staticConformanceSection": "Appendix E"
         },
-        "implementationStatus": "partial",
+        "implementationStatus": "implemented",
         "ownerLayers": [
           "transport-rust"
         ],
@@ -4109,7 +4109,7 @@
           "documentId": "WAP-200_005-WDP",
           "staticConformanceSection": "Appendix E"
         },
-        "implementationStatus": "partial",
+        "implementationStatus": "implemented",
         "ownerLayers": [
           "transport-rust"
         ],
@@ -4132,7 +4132,7 @@
           "documentId": "WAP-200_005-WDP",
           "staticConformanceSection": "Appendix E"
         },
-        "implementationStatus": "partial",
+        "implementationStatus": "implemented",
         "ownerLayers": [
           "transport-rust"
         ],
@@ -4155,7 +4155,7 @@
           "documentId": "WAP-200_005-WDP",
           "staticConformanceSection": "Appendix E"
         },
-        "implementationStatus": "partial",
+        "implementationStatus": "implemented",
         "ownerLayers": [
           "transport-rust"
         ],
@@ -4178,7 +4178,7 @@
           "documentId": "WAP-200_005-WDP",
           "staticConformanceSection": "Appendix E"
         },
-        "implementationStatus": "partial",
+        "implementationStatus": "implemented",
         "ownerLayers": [
           "transport-rust"
         ],
@@ -4201,7 +4201,7 @@
           "documentId": "WAP-200_005-WDP",
           "staticConformanceSection": "Appendix E"
         },
-        "implementationStatus": "partial",
+        "implementationStatus": "implemented",
         "ownerLayers": [
           "transport-rust"
         ],
@@ -4224,7 +4224,7 @@
           "documentId": "WAP-200_005-WDP",
           "staticConformanceSection": "Appendix E"
         },
-        "implementationStatus": "partial",
+        "implementationStatus": "implemented",
         "ownerLayers": [
           "transport-rust"
         ],
@@ -4247,7 +4247,7 @@
           "documentId": "WAP-200_005-WDP",
           "staticConformanceSection": "Appendix E"
         },
-        "implementationStatus": "partial",
+        "implementationStatus": "implemented",
         "ownerLayers": [
           "transport-rust"
         ],
@@ -4636,7 +4636,7 @@
       "type": "work-item",
       "title": "Effective WDP service, addressing, port, and bearer profile",
       "properties": {
-        "status": "in-progress",
+        "status": "done",
         "ownerLayers": [
           "transport-rust",
           "qa"

--- a/spec-processing/source-manifests/wap-1.2.1-wdp-scr.json
+++ b/spec-processing/source-manifests/wap-1.2.1-wdp-scr.json
@@ -140,10 +140,10 @@
     "mandatoryClientCount": 7,
     "selectedClassCTransportPathCount": 9,
     "selectedImplementationStatus": {
-      "partial": 9
+      "implemented": 9
     },
-    "selectedDirectNormativeTestEvidenceCount": 0,
-    "selectedProvisionalTestEvidenceCount": 9,
+    "selectedDirectNormativeTestEvidenceCount": 9,
+    "selectedProvisionalTestEvidenceCount": 0,
     "orderedIdsSha256": "d090dead796a8ba086e350455ceccb557f34e75ada6d25492c8ee603d3b7b4bc"
   },
   "obligations": [
@@ -165,7 +165,7 @@
         "classCProfile": "required-by-selected-class-c-transport-path",
         "enhancementMayReplaceStrictBehavior": false
       },
-      "reviewState": "source-extracted-class-c-path-applied-mapping-provisional",
+      "reviewState": "source-extracted-class-c-path-implemented-direct-evidence",
       "mapping": {
         "implementationDomain": "wdp-client-profile",
         "ownerLayers": [
@@ -178,22 +178,24 @@
           "TRN-701",
           "T0-19"
         ],
-        "implementationStatus": "partial",
-        "assessmentNote": "A WDP datagram/UDP path exists, but no historical bearer alternative is capability-selected and proven against the WAP-200 dependency closure.",
+        "implementationStatus": "implemented",
+        "assessmentNote": "The selected Class C client path declares the CDPD/IPv4 bearer alternative and exposes a connectionless WDP datagram service over bounded UDP/IPv4 codec and primitive boundaries.",
         "implementationEvidence": [
           {
-            "path": "transport-rust/src/network/wdp/datagram.rs",
-            "symbol": "WdpDatagram"
+            "path": "transport-rust/src/network/wdp/profile.rs",
+            "symbol": "pub struct CdpdIpv4Profile"
           }
         ],
         "testEvidence": [
           {
-            "path": "transport-rust/src/network/wdp/udp_adapter.rs",
-            "test": "udp_send_and_receive_roundtrip_with_known_service_ports",
-            "limitation": "Synthetic transport evidence; does not close the WAP-200 bearer/address dependency choice."
+            "path": "transport-rust/src/network/wdp/tests.rs",
+            "test": "source_derived_fixture_covers_selected_class_c_rows_and_clauses",
+            "fixture": "transport-rust/tests/fixtures/transport/wdp_cdpd_ipv4_mapped/wdp_fixture.json",
+            "evidenceClass": "direct-normative",
+            "limitation": "Closes only the nine selected CDPD/IPv4 WDP client rows and their mapped TRN-701 clauses; TRN-702 reassembly policy, alternate bearers, server rows, and optional services remain unclaimed."
           }
         ],
-        "evidenceState": "provisional-non-normative-test-linked"
+        "evidenceState": "direct-normative-test-linked"
       }
     },
     {
@@ -252,7 +254,7 @@
         "classCProfile": "required-by-selected-class-c-transport-path",
         "enhancementMayReplaceStrictBehavior": false
       },
-      "reviewState": "source-extracted-class-c-path-applied-mapping-provisional",
+      "reviewState": "source-extracted-class-c-path-implemented-direct-evidence",
       "mapping": {
         "implementationDomain": "wdp-client-profile",
         "ownerLayers": [
@@ -265,22 +267,24 @@
           "TRN-701",
           "T0-19"
         ],
-        "implementationStatus": "partial",
-        "assessmentNote": "The Rust datagram model composes send/receive and address/port fields, but the complete WAP-200 abstract-service contract lacks source-derived fixtures.",
+        "implementationStatus": "implemented",
+        "assessmentNote": "The transport-owned WDP profile preserves service data, addresses, and ports while enforcing source-derived UDP/IPv4 header, length, checksum, and deterministic failure rules.",
         "implementationEvidence": [
           {
-            "path": "transport-rust/src/network/wdp/datagram.rs",
-            "symbol": "WdpDatagram"
+            "path": "transport-rust/src/network/wdp/ipv4_udp.rs",
+            "symbol": "pub fn decode_cdpd_ipv4_udp"
           }
         ],
         "testEvidence": [
           {
-            "path": "transport-rust/src/network/wdp/udp_adapter.rs",
-            "test": "udp_send_and_receive_roundtrip_with_known_service_ports",
-            "limitation": "Synthetic transport evidence; does not close the WAP-200 bearer/address dependency choice."
+            "path": "transport-rust/src/network/wdp/tests.rs",
+            "test": "selected_cdpd_ipv4_profile_preserves_exact_udp_ipv4_bytes",
+            "fixture": "transport-rust/tests/fixtures/transport/wdp_cdpd_ipv4_mapped/wdp_fixture.json",
+            "evidenceClass": "direct-normative",
+            "limitation": "Closes only the nine selected CDPD/IPv4 WDP client rows and their mapped TRN-701 clauses; TRN-702 reassembly policy, alternate bearers, server rows, and optional services remain unclaimed."
           }
         ],
-        "evidenceState": "provisional-non-normative-test-linked"
+        "evidenceState": "direct-normative-test-linked"
       }
     },
     {
@@ -339,7 +343,7 @@
         "classCProfile": "required-by-selected-class-c-transport-path",
         "enhancementMayReplaceStrictBehavior": false
       },
-      "reviewState": "source-extracted-class-c-path-applied-mapping-provisional",
+      "reviewState": "source-extracted-class-c-path-implemented-direct-evidence",
       "mapping": {
         "implementationDomain": "wdp-service-primitives",
         "ownerLayers": [
@@ -352,22 +356,24 @@
           "TRN-701",
           "T0-19"
         ],
-        "implementationStatus": "partial",
-        "assessmentNote": "Send/receive operations exist behind DatagramTransport, but exact T-DUnitdata primitive semantics and error boundaries are not tested from WAP-200 vectors.",
+        "implementationStatus": "implemented",
+        "assessmentNote": "Typed T-DUnitdata request and indication structures preserve the exact selected address, port, and user-data parameters without connection state or content mutation.",
         "implementationEvidence": [
           {
-            "path": "transport-rust/src/network/wdp/transport_trait.rs",
-            "symbol": "fn send(&mut self"
+            "path": "transport-rust/src/network/wdp/primitive.rs",
+            "symbol": "pub struct TDUnitdataRequest"
           }
         ],
         "testEvidence": [
           {
-            "path": "transport-rust/src/network/wdp/udp_adapter.rs",
-            "test": "udp_send_and_receive_roundtrip_with_known_service_ports",
-            "limitation": "Synthetic UDP round trip; not a source-derived T-DUnitdata request vector."
+            "path": "transport-rust/src/network/wdp/tests.rs",
+            "test": "td_unitdata_request_and_indication_preserve_address_port_and_payload_semantics",
+            "fixture": "transport-rust/tests/fixtures/transport/wdp_cdpd_ipv4_mapped/wdp_fixture.json",
+            "evidenceClass": "direct-normative",
+            "limitation": "Closes only the nine selected CDPD/IPv4 WDP client rows and their mapped TRN-701 clauses; TRN-702 reassembly policy, alternate bearers, server rows, and optional services remain unclaimed."
           }
         ],
-        "evidenceState": "provisional-non-normative-test-linked"
+        "evidenceState": "direct-normative-test-linked"
       }
     },
     {
@@ -388,7 +394,7 @@
         "classCProfile": "required-by-selected-class-c-transport-path",
         "enhancementMayReplaceStrictBehavior": false
       },
-      "reviewState": "source-extracted-class-c-path-applied-mapping-provisional",
+      "reviewState": "source-extracted-class-c-path-implemented-direct-evidence",
       "mapping": {
         "implementationDomain": "wdp-service-primitives",
         "ownerLayers": [
@@ -401,22 +407,24 @@
           "TRN-701",
           "T0-19"
         ],
-        "implementationStatus": "partial",
-        "assessmentNote": "Send/receive operations exist behind DatagramTransport, but exact T-DUnitdata primitive semantics and error boundaries are not tested from WAP-200 vectors.",
+        "implementationStatus": "implemented",
+        "assessmentNote": "Typed T-DUnitdata request and indication structures preserve the exact selected address, port, and user-data parameters without connection state or content mutation.",
         "implementationEvidence": [
           {
-            "path": "transport-rust/src/network/wdp/transport_trait.rs",
-            "symbol": "fn receive(&mut self"
+            "path": "transport-rust/src/network/wdp/primitive.rs",
+            "symbol": "pub struct TDUnitdataIndication"
           }
         ],
         "testEvidence": [
           {
-            "path": "transport-rust/src/network/wdp/udp_adapter.rs",
-            "test": "udp_send_and_receive_roundtrip_with_known_service_ports",
-            "limitation": "Synthetic UDP round trip; not a source-derived T-DUnitdata indication vector."
+            "path": "transport-rust/src/network/wdp/tests.rs",
+            "test": "td_unitdata_request_and_indication_preserve_address_port_and_payload_semantics",
+            "fixture": "transport-rust/tests/fixtures/transport/wdp_cdpd_ipv4_mapped/wdp_fixture.json",
+            "evidenceClass": "direct-normative",
+            "limitation": "Closes only the nine selected CDPD/IPv4 WDP client rows and their mapped TRN-701 clauses; TRN-702 reassembly policy, alternate bearers, server rows, and optional services remain unclaimed."
           }
         ],
-        "evidenceState": "provisional-non-normative-test-linked"
+        "evidenceState": "direct-normative-test-linked"
       }
     },
     {
@@ -627,7 +635,7 @@
         "classCProfile": "required-by-selected-class-c-transport-path",
         "enhancementMayReplaceStrictBehavior": false
       },
-      "reviewState": "source-extracted-class-c-path-applied-mapping-provisional",
+      "reviewState": "source-extracted-class-c-path-implemented-direct-evidence",
       "mapping": {
         "implementationDomain": "wdp-client-profile",
         "ownerLayers": [
@@ -640,22 +648,24 @@
           "TRN-701",
           "T0-19"
         ],
-        "implementationStatus": "partial",
-        "assessmentNote": "The UDP/IP adapter matches the WAP-200 CDPD transport shape, but the CDPD capability is not declared and the cited TIA/EIA-732 authority remains an open external-source record.",
+        "implementationStatus": "implemented",
+        "assessmentNote": "The selected AMPS/CDPD/IPv4 profile declares bearer value 0x0D and maps WDP directly to UDP protocol 17; the informative TIA/EIA-732 payload remains metadata-only and uncredited.",
         "implementationEvidence": [
           {
-            "path": "transport-rust/src/network/wdp/udp_adapter.rs",
-            "symbol": "UdpDatagramTransport"
+            "path": "transport-rust/src/network/wdp/profile.rs",
+            "symbol": "WDP_CDPD_IPV4_BEARER_TYPE"
           }
         ],
         "testEvidence": [
           {
-            "path": "transport-rust/src/network/wdp/udp_adapter.rs",
-            "test": "udp_send_and_receive_roundtrip_with_known_service_ports",
-            "limitation": "Synthetic transport evidence; does not close the WAP-200 bearer/address dependency choice."
+            "path": "transport-rust/src/network/wdp/tests.rs",
+            "test": "registered_port_and_bearer_profile_are_exact",
+            "fixture": "transport-rust/tests/fixtures/transport/wdp_cdpd_ipv4_mapped/wdp_fixture.json",
+            "evidenceClass": "direct-normative",
+            "limitation": "Closes only the nine selected CDPD/IPv4 WDP client rows and their mapped TRN-701 clauses; TRN-702 reassembly policy, alternate bearers, server rows, and optional services remain unclaimed."
           }
         ],
-        "evidenceState": "provisional-non-normative-test-linked"
+        "evidenceState": "direct-normative-test-linked"
       }
     },
     {
@@ -1512,7 +1522,7 @@
         "classCProfile": "required-by-selected-class-c-transport-path",
         "enhancementMayReplaceStrictBehavior": false
       },
-      "reviewState": "source-extracted-class-c-path-applied-mapping-provisional",
+      "reviewState": "source-extracted-class-c-path-implemented-direct-evidence",
       "mapping": {
         "implementationDomain": "wdp-addressing-and-ports",
         "ownerLayers": [
@@ -1525,22 +1535,24 @@
           "TRN-701",
           "T0-19"
         ],
-        "implementationStatus": "partial",
-        "assessmentNote": "IPv4/IPv6 and source/destination port fields exist, but the mandatory addressing dependency choice and exact WAP-200 port semantics are not yet declared and proven.",
+        "implementationStatus": "implemented",
+        "assessmentNote": "The selected IPv4 dependency uses four-octet source and destination addresses, both 16-bit port fields, and the exact WAP Appendix B registered service-port table with direct fixtures.",
         "implementationEvidence": [
           {
             "path": "transport-rust/src/network/wdp/datagram.rs",
-            "symbol": "WdpAddress"
+            "symbol": "pub struct WdpAddress"
           }
         ],
         "testEvidence": [
           {
-            "path": "transport-rust/src/network/wdp/udp_adapter.rs",
-            "test": "udp_send_and_receive_roundtrip_with_known_service_ports",
-            "limitation": "Synthetic transport evidence; does not close the WAP-200 bearer/address dependency choice."
+            "path": "transport-rust/src/network/wdp/tests.rs",
+            "test": "td_unitdata_request_and_indication_preserve_address_port_and_payload_semantics",
+            "fixture": "transport-rust/tests/fixtures/transport/wdp_cdpd_ipv4_mapped/wdp_fixture.json",
+            "evidenceClass": "direct-normative",
+            "limitation": "Closes only the nine selected CDPD/IPv4 WDP client rows and their mapped TRN-701 clauses; TRN-702 reassembly policy, alternate bearers, server rows, and optional services remain unclaimed."
           }
         ],
-        "evidenceState": "provisional-non-normative-test-linked"
+        "evidenceState": "direct-normative-test-linked"
       }
     },
     {
@@ -1637,7 +1649,7 @@
         "classCProfile": "required-by-selected-class-c-transport-path",
         "enhancementMayReplaceStrictBehavior": false
       },
-      "reviewState": "source-extracted-class-c-path-applied-mapping-provisional",
+      "reviewState": "source-extracted-class-c-path-implemented-direct-evidence",
       "mapping": {
         "implementationDomain": "wdp-addressing-and-ports",
         "ownerLayers": [
@@ -1650,22 +1662,24 @@
           "TRN-701",
           "T0-19"
         ],
-        "implementationStatus": "partial",
-        "assessmentNote": "IPv4/IPv6 and source/destination port fields exist, but the mandatory addressing dependency choice and exact WAP-200 port semantics are not yet declared and proven.",
+        "implementationStatus": "implemented",
+        "assessmentNote": "The selected IPv4 dependency uses four-octet source and destination addresses, both 16-bit port fields, and the exact WAP Appendix B registered service-port table with direct fixtures.",
         "implementationEvidence": [
           {
-            "path": "transport-rust/src/network/wdp/datagram.rs",
-            "symbol": "WdpDatagram"
+            "path": "transport-rust/src/network/wdp/ipv4_udp.rs",
+            "symbol": "WDP_UDP_IPV4_PROTOCOL_NUMBER"
           }
         ],
         "testEvidence": [
           {
-            "path": "transport-rust/src/network/wdp/udp_adapter.rs",
-            "test": "udp_send_and_receive_roundtrip_with_known_service_ports",
-            "limitation": "Synthetic transport evidence; does not close the WAP-200 bearer/address dependency choice."
+            "path": "transport-rust/src/network/wdp/tests.rs",
+            "test": "selected_cdpd_ipv4_profile_preserves_exact_udp_ipv4_bytes",
+            "fixture": "transport-rust/tests/fixtures/transport/wdp_cdpd_ipv4_mapped/wdp_fixture.json",
+            "evidenceClass": "direct-normative",
+            "limitation": "Closes only the nine selected CDPD/IPv4 WDP client rows and their mapped TRN-701 clauses; TRN-702 reassembly policy, alternate bearers, server rows, and optional services remain unclaimed."
           }
         ],
-        "evidenceState": "provisional-non-normative-test-linked"
+        "evidenceState": "direct-normative-test-linked"
       }
     },
     {
@@ -1762,7 +1776,7 @@
         "classCProfile": "required-by-selected-class-c-transport-path",
         "enhancementMayReplaceStrictBehavior": false
       },
-      "reviewState": "source-extracted-class-c-path-applied-mapping-provisional",
+      "reviewState": "source-extracted-class-c-path-implemented-direct-evidence",
       "mapping": {
         "implementationDomain": "wdp-addressing-and-ports",
         "ownerLayers": [
@@ -1775,22 +1789,24 @@
           "TRN-701",
           "T0-19"
         ],
-        "implementationStatus": "partial",
-        "assessmentNote": "IPv4/IPv6 and source/destination port fields exist, but the mandatory addressing dependency choice and exact WAP-200 port semantics are not yet declared and proven.",
+        "implementationStatus": "implemented",
+        "assessmentNote": "The selected IPv4 dependency uses four-octet source and destination addresses, both 16-bit port fields, and the exact WAP Appendix B registered service-port table with direct fixtures.",
         "implementationEvidence": [
           {
             "path": "transport-rust/src/network/wdp/datagram.rs",
-            "symbol": "pub dst_port"
+            "symbol": "pub enum WdpServicePort"
           }
         ],
         "testEvidence": [
           {
-            "path": "transport-rust/src/network/wdp/udp_adapter.rs",
-            "test": "udp_send_and_receive_roundtrip_with_known_service_ports",
-            "limitation": "Synthetic transport evidence; does not close the WAP-200 bearer/address dependency choice."
+            "path": "transport-rust/src/network/wdp/tests.rs",
+            "test": "registered_port_and_bearer_profile_are_exact",
+            "fixture": "transport-rust/tests/fixtures/transport/wdp_cdpd_ipv4_mapped/wdp_fixture.json",
+            "evidenceClass": "direct-normative",
+            "limitation": "Closes only the nine selected CDPD/IPv4 WDP client rows and their mapped TRN-701 clauses; TRN-702 reassembly policy, alternate bearers, server rows, and optional services remain unclaimed."
           }
         ],
-        "evidenceState": "provisional-non-normative-test-linked"
+        "evidenceState": "direct-normative-test-linked"
       }
     },
     {
@@ -1811,7 +1827,7 @@
         "classCProfile": "required-by-selected-class-c-transport-path",
         "enhancementMayReplaceStrictBehavior": false
       },
-      "reviewState": "source-extracted-class-c-path-applied-mapping-provisional",
+      "reviewState": "source-extracted-class-c-path-implemented-direct-evidence",
       "mapping": {
         "implementationDomain": "wdp-addressing-and-ports",
         "ownerLayers": [
@@ -1824,22 +1840,24 @@
           "TRN-701",
           "T0-19"
         ],
-        "implementationStatus": "partial",
-        "assessmentNote": "IPv4/IPv6 and source/destination port fields exist, but the mandatory addressing dependency choice and exact WAP-200 port semantics are not yet declared and proven.",
+        "implementationStatus": "implemented",
+        "assessmentNote": "The selected IPv4 dependency uses four-octet source and destination addresses, both 16-bit port fields, and the exact WAP Appendix B registered service-port table with direct fixtures.",
         "implementationEvidence": [
           {
-            "path": "transport-rust/src/network/wdp/datagram.rs",
-            "symbol": "pub src_port"
+            "path": "transport-rust/src/network/wdp/primitive.rs",
+            "symbol": "pub source_port"
           }
         ],
         "testEvidence": [
           {
-            "path": "transport-rust/src/network/wdp/udp_adapter.rs",
-            "test": "udp_send_and_receive_roundtrip_with_known_service_ports",
-            "limitation": "Synthetic transport evidence; does not close the WAP-200 bearer/address dependency choice."
+            "path": "transport-rust/src/network/wdp/tests.rs",
+            "test": "udp_source_port_zero_and_computed_zero_checksum_follow_rfc_768_encoding",
+            "fixture": "transport-rust/tests/fixtures/transport/wdp_cdpd_ipv4_mapped/wdp_fixture.json",
+            "evidenceClass": "direct-normative",
+            "limitation": "Closes only the nine selected CDPD/IPv4 WDP client rows and their mapped TRN-701 clauses; TRN-702 reassembly policy, alternate bearers, server rows, and optional services remain unclaimed."
           }
         ],
-        "evidenceState": "provisional-non-normative-test-linked"
+        "evidenceState": "direct-normative-test-linked"
       }
     },
     {

--- a/spec-processing/source-manifests/wap-1.2.1-wml-2-knowledge-graph.json
+++ b/spec-processing/source-manifests/wap-1.2.1-wml-2-knowledge-graph.json
@@ -13,7 +13,7 @@
     "generator": "spec-processing/scripts/generate-wap-knowledge-graph.mjs",
     "inputs": {
       "docs/waves/wap-1.2.1-compliance-program.json": {
-        "sha256": "e8076afef8391f966d8b1dcad1f1cbd3799efa1cf21034e95663bbc1af746614"
+        "sha256": "d8921b4b90be8bce678e3e44dd1032cf1b457a699240404b561174df4a128760"
       },
       "spec-processing/source-manifests/wap-1.2.1-class-conformance.json": {
         "sha256": "b76605b2144b32965a857b848b2e9e522baada6fae9fe51012b9eaa664e85d86"
@@ -25,7 +25,7 @@
         "sha256": "654284270a068b427ab05166247cb8e0644a99cf6af511f9b9c477d18ea36faa"
       },
       "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json": {
-        "sha256": "4d05178d0d5b7c1e9c76119aa6d91df6f30e7b93e1e29b0c1b02529cb8d0d28f"
+        "sha256": "6e8c6662c69af1612a1d5805ad9a87f56dc9d8a2bd5af53d1faeb892a8d34693"
       }
     },
     "policy": "Canonical manifests remain authoritative; this graph and its Obsidian/context projections are generated views."

--- a/transport-rust/src/network/wdp/datagram.rs
+++ b/transport-rust/src/network/wdp/datagram.rs
@@ -52,14 +52,24 @@ impl WdpAddress {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum WdpServicePort {
+    WtaSecureConnectionless = 2805,
+    WtaSecureSession = 2923,
+    PushConnectionless = 2948,
+    PushSecureConnectionless = 2949,
     Connectionless = 9200,
     Session = 9201,
     SecureConnectionless = 9202,
     SecureSession = 9203,
+    VCardDatagram = 9204,
+    VCalendarDatagram = 9205,
+    VCardSecureDatagram = 9206,
+    VCalendarSecureDatagram = 9207,
 }
 
 impl WdpServicePort {
-    pub const ALL: [u16; 4] = [9200, 9201, 9202, 9203];
+    pub const ALL: [u16; 12] = [
+        2805, 2923, 2948, 2949, 9200, 9201, 9202, 9203, 9204, 9205, 9206, 9207,
+    ];
 
     pub fn is_known(port: u16) -> bool {
         Self::from_u16(port).is_some()
@@ -67,10 +77,18 @@ impl WdpServicePort {
 
     pub fn from_u16(port: u16) -> Option<Self> {
         match port {
+            2805 => Some(Self::WtaSecureConnectionless),
+            2923 => Some(Self::WtaSecureSession),
+            2948 => Some(Self::PushConnectionless),
+            2949 => Some(Self::PushSecureConnectionless),
             9200 => Some(Self::Connectionless),
             9201 => Some(Self::Session),
             9202 => Some(Self::SecureConnectionless),
             9203 => Some(Self::SecureSession),
+            9204 => Some(Self::VCardDatagram),
+            9205 => Some(Self::VCalendarDatagram),
+            9206 => Some(Self::VCardSecureDatagram),
+            9207 => Some(Self::VCalendarSecureDatagram),
             _ => None,
         }
     }
@@ -112,6 +130,10 @@ mod tests {
     #[test]
     fn wdp_service_port_from_u16_returns_expected_mapping() {
         assert_eq!(
+            WdpServicePort::from_u16(2948),
+            Some(WdpServicePort::PushConnectionless)
+        );
+        assert_eq!(
             WdpServicePort::from_u16(9200),
             Some(WdpServicePort::Connectionless)
         );
@@ -126,6 +148,10 @@ mod tests {
         assert_eq!(
             WdpServicePort::from_u16(9203),
             Some(WdpServicePort::SecureSession)
+        );
+        assert_eq!(
+            WdpServicePort::from_u16(9207),
+            Some(WdpServicePort::VCalendarSecureDatagram)
         );
         assert_eq!(WdpServicePort::from_u16(1), None);
     }

--- a/transport-rust/src/network/wdp/ipv4_udp.rs
+++ b/transport-rust/src/network/wdp/ipv4_udp.rs
@@ -1,0 +1,263 @@
+use crate::network::wdp::datagram::{
+    WdpAddress, WdpAddressType, WdpDatagram, WdpServicePort, WDP_MAX_UDP_PAYLOAD_BYTES,
+};
+use crate::network::wdp::profile::{
+    WDP_IPV4_BASELINE_DATAGRAM_BYTES, WDP_UDP_IPV4_PROTOCOL_NUMBER,
+};
+use crate::network::wdp::transport_trait::{WdpError, WdpResult};
+
+const IPV4_MIN_HEADER_BYTES: usize = 20;
+const UDP_HEADER_BYTES: usize = 8;
+const IPV4_FLAG_DONT_FRAGMENT: u16 = 0x4000;
+const IPV4_FLAG_MORE_FRAGMENTS: u16 = 0x2000;
+const IPV4_FRAGMENT_OFFSET_MASK: u16 = 0x1FFF;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UdpChecksumPolicy {
+    Generate,
+    Omit,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CdpdIpv4SendPolicy {
+    pub identification: u16,
+    pub time_to_live: u8,
+    pub dont_fragment: bool,
+    pub path_mtu: Option<usize>,
+    pub destination_accepts_large_datagrams: bool,
+    pub udp_checksum: UdpChecksumPolicy,
+}
+
+impl Default for CdpdIpv4SendPolicy {
+    fn default() -> Self {
+        Self {
+            identification: 0,
+            time_to_live: 64,
+            dont_fragment: false,
+            path_mtu: None,
+            destination_accepts_large_datagrams: false,
+            udp_checksum: UdpChecksumPolicy::Generate,
+        }
+    }
+}
+
+fn ipv4_octets(address: &WdpAddress) -> WdpResult<[u8; 4]> {
+    if address.address_type != WdpAddressType::Ipv4 || address.value.len() != 4 {
+        return Err(WdpError::AddressTypeUnsupported);
+    }
+    let mut octets = [0; 4];
+    octets.copy_from_slice(&address.value);
+    Ok(octets)
+}
+
+fn ones_complement_sum(bytes: &[u8]) -> u32 {
+    let mut sum = 0u32;
+    for chunk in bytes.chunks(2) {
+        let word = if chunk.len() == 2 {
+            u16::from_be_bytes([chunk[0], chunk[1]])
+        } else {
+            u16::from_be_bytes([chunk[0], 0])
+        };
+        sum += u32::from(word);
+        while sum > u32::from(u16::MAX) {
+            sum = (sum & u32::from(u16::MAX)) + (sum >> 16);
+        }
+    }
+    sum
+}
+
+fn checksum(bytes: &[u8]) -> u16 {
+    !(ones_complement_sum(bytes) as u16)
+}
+
+fn udp_checksum(source: [u8; 4], destination: [u8; 4], udp: &[u8]) -> u16 {
+    let udp_length = udp.len() as u16;
+    let mut covered = Vec::with_capacity(12 + udp.len());
+    covered.extend_from_slice(&source);
+    covered.extend_from_slice(&destination);
+    covered.push(0);
+    covered.push(WDP_UDP_IPV4_PROTOCOL_NUMBER);
+    covered.extend_from_slice(&udp_length.to_be_bytes());
+    covered.extend_from_slice(udp);
+    checksum(&covered)
+}
+
+pub fn encode_cdpd_ipv4_udp(
+    datagram: &WdpDatagram,
+    policy: CdpdIpv4SendPolicy,
+) -> WdpResult<Vec<u8>> {
+    let source = ipv4_octets(&datagram.src_addr)?;
+    let destination = ipv4_octets(&datagram.dst_addr)?;
+    if !WdpServicePort::is_known(datagram.dst_port) {
+        return Err(WdpError::DestinationPortUnsupported(datagram.dst_port));
+    }
+    if datagram.payload.len() > WDP_MAX_UDP_PAYLOAD_BYTES {
+        return Err(WdpError::PayloadOversize {
+            actual: datagram.payload.len(),
+            max: WDP_MAX_UDP_PAYLOAD_BYTES,
+        });
+    }
+    if policy.time_to_live == 0 {
+        return Err(WdpError::Ipv4TtlExpired);
+    }
+
+    let udp_length =
+        UDP_HEADER_BYTES
+            .checked_add(datagram.payload.len())
+            .ok_or(WdpError::PayloadOversize {
+                actual: datagram.payload.len(),
+                max: WDP_MAX_UDP_PAYLOAD_BYTES,
+            })?;
+    let total_length =
+        IPV4_MIN_HEADER_BYTES
+            .checked_add(udp_length)
+            .ok_or(WdpError::PayloadOversize {
+                actual: datagram.payload.len(),
+                max: WDP_MAX_UDP_PAYLOAD_BYTES,
+            })?;
+    let total_length_u16 = u16::try_from(total_length).map_err(|_| WdpError::PayloadOversize {
+        actual: datagram.payload.len(),
+        max: WDP_MAX_UDP_PAYLOAD_BYTES,
+    })?;
+    let udp_length_u16 = u16::try_from(udp_length).map_err(|_| WdpError::PayloadOversize {
+        actual: datagram.payload.len(),
+        max: WDP_MAX_UDP_PAYLOAD_BYTES,
+    })?;
+
+    if total_length > WDP_IPV4_BASELINE_DATAGRAM_BYTES
+        && !policy.destination_accepts_large_datagrams
+    {
+        return Err(WdpError::Ipv4LargeDatagramUnassured {
+            actual: total_length,
+            baseline: WDP_IPV4_BASELINE_DATAGRAM_BYTES,
+        });
+    }
+    if let Some(path_mtu) = policy.path_mtu {
+        if policy.dont_fragment && total_length > path_mtu {
+            return Err(WdpError::Ipv4DontFragmentMtuExceeded {
+                actual: total_length,
+                mtu: path_mtu,
+            });
+        }
+    }
+
+    let mut packet = vec![0u8; total_length];
+    packet[0] = 0x45;
+    packet[2..4].copy_from_slice(&total_length_u16.to_be_bytes());
+    packet[4..6].copy_from_slice(&policy.identification.to_be_bytes());
+    let flags_and_offset = if policy.dont_fragment {
+        IPV4_FLAG_DONT_FRAGMENT
+    } else {
+        0
+    };
+    packet[6..8].copy_from_slice(&flags_and_offset.to_be_bytes());
+    packet[8] = policy.time_to_live;
+    packet[9] = WDP_UDP_IPV4_PROTOCOL_NUMBER;
+    packet[12..16].copy_from_slice(&source);
+    packet[16..20].copy_from_slice(&destination);
+    let header_checksum = checksum(&packet[..IPV4_MIN_HEADER_BYTES]);
+    packet[10..12].copy_from_slice(&header_checksum.to_be_bytes());
+
+    let udp = &mut packet[IPV4_MIN_HEADER_BYTES..];
+    udp[0..2].copy_from_slice(&datagram.src_port.to_be_bytes());
+    udp[2..4].copy_from_slice(&datagram.dst_port.to_be_bytes());
+    udp[4..6].copy_from_slice(&udp_length_u16.to_be_bytes());
+    udp[8..].copy_from_slice(&datagram.payload);
+    if policy.udp_checksum == UdpChecksumPolicy::Generate {
+        let computed = udp_checksum(source, destination, udp);
+        let encoded = if computed == 0 { u16::MAX } else { computed };
+        udp[6..8].copy_from_slice(&encoded.to_be_bytes());
+    }
+    Ok(packet)
+}
+
+pub fn decode_cdpd_ipv4_udp(packet: &[u8]) -> WdpResult<WdpDatagram> {
+    if packet.len() < IPV4_MIN_HEADER_BYTES {
+        return Err(WdpError::Ipv4PacketTruncated {
+            actual: packet.len(),
+            minimum: IPV4_MIN_HEADER_BYTES,
+        });
+    }
+
+    let version = packet[0] >> 4;
+    if version != 4 {
+        return Err(WdpError::Ipv4VersionUnsupported(version));
+    }
+    let ihl = packet[0] & 0x0F;
+    if ihl < 5 {
+        return Err(WdpError::Ipv4HeaderLengthInvalid(ihl));
+    }
+    let header_length = usize::from(ihl) * 4;
+    if packet.len() < header_length {
+        return Err(WdpError::Ipv4PacketTruncated {
+            actual: packet.len(),
+            minimum: header_length,
+        });
+    }
+    let total_length = usize::from(u16::from_be_bytes([packet[2], packet[3]]));
+    if total_length < header_length || total_length != packet.len() {
+        return Err(WdpError::Ipv4TotalLengthInvalid {
+            declared: total_length,
+            actual: packet.len(),
+            header: header_length,
+        });
+    }
+    if checksum(&packet[..header_length]) != 0 {
+        return Err(WdpError::Ipv4HeaderChecksumInvalid);
+    }
+    if packet[8] == 0 {
+        return Err(WdpError::Ipv4TtlExpired);
+    }
+    if packet[9] != WDP_UDP_IPV4_PROTOCOL_NUMBER {
+        return Err(WdpError::Ipv4ProtocolUnsupported(packet[9]));
+    }
+
+    let source = [packet[12], packet[13], packet[14], packet[15]];
+    let destination = [packet[16], packet[17], packet[18], packet[19]];
+    let identification = u16::from_be_bytes([packet[4], packet[5]]);
+    let flags_and_offset = u16::from_be_bytes([packet[6], packet[7]]);
+    let fragment_offset_units = flags_and_offset & IPV4_FRAGMENT_OFFSET_MASK;
+    let more_fragments = flags_and_offset & IPV4_FLAG_MORE_FRAGMENTS != 0;
+    if fragment_offset_units != 0 || more_fragments {
+        return Err(WdpError::Ipv4FragmentRequiresReassembly {
+            identification,
+            source,
+            destination,
+            protocol: packet[9],
+            fragment_offset_units,
+            more_fragments,
+        });
+    }
+
+    let udp = &packet[header_length..];
+    if udp.len() < UDP_HEADER_BYTES {
+        return Err(WdpError::UdpLengthInvalid {
+            declared: udp.len(),
+            actual: udp.len(),
+        });
+    }
+    let udp_length = usize::from(u16::from_be_bytes([udp[4], udp[5]]));
+    if udp_length < UDP_HEADER_BYTES || udp_length != udp.len() {
+        return Err(WdpError::UdpLengthInvalid {
+            declared: udp_length,
+            actual: udp.len(),
+        });
+    }
+    let source_port = u16::from_be_bytes([udp[0], udp[1]]);
+    let destination_port = u16::from_be_bytes([udp[2], udp[3]]);
+    if !WdpServicePort::is_known(destination_port) {
+        return Err(WdpError::DestinationPortUnsupported(destination_port));
+    }
+    let encoded_checksum = u16::from_be_bytes([udp[6], udp[7]]);
+    if encoded_checksum != 0 && udp_checksum(source, destination, udp) != 0 {
+        return Err(WdpError::UdpChecksumInvalid);
+    }
+
+    Ok(WdpDatagram {
+        src_addr: WdpAddress::ipv4(source),
+        dst_addr: WdpAddress::ipv4(destination),
+        src_port: source_port,
+        dst_port: destination_port,
+        payload: udp[UDP_HEADER_BYTES..].to_vec(),
+    })
+}

--- a/transport-rust/src/network/wdp/mod.rs
+++ b/transport-rust/src/network/wdp/mod.rs
@@ -2,11 +2,25 @@
 #![allow(unused_imports)]
 
 pub mod datagram;
+pub mod ipv4_udp;
+pub mod primitive;
+pub mod profile;
 pub mod sar;
 pub mod transport_trait;
 pub mod udp_adapter;
 
 pub use datagram::{WdpAddress, WdpAddressType, WdpDatagram, WdpServicePort};
+pub use ipv4_udp::{
+    decode_cdpd_ipv4_udp, encode_cdpd_ipv4_udp, CdpdIpv4SendPolicy, UdpChecksumPolicy,
+};
+pub use primitive::{TDUnitdataIndication, TDUnitdataRequest};
+pub use profile::{
+    CdpdIpv4Profile, WDP_CDPD_IPV4_BEARER_TYPE, WDP_IPV4_BASELINE_DATAGRAM_BYTES,
+    WDP_UDP_IPV4_PROTOCOL_NUMBER,
+};
 pub use sar::{classify_sar_packet, WdpSarDecision, WdpSarPolicy, WdpSarTrace};
 pub use transport_trait::{DatagramTransport, WdpError, WdpResult};
 pub use udp_adapter::{UdpDatagramTransport, UdpDatagramTransportConfig};
+
+#[cfg(test)]
+mod tests;

--- a/transport-rust/src/network/wdp/primitive.rs
+++ b/transport-rust/src/network/wdp/primitive.rs
@@ -1,0 +1,43 @@
+use crate::network::wdp::datagram::{WdpAddress, WdpDatagram};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TDUnitdataRequest {
+    pub source_address: WdpAddress,
+    pub source_port: u16,
+    pub destination_address: WdpAddress,
+    pub destination_port: u16,
+    pub user_data: Vec<u8>,
+}
+
+impl TDUnitdataRequest {
+    pub fn into_datagram(self) -> WdpDatagram {
+        WdpDatagram {
+            src_addr: self.source_address,
+            dst_addr: self.destination_address,
+            src_port: self.source_port,
+            dst_port: self.destination_port,
+            payload: self.user_data,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TDUnitdataIndication {
+    pub source_address: WdpAddress,
+    pub source_port: u16,
+    pub destination_address: Option<WdpAddress>,
+    pub destination_port: Option<u16>,
+    pub user_data: Vec<u8>,
+}
+
+impl From<WdpDatagram> for TDUnitdataIndication {
+    fn from(datagram: WdpDatagram) -> Self {
+        Self {
+            source_address: datagram.src_addr,
+            source_port: datagram.src_port,
+            destination_address: Some(datagram.dst_addr),
+            destination_port: Some(datagram.dst_port),
+            user_data: datagram.payload,
+        }
+    }
+}

--- a/transport-rust/src/network/wdp/profile.rs
+++ b/transport-rust/src/network/wdp/profile.rs
@@ -1,0 +1,17 @@
+use crate::network::wdp::datagram::{WdpAddressType, WdpServicePort};
+
+pub const WDP_CDPD_IPV4_BEARER_TYPE: u8 = 0x0D;
+pub const WDP_UDP_IPV4_PROTOCOL_NUMBER: u8 = 17;
+pub const WDP_IPV4_BASELINE_DATAGRAM_BYTES: usize = 576;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CdpdIpv4Profile;
+
+impl CdpdIpv4Profile {
+    pub const BEARER_TYPE: u8 = WDP_CDPD_IPV4_BEARER_TYPE;
+    pub const ADDRESS_TYPE: WdpAddressType = WdpAddressType::Ipv4;
+    pub const ADDRESS_OCTETS: usize = 4;
+    pub const IP_PROTOCOL: u8 = WDP_UDP_IPV4_PROTOCOL_NUMBER;
+    pub const SELECTED_CONNECTIONLESS_WSP_PORT: u16 = WdpServicePort::Connectionless as u16;
+    pub const WDP_SEGMENTATION_HEADER_PRESENT: bool = false;
+}

--- a/transport-rust/src/network/wdp/tests.rs
+++ b/transport-rust/src/network/wdp/tests.rs
@@ -1,0 +1,370 @@
+use super::*;
+use serde::Deserialize;
+
+const FIXTURE_SOURCE: &str =
+    include_str!("../../../tests/fixtures/transport/wdp_cdpd_ipv4_mapped/wdp_fixture.json");
+const WDP_LEDGER_SOURCE: &str =
+    include_str!("../../../../spec-processing/source-manifests/wap-1.2.1-wdp-scr.json");
+const CLAUSE_LEDGER_SOURCE: &str = include_str!(
+    "../../../../spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
+);
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct WdpFixture {
+    source_documents: Vec<SourceDocument>,
+    selected_rows: Vec<String>,
+    clause_ids: Vec<String>,
+    profile: FixtureProfile,
+    registered_ports: Vec<RegisteredPort>,
+    datagram: FixtureDatagram,
+    send_policy: FixtureSendPolicy,
+    cases: Vec<FixtureCase>,
+    malformed: Vec<MalformedCase>,
+}
+
+#[derive(Debug, Deserialize)]
+struct SourceDocument {
+    id: String,
+    sections: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct FixtureProfile {
+    bearer_type: u8,
+    address_octets: usize,
+    ip_protocol: u8,
+    selected_wsp_port: u16,
+    ipv4_baseline_datagram_bytes: usize,
+    wdp_segmentation_header_present: bool,
+}
+
+#[derive(Debug, Deserialize)]
+struct RegisteredPort {
+    port: u16,
+    service: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct FixtureDatagram {
+    source_address: [u8; 4],
+    source_port: u16,
+    destination_address: [u8; 4],
+    destination_port: u16,
+    user_data: Vec<u8>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct FixtureSendPolicy {
+    identification: u16,
+    time_to_live: u8,
+    dont_fragment: bool,
+    destination_accepts_large_datagrams: bool,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct FixtureCase {
+    name: String,
+    udp_checksum: String,
+    encoded: Vec<u8>,
+}
+
+#[derive(Debug, Deserialize)]
+struct MalformedCase {
+    name: String,
+    encoded: Vec<u8>,
+    error: String,
+}
+
+fn fixture() -> WdpFixture {
+    serde_json::from_str(FIXTURE_SOURCE).expect("WDP fixture should parse")
+}
+
+fn fixture_datagram(fixture: &WdpFixture) -> WdpDatagram {
+    WdpDatagram {
+        src_addr: WdpAddress::ipv4(fixture.datagram.source_address),
+        dst_addr: WdpAddress::ipv4(fixture.datagram.destination_address),
+        src_port: fixture.datagram.source_port,
+        dst_port: fixture.datagram.destination_port,
+        payload: fixture.datagram.user_data.clone(),
+    }
+}
+
+fn fixture_policy(fixture: &WdpFixture, checksum: UdpChecksumPolicy) -> CdpdIpv4SendPolicy {
+    CdpdIpv4SendPolicy {
+        identification: fixture.send_policy.identification,
+        time_to_live: fixture.send_policy.time_to_live,
+        dont_fragment: fixture.send_policy.dont_fragment,
+        path_mtu: None,
+        destination_accepts_large_datagrams: fixture
+            .send_policy
+            .destination_accepts_large_datagrams,
+        udp_checksum: checksum,
+    }
+}
+
+#[test]
+fn source_derived_fixture_covers_selected_class_c_rows_and_clauses() {
+    let fixture = fixture();
+    assert_eq!(
+        fixture
+            .source_documents
+            .iter()
+            .map(|source| source.id.as_str())
+            .collect::<Vec<_>>(),
+        ["WAP-200-WDP", "rfc-768", "rfc-791"]
+    );
+    assert!(fixture
+        .source_documents
+        .iter()
+        .all(|source| !source.sections.is_empty()));
+    let wdp_ledger: serde_json::Value =
+        serde_json::from_str(WDP_LEDGER_SOURCE).expect("WDP ledger should parse");
+    let selected_rows = wdp_ledger["obligations"]
+        .as_array()
+        .expect("WDP obligations should be an array")
+        .iter()
+        .filter(|row| {
+            row["disposition"]["classCProfile"] == "required-by-selected-class-c-transport-path"
+        })
+        .map(|row| {
+            row["id"]
+                .as_str()
+                .expect("selected WDP row should have an ID")
+                .to_string()
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(fixture.selected_rows, selected_rows);
+
+    let clause_ledger: serde_json::Value =
+        serde_json::from_str(CLAUSE_LEDGER_SOURCE).expect("clause ledger should parse");
+    let clause_ids = clause_ledger["families"]
+        .as_array()
+        .expect("clause families should be an array")
+        .iter()
+        .find(|family| family["family"] == "wdp")
+        .expect("clause ledger should contain WDP")
+        .get("clauses")
+        .and_then(serde_json::Value::as_array)
+        .expect("WDP clauses should be an array")
+        .iter()
+        .map(|clause| {
+            clause["id"]
+                .as_str()
+                .expect("WDP clause should have an ID")
+                .to_string()
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(fixture.clause_ids, clause_ids);
+    assert_eq!(fixture.clause_ids.len(), 49);
+}
+
+#[test]
+fn registered_port_and_bearer_profile_are_exact() {
+    let fixture = fixture();
+    assert_eq!(fixture.profile.bearer_type, WDP_CDPD_IPV4_BEARER_TYPE);
+    assert_eq!(
+        fixture.profile.address_octets,
+        CdpdIpv4Profile::ADDRESS_OCTETS
+    );
+    assert_eq!(fixture.profile.ip_protocol, WDP_UDP_IPV4_PROTOCOL_NUMBER);
+    assert_eq!(
+        fixture.profile.selected_wsp_port,
+        CdpdIpv4Profile::SELECTED_CONNECTIONLESS_WSP_PORT
+    );
+    assert_eq!(
+        fixture.profile.ipv4_baseline_datagram_bytes,
+        WDP_IPV4_BASELINE_DATAGRAM_BYTES
+    );
+    assert_eq!(
+        fixture.profile.wdp_segmentation_header_present,
+        CdpdIpv4Profile::WDP_SEGMENTATION_HEADER_PRESENT
+    );
+    assert!(!fixture.profile.wdp_segmentation_header_present);
+
+    let fixture_ports = fixture
+        .registered_ports
+        .iter()
+        .map(|entry| entry.port)
+        .collect::<Vec<_>>();
+    assert_eq!(fixture_ports, WdpServicePort::ALL);
+    assert!(fixture
+        .registered_ports
+        .iter()
+        .all(|entry| !entry.service.is_empty() && WdpServicePort::is_known(entry.port)));
+}
+
+#[test]
+fn td_unitdata_request_and_indication_preserve_address_port_and_payload_semantics() {
+    let fixture = fixture();
+    let datagram = fixture_datagram(&fixture);
+    let request = TDUnitdataRequest {
+        source_address: datagram.src_addr.clone(),
+        source_port: datagram.src_port,
+        destination_address: datagram.dst_addr.clone(),
+        destination_port: datagram.dst_port,
+        user_data: datagram.payload.clone(),
+    };
+    assert_eq!(request.into_datagram(), datagram);
+
+    let indication = TDUnitdataIndication::from(datagram.clone());
+    assert_eq!(indication.source_address, datagram.src_addr);
+    assert_eq!(indication.source_port, datagram.src_port);
+    assert_eq!(indication.destination_address, Some(datagram.dst_addr));
+    assert_eq!(indication.destination_port, Some(datagram.dst_port));
+    assert_eq!(indication.user_data, datagram.payload);
+}
+
+#[test]
+fn simultaneous_connectionless_instances_are_multiplexed_by_port_fields() {
+    let fixture = fixture();
+    let first = fixture_datagram(&fixture);
+    let mut second = first.clone();
+    second.src_port += 1;
+    second.dst_port = WdpServicePort::VCardDatagram as u16;
+
+    let first_packet = encode_cdpd_ipv4_udp(
+        &first,
+        fixture_policy(&fixture, UdpChecksumPolicy::Generate),
+    )
+    .expect("first communication instance should encode");
+    let second_packet = encode_cdpd_ipv4_udp(
+        &second,
+        fixture_policy(&fixture, UdpChecksumPolicy::Generate),
+    )
+    .expect("second communication instance should encode");
+    assert_ne!(&first_packet[20..24], &second_packet[20..24]);
+    assert_eq!(
+        decode_cdpd_ipv4_udp(&first_packet).expect("first instance should decode"),
+        first
+    );
+    assert_eq!(
+        decode_cdpd_ipv4_udp(&second_packet).expect("second instance should decode"),
+        second
+    );
+}
+
+#[test]
+fn selected_cdpd_ipv4_profile_preserves_exact_udp_ipv4_bytes() {
+    let fixture = fixture();
+    let datagram = fixture_datagram(&fixture);
+    for case in &fixture.cases {
+        let checksum = match case.udp_checksum.as_str() {
+            "generate" => UdpChecksumPolicy::Generate,
+            "omit" => UdpChecksumPolicy::Omit,
+            other => panic!("unknown fixture checksum policy {other}"),
+        };
+        let encoded = encode_cdpd_ipv4_udp(&datagram, fixture_policy(&fixture, checksum))
+            .expect("fixture datagram should encode");
+        assert_eq!(encoded, case.encoded, "case '{}' encoded bytes", case.name);
+        assert_eq!(
+            decode_cdpd_ipv4_udp(&case.encoded).expect("fixture datagram should decode"),
+            datagram,
+            "case '{}' decoded primitive",
+            case.name
+        );
+    }
+}
+
+#[test]
+fn udp_source_port_zero_and_computed_zero_checksum_follow_rfc_768_encoding() {
+    let fixture = fixture();
+    let mut datagram = fixture_datagram(&fixture);
+    datagram.src_port = 0;
+    let encoded = encode_cdpd_ipv4_udp(
+        &datagram,
+        fixture_policy(&fixture, UdpChecksumPolicy::Generate),
+    )
+    .expect("zero source port should encode");
+    assert_eq!(&encoded[20..22], &[0, 0]);
+    assert_eq!(
+        decode_cdpd_ipv4_udp(&encoded)
+            .expect("zero source port should decode")
+            .src_port,
+        0
+    );
+
+    datagram.src_port = fixture.datagram.source_port;
+    datagram.payload = vec![0x97, 0xD7];
+    let encoded = encode_cdpd_ipv4_udp(
+        &datagram,
+        fixture_policy(&fixture, UdpChecksumPolicy::Generate),
+    )
+    .expect("computed zero checksum fixture should encode");
+    assert_eq!(&encoded[26..28], &[0xFF, 0xFF]);
+    assert_eq!(
+        decode_cdpd_ipv4_udp(&encoded)
+            .expect("all-one checksum encoding should decode")
+            .payload,
+        datagram.payload
+    );
+}
+
+#[test]
+fn malformed_ipv4_udp_fixture_outcomes_are_stable() {
+    let fixture = fixture();
+    for case in fixture.malformed {
+        let error = decode_cdpd_ipv4_udp(&case.encoded)
+            .expect_err("malformed fixture should fail")
+            .to_string();
+        assert_eq!(error, case.error, "case '{}' error mapping", case.name);
+    }
+}
+
+#[test]
+fn large_datagram_and_df_policies_are_deterministic() {
+    let fixture = fixture();
+    let mut datagram = fixture_datagram(&fixture);
+    datagram.payload = vec![0xA5; 549];
+    let error = encode_cdpd_ipv4_udp(
+        &datagram,
+        CdpdIpv4SendPolicy {
+            destination_accepts_large_datagrams: false,
+            ..fixture_policy(&fixture, UdpChecksumPolicy::Generate)
+        },
+    )
+    .expect_err("datagram above 576 octets needs destination assurance");
+    assert_eq!(
+        error,
+        WdpError::Ipv4LargeDatagramUnassured {
+            actual: 577,
+            baseline: 576
+        }
+    );
+
+    let error = encode_cdpd_ipv4_udp(
+        &datagram,
+        CdpdIpv4SendPolicy {
+            dont_fragment: true,
+            path_mtu: Some(576),
+            destination_accepts_large_datagrams: true,
+            ..fixture_policy(&fixture, UdpChecksumPolicy::Generate)
+        },
+    )
+    .expect_err("DF datagram above the path MTU should be discarded");
+    assert_eq!(
+        error,
+        WdpError::Ipv4DontFragmentMtuExceeded {
+            actual: 577,
+            mtu: 576
+        }
+    );
+
+    datagram.payload.pop();
+    assert_eq!(
+        encode_cdpd_ipv4_udp(
+            &datagram,
+            CdpdIpv4SendPolicy {
+                destination_accepts_large_datagrams: false,
+                ..fixture_policy(&fixture, UdpChecksumPolicy::Generate)
+            }
+        )
+        .expect("576-octet baseline datagram should encode")
+        .len(),
+        576
+    );
+}

--- a/transport-rust/src/network/wdp/transport_trait.rs
+++ b/transport-rust/src/network/wdp/transport_trait.rs
@@ -13,8 +13,48 @@ pub enum WdpError {
     CommunicationAdministrativelyProhibited,
     AddressUnreachable,
     DestinationPortUnsupported(u16),
-    PayloadOversize { actual: usize, max: usize },
-    PeerMessageTooBig { max: usize },
+    PayloadOversize {
+        actual: usize,
+        max: usize,
+    },
+    PeerMessageTooBig {
+        max: usize,
+    },
+    Ipv4PacketTruncated {
+        actual: usize,
+        minimum: usize,
+    },
+    Ipv4VersionUnsupported(u8),
+    Ipv4HeaderLengthInvalid(u8),
+    Ipv4TotalLengthInvalid {
+        declared: usize,
+        actual: usize,
+        header: usize,
+    },
+    Ipv4HeaderChecksumInvalid,
+    Ipv4TtlExpired,
+    Ipv4ProtocolUnsupported(u8),
+    Ipv4FragmentRequiresReassembly {
+        identification: u16,
+        source: [u8; 4],
+        destination: [u8; 4],
+        protocol: u8,
+        fragment_offset_units: u16,
+        more_fragments: bool,
+    },
+    Ipv4LargeDatagramUnassured {
+        actual: usize,
+        baseline: usize,
+    },
+    Ipv4DontFragmentMtuExceeded {
+        actual: usize,
+        mtu: usize,
+    },
+    UdpLengthInvalid {
+        declared: usize,
+        actual: usize,
+    },
+    UdpChecksumInvalid,
     Timeout,
     CorruptOrMalformed,
     Internal(String),
@@ -42,6 +82,73 @@ impl std::fmt::Display for WdpError {
             Self::PeerMessageTooBig { max } => {
                 write!(f, "peer maximum message size is {max}")
             }
+            Self::Ipv4PacketTruncated { actual, minimum } => {
+                write!(
+                    f,
+                    "truncated IPv4 packet: need at least {minimum} octets, got {actual}"
+                )
+            }
+            Self::Ipv4VersionUnsupported(version) => {
+                write!(f, "unsupported IP version {version}; expected IPv4")
+            }
+            Self::Ipv4HeaderLengthInvalid(ihl) => {
+                write!(f, "invalid IPv4 IHL {ihl}; expected at least 5")
+            }
+            Self::Ipv4TotalLengthInvalid {
+                declared,
+                actual,
+                header,
+            } => {
+                write!(
+                    f,
+                    "invalid IPv4 total length {declared} for header {header} and packet {actual}"
+                )
+            }
+            Self::Ipv4HeaderChecksumInvalid => write!(f, "invalid IPv4 header checksum"),
+            Self::Ipv4TtlExpired => write!(f, "IPv4 time to live is zero"),
+            Self::Ipv4ProtocolUnsupported(protocol) => {
+                write!(f, "unsupported IPv4 protocol {protocol}; expected UDP 17")
+            }
+            Self::Ipv4FragmentRequiresReassembly {
+                identification,
+                source,
+                destination,
+                protocol,
+                fragment_offset_units,
+                more_fragments,
+            } => {
+                write!(
+                    f,
+                    "IPv4 fragment requires lower-layer reassembly: id={identification}, source={}.{}.{}.{}, destination={}.{}.{}.{}, protocol={protocol}, offset={fragment_offset_units}, more={more_fragments}",
+                    source[0],
+                    source[1],
+                    source[2],
+                    source[3],
+                    destination[0],
+                    destination[1],
+                    destination[2],
+                    destination[3]
+                )
+            }
+            Self::Ipv4LargeDatagramUnassured { actual, baseline } => {
+                write!(
+                    f,
+                    "IPv4 datagram size {actual} exceeds baseline {baseline} without destination assurance"
+                )
+            }
+            Self::Ipv4DontFragmentMtuExceeded { actual, mtu } => {
+                write!(
+                    f,
+                    "IPv4 datagram size {actual} exceeds path MTU {mtu} with DF set"
+                )
+            }
+            Self::UdpLengthInvalid { declared, actual } => {
+                write!(
+                    f,
+                    "invalid UDP length {declared}; available UDP octets {actual}"
+                )
+            }
+            Self::UdpChecksumInvalid => write!(f, "invalid UDP checksum"),
             Self::Timeout => write!(f, "transport timeout"),
             Self::CorruptOrMalformed => write!(f, "corrupt or malformed datagram"),
             Self::Internal(reason) => write!(f, "internal transport error: {reason}"),

--- a/transport-rust/tests/fixtures/transport/wdp_cdpd_ipv4_mapped/meta.toml
+++ b/transport-rust/tests/fixtures/transport/wdp_cdpd_ipv4_mapped/meta.toml
@@ -1,0 +1,28 @@
+name = "wdp-cdpd-ipv4-mapped"
+description = "Source-derived WAP-200, RFC 768, and RFC 791 evidence for the selected Class C CDPD/IPv4 WDP path."
+mode = "mapped"
+work_items = ["TRN-701", "T0-19"]
+spec_items = [
+  "WDP-C-001",
+  "WDP-CORE-C-001",
+  "WDP-PF-C-001",
+  "WDP-PF-C-002",
+  "WDP-CT-C-002",
+  "WDP-NA-C-000",
+  "WDP-NA-C-003",
+  "WDP-NA-C-006",
+  "WDP-NA-C-007",
+  "RQ-TRN-001",
+  "RQ-TRN-002",
+  "RQ-TRN-003",
+]
+testing_ac = [
+  "Preserves all T-DUnitdata request and indication address, port, and user-data parameters without a connection precondition.",
+  "Declares CDPD/IPv4 bearer value 0x0D, UDP protocol 17, four-octet addresses, and connectionless WSP port 9200.",
+  "Recognizes the complete WAP Appendix B registered port table without activating optional services.",
+  "Encodes and decodes the selected IPv4 and UDP headers, lengths, checksums, and odd-octet checksum padding byte-for-byte.",
+  "Accepts an omitted IPv4 UDP checksum and rejects invalid non-zero checksums deterministically.",
+  "Rejects invalid IPv4 version, IHL, total length, TTL, protocol, checksum, and unreassembled fragments deterministically.",
+  "Keeps IPv4 fragmentation/reassembly below WDP and does not claim WDP segmentation/reassembly closure.",
+  "Enforces the 576-octet IPv4 baseline send assurance and DF/path-MTU discard policies deterministically.",
+]

--- a/transport-rust/tests/fixtures/transport/wdp_cdpd_ipv4_mapped/wdp_fixture.json
+++ b/transport-rust/tests/fixtures/transport/wdp_cdpd_ipv4_mapped/wdp_fixture.json
@@ -1,0 +1,183 @@
+{
+  "sourceDocuments": [
+    {
+      "id": "WAP-200-WDP",
+      "sections": ["5.1", "5.2", "5.3", "5.4.3", "6.3.1.1", "7.1", "7.2", "appendix-b", "appendix-c"]
+    },
+    {
+      "id": "rfc-768",
+      "sections": ["introduction", "format", "fields", "interface", "ip-interface", "protocol-number"]
+    },
+    {
+      "id": "rfc-791",
+      "sections": ["1.4", "2.3", "3.1", "3.2"]
+    }
+  ],
+  "selectedRows": [
+    "WDP-C-001",
+    "WDP-CORE-C-001",
+    "WDP-PF-C-001",
+    "WDP-PF-C-002",
+    "WDP-CT-C-002",
+    "WDP-NA-C-000",
+    "WDP-NA-C-003",
+    "WDP-NA-C-006",
+    "WDP-NA-C-007"
+  ],
+  "clauseIds": [
+    "WDP-CL-CONSISTENT-TRANSPORT-SERVICE",
+    "WDP-CL-APPLICATION-PORT-ADDRESSING",
+    "WDP-CL-BEARER-TRANSPARENCY",
+    "WDP-CL-SIMULTANEOUS-INSTANCES",
+    "WDP-CL-ADAPTATION-LAYER-BOUNDARY",
+    "WDP-CL-IP-BEARER-REQUIRES-UDP",
+    "WDP-CL-CDPD-UDP-IP-PROFILE",
+    "WDP-CL-UNITDATA-REQUEST-ANYTIME",
+    "WDP-CL-UNITDATA-REQUEST-PARAMETERS",
+    "WDP-CL-UNITDATA-INDICATION-PARAMETERS",
+    "WDP-CL-DESTINATION-ADDRESS-SEMANTICS",
+    "WDP-CL-SOURCE-ADDRESS-SEMANTICS",
+    "WDP-CL-DESTINATION-PORT-SEMANTICS",
+    "WDP-CL-SOURCE-PORT-SEMANTICS",
+    "WDP-CL-UNITDATA-CONTENT-TRANSPARENCY",
+    "WDP-CL-PROTOCOL-REQUIRED-PORT-FIELDS",
+    "WDP-CL-IP-MAPPING-IS-UDP",
+    "WDP-CL-IP-MAPPING-FRAGMENTATION",
+    "WDP-CL-WAP-PORT-REGISTRY",
+    "WDP-CL-SELECTED-WSP-PORT",
+    "WDP-CL-SELECTED-BEARER-ASSIGNMENT",
+    "WDP-CL-UDP-UNRELIABLE-DATAGRAMS",
+    "WDP-CL-UDP-HEADER-LAYOUT",
+    "WDP-CL-UDP-SOURCE-PORT-ZERO",
+    "WDP-CL-UDP-DESTINATION-PORT-CONTEXT",
+    "WDP-CL-UDP-LENGTH-BOUNDS",
+    "WDP-CL-UDP-CHECKSUM-COVERAGE",
+    "WDP-CL-UDP-CHECKSUM-PADDING",
+    "WDP-CL-UDP-CHECKSUM-ZERO-ENCODING",
+    "WDP-CL-UDP-CHECKSUM-OMISSION",
+    "WDP-CL-UDP-RECEIVE-INTERFACE",
+    "WDP-CL-UDP-SEND-INTERFACE",
+    "WDP-CL-UDP-IP-INTERFACE-METADATA",
+    "WDP-CL-UDP-IP-PROTOCOL-NUMBER",
+    "WDP-CL-IPV4-INDEPENDENT-DATAGRAMS",
+    "WDP-CL-IPV4-FIXED-ADDRESS-SIZE",
+    "WDP-CL-IPV4-HEADER-LAYOUT",
+    "WDP-CL-IPV4-VERSION-AND-IHL",
+    "WDP-CL-IPV4-TOTAL-LENGTH",
+    "WDP-CL-IPV4-BASELINE-RECEIVE-SIZE",
+    "WDP-CL-IPV4-LARGE-SEND-GUARD",
+    "WDP-CL-IPV4-FRAGMENTATION-LOCATION",
+    "WDP-CL-IPV4-FRAGMENT-REASSEMBLY-KEY",
+    "WDP-CL-IPV4-DONT-FRAGMENT",
+    "WDP-CL-IPV4-TTL-ZERO",
+    "WDP-CL-IPV4-HEADER-CHECKSUM",
+    "WDP-CL-IPV4-SOURCE-DESTINATION-FIELDS",
+    "WDP-CL-IPV4-ROBUST-INTEROPERATION",
+    "WDP-CL-IPV4-NO-RELIABILITY"
+  ],
+  "profile": {
+    "bearer": "AMPS/CDPD/IPv4",
+    "bearerType": 13,
+    "addressOctets": 4,
+    "ipProtocol": 17,
+    "selectedWspPort": 9200,
+    "ipv4BaselineDatagramBytes": 576,
+    "wdpSegmentationHeaderPresent": false
+  },
+  "registeredPorts": [
+    {"port": 2805, "service": "WTA secure connectionless session"},
+    {"port": 2923, "service": "WTA secure session"},
+    {"port": 2948, "service": "Push connectionless session"},
+    {"port": 2949, "service": "Push secure connectionless session"},
+    {"port": 9200, "service": "WAP connectionless session"},
+    {"port": 9201, "service": "WAP session"},
+    {"port": 9202, "service": "WAP secure connectionless session"},
+    {"port": 9203, "service": "WAP secure session"},
+    {"port": 9204, "service": "vCard datagram"},
+    {"port": 9205, "service": "vCalendar datagram"},
+    {"port": 9206, "service": "vCard secure datagram"},
+    {"port": 9207, "service": "vCalendar secure datagram"}
+  ],
+  "datagram": {
+    "sourceAddress": [192, 0, 2, 10],
+    "sourcePort": 49152,
+    "destinationAddress": [192, 0, 2, 7],
+    "destinationPort": 9200,
+    "userData": [222, 173, 190, 239, 1]
+  },
+  "sendPolicy": {
+    "identification": 4660,
+    "timeToLive": 64,
+    "dontFragment": false,
+    "destinationAcceptsLargeDatagrams": false
+  },
+  "cases": [
+    {
+      "name": "udp-checksum-generated",
+      "udpChecksum": "generate",
+      "encoded": [69, 0, 0, 33, 18, 52, 0, 0, 64, 17, 228, 134, 192, 0, 2, 10, 192, 0, 2, 7, 192, 0, 35, 240, 0, 13, 249, 51, 222, 173, 190, 239, 1]
+    },
+    {
+      "name": "udp-checksum-omitted",
+      "udpChecksum": "omit",
+      "encoded": [69, 0, 0, 33, 18, 52, 0, 0, 64, 17, 228, 134, 192, 0, 2, 10, 192, 0, 2, 7, 192, 0, 35, 240, 0, 13, 0, 0, 222, 173, 190, 239, 1]
+    }
+  ],
+  "malformed": [
+    {
+      "name": "truncated-ipv4-header",
+      "encoded": [69, 0, 0, 20],
+      "error": "truncated IPv4 packet: need at least 20 octets, got 4"
+    },
+    {
+      "name": "wrong-ip-version",
+      "encoded": [101, 0, 0, 33, 18, 52, 0, 0, 64, 17, 228, 134, 192, 0, 2, 10, 192, 0, 2, 7, 192, 0, 35, 240, 0, 13, 249, 51, 222, 173, 190, 239, 1],
+      "error": "unsupported IP version 6; expected IPv4"
+    },
+    {
+      "name": "short-ihl",
+      "encoded": [68, 0, 0, 33, 18, 52, 0, 0, 64, 17, 228, 134, 192, 0, 2, 10, 192, 0, 2, 7, 192, 0, 35, 240, 0, 13, 249, 51, 222, 173, 190, 239, 1],
+      "error": "invalid IPv4 IHL 4; expected at least 5"
+    },
+    {
+      "name": "total-length-mismatch",
+      "encoded": [69, 0, 0, 32, 18, 52, 0, 0, 64, 17, 228, 134, 192, 0, 2, 10, 192, 0, 2, 7, 192, 0, 35, 240, 0, 13, 249, 51, 222, 173, 190, 239, 1],
+      "error": "invalid IPv4 total length 32 for header 20 and packet 33"
+    },
+    {
+      "name": "invalid-ipv4-checksum",
+      "encoded": [69, 0, 0, 33, 18, 52, 0, 0, 64, 17, 229, 134, 192, 0, 2, 10, 192, 0, 2, 7, 192, 0, 35, 240, 0, 13, 249, 51, 222, 173, 190, 239, 1],
+      "error": "invalid IPv4 header checksum"
+    },
+    {
+      "name": "ttl-zero",
+      "encoded": [69, 0, 0, 33, 18, 52, 0, 0, 0, 17, 36, 135, 192, 0, 2, 10, 192, 0, 2, 7, 192, 0, 35, 240, 0, 13, 249, 51, 222, 173, 190, 239, 1],
+      "error": "IPv4 time to live is zero"
+    },
+    {
+      "name": "non-udp-protocol",
+      "encoded": [69, 0, 0, 33, 18, 52, 0, 0, 64, 6, 228, 145, 192, 0, 2, 10, 192, 0, 2, 7, 192, 0, 35, 240, 0, 13, 249, 51, 222, 173, 190, 239, 1],
+      "error": "unsupported IPv4 protocol 6; expected UDP 17"
+    },
+    {
+      "name": "fragment-requires-lower-layer-reassembly",
+      "encoded": [69, 0, 0, 33, 18, 52, 32, 1, 64, 17, 196, 133, 192, 0, 2, 10, 192, 0, 2, 7, 192, 0, 35, 240, 0, 13, 249, 51, 222, 173, 190, 239, 1],
+      "error": "IPv4 fragment requires lower-layer reassembly: id=4660, source=192.0.2.10, destination=192.0.2.7, protocol=17, offset=1, more=true"
+    },
+    {
+      "name": "udp-length-below-header",
+      "encoded": [69, 0, 0, 33, 18, 52, 0, 0, 64, 17, 228, 134, 192, 0, 2, 10, 192, 0, 2, 7, 192, 0, 35, 240, 0, 7, 249, 51, 222, 173, 190, 239, 1],
+      "error": "invalid UDP length 7; available UDP octets 13"
+    },
+    {
+      "name": "unregistered-destination-port",
+      "encoded": [69, 0, 0, 33, 18, 52, 0, 0, 64, 17, 228, 134, 192, 0, 2, 10, 192, 0, 2, 7, 192, 0, 39, 15, 0, 13, 249, 51, 222, 173, 190, 239, 1],
+      "error": "destination port 9999 is not a supported WAP service"
+    },
+    {
+      "name": "invalid-udp-checksum",
+      "encoded": [69, 0, 0, 33, 18, 52, 0, 0, 64, 17, 228, 134, 192, 0, 2, 10, 192, 0, 2, 7, 192, 0, 35, 240, 0, 13, 249, 51, 222, 173, 190, 239, 0],
+      "error": "invalid UDP checksum"
+    }
+  ]
+}

--- a/transport-rust/tests/interop_replay.rs
+++ b/transport-rust/tests/interop_replay.rs
@@ -429,7 +429,7 @@ fn mode_for_datagram(datagram: &WdpDatagram) -> Option<(WspSessionMode, u16)> {
             Some(WdpServicePort::Session | WdpServicePort::SecureSession) => {
                 return Some((WspSessionMode::ConnectionOriented, port));
             }
-            None => {}
+            Some(_) | None => {}
         }
     }
     None


### PR DESCRIPTION
## Summary

- implement source-derived WDP service primitive and CDPD/IPv4 bearer-profile behavior for the selected Class C path
- add deterministic IPv4/UDP encoding, decoding, checksum, length, port, MTU, fragmentation-boundary, and error-policy fixtures
- map direct evidence to all nine selected WDP rows and their 49 canonical clauses
- regenerate the transport ledgers, compliance rollups, successor delta, TRN-7 context pack, and knowledge-graph projections

## Why

TRN-701 previously had implementation-shaped WDP code but no direct source-derived evidence for the selected WAP-200, RFC 768, and RFC 791 obligations. This change makes the selected CDPD/IPv4 behavior explicit and mechanically checks the fixture's row and clause coverage against the canonical manifests.

## Scope

This closes only the mapped TRN-701 Class C CDPD/IPv4 slice. TRN-702 remains an explicit zero-clause/family mapping gap. Alternate bearers, connection-oriented services, server rows, optional-service activation, and IPv4 fragment collection/reassembly remain unclaimed.

## Validation

- `make lint-rust-transport`
- `make test-rust-transport` — 188 library tests and 2 integration tests passed; 3 live Kannel tests ignored
- focused WDP suite — 20 passed
- transport-ledger, selected-clause, aggregate-ledger, compliance-program, successor-delta, knowledge-graph, requirement-drift, and `git diff --check` validations passed
- repository pre-commit and pre-push hooks passed
