### PR TITLE
WML-204: implement select initialization and control semantics

### DIFF
--- a/docs/knowledge-graph/context-packs/WML-2.md
+++ b/docs/knowledge-graph/context-packs/WML-2.md
@@ -114,6 +114,7 @@ Evidence commands:
 Outputs:
 
 - Complete field/control syntax and attribute validation
+- Source-derived select initialization, selection, serialization, and onpick runtime evidence
 
 Acceptance:
 
@@ -122,6 +123,7 @@ Acceptance:
 Evidence commands:
 
 - `cargo test --manifest-path engine-wasm/engine/Cargo.toml`
+- `pnpm test:story WML-204`
 
 ### WML-205: WML parse/error taxonomy
 
@@ -518,13 +520,13 @@ Evidence commands:
   - Source: `WAP-191_104-WML` §11.6.2.2 (11.6.2.2 The Option Element)
   - Parents: `WML-C-41`, `WML-C-09`
   - Requirements: `RQ-RMK-001`, `RQ-RMK-004`
-  - Fixture: `WML-FX-OPTION-ONPICK-MULTI` (`runtime`, `planned`)
+  - Fixture: `WML-FX-OPTION-ONPICK-MULTI` (`runtime`, `implemented`)
 - **WML-CL-OPTION-ONPICK-SINGLE** — For single selection, dispatch onpick for the newly selected option but not for implicit deselection.
   - Family: `wml`; force: `implicit-must`; level: `required`
   - Source: `WAP-191_104-WML` §11.6.2.2 (11.6.2.2 The Option Element)
   - Parents: `WML-C-41`, `WML-C-09`
   - Requirements: `RQ-RMK-001`, `RQ-RMK-004`
-  - Fixture: `WML-FX-OPTION-ONPICK-SINGLE` (`runtime`, `planned`)
+  - Fixture: `WML-FX-OPTION-ONPICK-SINGLE` (`runtime`, `implemented`)
 - **WML-CL-OPTION-VALUE-EVALUATION** — Evaluate option value variable references before assigning the containing select name variable.
   - Family: `wml`; force: `implicit-must`; level: `required`
   - Source: `WAP-191_104-WML` §11.6.2.2 (11.6.2.2 The Option Element)
@@ -536,25 +538,25 @@ Evidence commands:
   - Source: `WAP-191_104-WML` §11.6.2.1 (11.6.2.1 The Select Element)
   - Parents: `WML-C-43`
   - Requirements: `RQ-RMK-001`
-  - Fixture: `WML-FX-SELECT-DEFAULT-PRECEDENCE` (`runtime`, `planned`)
+  - Fixture: `WML-FX-SELECT-DEFAULT-PRECEDENCE` (`runtime`, `implemented`)
 - **WML-CL-SELECT-INDEX-VALIDATION** — Validate selection indices by removing non-integers, out-of-range entries, and duplicates.
   - Family: `wml`; force: `implicit-must`; level: `required`
   - Source: `WAP-191_104-WML` §11.6.2.1 (11.6.2.1 The Select Element)
   - Parents: `WML-C-43`
   - Requirements: `RQ-RMK-001`
-  - Fixture: `WML-FX-SELECT-INDEX-VALIDATION` (`runtime`, `planned`)
+  - Fixture: `WML-FX-SELECT-INDEX-VALIDATION` (`runtime`, `implemented`)
 - **WML-CL-SELECT-INIT-ORDER** — Initialize input and select controls in document order when entering the card.
   - Family: `wml`; force: `explicit-must`; level: `required`
   - Source: `WAP-191_104-WML` §11.6.2.1 (11.6.2.1 The Select Element)
   - Parents: `WML-C-43`, `WML-C-33`
   - Requirements: `RQ-RMK-001`
-  - Fixture: `WML-FX-SELECT-INIT-ORDER` (`runtime`, `planned`)
+  - Fixture: `WML-FX-SELECT-INIT-ORDER` (`runtime`, `implemented`)
 - **WML-CL-SELECT-MULTI-SERIALIZATION** — Serialize multiple results as semicolon-delimited lists with unique indices, duplicate non-empty values preserved, and no empty value entries.
   - Family: `wml`; force: `explicit-must`; level: `required`
   - Source: `WAP-191_104-WML` §11.6.2.1 (11.6.2.1 The Select Element)
   - Parents: `WML-C-43`
   - Requirements: `RQ-RMK-001`
-  - Fixture: `WML-FX-SELECT-MULTI-SERIALIZATION` (`runtime`, `planned`)
+  - Fixture: `WML-FX-SELECT-MULTI-SERIALIZATION` (`runtime`, `implemented`)
 - **WML-CL-SELECT-NO-IMPLICIT-REFRESH** — Do not create display side effects from select-variable updates without an explicit refresh task.
   - Family: `wml`; force: `explicit-must`; level: `required`
   - Source: `WAP-191_104-WML` §11.6.2.1 (11.6.2.1 The Select Element)
@@ -566,37 +568,37 @@ Evidence commands:
   - Source: `WAP-191_104-WML` §11.6.2.1 (11.6.2.1 The Select Element)
   - Parents: `WML-C-43`
   - Requirements: `RQ-RMK-001`
-  - Fixture: `WML-FX-SELECT-PRESELECTION` (`runtime`, `planned`)
+  - Fixture: `WML-FX-SELECT-PRESELECTION` (`runtime`, `implemented`)
 - **WML-CL-SELECT-SINGLE-MULTI-MODE** — Allow one selected option by default and multiple selections only when multiple is true.
   - Family: `wml`; force: `implicit-must`; level: `required`
   - Source: `WAP-191_104-WML` §11.6.2.1 (11.6.2.1 The Select Element)
   - Parents: `WML-C-43`
   - Requirements: `RQ-RMK-001`
-  - Fixture: `WML-FX-SELECT-SINGLE-MULTI-MODE` (`runtime`, `planned`)
+  - Fixture: `WML-FX-SELECT-SINGLE-MULTI-MODE` (`runtime`, `implemented`)
 - **WML-CL-SELECT-STRUCTURE** — Require one or more option or optgroup children in each select element.
   - Family: `wml`; force: `grammar`; level: `required`
   - Source: `WAP-191_104-WML` §11.6.2.1 (11.6.2.1 The Select Element)
   - Parents: `WML-C-43`
   - Requirements: `RQ-RMK-001`
-  - Fixture: `WML-FX-SELECT-STRUCTURE` (`parser`, `planned`)
+  - Fixture: `WML-FX-SELECT-STRUCTURE` (`parser`, `implemented`)
 - **WML-CL-SELECT-USER-UPDATE** — Update name and iname after user selection changes and again before every task invocation.
   - Family: `wml`; force: `explicit-must`; level: `required`
   - Source: `WAP-191_104-WML` §11.6.2.1 (11.6.2.1 The Select Element)
   - Parents: `WML-C-43`
   - Requirements: `RQ-RMK-001`
-  - Fixture: `WML-FX-SELECT-USER-UPDATE` (`runtime`, `planned`)
+  - Fixture: `WML-FX-SELECT-USER-UPDATE` (`runtime`, `implemented`)
 - **WML-CL-SELECT-VARIABLE-INITIALIZATION** — Initialize name from selected option values and iname from the validated selected indices.
   - Family: `wml`; force: `implicit-must`; level: `required`
   - Source: `WAP-191_104-WML` §11.6.2.1 (11.6.2.1 The Select Element)
   - Parents: `WML-C-43`
   - Requirements: `RQ-RMK-001`
-  - Fixture: `WML-FX-SELECT-VARIABLE-INITIALIZATION` (`runtime`, `planned`)
+  - Fixture: `WML-FX-SELECT-VARIABLE-INITIALIZATION` (`runtime`, `implemented`)
 - **WML-CL-VARIABLE-COMMIT-BEFORE-TASK** — Commit input and selection variables before invoking any task.
   - Family: `wml`; force: `explicit-must`; level: `required`
   - Source: `WAP-191_104-WML` §10.3.4 (10.3.4 Setting Variables)
   - Parents: `WML-C-12`, `WML-C-33`, `WML-C-43`
   - Requirements: `RQ-RMK-001`, `RQ-RMK-003`, `RQ-RMK-005`
-  - Fixture: `WML-FX-VARIABLE-COMMIT-BEFORE-TASK` (`runtime`, `planned`)
+  - Fixture: `WML-FX-VARIABLE-COMMIT-BEFORE-TASK` (`runtime`, `implemented`)
 
 ## Explicit mapping gaps
 

--- a/docs/knowledge-graph/vault/clauses/WML-CL-OPTION-ONPICK-MULTI.md
+++ b/docs/knowledge-graph/vault/clauses/WML-CL-OPTION-ONPICK-MULTI.md
@@ -55,7 +55,7 @@ tags:
     "RQ-RMK-001",
     "RQ-RMK-004"
   ],
-  "implementationStatus": "not-assessed",
+  "implementationStatus": "implemented",
   "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented.",
   "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
 }

--- a/docs/knowledge-graph/vault/clauses/WML-CL-OPTION-ONPICK-SINGLE.md
+++ b/docs/knowledge-graph/vault/clauses/WML-CL-OPTION-ONPICK-SINGLE.md
@@ -55,7 +55,7 @@ tags:
     "RQ-RMK-001",
     "RQ-RMK-004"
   ],
-  "implementationStatus": "not-assessed",
+  "implementationStatus": "implemented",
   "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented.",
   "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
 }

--- a/docs/knowledge-graph/vault/clauses/WML-CL-SELECT-DEFAULT-PRECEDENCE.md
+++ b/docs/knowledge-graph/vault/clauses/WML-CL-SELECT-DEFAULT-PRECEDENCE.md
@@ -49,7 +49,7 @@ tags:
   "requirementIds": [
     "RQ-RMK-001"
   ],
-  "implementationStatus": "not-assessed",
+  "implementationStatus": "implemented",
   "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented.",
   "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
 }

--- a/docs/knowledge-graph/vault/clauses/WML-CL-SELECT-INDEX-VALIDATION.md
+++ b/docs/knowledge-graph/vault/clauses/WML-CL-SELECT-INDEX-VALIDATION.md
@@ -49,7 +49,7 @@ tags:
   "requirementIds": [
     "RQ-RMK-001"
   ],
-  "implementationStatus": "not-assessed",
+  "implementationStatus": "implemented",
   "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented.",
   "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
 }

--- a/docs/knowledge-graph/vault/clauses/WML-CL-SELECT-INIT-ORDER.md
+++ b/docs/knowledge-graph/vault/clauses/WML-CL-SELECT-INIT-ORDER.md
@@ -51,7 +51,7 @@ tags:
   "requirementIds": [
     "RQ-RMK-001"
   ],
-  "implementationStatus": "not-assessed",
+  "implementationStatus": "implemented",
   "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented.",
   "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
 }

--- a/docs/knowledge-graph/vault/clauses/WML-CL-SELECT-MULTI-SERIALIZATION.md
+++ b/docs/knowledge-graph/vault/clauses/WML-CL-SELECT-MULTI-SERIALIZATION.md
@@ -49,7 +49,7 @@ tags:
   "requirementIds": [
     "RQ-RMK-001"
   ],
-  "implementationStatus": "not-assessed",
+  "implementationStatus": "implemented",
   "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented.",
   "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
 }

--- a/docs/knowledge-graph/vault/clauses/WML-CL-SELECT-PRESELECTION.md
+++ b/docs/knowledge-graph/vault/clauses/WML-CL-SELECT-PRESELECTION.md
@@ -49,7 +49,7 @@ tags:
   "requirementIds": [
     "RQ-RMK-001"
   ],
-  "implementationStatus": "not-assessed",
+  "implementationStatus": "implemented",
   "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented.",
   "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
 }

--- a/docs/knowledge-graph/vault/clauses/WML-CL-SELECT-SINGLE-MULTI-MODE.md
+++ b/docs/knowledge-graph/vault/clauses/WML-CL-SELECT-SINGLE-MULTI-MODE.md
@@ -49,7 +49,7 @@ tags:
   "requirementIds": [
     "RQ-RMK-001"
   ],
-  "implementationStatus": "not-assessed",
+  "implementationStatus": "implemented",
   "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented.",
   "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
 }

--- a/docs/knowledge-graph/vault/clauses/WML-CL-SELECT-STRUCTURE.md
+++ b/docs/knowledge-graph/vault/clauses/WML-CL-SELECT-STRUCTURE.md
@@ -49,7 +49,7 @@ tags:
   "requirementIds": [
     "RQ-RMK-001"
   ],
-  "implementationStatus": "not-assessed",
+  "implementationStatus": "implemented",
   "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented.",
   "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
 }

--- a/docs/knowledge-graph/vault/clauses/WML-CL-SELECT-USER-UPDATE.md
+++ b/docs/knowledge-graph/vault/clauses/WML-CL-SELECT-USER-UPDATE.md
@@ -49,7 +49,7 @@ tags:
   "requirementIds": [
     "RQ-RMK-001"
   ],
-  "implementationStatus": "not-assessed",
+  "implementationStatus": "implemented",
   "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented.",
   "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
 }

--- a/docs/knowledge-graph/vault/clauses/WML-CL-SELECT-VARIABLE-INITIALIZATION.md
+++ b/docs/knowledge-graph/vault/clauses/WML-CL-SELECT-VARIABLE-INITIALIZATION.md
@@ -49,7 +49,7 @@ tags:
   "requirementIds": [
     "RQ-RMK-001"
   ],
-  "implementationStatus": "not-assessed",
+  "implementationStatus": "implemented",
   "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented.",
   "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
 }

--- a/docs/knowledge-graph/vault/clauses/WML-CL-VARIABLE-COMMIT-BEFORE-TASK.md
+++ b/docs/knowledge-graph/vault/clauses/WML-CL-VARIABLE-COMMIT-BEFORE-TASK.md
@@ -59,7 +59,7 @@ tags:
     "RQ-RMK-003",
     "RQ-RMK-005"
   ],
-  "implementationStatus": "not-assessed",
+  "implementationStatus": "implemented",
   "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented.",
   "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
 }

--- a/docs/knowledge-graph/vault/fixtures/WML-FX-OPTION-ONPICK-MULTI.md
+++ b/docs/knowledge-graph/vault/fixtures/WML-FX-OPTION-ONPICK-MULTI.md
@@ -4,7 +4,7 @@ key: "WML-FX-OPTION-ONPICK-MULTI"
 type: "fixture"
 generated: true
 pilot: "WML-2"
-status: "planned"
+status: "implemented"
 tags:
   - "wap-knowledge-graph"
   - "wap-knowledge-graph/fixture"
@@ -23,7 +23,7 @@ tags:
 ```json
 {
   "kind": "runtime",
-  "status": "planned",
+  "status": "implemented",
   "assertion": "For multiple selection, dispatch onpick whenever the option is selected or deselected.",
   "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
 }

--- a/docs/knowledge-graph/vault/fixtures/WML-FX-OPTION-ONPICK-SINGLE.md
+++ b/docs/knowledge-graph/vault/fixtures/WML-FX-OPTION-ONPICK-SINGLE.md
@@ -4,7 +4,7 @@ key: "WML-FX-OPTION-ONPICK-SINGLE"
 type: "fixture"
 generated: true
 pilot: "WML-2"
-status: "planned"
+status: "implemented"
 tags:
   - "wap-knowledge-graph"
   - "wap-knowledge-graph/fixture"
@@ -23,7 +23,7 @@ tags:
 ```json
 {
   "kind": "runtime",
-  "status": "planned",
+  "status": "implemented",
   "assertion": "For single selection, dispatch onpick for the newly selected option but not for implicit deselection.",
   "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
 }

--- a/docs/knowledge-graph/vault/fixtures/WML-FX-SELECT-DEFAULT-PRECEDENCE.md
+++ b/docs/knowledge-graph/vault/fixtures/WML-FX-SELECT-DEFAULT-PRECEDENCE.md
@@ -4,7 +4,7 @@ key: "WML-FX-SELECT-DEFAULT-PRECEDENCE"
 type: "fixture"
 generated: true
 pilot: "WML-2"
-status: "planned"
+status: "implemented"
 tags:
   - "wap-knowledge-graph"
   - "wap-knowledge-graph/fixture"
@@ -23,7 +23,7 @@ tags:
 ```json
 {
   "kind": "runtime",
-  "status": "planned",
+  "status": "implemented",
   "assertion": "Choose initial selections in iname, ivalue, name, value, then single/multiple fallback order.",
   "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
 }

--- a/docs/knowledge-graph/vault/fixtures/WML-FX-SELECT-INDEX-VALIDATION.md
+++ b/docs/knowledge-graph/vault/fixtures/WML-FX-SELECT-INDEX-VALIDATION.md
@@ -4,7 +4,7 @@ key: "WML-FX-SELECT-INDEX-VALIDATION"
 type: "fixture"
 generated: true
 pilot: "WML-2"
-status: "planned"
+status: "implemented"
 tags:
   - "wap-knowledge-graph"
   - "wap-knowledge-graph/fixture"
@@ -23,7 +23,7 @@ tags:
 ```json
 {
   "kind": "runtime",
-  "status": "planned",
+  "status": "implemented",
   "assertion": "Validate selection indices by removing non-integers, out-of-range entries, and duplicates.",
   "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
 }

--- a/docs/knowledge-graph/vault/fixtures/WML-FX-SELECT-INIT-ORDER.md
+++ b/docs/knowledge-graph/vault/fixtures/WML-FX-SELECT-INIT-ORDER.md
@@ -4,7 +4,7 @@ key: "WML-FX-SELECT-INIT-ORDER"
 type: "fixture"
 generated: true
 pilot: "WML-2"
-status: "planned"
+status: "implemented"
 tags:
   - "wap-knowledge-graph"
   - "wap-knowledge-graph/fixture"
@@ -23,7 +23,7 @@ tags:
 ```json
 {
   "kind": "runtime",
-  "status": "planned",
+  "status": "implemented",
   "assertion": "Initialize input and select controls in document order when entering the card.",
   "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
 }

--- a/docs/knowledge-graph/vault/fixtures/WML-FX-SELECT-MULTI-SERIALIZATION.md
+++ b/docs/knowledge-graph/vault/fixtures/WML-FX-SELECT-MULTI-SERIALIZATION.md
@@ -4,7 +4,7 @@ key: "WML-FX-SELECT-MULTI-SERIALIZATION"
 type: "fixture"
 generated: true
 pilot: "WML-2"
-status: "planned"
+status: "implemented"
 tags:
   - "wap-knowledge-graph"
   - "wap-knowledge-graph/fixture"
@@ -23,7 +23,7 @@ tags:
 ```json
 {
   "kind": "runtime",
-  "status": "planned",
+  "status": "implemented",
   "assertion": "Serialize multiple results as semicolon-delimited lists with unique indices, duplicate non-empty values preserved, and no empty value entries.",
   "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
 }

--- a/docs/knowledge-graph/vault/fixtures/WML-FX-SELECT-PRESELECTION.md
+++ b/docs/knowledge-graph/vault/fixtures/WML-FX-SELECT-PRESELECTION.md
@@ -4,7 +4,7 @@ key: "WML-FX-SELECT-PRESELECTION"
 type: "fixture"
 generated: true
 pilot: "WML-2"
-status: "planned"
+status: "implemented"
 tags:
   - "wap-knowledge-graph"
   - "wap-knowledge-graph/fixture"
@@ -23,7 +23,7 @@ tags:
 ```json
 {
   "kind": "runtime",
-  "status": "planned",
+  "status": "implemented",
   "assertion": "Deselect all options and then select every positive validated default index.",
   "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
 }

--- a/docs/knowledge-graph/vault/fixtures/WML-FX-SELECT-SINGLE-MULTI-MODE.md
+++ b/docs/knowledge-graph/vault/fixtures/WML-FX-SELECT-SINGLE-MULTI-MODE.md
@@ -4,7 +4,7 @@ key: "WML-FX-SELECT-SINGLE-MULTI-MODE"
 type: "fixture"
 generated: true
 pilot: "WML-2"
-status: "planned"
+status: "implemented"
 tags:
   - "wap-knowledge-graph"
   - "wap-knowledge-graph/fixture"
@@ -23,7 +23,7 @@ tags:
 ```json
 {
   "kind": "runtime",
-  "status": "planned",
+  "status": "implemented",
   "assertion": "Allow one selected option by default and multiple selections only when multiple is true.",
   "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
 }

--- a/docs/knowledge-graph/vault/fixtures/WML-FX-SELECT-STRUCTURE.md
+++ b/docs/knowledge-graph/vault/fixtures/WML-FX-SELECT-STRUCTURE.md
@@ -4,7 +4,7 @@ key: "WML-FX-SELECT-STRUCTURE"
 type: "fixture"
 generated: true
 pilot: "WML-2"
-status: "planned"
+status: "implemented"
 tags:
   - "wap-knowledge-graph"
   - "wap-knowledge-graph/fixture"
@@ -23,7 +23,7 @@ tags:
 ```json
 {
   "kind": "parser",
-  "status": "planned",
+  "status": "implemented",
   "assertion": "Require one or more option or optgroup children in each select element.",
   "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
 }

--- a/docs/knowledge-graph/vault/fixtures/WML-FX-SELECT-USER-UPDATE.md
+++ b/docs/knowledge-graph/vault/fixtures/WML-FX-SELECT-USER-UPDATE.md
@@ -4,7 +4,7 @@ key: "WML-FX-SELECT-USER-UPDATE"
 type: "fixture"
 generated: true
 pilot: "WML-2"
-status: "planned"
+status: "implemented"
 tags:
   - "wap-knowledge-graph"
   - "wap-knowledge-graph/fixture"
@@ -23,7 +23,7 @@ tags:
 ```json
 {
   "kind": "runtime",
-  "status": "planned",
+  "status": "implemented",
   "assertion": "Update name and iname after user selection changes and again before every task invocation.",
   "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
 }

--- a/docs/knowledge-graph/vault/fixtures/WML-FX-SELECT-VARIABLE-INITIALIZATION.md
+++ b/docs/knowledge-graph/vault/fixtures/WML-FX-SELECT-VARIABLE-INITIALIZATION.md
@@ -4,7 +4,7 @@ key: "WML-FX-SELECT-VARIABLE-INITIALIZATION"
 type: "fixture"
 generated: true
 pilot: "WML-2"
-status: "planned"
+status: "implemented"
 tags:
   - "wap-knowledge-graph"
   - "wap-knowledge-graph/fixture"
@@ -23,7 +23,7 @@ tags:
 ```json
 {
   "kind": "runtime",
-  "status": "planned",
+  "status": "implemented",
   "assertion": "Initialize name from selected option values and iname from the validated selected indices.",
   "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
 }

--- a/docs/knowledge-graph/vault/fixtures/WML-FX-VARIABLE-COMMIT-BEFORE-TASK.md
+++ b/docs/knowledge-graph/vault/fixtures/WML-FX-VARIABLE-COMMIT-BEFORE-TASK.md
@@ -4,7 +4,7 @@ key: "WML-FX-VARIABLE-COMMIT-BEFORE-TASK"
 type: "fixture"
 generated: true
 pilot: "WML-2"
-status: "planned"
+status: "implemented"
 tags:
   - "wap-knowledge-graph"
   - "wap-knowledge-graph/fixture"
@@ -23,7 +23,7 @@ tags:
 ```json
 {
   "kind": "runtime",
-  "status": "planned",
+  "status": "implemented",
   "assertion": "Commit input and selection variables before invoking any task.",
   "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
 }

--- a/docs/knowledge-graph/vault/work-items/WML-204.md
+++ b/docs/knowledge-graph/vault/work-items/WML-204.md
@@ -68,13 +68,15 @@ tags:
     "C5-05"
   ],
   "outputs": [
-    "Complete field/control syntax and attribute validation"
+    "Complete field/control syntax and attribute validation",
+    "Source-derived select initialization, selection, serialization, and onpick runtime evidence"
   ],
   "acceptance": [
     "Input/select/option/optgroup/fieldset constraints, masks, defaults, and validation failures are deterministic."
   ],
   "evidence": [
-    "cargo test --manifest-path engine-wasm/engine/Cargo.toml"
+    "cargo test --manifest-path engine-wasm/engine/Cargo.toml",
+    "pnpm test:story WML-204"
   ],
   "source": "docs/waves/wap-1.2.1-compliance-program.json"
 }

--- a/docs/waves/wap-1.2.1-compliance-program.json
+++ b/docs/waves/wap-1.2.1-compliance-program.json
@@ -434,13 +434,15 @@
           "sourceFamilies": ["wml"],
           "existingTickets": ["R0-04", "B5-01", "C5-05"],
           "outputs": [
-            "Complete field/control syntax and attribute validation"
+            "Complete field/control syntax and attribute validation",
+            "Source-derived select initialization, selection, serialization, and onpick runtime evidence"
           ],
           "acceptance": [
             "Input/select/option/optgroup/fieldset constraints, masks, defaults, and validation failures are deterministic."
           ],
           "evidence": [
-            "cargo test --manifest-path engine-wasm/engine/Cargo.toml"
+            "cargo test --manifest-path engine-wasm/engine/Cargo.toml",
+            "pnpm test:story WML-204"
           ]
         },
         {

--- a/engine-wasm/engine/src/engine_public_api.rs
+++ b/engine-wasm/engine/src/engine_public_api.rs
@@ -99,7 +99,7 @@ impl WmlEngine {
         self.clear_trace_entries();
         self.active_timer = None;
         self.push_trace("LOAD_DECK", format!("contentType={content_type}"));
-        self.initialize_inputs_on_active_card()?;
+        self.initialize_controls_on_active_card()?;
         self.start_or_resume_timer_for_active_card(false)?;
         Ok(())
     }

--- a/engine-wasm/engine/src/engine_runtime_internal.rs
+++ b/engine-wasm/engine/src/engine_runtime_internal.rs
@@ -269,9 +269,9 @@ impl WmlEngine {
         Ok(true)
     }
 
-    pub(crate) fn initialize_inputs_on_active_card(&mut self) -> Result<(), String> {
-        let card = self
-            .deck
+    pub(crate) fn initialize_controls_on_active_card(&mut self) -> Result<(), String> {
+        let (deck, vars) = (&mut self.deck, &mut self.vars);
+        let card = deck
             .as_mut()
             .and_then(|deck| deck.cards.get_mut(self.active_card_idx))
             .ok_or_else(|| "Active card not found".to_string())?;
@@ -281,38 +281,66 @@ impl WmlEngine {
                 continue;
             };
             for item in items {
-                let runtime::node::InlineNode::Input {
-                    name,
-                    value,
-                    default_value,
-                    mask,
-                    empty_ok,
-                    ..
-                } = item
-                else {
-                    continue;
-                };
+                match item {
+                    runtime::node::InlineNode::Input {
+                        name,
+                        value,
+                        default_value,
+                        mask,
+                        empty_ok,
+                        ..
+                    } => {
+                        let valid_existing = vars
+                            .get(name)
+                            .cloned()
+                            .filter(|candidate| input_value_is_valid(mask, *empty_ok, candidate));
+                        let initial_value = if let Some(existing) = valid_existing {
+                            Some(existing)
+                        } else {
+                            vars.remove(name);
+                            default_value.clone().filter(|candidate| {
+                                input_value_is_valid(mask, *empty_ok, candidate)
+                            })
+                        };
 
-                let valid_existing = self
-                    .vars
-                    .get(name)
-                    .cloned()
-                    .filter(|candidate| input_value_is_valid(mask, *empty_ok, candidate));
-                let initial_value = if let Some(existing) = valid_existing {
-                    Some(existing)
-                } else {
-                    self.vars.remove(name);
-                    default_value
-                        .clone()
-                        .filter(|candidate| input_value_is_valid(mask, *empty_ok, candidate))
-                };
-
-                if let Some(initial_value) = initial_value {
-                    self.vars.insert(name.clone(), initial_value.clone());
-                    *value = initial_value;
-                } else {
-                    self.vars.remove(name);
-                    value.clear();
+                        if let Some(initial_value) = initial_value {
+                            vars.insert(name.clone(), initial_value.clone());
+                            *value = initial_value;
+                        } else {
+                            vars.remove(name);
+                            value.clear();
+                        }
+                    }
+                    runtime::node::InlineNode::Select {
+                        name,
+                        iname,
+                        default_value,
+                        default_index_value,
+                        multiple,
+                        options,
+                        selected_indices,
+                        ..
+                    } => {
+                        *selected_indices = initial_select_indices(
+                            name.as_deref(),
+                            iname.as_deref(),
+                            default_value.as_deref(),
+                            default_index_value.as_deref(),
+                            *multiple,
+                            options,
+                            vars,
+                        );
+                        sync_select_variables(
+                            vars,
+                            name.as_deref(),
+                            iname.as_deref(),
+                            *multiple,
+                            options,
+                            selected_indices,
+                        );
+                    }
+                    runtime::node::InlineNode::Text(_) | runtime::node::InlineNode::Link { .. } => {
+                    }
                 }
             }
         }
@@ -329,7 +357,6 @@ impl WmlEngine {
         self.active_input_edit = None;
         self.active_select_edit = Some(SelectEditState {
             select_name: select_name.clone(),
-            original_index: current_index,
             draft_index: current_index,
         });
         self.push_trace("SELECT_EDIT_START", select_name);
@@ -340,16 +367,37 @@ impl WmlEngine {
         let Some(edit) = self.active_select_edit.clone() else {
             return Ok(false);
         };
+        let Some((multiple, mut selected_indices, onpick)) =
+            self.select_state_on_active_card(&edit.select_name, edit.draft_index)
+        else {
+            return Ok(false);
+        };
+        if multiple {
+            if let Some(position) = selected_indices
+                .iter()
+                .position(|index| *index == edit.draft_index)
+            {
+                selected_indices.remove(position);
+            } else {
+                selected_indices.push(edit.draft_index);
+            }
+        } else {
+            selected_indices.clear();
+            selected_indices.push(edit.draft_index);
+        }
         let committed =
-            self.set_select_selected_index_on_active_card(&edit.select_name, edit.draft_index)?;
+            self.set_select_selected_indices_on_active_card(&edit.select_name, &selected_indices)?;
         if !committed {
             return Ok(false);
         }
-        if let Some(value) = self.select_value_on_active_card(&edit.select_name, edit.draft_index) {
-            self.set_var(edit.select_name.clone(), value);
-        }
+        self.sync_select_variables_on_active_card(&edit.select_name)?;
         self.active_select_edit = None;
-        self.push_trace("SELECT_EDIT_COMMIT", edit.select_name);
+        self.push_trace("SELECT_EDIT_COMMIT", edit.select_name.clone());
+        if let Some(onpick) = onpick {
+            let onpick = evaluate_vdata(&onpick, &self.vars);
+            self.push_trace("ACTION_ONPICK", onpick.clone());
+            self.execute_action_href(&onpick, None, &[])?;
+        }
         Ok(true)
     }
 
@@ -462,13 +510,13 @@ impl WmlEngine {
             };
             for item in items {
                 if let runtime::node::InlineNode::Select {
-                    name,
-                    selected_index,
+                    control_id,
+                    selected_indices,
                     ..
                 } = item
                 {
-                    if name == select_name {
-                        return Some(*selected_index);
+                    if control_id == select_name {
+                        return Some(selected_indices.first().copied().unwrap_or(0));
                     }
                 }
             }
@@ -483,8 +531,13 @@ impl WmlEngine {
                 continue;
             };
             for item in items {
-                if let runtime::node::InlineNode::Select { name, options, .. } = item {
-                    if name == select_name {
+                if let runtime::node::InlineNode::Select {
+                    control_id,
+                    options,
+                    ..
+                } = item
+                {
+                    if control_id == select_name {
                         return Some(options.len());
                     }
                 }
@@ -504,12 +557,16 @@ impl WmlEngine {
                 continue;
             };
             for item in items {
-                if let runtime::node::InlineNode::Select { name, options, .. } = item {
-                    if name == select_name {
+                if let runtime::node::InlineNode::Select {
+                    control_id,
+                    options,
+                    ..
+                } = item
+                {
+                    if control_id == select_name {
                         return options
                             .get(selected_index)
-                            .or_else(|| options.first())
-                            .map(|option| option.value.clone());
+                            .map(|option| evaluate_vdata(&option.value, &self.vars));
                     }
                 }
             }
@@ -517,10 +574,10 @@ impl WmlEngine {
         None
     }
 
-    pub(crate) fn set_select_selected_index_on_active_card(
+    pub(crate) fn set_select_selected_indices_on_active_card(
         &mut self,
         select_name: &str,
-        selected_index: usize,
+        selected_indices: &[usize],
     ) -> Result<bool, String> {
         let card = self.active_card_internal_mut()?;
         let mut updated = false;
@@ -530,14 +587,16 @@ impl WmlEngine {
             };
             for item in items {
                 if let runtime::node::InlineNode::Select {
-                    name,
+                    control_id,
                     options,
-                    selected_index: current_index,
+                    selected_indices: current_indices,
                     ..
                 } = item
                 {
-                    if name == select_name && selected_index < options.len() {
-                        *current_index = selected_index;
+                    if control_id == select_name
+                        && selected_indices.iter().all(|index| *index < options.len())
+                    {
+                        *current_indices = selected_indices.to_vec();
                         updated = true;
                         break;
                     }
@@ -562,19 +621,125 @@ impl WmlEngine {
             };
             for item in items {
                 if let runtime::node::InlineNode::Select {
-                    name,
+                    control_id,
                     options,
-                    selected_index: current_index,
+                    multiple,
+                    selected_indices,
                     ..
                 } = item
                 {
-                    if name == select_name && selected_index < options.len() {
-                        *current_index = selected_index;
+                    if control_id == select_name && !*multiple && selected_index < options.len() {
+                        selected_indices.clear();
+                        selected_indices.push(selected_index);
                         return;
                     }
                 }
             }
         }
+    }
+
+    fn select_state_on_active_card(
+        &self,
+        select_name: &str,
+        selected_index: usize,
+    ) -> Option<(bool, Vec<usize>, Option<String>)> {
+        let card = self.active_card_internal().ok()?;
+        for node in &card.nodes {
+            let runtime::node::Node::Paragraph(items) = node else {
+                continue;
+            };
+            for item in items {
+                if let runtime::node::InlineNode::Select {
+                    control_id,
+                    multiple,
+                    options,
+                    selected_indices,
+                    ..
+                } = item
+                {
+                    if control_id == select_name {
+                        let option = options.get(selected_index)?;
+                        return Some((*multiple, selected_indices.clone(), option.onpick.clone()));
+                    }
+                }
+            }
+        }
+        None
+    }
+
+    pub(crate) fn sync_select_variables_on_active_card(
+        &mut self,
+        select_name: &str,
+    ) -> Result<(), String> {
+        let (deck, vars) = (&self.deck, &mut self.vars);
+        let card = deck
+            .as_ref()
+            .and_then(|deck| deck.cards.get(self.active_card_idx))
+            .ok_or_else(|| "Active card not found".to_string())?;
+        for node in &card.nodes {
+            let runtime::node::Node::Paragraph(items) = node else {
+                continue;
+            };
+            for item in items {
+                if let runtime::node::InlineNode::Select {
+                    control_id,
+                    name,
+                    iname,
+                    multiple,
+                    options,
+                    selected_indices,
+                    ..
+                } = item
+                {
+                    if control_id == select_name {
+                        sync_select_variables(
+                            vars,
+                            name.as_deref(),
+                            iname.as_deref(),
+                            *multiple,
+                            options,
+                            selected_indices,
+                        );
+                        return Ok(());
+                    }
+                }
+            }
+        }
+        Err(format!("Select '{select_name}' not found"))
+    }
+
+    pub(crate) fn sync_all_select_variables_on_active_card(&mut self) -> Result<(), String> {
+        let (deck, vars) = (&self.deck, &mut self.vars);
+        let card = deck
+            .as_ref()
+            .and_then(|deck| deck.cards.get(self.active_card_idx))
+            .ok_or_else(|| "Active card not found".to_string())?;
+        for node in &card.nodes {
+            let runtime::node::Node::Paragraph(items) = node else {
+                continue;
+            };
+            for item in items {
+                if let runtime::node::InlineNode::Select {
+                    name,
+                    iname,
+                    multiple,
+                    options,
+                    selected_indices,
+                    ..
+                } = item
+                {
+                    sync_select_variables(
+                        vars,
+                        name.as_deref(),
+                        iname.as_deref(),
+                        *multiple,
+                        options,
+                        selected_indices,
+                    );
+                }
+            }
+        }
+        Ok(())
     }
 
     pub(crate) fn input_max_len_on_active_card(&self, input_name: &str) -> Option<usize> {
@@ -634,4 +799,184 @@ fn input_value_is_valid(
     } else {
         mask.accepts(value)
     }
+}
+
+fn initial_select_indices(
+    name: Option<&str>,
+    iname: Option<&str>,
+    default_value: Option<&str>,
+    default_index_value: Option<&str>,
+    multiple: bool,
+    options: &[runtime::node::SelectOption],
+    vars: &HashMap<String, String>,
+) -> Vec<usize> {
+    let mut indices = iname
+        .and_then(|variable| vars.get(variable))
+        .map(|value| validate_select_indices(value, multiple, options.len()))
+        .unwrap_or_default();
+    if indices.is_empty() {
+        indices = default_index_value
+            .map(|value| evaluate_vdata(value, vars))
+            .map(|value| validate_select_indices(&value, multiple, options.len()))
+            .unwrap_or_default();
+    }
+    if indices.is_empty() {
+        indices = name
+            .and_then(|variable| vars.get(variable))
+            .map(|value| select_indices_for_values(value, multiple, options, vars))
+            .unwrap_or_default();
+    }
+    if indices.is_empty() {
+        indices = default_value
+            .map(|value| evaluate_vdata(value, vars))
+            .map(|value| select_indices_for_values(&value, multiple, options, vars))
+            .unwrap_or_default();
+    }
+    if indices.is_empty() && !multiple && !options.is_empty() {
+        indices.push(0);
+    }
+    indices
+}
+
+fn validate_select_indices(raw: &str, multiple: bool, option_count: usize) -> Vec<usize> {
+    let candidates = if multiple {
+        raw.split(';').collect::<Vec<_>>()
+    } else {
+        vec![raw]
+    };
+    let mut indices = Vec::new();
+    for candidate in candidates {
+        let candidate = candidate.trim();
+        if candidate.is_empty() || !candidate.bytes().all(|byte| byte.is_ascii_digit()) {
+            continue;
+        }
+        let Ok(index) = candidate.parse::<usize>() else {
+            continue;
+        };
+        if index == 0 || index > option_count {
+            continue;
+        }
+        let zero_based = index - 1;
+        if !indices.contains(&zero_based) {
+            indices.push(zero_based);
+        }
+    }
+    indices
+}
+
+fn select_indices_for_values(
+    raw: &str,
+    multiple: bool,
+    options: &[runtime::node::SelectOption],
+    vars: &HashMap<String, String>,
+) -> Vec<usize> {
+    let values = if multiple {
+        raw.split(';').collect::<Vec<_>>()
+    } else {
+        vec![raw]
+    };
+    let mut indices = Vec::new();
+    for value in values {
+        if let Some(index) = options
+            .iter()
+            .position(|option| evaluate_vdata(&option.value, vars) == value)
+        {
+            if !indices.contains(&index) {
+                indices.push(index);
+            }
+        }
+    }
+    indices
+}
+
+fn sync_select_variables(
+    vars: &mut HashMap<String, String>,
+    name: Option<&str>,
+    iname: Option<&str>,
+    multiple: bool,
+    options: &[runtime::node::SelectOption],
+    selected_indices: &[usize],
+) {
+    if let Some(name) = name {
+        let values = selected_indices
+            .iter()
+            .filter_map(|index| options.get(*index))
+            .map(|option| evaluate_vdata(&option.value, vars))
+            .filter(|value| !value.is_empty())
+            .collect::<Vec<_>>();
+        if values.is_empty() {
+            vars.remove(name);
+        } else {
+            vars.insert(
+                name.to_string(),
+                values.join(if multiple { ";" } else { "" }),
+            );
+        }
+    }
+    if let Some(iname) = iname {
+        let serialized = if selected_indices.is_empty() {
+            "0".to_string()
+        } else {
+            selected_indices
+                .iter()
+                .map(|index| (index + 1).to_string())
+                .collect::<Vec<_>>()
+                .join(if multiple { ";" } else { "" })
+        };
+        vars.insert(iname.to_string(), serialized);
+    }
+}
+
+fn evaluate_vdata(raw: &str, vars: &HashMap<String, String>) -> String {
+    let mut out = String::new();
+    let chars = raw.char_indices().collect::<Vec<_>>();
+    let mut cursor = 0usize;
+    while cursor < chars.len() {
+        let (byte_index, ch) = chars[cursor];
+        if ch != '$' {
+            out.push(ch);
+            cursor += 1;
+            continue;
+        }
+        if chars.get(cursor + 1).is_some_and(|(_, next)| *next == '$') {
+            out.push('$');
+            cursor += 2;
+            continue;
+        }
+        if chars.get(cursor + 1).is_some_and(|(_, next)| *next == '(') {
+            let Some(close_offset) = raw[byte_index + 2..].find(')') else {
+                out.push('$');
+                cursor += 1;
+                continue;
+            };
+            let close = byte_index + 2 + close_offset;
+            let variable = raw[byte_index + 2..close]
+                .split(':')
+                .next()
+                .unwrap_or_default();
+            out.push_str(vars.get(variable).map(String::as_str).unwrap_or_default());
+            cursor = chars
+                .iter()
+                .position(|(index, _)| *index > close)
+                .unwrap_or(chars.len());
+            continue;
+        }
+        let variable_start = byte_index + 1;
+        let variable_end = raw[variable_start..]
+            .find(|ch: char| !(ch == '_' || ch.is_ascii_alphanumeric()))
+            .map(|offset| variable_start + offset)
+            .unwrap_or(raw.len());
+        if variable_end == variable_start {
+            out.push('$');
+            cursor += 1;
+            continue;
+        }
+        let variable = &raw[variable_start..variable_end];
+        out.push_str(vars.get(variable).map(String::as_str).unwrap_or_default());
+        cursor = chars
+            .iter()
+            .position(|(index, _)| *index >= variable_end)
+            .unwrap_or(chars.len());
+    }
+    out
 }

--- a/engine-wasm/engine/src/engine_runtime_internal/navigation.rs
+++ b/engine-wasm/engine/src/engine_runtime_internal/navigation.rs
@@ -43,7 +43,7 @@ impl WmlEngine {
         self.nav_stack.push(self.active_card_idx);
         self.active_card_idx = next_idx;
         self.focused_link_idx = 0;
-        if let Err(err) = self.initialize_inputs_on_active_card() {
+        if let Err(err) = self.initialize_controls_on_active_card() {
             self.active_card_idx = previous_idx;
             self.focused_link_idx = previous_focus;
             self.nav_stack.truncate(previous_stack_len);
@@ -101,7 +101,7 @@ impl WmlEngine {
         self.active_card_idx = back_target_idx;
         self.focused_link_idx = 0;
         self.push_trace("ACTION_BACK", String::new());
-        if let Err(err) = self.initialize_inputs_on_active_card() {
+        if let Err(err) = self.initialize_controls_on_active_card() {
             self.push_trace("INPUT_INIT_ERROR", err);
             self.active_card_idx = rollback_active_idx;
             self.focused_link_idx = rollback_focus;
@@ -153,6 +153,7 @@ impl WmlEngine {
         if self.active_select_edit.is_some() {
             self.commit_focused_select_edit_internal()?;
         }
+        self.sync_all_select_variables_on_active_card()?;
 
         match action {
             CardTaskAction::Go {
@@ -167,7 +168,7 @@ impl WmlEngine {
             }
             CardTaskAction::Refresh => {
                 self.push_trace("ACTION_REFRESH", String::new());
-                self.initialize_inputs_on_active_card()?;
+                self.initialize_controls_on_active_card()?;
                 self.start_or_resume_timer_for_active_card(true)?;
                 Ok(())
             }
@@ -184,6 +185,14 @@ impl WmlEngine {
         method: Option<&str>,
         post_fields: &[CardPostField],
     ) -> Result<(), String> {
+        if self.active_input_edit.is_some() {
+            self.commit_focused_input_edit_internal()?;
+        }
+        if self.active_select_edit.is_some() {
+            self.commit_focused_select_edit_internal()?;
+        }
+        self.sync_all_select_variables_on_active_card()?;
+
         if let Some(script_ref) = parse_script_href(href) {
             let function_name = script_ref.function_name.unwrap_or("main");
             self.push_trace(

--- a/engine-wasm/engine/src/engine_tests/mod.rs
+++ b/engine-wasm/engine/src/engine_tests/mod.rs
@@ -93,4 +93,5 @@ mod actions_timers;
 mod navigation_metadata;
 mod panic_containment;
 mod script_runtime;
+mod select_semantics;
 mod traces_public_api;

--- a/engine-wasm/engine/src/engine_tests/navigation_metadata.rs
+++ b/engine-wasm/engine/src/engine_tests/navigation_metadata.rs
@@ -673,7 +673,10 @@ fn focused_select_edit_cancel_keeps_original_value() {
     );
     assert!(engine.cancel_focused_select_edit());
     assert_eq!(engine.focused_select_edit_name(), None);
-    assert_eq!(engine.get_var("Country".to_string()), None);
+    assert_eq!(
+        engine.get_var("Country".to_string()),
+        Some("Jordan".to_string())
+    );
     let lines = render_snapshot_lines(&engine);
     assert!(lines
         .iter()

--- a/engine-wasm/engine/src/engine_tests/select_semantics.rs
+++ b/engine-wasm/engine/src/engine_tests/select_semantics.rs
@@ -1,0 +1,344 @@
+use super::*;
+
+#[test]
+fn wml_fx_select_init_order_precedence_validation_and_serialization() {
+    // WML-CL-SELECT-INIT-ORDER, WML-CL-SELECT-DEFAULT-PRECEDENCE,
+    // WML-CL-SELECT-INDEX-VALIDATION, WML-CL-SELECT-VARIABLE-INITIALIZATION,
+    // WML-CL-SELECT-PRESELECTION, and WML-CL-SELECT-MULTI-SERIALIZATION.
+    // WAP-191_104-WML section 11.6.2.1.
+    let mut engine = WmlEngine::new();
+    let xml = r#"
+        <wml>
+          <card id="start">
+            <p>Start</p>
+          </card>
+          <card id="controls">
+            <input name="default-index" value="3;2"/>
+            <select
+              name="choices"
+              iname="choice-indexes"
+              value="fallback"
+              ivalue="$(default-index)"
+              multiple="true"
+              title="Choices"
+            >
+              <option value="alpha">Alpha</option>
+              <option value="beta">Beta</option>
+              <option value="gamma">Gamma</option>
+            </select>
+            <select
+              name="ordered-choices"
+              iname="ordered-indexes"
+              ivalue="$(default-index)"
+              multiple="true"
+            >
+              <option value="alpha">Alpha</option>
+              <option value="beta">Beta</option>
+              <option value="gamma">Gamma</option>
+            </select>
+          </card>
+        </wml>
+        "#;
+
+    engine.load_deck(xml).expect("deck should load");
+    assert!(engine.set_var("choice-indexes".to_string(), "bad;2;2;8;1".to_string()));
+    assert!(engine.set_var("choices".to_string(), "gamma".to_string()));
+    engine
+        .navigate_to_card("controls".to_string())
+        .expect("controls should initialize");
+
+    assert_eq!(
+        engine.get_var("choice-indexes".to_string()),
+        Some("2;1".to_string())
+    );
+    assert_eq!(
+        engine.get_var("choices".to_string()),
+        Some("beta;alpha".to_string())
+    );
+    assert_eq!(
+        engine.get_var("ordered-indexes".to_string()),
+        Some("3;2".to_string())
+    );
+    assert_eq!(
+        engine.get_var("ordered-choices".to_string()),
+        Some("gamma;beta".to_string())
+    );
+
+    engine.set_viewport_cols(80);
+    let lines = render_snapshot_lines(&engine);
+    assert!(lines
+        .iter()
+        .any(|line| line.contains("href=select:choices:text=[Choices: Beta; Alpha]")));
+}
+
+#[test]
+fn wml_fx_select_value_and_ivalue_references_are_evaluated_before_assignment() {
+    // WML-CL-OPTION-VALUE-EVALUATION and WML-CL-SELECT-DEFAULT-PRECEDENCE,
+    // WAP-191_104-WML sections 11.6.2.1-11.6.2.2.
+    let mut engine = WmlEngine::new();
+    let xml = r#"
+        <wml>
+          <card id="start"><p>Start</p></card>
+          <card id="controls">
+            <select
+              name="values"
+              iname="indexes"
+              ivalue="$(initial-indexes)"
+              multiple="true"
+            >
+              <option value="$(shared-value)">First</option>
+              <option value="$(shared-value)">Second</option>
+              <option value="">Empty</option>
+            </select>
+          </card>
+        </wml>
+        "#;
+
+    engine.load_deck(xml).expect("deck should load");
+    assert!(engine.set_var("initial-indexes".to_string(), "1;2;3".to_string()));
+    assert!(engine.set_var("shared-value".to_string(), "duplicate".to_string()));
+    engine
+        .navigate_to_card("controls".to_string())
+        .expect("controls should initialize");
+
+    assert_eq!(
+        engine.get_var("indexes".to_string()),
+        Some("1;2;3".to_string())
+    );
+    assert_eq!(
+        engine.get_var("values".to_string()),
+        Some("duplicate;duplicate".to_string())
+    );
+}
+
+#[test]
+fn wml_fx_select_default_precedence_covers_every_source_and_fallback() {
+    // WML-CL-SELECT-DEFAULT-PRECEDENCE and WML-CL-SELECT-INDEX-VALIDATION,
+    // WAP-191_104-WML section 11.6.2.1 step 1.
+    let mut engine = WmlEngine::new();
+    let xml = r#"
+        <wml>
+          <card id="start"><p>Start</p></card>
+          <card id="controls">
+            <input name="default-value" value="beta"/>
+            <select name="from-iname" iname="index-a" ivalue="2" value="alpha">
+              <option value="alpha">Alpha</option>
+              <option value="beta">Beta</option>
+              <option value="gamma">Gamma</option>
+            </select>
+            <select name="from-ivalue" iname="index-b" ivalue="2" value="alpha">
+              <option value="alpha">Alpha</option>
+              <option value="beta">Beta</option>
+            </select>
+            <select name="from-name" value="alpha">
+              <option value="alpha">Alpha</option>
+              <option value="gamma">Gamma</option>
+            </select>
+            <select name="from-value" value="$(default-value)">
+              <option value="alpha">Alpha</option>
+              <option value="beta">Beta</option>
+            </select>
+            <select name="single-fallback">
+              <option value="alpha">Alpha</option>
+              <option value="beta">Beta</option>
+            </select>
+            <select name="multi-fallback" iname="multi-index" multiple="true">
+              <option value="alpha">Alpha</option>
+              <option value="beta">Beta</option>
+            </select>
+          </card>
+        </wml>
+        "#;
+
+    engine.load_deck(xml).expect("deck should load");
+    assert!(engine.set_var("index-a".to_string(), "3".to_string()));
+    assert!(engine.set_var("from-iname".to_string(), "alpha".to_string()));
+    assert!(engine.set_var("index-b".to_string(), "1;2".to_string()));
+    assert!(engine.set_var("from-ivalue".to_string(), "alpha".to_string()));
+    assert!(engine.set_var("from-name".to_string(), "gamma".to_string()));
+    engine
+        .navigate_to_card("controls".to_string())
+        .expect("controls should initialize");
+
+    assert_eq!(
+        engine.get_var("from-iname".to_string()),
+        Some("gamma".to_string())
+    );
+    assert_eq!(engine.get_var("index-a".to_string()), Some("3".to_string()));
+    assert_eq!(
+        engine.get_var("from-ivalue".to_string()),
+        Some("beta".to_string())
+    );
+    assert_eq!(engine.get_var("index-b".to_string()), Some("2".to_string()));
+    assert_eq!(
+        engine.get_var("from-name".to_string()),
+        Some("gamma".to_string())
+    );
+    assert_eq!(
+        engine.get_var("from-value".to_string()),
+        Some("beta".to_string())
+    );
+    assert_eq!(
+        engine.get_var("single-fallback".to_string()),
+        Some("alpha".to_string())
+    );
+    assert_eq!(engine.get_var("multi-fallback".to_string()), None);
+    assert_eq!(
+        engine.get_var("multi-index".to_string()),
+        Some("0".to_string())
+    );
+}
+
+#[test]
+fn wml_fx_select_variables_are_resynchronized_before_link_task_execution() {
+    // WML-CL-SELECT-USER-UPDATE and WML-CL-VARIABLE-COMMIT-BEFORE-TASK,
+    // WAP-191_104-WML sections 10.3.4 and 11.6.2.1.
+    let mut engine = WmlEngine::new();
+    let xml = r#"
+        <wml>
+          <card id="controls">
+            <select name="choice" iname="choice-index">
+              <option value="alpha">Alpha</option>
+              <option value="beta">Beta</option>
+            </select>
+            <a href="/submit">Submit</a>
+          </card>
+        </wml>
+        "#;
+
+    engine.load_deck(xml).expect("deck should load");
+    assert!(engine.set_var("choice".to_string(), "tampered".to_string()));
+    assert!(engine.set_var("choice-index".to_string(), "99".to_string()));
+    engine
+        .handle_key("down".to_string())
+        .expect("focus should move to the task");
+    engine
+        .handle_key("enter".to_string())
+        .expect("link task should execute");
+
+    assert_eq!(
+        engine.get_var("choice".to_string()),
+        Some("alpha".to_string())
+    );
+    assert_eq!(
+        engine.get_var("choice-index".to_string()),
+        Some("1".to_string())
+    );
+    assert_eq!(
+        engine.external_navigation_intent(),
+        Some("/submit".to_string())
+    );
+}
+
+#[test]
+fn wml_fx_option_onpick_single_updates_state_before_only_selected_task() {
+    // WML-CL-SELECT-USER-UPDATE and WML-CL-OPTION-ONPICK-SINGLE,
+    // WAP-191_104-WML sections 11.6.2.1-11.6.2.2.
+    let mut engine = WmlEngine::new();
+    let xml = r##"
+        <wml>
+          <card id="controls">
+            <select name="choice" iname="choice-index" ivalue="1">
+              <option value="alpha" onpick="#wrong">Alpha</option>
+              <option value="beta" onpick="#picked">Beta</option>
+            </select>
+          </card>
+          <card id="wrong"><p>Wrong</p></card>
+          <card id="picked"><p>Picked</p></card>
+        </wml>
+        "##;
+
+    engine.load_deck(xml).expect("deck should load");
+    engine
+        .begin_focused_select_edit()
+        .expect("select edit should begin");
+    assert!(engine.move_focused_select_edit(1));
+    engine
+        .commit_focused_select_edit()
+        .expect("select commit and onpick should succeed");
+
+    assert_eq!(engine.active_card_id().expect("active card"), "picked");
+    assert_eq!(
+        engine.get_var("choice".to_string()),
+        Some("beta".to_string())
+    );
+    assert_eq!(
+        engine.get_var("choice-index".to_string()),
+        Some("2".to_string())
+    );
+}
+
+#[test]
+fn wml_fx_option_onpick_multi_fires_for_deselection_after_state_update() {
+    // WML-CL-SELECT-SINGLE-MULTI-MODE, WML-CL-SELECT-USER-UPDATE, and
+    // WML-CL-OPTION-ONPICK-MULTI, WAP-191_104-WML sections 11.6.2.1-11.6.2.2.
+    let mut engine = WmlEngine::new();
+    let xml = r##"
+        <wml>
+          <card id="controls">
+            <select
+              name="choices"
+              iname="choice-indexes"
+              ivalue="1"
+              multiple="true"
+            >
+              <option value="alpha" onpick="#toggled">Alpha</option>
+              <option value="beta">Beta</option>
+            </select>
+          </card>
+          <card id="toggled"><p>Toggled</p></card>
+        </wml>
+        "##;
+
+    engine.load_deck(xml).expect("deck should load");
+    engine
+        .begin_focused_select_edit()
+        .expect("select edit should begin");
+    engine
+        .commit_focused_select_edit()
+        .expect("deselect and onpick should succeed");
+
+    assert_eq!(engine.active_card_id().expect("active card"), "toggled");
+    assert_eq!(engine.get_var("choices".to_string()), None);
+    assert_eq!(
+        engine.get_var("choice-indexes".to_string()),
+        Some("0".to_string())
+    );
+}
+
+#[test]
+fn wml_fx_option_onpick_failure_is_deterministic_after_committing_user_state() {
+    // WML-CL-SELECT-USER-UPDATE and WML-CL-OPTION-ONPICK-SINGLE.
+    let mut engine = WmlEngine::new();
+    let xml = r##"
+        <wml>
+          <card id="controls">
+            <select name="choice" iname="choice-index" ivalue="1">
+              <option value="alpha">Alpha</option>
+              <option value="beta" onpick="#missing">Beta</option>
+            </select>
+          </card>
+        </wml>
+        "##;
+
+    engine.load_deck(xml).expect("deck should load");
+    engine
+        .begin_focused_select_edit()
+        .expect("select edit should begin");
+    assert!(engine.move_focused_select_edit(1));
+    assert_eq!(
+        engine.commit_focused_select_edit(),
+        Err("Card id not found".to_string())
+    );
+
+    assert_eq!(engine.active_card_id().expect("active card"), "controls");
+    assert_eq!(engine.focused_select_edit_name(), None);
+    assert_eq!(
+        engine.get_var("choice".to_string()),
+        Some("beta".to_string())
+    );
+    assert_eq!(
+        engine.get_var("choice-index".to_string()),
+        Some("2".to_string())
+    );
+}

--- a/engine-wasm/engine/src/engine_wasm_bindings_tests.rs
+++ b/engine-wasm/engine/src/engine_wasm_bindings_tests.rs
@@ -299,3 +299,50 @@ fn wasm_wml_204_input_initialization_matches_native_state() {
         Some("1234".to_string())
     );
 }
+
+#[wasm_bindgen_test]
+fn wasm_wml_204_select_initialization_and_commit_match_native_state() {
+    let mut engine = WmlEngine::wasm_new();
+    engine
+        .load_deck_wasm(
+            r#"
+              <wml>
+                <card id="home">
+                  <select
+                    name="Choices"
+                    iname="ChoiceIndexes"
+                    ivalue="2;2;8;1"
+                    multiple="true"
+                  >
+                    <option value="alpha">Alpha</option>
+                    <option value="beta">Beta</option>
+                  </select>
+                </card>
+              </wml>
+            "#,
+        )
+        .expect("deck should load");
+
+    assert_eq!(
+        engine.get_var_wasm("Choices".to_string()),
+        Some("beta;alpha".to_string())
+    );
+    assert_eq!(
+        engine.get_var_wasm("ChoiceIndexes".to_string()),
+        Some("2;1".to_string())
+    );
+    assert!(engine
+        .begin_focused_select_edit_wasm()
+        .expect("select edit should begin"));
+    assert!(engine
+        .commit_focused_select_edit_wasm()
+        .expect("multiple selection should toggle"));
+    assert_eq!(
+        engine.get_var_wasm("Choices".to_string()),
+        Some("alpha".to_string())
+    );
+    assert_eq!(
+        engine.get_var_wasm("ChoiceIndexes".to_string()),
+        Some("1".to_string())
+    );
+}

--- a/engine-wasm/engine/src/layout/flow_layout.rs
+++ b/engine-wasm/engine/src/layout/flow_layout.rs
@@ -47,19 +47,28 @@ pub fn layout_card(card: &Card, viewport_cols: usize, focused_link_idx: usize) -
                             parts.push((rendered, Some(format!("input:{name}"))));
                         }
                         InlineNode::Select {
+                            control_id,
                             name,
+                            iname,
                             title,
                             options,
-                            selected_index,
+                            selected_indices,
+                            multiple,
+                            ..
                         } => {
-                            let selected = options
-                                .get(*selected_index)
-                                .or_else(|| options.first())
+                            let selected = selected_indices
+                                .iter()
+                                .filter_map(|index| options.get(*index))
                                 .map(|option| option.label.clone())
-                                .unwrap_or_default();
-                            let label = title.clone().unwrap_or_else(|| name.clone());
+                                .collect::<Vec<_>>()
+                                .join(if *multiple { "; " } else { "" });
+                            let label = title
+                                .clone()
+                                .or_else(|| name.clone())
+                                .or_else(|| iname.clone())
+                                .unwrap_or_else(|| control_id.clone());
                             let rendered = format!("[{label}: {selected}]");
-                            parts.push((rendered, Some(format!("select:{name}"))));
+                            parts.push((rendered, Some(format!("select:{control_id}"))));
                         }
                     }
                 }
@@ -292,19 +301,26 @@ mod tests {
                     empty_ok: true,
                 },
                 InlineNode::Select {
-                    name: "Country".to_string(),
+                    control_id: "Country".to_string(),
+                    name: Some("Country".to_string()),
+                    iname: None,
                     title: Some("Country".to_string()),
+                    default_value: None,
+                    default_index_value: None,
+                    multiple: false,
                     options: vec![
                         crate::runtime::node::SelectOption {
                             label: "Jordan".to_string(),
                             value: "Jordan".to_string(),
+                            onpick: None,
                         },
                         crate::runtime::node::SelectOption {
                             label: "France".to_string(),
                             value: "France".to_string(),
+                            onpick: None,
                         },
                     ],
-                    selected_index: 1,
+                    selected_indices: vec![1],
                 },
             ])],
             accept_action: None,

--- a/engine-wasm/engine/src/lib.rs
+++ b/engine-wasm/engine/src/lib.rs
@@ -130,7 +130,6 @@ struct InputEditState {
 #[derive(Clone, Debug, PartialEq, Eq)]
 struct SelectEditState {
     select_name: String,
-    original_index: usize,
     draft_index: usize,
 }
 

--- a/engine-wasm/engine/src/parser/wml_parser/nodes.rs
+++ b/engine-wasm/engine/src/parser/wml_parser/nodes.rs
@@ -11,7 +11,8 @@ pub(super) fn parse_card_nodes_xml(
     budget: &mut ParseBudget,
 ) -> Result<Vec<Node>, String> {
     let mut out = Vec::new();
-    map_card_level_nodes(&card.children, &mut out, budget, 0)?;
+    let mut select_ordinal = 0usize;
+    map_card_level_nodes(&card.children, &mut out, budget, 0, &mut select_ordinal)?;
     Ok(out)
 }
 
@@ -20,6 +21,7 @@ fn map_card_level_nodes(
     out: &mut Vec<Node>,
     budget: &mut ParseBudget,
     depth: usize,
+    select_ordinal: &mut usize,
 ) -> Result<(), String> {
     budget.enter_scope(depth, "card-node traversal")?;
     for node in nodes {
@@ -34,7 +36,8 @@ fn map_card_level_nodes(
             XmlNode::Element(element) => match element.name.as_str() {
                 "br" => out.push(Node::Break),
                 "p" => {
-                    let inline = map_inline_nodes(&element.children, budget, depth + 1)?;
+                    let inline =
+                        map_inline_nodes(&element.children, budget, depth + 1, select_ordinal)?;
                     if !inline.is_empty() {
                         out.push(Node::Paragraph(inline));
                     }
@@ -56,17 +59,36 @@ fn map_card_level_nodes(
                     out.push(Node::Paragraph(vec![input_node]));
                 }
                 "select" => {
-                    if let Some(select_node) = parse_select_inline_node(element, budget, depth + 1)?
+                    if let Some(select_node) =
+                        parse_select_inline_node(element, budget, depth + 1, select_ordinal)?
                     {
                         out.push(Node::Paragraph(vec![select_node]));
                     }
+                }
+                "fieldset" => {
+                    validate_fieldset_element(element)?;
+                    map_card_level_nodes(
+                        &element.children,
+                        out,
+                        budget,
+                        depth + 1,
+                        select_ordinal,
+                    )?;
                 }
                 "option" => {
                     return Err(
                         "Invalid <option>: must be contained by <select> or <optgroup>".to_string(),
                     )
                 }
-                _ => map_card_level_nodes(&element.children, out, budget, depth + 1)?,
+                "optgroup" => {
+                    return Err(
+                        "Invalid <optgroup>: must be contained by <select> or <optgroup>"
+                            .to_string(),
+                    )
+                }
+                _ => {
+                    map_card_level_nodes(&element.children, out, budget, depth + 1, select_ordinal)?
+                }
             },
         }
     }
@@ -77,10 +99,18 @@ fn map_inline_nodes(
     nodes: &[XmlNode],
     budget: &mut ParseBudget,
     depth: usize,
+    select_ordinal: &mut usize,
 ) -> Result<Vec<InlineNode>, String> {
     let mut out = Vec::new();
     let mut pending_text = String::new();
-    map_inline_nodes_recursive(nodes, &mut pending_text, &mut out, budget, depth)?;
+    map_inline_nodes_recursive(
+        nodes,
+        &mut pending_text,
+        &mut out,
+        budget,
+        depth,
+        select_ordinal,
+    )?;
     flush_pending_inline_text(&mut pending_text, &mut out);
     Ok(out)
 }
@@ -91,6 +121,7 @@ fn map_inline_nodes_recursive(
     out: &mut Vec<InlineNode>,
     budget: &mut ParseBudget,
     depth: usize,
+    select_ordinal: &mut usize,
 ) -> Result<(), String> {
     budget.enter_scope(depth, "inline-node traversal")?;
     for node in nodes {
@@ -123,14 +154,32 @@ fn map_inline_nodes_recursive(
                 }
                 "select" => {
                     flush_pending_inline_text(pending_text, out);
-                    if let Some(select_node) = parse_select_inline_node(element, budget, depth + 1)?
+                    if let Some(select_node) =
+                        parse_select_inline_node(element, budget, depth + 1, select_ordinal)?
                     {
                         out.push(select_node);
                     }
                 }
+                "fieldset" => {
+                    validate_fieldset_element(element)?;
+                    map_inline_nodes_recursive(
+                        &element.children,
+                        pending_text,
+                        out,
+                        budget,
+                        depth + 1,
+                        select_ordinal,
+                    )?;
+                }
                 "option" => {
                     return Err(
                         "Invalid <option>: must be contained by <select> or <optgroup>".to_string(),
+                    )
+                }
+                "optgroup" => {
+                    return Err(
+                        "Invalid <optgroup>: must be contained by <select> or <optgroup>"
+                            .to_string(),
                     )
                 }
                 _ => map_inline_nodes_recursive(
@@ -139,6 +188,7 @@ fn map_inline_nodes_recursive(
                     out,
                     budget,
                     depth + 1,
+                    select_ordinal,
                 )?,
             },
         }
@@ -232,6 +282,7 @@ fn parse_select_inline_node(
     element: &XmlElement,
     budget: &mut ParseBudget,
     depth: usize,
+    select_ordinal: &mut usize,
 ) -> Result<Option<InlineNode>, String> {
     validate_allowed_attributes(
         element,
@@ -257,65 +308,136 @@ fn parse_select_inline_node(
     };
 
     let mut options = Vec::new();
-    let mut choice_child_count = 0usize;
-
-    budget.enter_scope(depth, "select option traversal")?;
-    for child in &element.children {
-        budget.visit_node("select option traversal")?;
-        let option = match child {
-            XmlNode::Text(text) => {
-                if text.trim().is_empty() {
-                    continue;
-                }
-                return Err("Invalid <select>: text content is not allowed".to_string());
-            }
-            XmlNode::Element(child) if child.name == "optgroup" => {
-                // WML-C-40 is an optional feature. Accept its DTD-permitted
-                // presence without adding optgroup modeling in this mandatory
-                // input/select/option validation slice.
-                choice_child_count = choice_child_count.saturating_add(1);
-                continue;
-            }
-            XmlNode::Element(child) if child.name == "option" => child,
-            XmlNode::Element(child) => {
-                return Err(format!(
-                    "Invalid <select>: unexpected child <{}>",
-                    child.name
-                ))
-            }
-        };
-        choice_child_count = choice_child_count.saturating_add(1);
-        validate_option_element(option)?;
-
-        let label = normalize_text(&inline_text_content(&option.children, budget, depth + 1)?);
-        let value = {
-            let explicit = normalize_text(option.attr("value").unwrap_or_default());
-            if explicit.is_empty() {
-                label.clone()
-            } else {
-                explicit
-            }
-        };
-        options.push(SelectOption { label, value });
-    }
-
+    let choice_child_count =
+        collect_select_options(element, "select", &mut options, budget, depth)?;
     if choice_child_count == 0 {
         return Err(
             "Invalid <select>: expected one or more <option> or <optgroup> children".to_string(),
         );
     }
 
-    let name = normalize_text(element.attr("name").unwrap_or_default());
-    if name.is_empty() || options.is_empty() {
+    if options.is_empty() {
         return Ok(None);
     }
+    *select_ordinal = select_ordinal.saturating_add(1);
+    let name = element.attr("name").map(str::to_string);
+    let iname = element.attr("iname").map(str::to_string);
+    let control_id = name
+        .clone()
+        .or_else(|| iname.clone())
+        .unwrap_or_else(|| format!("select-{}", *select_ordinal));
 
     Ok(Some(InlineNode::Select {
+        control_id,
         name,
+        iname,
         title,
+        default_value: element.attr("value").map(str::to_string),
+        default_index_value: element.attr("ivalue").map(str::to_string),
+        multiple: element.attr("multiple") == Some("true"),
         options,
-        selected_index: 0,
+        selected_indices: Vec::new(),
     }))
+}
+
+fn collect_select_options(
+    element: &XmlElement,
+    container_name: &str,
+    options: &mut Vec<SelectOption>,
+    budget: &mut ParseBudget,
+    depth: usize,
+) -> Result<usize, String> {
+    budget.enter_scope(depth, "select option traversal")?;
+    let mut choice_child_count = 0usize;
+    for child in &element.children {
+        budget.visit_node("select option traversal")?;
+        match child {
+            XmlNode::Text(text) if text.trim().is_empty() => {}
+            XmlNode::Text(_) => {
+                return Err(format!(
+                    "Invalid <{container_name}>: text content is not allowed"
+                ))
+            }
+            XmlNode::Element(child) if child.name == "option" => {
+                choice_child_count = choice_child_count.saturating_add(1);
+                validate_option_element(child)?;
+                let label = normalize_text(
+                    &child
+                        .children
+                        .iter()
+                        .filter_map(|node| match node {
+                            XmlNode::Text(text) => Some(text.as_str()),
+                            XmlNode::Element(_) => None,
+                        })
+                        .collect::<String>(),
+                );
+                let value = child
+                    .attr("value")
+                    .map(normalize_text)
+                    .unwrap_or_else(|| label.clone());
+                options.push(SelectOption {
+                    label,
+                    value,
+                    onpick: child.attr("onpick").map(str::to_string),
+                });
+            }
+            XmlNode::Element(child) if child.name == "optgroup" => {
+                choice_child_count = choice_child_count.saturating_add(1);
+                validate_optgroup_element(child)?;
+                collect_select_options(child, "optgroup", options, budget, depth + 1)?;
+            }
+            XmlNode::Element(child) => {
+                return Err(format!(
+                    "Invalid <{container_name}>: unexpected child <{}>",
+                    child.name
+                ))
+            }
+        }
+    }
+    Ok(choice_child_count)
+}
+
+fn validate_optgroup_element(element: &XmlElement) -> Result<(), String> {
+    validate_allowed_attributes(element, &["class", "id", "title", "xml:lang"])?;
+    validate_optional_xml_name(element, "id")?;
+    validate_optional_nmtoken(element, "xml:lang")?;
+    for child in &element.children {
+        match child {
+            XmlNode::Text(text) if text.trim().is_empty() => {}
+            XmlNode::Text(_) => {
+                return Err("Invalid <optgroup>: text content is not allowed".to_string())
+            }
+            XmlNode::Element(child) if child.name == "option" || child.name == "optgroup" => {}
+            XmlNode::Element(child) => {
+                return Err(format!(
+                    "Invalid <optgroup>: unexpected child <{}>",
+                    child.name
+                ))
+            }
+        }
+    }
+    let choice_count = element
+        .children
+        .iter()
+        .filter(|child| {
+            matches!(
+                child,
+                XmlNode::Element(child) if child.name == "option" || child.name == "optgroup"
+            )
+        })
+        .count();
+    if choice_count == 0 {
+        return Err(
+            "Invalid <optgroup>: expected one or more <option> or <optgroup> children".to_string(),
+        );
+    }
+    Ok(())
+}
+
+fn validate_fieldset_element(element: &XmlElement) -> Result<(), String> {
+    validate_allowed_attributes(element, &["class", "id", "title", "xml:lang"])?;
+    validate_optional_xml_name(element, "id")?;
+    validate_optional_nmtoken(element, "xml:lang")
 }
 
 fn validate_option_element(element: &XmlElement) -> Result<(), String> {

--- a/engine-wasm/engine/src/parser/wml_parser/tests.rs
+++ b/engine-wasm/engine/src/parser/wml_parser/tests.rs
@@ -380,7 +380,7 @@ fn wml_fx_select_structure_accepts_declared_control_grammar() {
             if matches!(
                 &items[0],
                 InlineNode::Select { name, options, .. }
-                    if name == "choice"
+                    if name.as_deref() == Some("choice")
                         && options.len() == 1
                         && options[0].label.is_empty()
                         && options[0].value == "alpha"
@@ -428,6 +428,67 @@ fn wml_fx_select_structure_rejects_invalid_syntax_deterministically() {
         (
             r#"<option value="orphan">Orphan</option>"#,
             "Invalid <option>: must be contained by <select> or <optgroup>",
+        ),
+    ];
+
+    for (control, expected) in cases {
+        let xml = format!("<wml><card id=\"home\">{control}</card></wml>");
+        assert_eq!(parse_wml(&xml).expect_err(control), expected);
+    }
+}
+
+#[test]
+fn wml_fx_select_structure_flattens_nested_optgroups_in_document_order() {
+    // WML-CL-SELECT-STRUCTURE and the WML 1.3 DTD declarations for select,
+    // optgroup, option, and fieldset.
+    let xml = r#"
+        <wml>
+          <card id="home">
+            <fieldset title="Grouped choices" xml:lang="en" id="grouped" class="controls">
+              <select name="choice">
+                <optgroup title="Primary">
+                  <option value="alpha">Alpha</option>
+                  <optgroup title="Secondary">
+                    <option value="beta">Beta</option>
+                  </optgroup>
+                </optgroup>
+              </select>
+            </fieldset>
+          </card>
+        </wml>
+        "#;
+
+    let deck = parse_wml(xml).expect("nested declared control grammar should parse");
+    assert!(matches!(
+        &deck.cards[0].nodes[0],
+        Node::Paragraph(items)
+            if matches!(
+                &items[0],
+                InlineNode::Select { options, .. }
+                    if options.iter().map(|option| option.value.as_str()).collect::<Vec<_>>()
+                        == vec!["alpha", "beta"]
+            )
+    ));
+}
+
+#[test]
+fn wml_fx_grouped_control_structure_rejects_invalid_syntax_deterministically() {
+    let cases = [
+        (
+            r#"<select name="choice"><optgroup title="Empty"></optgroup></select>"#,
+            "Invalid <optgroup>: expected one or more <option> or <optgroup> children",
+        ),
+        (
+            r#"<select name="choice"><optgroup><p>wrong</p></optgroup></select>"#,
+            "Invalid <optgroup>: unexpected child <p>",
+        ),
+        (
+            r#"<fieldset title="Group" unexpected="true"><input name="value"/></fieldset>"#,
+            "Invalid <fieldset>: unexpected attribute 'unexpected'",
+        ),
+        (
+            r#"<optgroup><option>Orphan</option></optgroup>"#,
+            "Invalid <optgroup>: must be contained by <select> or <optgroup>",
         ),
     ];
 

--- a/engine-wasm/engine/src/runtime/node.rs
+++ b/engine-wasm/engine/src/runtime/node.rs
@@ -10,6 +10,7 @@ pub enum Node {
 pub struct SelectOption {
     pub label: String,
     pub value: String,
+    pub onpick: Option<String>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -29,9 +30,14 @@ pub enum InlineNode {
         empty_ok: bool,
     },
     Select {
-        name: String,
+        control_id: String,
+        name: Option<String>,
+        iname: Option<String>,
         title: Option<String>,
+        default_value: Option<String>,
+        default_index_value: Option<String>,
+        multiple: bool,
         options: Vec<SelectOption>,
-        selected_index: usize,
+        selected_indices: Vec<usize>,
     },
 }

--- a/engine-wasm/examples/generated/examples.ts
+++ b/engine-wasm/examples/generated/examples.ts
@@ -732,6 +732,100 @@ export const EXAMPLES: HostExample[] = [
     "wml": "<wml>\n  <card id=\"controls\" title=\"WML Controls\">\n    <p>\n      User:\n      <input\n        name=\"UserName\"\n        title=\"User name\"\n        type=\"text\"\n        value=\"AHMED\"\n        size=\"12\"\n        maxlength=\"24\"\n        tabindex=\"1\"\n        accesskey=\"1\"\n      />\n    </p>\n    <p>\n      PIN:\n      <input\n        name=\"Pin\"\n        title=\"Numeric PIN\"\n        type=\"password\"\n        value=\"1234\"\n        format=\"4N\"\n        emptyok=\"false\"\n        size=\"4\"\n        maxlength=\"4\"\n        tabindex=\"2\"\n        accesskey=\"2\"\n      />\n    </p>\n    <p>\n      Country:\n      <select\n        name=\"Country\"\n        title=\"Country\"\n        multiple=\"false\"\n        iname=\"CountryIndex\"\n        ivalue=\"1\"\n        tabindex=\"3\"\n      >\n        <option value=\"Jordan\" title=\"Jordan\">Jordan</option>\n        <option value=\"France\" title=\"France\">France</option>\n        <option value=\"Germany\" title=\"Germany\">Germany</option>\n      </select>\n    </p>\n  </card>\n</wml>\n"
   },
   {
+    "key": "wml204SelectSemantics",
+    "label": "WML 1.3 Select Semantics",
+    "description": "Source-derived single-select initialization and user-commit behavior with name and iname variables.",
+    "goal": "Verify that ivalue preselection initializes both result variables and that a committed user choice updates them deterministically.",
+    "workItems": [
+      "R0-04",
+      "C5-05",
+      "WML-204"
+    ],
+    "specItems": [
+      "WML-C-41",
+      "WML-C-43"
+    ],
+    "testingAc": [
+      "Load the example and confirm France is initially selected from ivalue 2.",
+      "Confirm nextCard is initialized to France and nextCardIndex is initialized to 2.",
+      "Begin select editing, move once to Germany, and confirm the draft does not change the committed variable.",
+      "Commit Germany and confirm nextCard becomes Germany and nextCardIndex becomes 3."
+    ],
+    "flows": [
+      {
+        "id": "initialization-and-user-commit",
+        "title": "Select initialization and committed user state stay deterministic",
+        "workItems": [
+          "R0-04",
+          "C5-05",
+          "WML-204"
+        ],
+        "specItems": [
+          "WML-C-41",
+          "WML-C-43"
+        ],
+        "initial": {
+          "state": {
+            "activeCardId": "select-semantics",
+            "focusedLinkIndex": 0,
+            "nextCardVar": "France",
+            "externalNavigationIntent": null
+          }
+        },
+        "steps": [
+          {
+            "action": {
+              "type": "key",
+              "key": "enter"
+            },
+            "expect": {
+              "state": {
+                "activeCardId": "select-semantics",
+                "focusedLinkIndex": 0,
+                "nextCardVar": "France"
+              },
+              "traceKinds": [
+                "SELECT_EDIT_START"
+              ]
+            }
+          },
+          {
+            "action": {
+              "type": "key",
+              "key": "down"
+            },
+            "expect": {
+              "state": {
+                "activeCardId": "select-semantics",
+                "focusedLinkIndex": 0,
+                "nextCardVar": "France"
+              }
+            }
+          },
+          {
+            "action": {
+              "type": "key",
+              "key": "enter"
+            },
+            "expect": {
+              "state": {
+                "activeCardId": "select-semantics",
+                "focusedLinkIndex": 0,
+                "nextCardVar": "Germany",
+                "externalNavigationIntent": null
+              },
+              "traceKinds": [
+                "SELECT_EDIT_START",
+                "SELECT_EDIT_COMMIT"
+              ]
+            }
+          }
+        ]
+      }
+    ],
+    "wml": "<wml>\n  <card id=\"select-semantics\" title=\"Select Semantics\">\n    <p>\n      Destination:\n      <select\n        name=\"nextCard\"\n        iname=\"nextCardIndex\"\n        ivalue=\"2\"\n        title=\"Destination\"\n      >\n        <option value=\"Jordan\">Jordan</option>\n        <option value=\"France\">France</option>\n        <option value=\"Germany\">Germany</option>\n      </select>\n    </p>\n  </card>\n</wml>\n"
+  },
+  {
     "key": "wmlbrowserContextFidelity",
     "label": "WMLBrowser Context Fidelity",
     "description": "Exercises getCurrentCard and newContext semantics, including context reset side effects and prev suppression.",

--- a/engine-wasm/examples/source/wml-204-select-semantics.flow.json
+++ b/engine-wasm/examples/source/wml-204-select-semantics.flow.json
@@ -1,0 +1,55 @@
+{
+  "version": 1,
+  "example": "wml204SelectSemantics",
+  "flows": [
+    {
+      "id": "initialization-and-user-commit",
+      "title": "Select initialization and committed user state stay deterministic",
+      "workItems": ["R0-04", "C5-05", "WML-204"],
+      "specItems": ["WML-C-41", "WML-C-43"],
+      "initial": {
+        "state": {
+          "activeCardId": "select-semantics",
+          "focusedLinkIndex": 0,
+          "nextCardVar": "France",
+          "externalNavigationIntent": null
+        }
+      },
+      "steps": [
+        {
+          "action": { "type": "key", "key": "enter" },
+          "expect": {
+            "state": {
+              "activeCardId": "select-semantics",
+              "focusedLinkIndex": 0,
+              "nextCardVar": "France"
+            },
+            "traceKinds": ["SELECT_EDIT_START"]
+          }
+        },
+        {
+          "action": { "type": "key", "key": "down" },
+          "expect": {
+            "state": {
+              "activeCardId": "select-semantics",
+              "focusedLinkIndex": 0,
+              "nextCardVar": "France"
+            }
+          }
+        },
+        {
+          "action": { "type": "key", "key": "enter" },
+          "expect": {
+            "state": {
+              "activeCardId": "select-semantics",
+              "focusedLinkIndex": 0,
+              "nextCardVar": "Germany",
+              "externalNavigationIntent": null
+            },
+            "traceKinds": ["SELECT_EDIT_START", "SELECT_EDIT_COMMIT"]
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/engine-wasm/examples/source/wml-204-select-semantics.wml
+++ b/engine-wasm/examples/source/wml-204-select-semantics.wml
@@ -1,0 +1,29 @@
+<!--
+label: WML 1.3 Select Semantics
+work-items: R0-04, C5-05, WML-204
+spec-items: WML-C-41, WML-C-43
+description: Source-derived single-select initialization and user-commit behavior with name and iname variables.
+goal: Verify that ivalue preselection initializes both result variables and that a committed user choice updates them deterministically.
+testing-ac:
+- Load the example and confirm France is initially selected from ivalue 2.
+- Confirm nextCard is initialized to France and nextCardIndex is initialized to 2.
+- Begin select editing, move once to Germany, and confirm the draft does not change the committed variable.
+- Commit Germany and confirm nextCard becomes Germany and nextCardIndex becomes 3.
+-->
+<wml>
+  <card id="select-semantics" title="Select Semantics">
+    <p>
+      Destination:
+      <select
+        name="nextCard"
+        iname="nextCardIndex"
+        ivalue="2"
+        title="Destination"
+      >
+        <option value="Jordan">Jordan</option>
+        <option value="France">France</option>
+        <option value="Germany">Germany</option>
+      </select>
+    </p>
+  </card>
+</wml>

--- a/scripts/check-wap-selected-normative-clauses.mjs
+++ b/scripts/check-wap-selected-normative-clauses.mjs
@@ -6,33 +6,16 @@ import path from 'node:path';
 import process from 'node:process';
 
 const root = process.cwd();
-const manifestDirectory = path.join(
-  root,
-  'spec-processing/source-manifests'
-);
-const ledgerPath = path.join(
-  manifestDirectory,
-  'wap-1.2.1-selected-normative-clauses.json'
-);
+const manifestDirectory = path.join(root, 'spec-processing/source-manifests');
+const ledgerPath = path.join(manifestDirectory, 'wap-1.2.1-selected-normative-clauses.json');
 const ledger = readJson(ledgerPath);
-const release = readJson(
-  path.join(manifestDirectory, 'wap-1.2.1-release.json')
-);
-const ingestion = readJson(
-  path.join(manifestDirectory, 'wap-1.2.1-ingestion-status.json')
-);
+const release = readJson(path.join(manifestDirectory, 'wap-1.2.1-release.json'));
+const ingestion = readJson(path.join(manifestDirectory, 'wap-1.2.1-ingestion-status.json'));
 const externalIngestion = readJson(
-  path.join(
-    manifestDirectory,
-    'wap-1.2.1-external-ingestion-status.json'
-  )
+  path.join(manifestDirectory, 'wap-1.2.1-external-ingestion-status.json')
 );
-const effectiveSpec = readJson(
-  path.join(manifestDirectory, 'wap-1.2.1-effective-spec.json')
-);
-const classConformance = readJson(
-  path.join(manifestDirectory, 'wap-1.2.1-class-conformance.json')
-);
+const effectiveSpec = readJson(path.join(manifestDirectory, 'wap-1.2.1-effective-spec.json'));
+const classConformance = readJson(path.join(manifestDirectory, 'wap-1.2.1-class-conformance.json'));
 
 function readJson(filename) {
   return JSON.parse(fs.readFileSync(filename, 'utf8'));
@@ -166,18 +149,25 @@ const allowedFixtureKinds = new Set([
   'rendering',
   'binary-decoder'
 ]);
+const implementedWmlClauseIds = new Set([
+  'WML-CL-VARIABLE-COMMIT-BEFORE-TASK',
+  'WML-CL-SELECT-STRUCTURE',
+  'WML-CL-SELECT-SINGLE-MULTI-MODE',
+  'WML-CL-SELECT-INIT-ORDER',
+  'WML-CL-SELECT-INDEX-VALIDATION',
+  'WML-CL-SELECT-DEFAULT-PRECEDENCE',
+  'WML-CL-SELECT-VARIABLE-INITIALIZATION',
+  'WML-CL-SELECT-PRESELECTION',
+  'WML-CL-SELECT-USER-UPDATE',
+  'WML-CL-SELECT-MULTI-SERIALIZATION',
+  'WML-CL-OPTION-ONPICK-MULTI',
+  'WML-CL-OPTION-ONPICK-SINGLE'
+]);
 const hashPattern = /^[a-f0-9]{64}$/;
-const releaseById = new Map(
-  release.members.map((member) => [member.documentId, member])
-);
-const ingestionById = new Map(
-  ingestion.members.map((member) => [member.documentId, member])
-);
+const releaseById = new Map(release.members.map((member) => [member.documentId, member]));
+const ingestionById = new Map(ingestion.members.map((member) => [member.documentId, member]));
 const externalIngestionById = new Map(
-  externalIngestion.dependencies.map((dependency) => [
-    dependency.dependencyId,
-    dependency
-  ])
+  externalIngestion.dependencies.map((dependency) => [dependency.dependencyId, dependency])
 );
 
 if (ledger.schemaVersion !== 1) {
@@ -187,8 +177,7 @@ if (ledger.releaseId !== release.release.id) {
   failures.push('selected-clause ledger release lock drift');
 }
 if (
-  ledger.target?.classProfile !==
-    'WAP-215 Class C client (CCR-CLASSC-C-001)' ||
+  ledger.target?.classProfile !== 'WAP-215 Class C client (CCR-CLASSC-C-001)' ||
   classConformance.selectedTarget?.identifier !== 'CCR-CLASSC-C-001'
 ) {
   failures.push('selected-clause ledger must target the WAP-215 Class C client');
@@ -202,19 +191,15 @@ if (
   failures.push('generator provenance or CONF-003 ownership is incomplete');
 }
 if (
-  !ledger.generatedFrom?.redistributionPolicy?.includes(
-    'full text extractions remain outside Git'
-  )
+  !ledger.generatedFrom?.redistributionPolicy?.includes('full text extractions remain outside Git')
 ) {
   failures.push('redistribution boundary is not explicit');
 }
 if (
   ledger.scope?.status !== 'complete' ||
   ledger.scope?.selectedProfileParentCount !== 201 ||
-  JSON.stringify(ledger.scope?.coveredFamilies) !==
-    JSON.stringify(coveredFamilies) ||
-  JSON.stringify(ledger.scope?.remainingFamilies) !==
-    JSON.stringify(remainingFamilies) ||
+  JSON.stringify(ledger.scope?.coveredFamilies) !== JSON.stringify(coveredFamilies) ||
+  JSON.stringify(ledger.scope?.remainingFamilies) !== JSON.stringify(remainingFamilies) ||
   ledger.scope?.coveredSelectedParentCount !== 201 ||
   ledger.scope?.remainingSelectedParentCount !== 0 ||
   !ledger.scope?.completionRule?.includes('CONF-003 is complete')
@@ -224,9 +209,7 @@ if (
 if (
   !ledger.interpretation?.normativeForce?.includes('implicit-MUST') ||
   !ledger.interpretation?.deduplication?.includes('multiple selected SCR') ||
-  !ledger.interpretation?.implementationAssessment?.includes(
-    'not-assessed'
-  )
+  !ledger.interpretation?.implementationAssessment?.includes('not-assessed')
 ) {
   failures.push('clause interpretation and evidence policy drift');
 }
@@ -252,37 +235,30 @@ for (const family of ledger.families ?? []) {
     failures.push(`${family.family}: unexpected covered family`);
     continue;
   }
-  const parentLedgerPath = path.join(
-    manifestDirectory,
-    definition.ledgerFile
-  );
-  const expectedParentLedgerPath =
-    `spec-processing/source-manifests/${definition.ledgerFile}`;
+  const parentLedgerPath = path.join(manifestDirectory, definition.ledgerFile);
+  const expectedParentLedgerPath = `spec-processing/source-manifests/${definition.ledgerFile}`;
   const parentLedgerText = fs.readFileSync(parentLedgerPath, 'utf8');
   const parentLedger = JSON.parse(parentLedgerText);
   const selectedParents = parentLedger.obligations.filter(
-    (obligation) =>
-      obligation.disposition?.classCProfile ===
-      definition.selectedDisposition
+    (obligation) => obligation.disposition?.classCProfile === definition.selectedDisposition
   );
-  const selectedById = new Map(
-    selectedParents.map((parent) => [parent.id, parent])
-  );
+  const selectedById = new Map(selectedParents.map((parent) => [parent.id, parent]));
   const effectiveFamily = effectiveSpec.families.find(
     (candidate) => candidate.family === family.family
   );
   const expectedFamilyStatus =
     family.family === 'wcmp'
       ? 'nested-clauses-fixture-backed'
-      : 'nested-clauses-anchored-fixtures-planned';
+      : family.family === 'wml'
+        ? 'nested-clauses-partially-fixture-backed'
+        : 'nested-clauses-anchored-fixtures-planned';
 
   if (
     family.status !== expectedFamilyStatus ||
     family.parentLedger !== expectedParentLedgerPath ||
     family.parentLedgerSha256 !== sha256(parentLedgerText) ||
     family.selectedDisposition !== definition.selectedDisposition ||
-    JSON.stringify(family.effectiveSequence) !==
-      JSON.stringify(effectiveFamily?.effectiveSequence)
+    JSON.stringify(family.effectiveSequence) !== JSON.stringify(effectiveFamily?.effectiveSequence)
   ) {
     failures.push(`${family.family}: family authority or status drift`);
   }
@@ -316,19 +292,14 @@ for (const family of ledger.families ?? []) {
       externalDependency &&
       externalArtifact &&
       source.authority === externalDependency.authority &&
-      source.authorityRecordUrl ===
-        externalDependency.authorityRecordUrl &&
+      source.authorityRecordUrl === externalDependency.authorityRecordUrl &&
       source.artifactSha256 === externalArtifact.sha256 &&
       source.artifactBytes === externalArtifact.bytes;
     if (!releaseSourceValid && !externalSourceValid) {
-      failures.push(
-        `${family.family}/${source.documentId}: clause source lock drift`
-      );
+      failures.push(`${family.family}/${source.documentId}: clause source lock drift`);
     }
   }
-  const clauseSourceIds = new Set(
-    (family.clauseSources ?? []).map((source) => source.documentId)
-  );
+  const clauseSourceIds = new Set((family.clauseSources ?? []).map((source) => source.documentId));
 
   const actualParentIds = (family.parents ?? []).map((parent) => parent.id);
   const expectedParentIds = selectedParents.map((parent) => parent.id);
@@ -336,9 +307,7 @@ for (const family of ledger.families ?? []) {
     failures.push(`${family.family}: selected parent set/order drift`);
   }
 
-  const clauseById = new Map(
-    (family.clauses ?? []).map((candidate) => [candidate.id, candidate])
-  );
+  const clauseById = new Map((family.clauses ?? []).map((candidate) => [candidate.id, candidate]));
   if (clauseById.size !== family.clauses?.length) {
     failures.push(`${family.family}: duplicate family clause IDs`);
   }
@@ -352,37 +321,25 @@ for (const family of ledger.families ?? []) {
     if (
       parent.feature !== sourceParent.feature ||
       parent.referencedSection !== sourceParent.referencedSection ||
-      JSON.stringify(parent.sourceAnchor) !==
-        JSON.stringify(sourceParent.sourceAnchor) ||
-      parent.implementationStatus !==
-        sourceParent.mapping.implementationStatus ||
-      JSON.stringify(parent.ownerLayers) !==
-        JSON.stringify(sourceParent.mapping.ownerLayers) ||
-      JSON.stringify(parent.workItems) !==
-        JSON.stringify(sourceParent.mapping.workItems) ||
+      JSON.stringify(parent.sourceAnchor) !== JSON.stringify(sourceParent.sourceAnchor) ||
+      parent.implementationStatus !== sourceParent.mapping.implementationStatus ||
+      JSON.stringify(parent.ownerLayers) !== JSON.stringify(sourceParent.mapping.ownerLayers) ||
+      JSON.stringify(parent.workItems) !== JSON.stringify(sourceParent.mapping.workItems) ||
       !Array.isArray(parent.clauseIds) ||
       parent.clauseIds.length === 0
     ) {
-      failures.push(
-        `${family.family}/${parent.id}: parent traceability drift`
-      );
+      failures.push(`${family.family}/${parent.id}: parent traceability drift`);
     }
     const expectedClauseIds = (family.clauses ?? [])
       .filter((candidate) => candidate.parentRows.includes(parent.id))
       .map((candidate) => candidate.id)
       .sort();
-    if (
-      JSON.stringify(parent.clauseIds) !== JSON.stringify(expectedClauseIds)
-    ) {
-      failures.push(
-        `${family.family}/${parent.id}: inverse clause mapping drift`
-      );
+    if (JSON.stringify(parent.clauseIds) !== JSON.stringify(expectedClauseIds)) {
+      failures.push(`${family.family}/${parent.id}: inverse clause mapping drift`);
     }
     for (const clauseId of parent.clauseIds ?? []) {
       if (!clauseById.has(clauseId)) {
-        failures.push(
-          `${family.family}/${parent.id}: unknown clause ${clauseId}`
-        );
+        failures.push(`${family.family}/${parent.id}: unknown clause ${clauseId}`);
       }
     }
   }
@@ -416,17 +373,14 @@ for (const family of ledger.families ?? []) {
     if (
       !candidate.sourceAnchor?.section ||
       !candidate.sourceAnchor?.heading ||
-      !hashPattern.test(
-        candidate.sourceAnchor?.normalizedTextSha256 ?? ''
-      ) ||
+      !hashPattern.test(candidate.sourceAnchor?.normalizedTextSha256 ?? '') ||
       !clauseSourceIds.has(candidate.sourceAnchor?.documentId)
     ) {
       failures.push(`${candidate.id}: incomplete or unlocked source anchor`);
     }
     if (
       !allowedForces.has(candidate.normativeForce) ||
-      candidate.obligationLevel !==
-        expectedLevelByForce[candidate.normativeForce]
+      candidate.obligationLevel !== expectedLevelByForce[candidate.normativeForce]
     ) {
       failures.push(`${candidate.id}: normative force/level drift`);
     }
@@ -437,9 +391,7 @@ for (const family of ledger.families ?? []) {
       candidate.obligationSynopsis.includes('\n') ||
       candidate.obligationSynopsis.trim().split(/\s+/).length > 45
     ) {
-      failures.push(
-        `${candidate.id}: synopsis violates the redistribution-safe shape`
-      );
+      failures.push(`${candidate.id}: synopsis violates the redistribution-safe shape`);
     }
     const clauseKey = [
       candidate.family,
@@ -461,31 +413,20 @@ for (const family of ledger.families ?? []) {
       ...new Set(parents.flatMap((parent) => parent.mapping.requirementIds))
     ].sort();
     const expectedSnapshot = Object.fromEntries(
-      parents.map((parent) => [
-        parent.id,
-        parent.mapping.implementationStatus
-      ])
+      parents.map((parent) => [parent.id, parent.mapping.implementationStatus])
     );
-    const directFixtureImplemented = candidate.family === 'wcmp';
-    const expectedClauseStatus = directFixtureImplemented
-      ? 'implemented'
-      : 'not-assessed';
-    const expectedFixtureStatus = directFixtureImplemented
-      ? 'implemented'
-      : 'planned';
+    const directFixtureImplemented =
+      candidate.family === 'wcmp' || implementedWmlClauseIds.has(candidate.id);
+    const expectedClauseStatus = directFixtureImplemented ? 'implemented' : 'not-assessed';
+    const expectedFixtureStatus = directFixtureImplemented ? 'implemented' : 'planned';
     if (
-      JSON.stringify(candidate.mapping?.ownerLayers) !==
-        JSON.stringify(expectedOwners) ||
-      JSON.stringify(candidate.mapping?.workItems) !==
-        JSON.stringify(expectedWorkItems) ||
-      JSON.stringify(candidate.mapping?.requirementIds) !==
-        JSON.stringify(expectedRequirements) ||
+      JSON.stringify(candidate.mapping?.ownerLayers) !== JSON.stringify(expectedOwners) ||
+      JSON.stringify(candidate.mapping?.workItems) !== JSON.stringify(expectedWorkItems) ||
+      JSON.stringify(candidate.mapping?.requirementIds) !== JSON.stringify(expectedRequirements) ||
       JSON.stringify(candidate.mapping?.parentImplementationSnapshot) !==
         JSON.stringify(expectedSnapshot) ||
       candidate.mapping?.clauseImplementationStatus !== expectedClauseStatus ||
-      !candidate.mapping?.evidenceGate?.includes(
-        'source-derived direct fixture'
-      )
+      !candidate.mapping?.evidenceGate?.includes('source-derived direct fixture')
     ) {
       failures.push(`${candidate.id}: owner/work/evidence mapping drift`);
     }
@@ -497,12 +438,16 @@ for (const family of ledger.families ?? []) {
       !allowedFixtureKinds.has(candidate.fixturePlan.kind) ||
       candidate.fixturePlan.assertion !== candidate.obligationSynopsis ||
       (directFixtureImplemented &&
+        candidate.family === 'wcmp' &&
         (candidate.fixturePlan.evidence?.path !==
           'transport-rust/tests/fixtures/transport/wcmp_core_mapped/wcmp_fixture.json' ||
-          candidate.fixturePlan.evidence?.testPath !==
-            'transport-rust/src/network/wcmp/tests.rs' ||
+          candidate.fixturePlan.evidence?.testPath !== 'transport-rust/src/network/wcmp/tests.rs' ||
+          !candidate.fixturePlan.evidence?.command?.includes('network::wcmp'))) ||
+      (implementedWmlClauseIds.has(candidate.id) &&
+        (candidate.fixturePlan.evidence?.path !== candidate.fixturePlan.evidence?.testPath ||
+          !fs.existsSync(path.join(root, candidate.fixturePlan.evidence?.testPath ?? '')) ||
           !candidate.fixturePlan.evidence?.command?.includes(
-            'network::wcmp'
+            'cargo test --manifest-path engine-wasm/engine/Cargo.toml'
           )))
     ) {
       failures.push(`${candidate.id}: direct fixture plan is incomplete`);
@@ -536,22 +481,13 @@ if (
   clauseCount !== 781 ||
   JSON.stringify(ledger.summary) !== JSON.stringify(expectedSummary)
 ) {
-  failures.push(
-    `summary drift: ${selectedParentCount} parents / ${clauseCount} clauses`
-  );
+  failures.push(`summary drift: ${selectedParentCount} parents / ${clauseCount} clauses`);
 }
 
-const forbiddenKeys = new Set([
-  'sourceText',
-  'sourceExcerpt',
-  'normativeText',
-  'verbatimQuote'
-]);
+const forbiddenKeys = new Set(['sourceText', 'sourceExcerpt', 'normativeText', 'verbatimQuote']);
 function rejectProtectedPayload(value, location = 'ledger') {
   if (Array.isArray(value)) {
-    value.forEach((item, index) =>
-      rejectProtectedPayload(item, `${location}[${index}]`)
-    );
+    value.forEach((item, index) => rejectProtectedPayload(item, `${location}[${index}]`));
     return;
   }
   if (!value || typeof value !== 'object') return;

--- a/spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json
+++ b/spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json
@@ -48,9 +48,9 @@
   "families": [
     {
       "family": "wml",
-      "status": "nested-clauses-anchored-fixtures-planned",
+      "status": "nested-clauses-partially-fixture-backed",
       "parentLedger": "spec-processing/source-manifests/wap-1.2.1-wml-scr.json",
-      "parentLedgerSha256": "173ca35025962f3a18737a02c3b66e4d25ce6faae1d727048b2c98f89d5546ec",
+      "parentLedgerSha256": "8564469f6b7f9ec54d72d387c655953f9ebbb029af71e45651fe9b28231d5d0a",
       "effectiveSequence": [
         "WAP-191-WML",
         "WAP-191_102-WML",
@@ -2864,8 +2864,13 @@
           "fixturePlan": {
             "id": "WML-FX-VARIABLE-COMMIT-BEFORE-TASK",
             "kind": "runtime",
-            "status": "planned",
-            "assertion": "Commit input and selection variables before invoking any task."
+            "status": "implemented",
+            "assertion": "Commit input and selection variables before invoking any task.",
+            "evidence": {
+              "path": "engine-wasm/engine/src/engine_tests/select_semantics.rs",
+              "testPath": "engine-wasm/engine/src/engine_tests/select_semantics.rs",
+              "command": "cargo test --manifest-path engine-wasm/engine/Cargo.toml wml_fx_select_variables_are_resynchronized_before_link_task_execution"
+            }
           },
           "mapping": {
             "ownerLayers": [
@@ -2888,7 +2893,7 @@
               "WML-C-33": "partial",
               "WML-C-43": "partial"
             },
-            "clauseImplementationStatus": "not-assessed",
+            "clauseImplementationStatus": "implemented",
             "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented."
           }
         },
@@ -6144,8 +6149,13 @@
           "fixturePlan": {
             "id": "WML-FX-SELECT-STRUCTURE",
             "kind": "parser",
-            "status": "planned",
-            "assertion": "Require one or more option or optgroup children in each select element."
+            "status": "implemented",
+            "assertion": "Require one or more option or optgroup children in each select element.",
+            "evidence": {
+              "path": "engine-wasm/engine/src/parser/wml_parser/tests.rs",
+              "testPath": "engine-wasm/engine/src/parser/wml_parser/tests.rs",
+              "command": "cargo test --manifest-path engine-wasm/engine/Cargo.toml wml_fx_select_structure_flattens_nested_optgroups_in_document_order"
+            }
           },
           "mapping": {
             "ownerLayers": [
@@ -6162,7 +6172,7 @@
             "parentImplementationSnapshot": {
               "WML-C-43": "partial"
             },
-            "clauseImplementationStatus": "not-assessed",
+            "clauseImplementationStatus": "implemented",
             "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented."
           }
         },
@@ -6184,8 +6194,13 @@
           "fixturePlan": {
             "id": "WML-FX-SELECT-SINGLE-MULTI-MODE",
             "kind": "runtime",
-            "status": "planned",
-            "assertion": "Allow one selected option by default and multiple selections only when multiple is true."
+            "status": "implemented",
+            "assertion": "Allow one selected option by default and multiple selections only when multiple is true.",
+            "evidence": {
+              "path": "engine-wasm/engine/src/engine_tests/select_semantics.rs",
+              "testPath": "engine-wasm/engine/src/engine_tests/select_semantics.rs",
+              "command": "cargo test --manifest-path engine-wasm/engine/Cargo.toml wml_fx_select_default_precedence_covers_every_source_and_fallback"
+            }
           },
           "mapping": {
             "ownerLayers": [
@@ -6202,7 +6217,7 @@
             "parentImplementationSnapshot": {
               "WML-C-43": "partial"
             },
-            "clauseImplementationStatus": "not-assessed",
+            "clauseImplementationStatus": "implemented",
             "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented."
           }
         },
@@ -6225,8 +6240,13 @@
           "fixturePlan": {
             "id": "WML-FX-SELECT-INIT-ORDER",
             "kind": "runtime",
-            "status": "planned",
-            "assertion": "Initialize input and select controls in document order when entering the card."
+            "status": "implemented",
+            "assertion": "Initialize input and select controls in document order when entering the card.",
+            "evidence": {
+              "path": "engine-wasm/engine/src/engine_tests/select_semantics.rs",
+              "testPath": "engine-wasm/engine/src/engine_tests/select_semantics.rs",
+              "command": "cargo test --manifest-path engine-wasm/engine/Cargo.toml wml_fx_select_init_order_precedence_validation_and_serialization"
+            }
           },
           "mapping": {
             "ownerLayers": [
@@ -6244,7 +6264,7 @@
               "WML-C-43": "partial",
               "WML-C-33": "partial"
             },
-            "clauseImplementationStatus": "not-assessed",
+            "clauseImplementationStatus": "implemented",
             "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented."
           }
         },
@@ -6266,8 +6286,13 @@
           "fixturePlan": {
             "id": "WML-FX-SELECT-INDEX-VALIDATION",
             "kind": "runtime",
-            "status": "planned",
-            "assertion": "Validate selection indices by removing non-integers, out-of-range entries, and duplicates."
+            "status": "implemented",
+            "assertion": "Validate selection indices by removing non-integers, out-of-range entries, and duplicates.",
+            "evidence": {
+              "path": "engine-wasm/engine/src/engine_tests/select_semantics.rs",
+              "testPath": "engine-wasm/engine/src/engine_tests/select_semantics.rs",
+              "command": "cargo test --manifest-path engine-wasm/engine/Cargo.toml wml_fx_select_init_order_precedence_validation_and_serialization"
+            }
           },
           "mapping": {
             "ownerLayers": [
@@ -6284,7 +6309,7 @@
             "parentImplementationSnapshot": {
               "WML-C-43": "partial"
             },
-            "clauseImplementationStatus": "not-assessed",
+            "clauseImplementationStatus": "implemented",
             "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented."
           }
         },
@@ -6306,8 +6331,13 @@
           "fixturePlan": {
             "id": "WML-FX-SELECT-DEFAULT-PRECEDENCE",
             "kind": "runtime",
-            "status": "planned",
-            "assertion": "Choose initial selections in iname, ivalue, name, value, then single/multiple fallback order."
+            "status": "implemented",
+            "assertion": "Choose initial selections in iname, ivalue, name, value, then single/multiple fallback order.",
+            "evidence": {
+              "path": "engine-wasm/engine/src/engine_tests/select_semantics.rs",
+              "testPath": "engine-wasm/engine/src/engine_tests/select_semantics.rs",
+              "command": "cargo test --manifest-path engine-wasm/engine/Cargo.toml wml_fx_select_default_precedence_covers_every_source_and_fallback"
+            }
           },
           "mapping": {
             "ownerLayers": [
@@ -6324,7 +6354,7 @@
             "parentImplementationSnapshot": {
               "WML-C-43": "partial"
             },
-            "clauseImplementationStatus": "not-assessed",
+            "clauseImplementationStatus": "implemented",
             "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented."
           }
         },
@@ -6346,8 +6376,13 @@
           "fixturePlan": {
             "id": "WML-FX-SELECT-VARIABLE-INITIALIZATION",
             "kind": "runtime",
-            "status": "planned",
-            "assertion": "Initialize name from selected option values and iname from the validated selected indices."
+            "status": "implemented",
+            "assertion": "Initialize name from selected option values and iname from the validated selected indices.",
+            "evidence": {
+              "path": "engine-wasm/engine/src/engine_tests/select_semantics.rs",
+              "testPath": "engine-wasm/engine/src/engine_tests/select_semantics.rs",
+              "command": "cargo test --manifest-path engine-wasm/engine/Cargo.toml wml_fx_select_init_order_precedence_validation_and_serialization"
+            }
           },
           "mapping": {
             "ownerLayers": [
@@ -6364,7 +6399,7 @@
             "parentImplementationSnapshot": {
               "WML-C-43": "partial"
             },
-            "clauseImplementationStatus": "not-assessed",
+            "clauseImplementationStatus": "implemented",
             "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented."
           }
         },
@@ -6386,8 +6421,13 @@
           "fixturePlan": {
             "id": "WML-FX-SELECT-PRESELECTION",
             "kind": "runtime",
-            "status": "planned",
-            "assertion": "Deselect all options and then select every positive validated default index."
+            "status": "implemented",
+            "assertion": "Deselect all options and then select every positive validated default index.",
+            "evidence": {
+              "path": "engine-wasm/engine/src/engine_tests/select_semantics.rs",
+              "testPath": "engine-wasm/engine/src/engine_tests/select_semantics.rs",
+              "command": "cargo test --manifest-path engine-wasm/engine/Cargo.toml wml_fx_select_init_order_precedence_validation_and_serialization"
+            }
           },
           "mapping": {
             "ownerLayers": [
@@ -6404,7 +6444,7 @@
             "parentImplementationSnapshot": {
               "WML-C-43": "partial"
             },
-            "clauseImplementationStatus": "not-assessed",
+            "clauseImplementationStatus": "implemented",
             "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented."
           }
         },
@@ -6426,8 +6466,13 @@
           "fixturePlan": {
             "id": "WML-FX-SELECT-USER-UPDATE",
             "kind": "runtime",
-            "status": "planned",
-            "assertion": "Update name and iname after user selection changes and again before every task invocation."
+            "status": "implemented",
+            "assertion": "Update name and iname after user selection changes and again before every task invocation.",
+            "evidence": {
+              "path": "engine-wasm/engine/src/engine_tests/select_semantics.rs",
+              "testPath": "engine-wasm/engine/src/engine_tests/select_semantics.rs",
+              "command": "cargo test --manifest-path engine-wasm/engine/Cargo.toml wml_fx_select_variables_are_resynchronized_before_link_task_execution"
+            }
           },
           "mapping": {
             "ownerLayers": [
@@ -6444,7 +6489,7 @@
             "parentImplementationSnapshot": {
               "WML-C-43": "partial"
             },
-            "clauseImplementationStatus": "not-assessed",
+            "clauseImplementationStatus": "implemented",
             "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented."
           }
         },
@@ -6506,8 +6551,13 @@
           "fixturePlan": {
             "id": "WML-FX-SELECT-MULTI-SERIALIZATION",
             "kind": "runtime",
-            "status": "planned",
-            "assertion": "Serialize multiple results as semicolon-delimited lists with unique indices, duplicate non-empty values preserved, and no empty value entries."
+            "status": "implemented",
+            "assertion": "Serialize multiple results as semicolon-delimited lists with unique indices, duplicate non-empty values preserved, and no empty value entries.",
+            "evidence": {
+              "path": "engine-wasm/engine/src/engine_tests/select_semantics.rs",
+              "testPath": "engine-wasm/engine/src/engine_tests/select_semantics.rs",
+              "command": "cargo test --manifest-path engine-wasm/engine/Cargo.toml wml_fx_select_value_and_ivalue_references_are_evaluated_before_assignment"
+            }
           },
           "mapping": {
             "ownerLayers": [
@@ -6524,7 +6574,7 @@
             "parentImplementationSnapshot": {
               "WML-C-43": "partial"
             },
-            "clauseImplementationStatus": "not-assessed",
+            "clauseImplementationStatus": "implemented",
             "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented."
           }
         },
@@ -6589,8 +6639,13 @@
           "fixturePlan": {
             "id": "WML-FX-OPTION-ONPICK-MULTI",
             "kind": "runtime",
-            "status": "planned",
-            "assertion": "For multiple selection, dispatch onpick whenever the option is selected or deselected."
+            "status": "implemented",
+            "assertion": "For multiple selection, dispatch onpick whenever the option is selected or deselected.",
+            "evidence": {
+              "path": "engine-wasm/engine/src/engine_tests/select_semantics.rs",
+              "testPath": "engine-wasm/engine/src/engine_tests/select_semantics.rs",
+              "command": "cargo test --manifest-path engine-wasm/engine/Cargo.toml wml_fx_option_onpick_multi_fires_for_deselection_after_state_update"
+            }
           },
           "mapping": {
             "ownerLayers": [
@@ -6611,7 +6666,7 @@
               "WML-C-41": "partial",
               "WML-C-09": "partial"
             },
-            "clauseImplementationStatus": "not-assessed",
+            "clauseImplementationStatus": "implemented",
             "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented."
           }
         },
@@ -6634,8 +6689,13 @@
           "fixturePlan": {
             "id": "WML-FX-OPTION-ONPICK-SINGLE",
             "kind": "runtime",
-            "status": "planned",
-            "assertion": "For single selection, dispatch onpick for the newly selected option but not for implicit deselection."
+            "status": "implemented",
+            "assertion": "For single selection, dispatch onpick for the newly selected option but not for implicit deselection.",
+            "evidence": {
+              "path": "engine-wasm/engine/src/engine_tests/select_semantics.rs",
+              "testPath": "engine-wasm/engine/src/engine_tests/select_semantics.rs",
+              "command": "cargo test --manifest-path engine-wasm/engine/Cargo.toml wml_fx_option_onpick_single_updates_state_before_only_selected_task"
+            }
           },
           "mapping": {
             "ownerLayers": [
@@ -6656,7 +6716,7 @@
               "WML-C-41": "partial",
               "WML-C-09": "partial"
             },
-            "clauseImplementationStatus": "not-assessed",
+            "clauseImplementationStatus": "implemented",
             "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented."
           }
         },

--- a/spec-processing/source-manifests/wap-1.2.1-trn-7-knowledge-graph.json
+++ b/spec-processing/source-manifests/wap-1.2.1-trn-7-knowledge-graph.json
@@ -13,7 +13,7 @@
     "generator": "spec-processing/scripts/generate-wap-knowledge-graph.mjs",
     "inputs": {
       "docs/waves/wap-1.2.1-compliance-program.json": {
-        "sha256": "e8076afef8391f966d8b1dcad1f1cbd3799efa1cf21034e95663bbc1af746614"
+        "sha256": "e7be2f0ac1198b749da58b2cc864651d8770b675092f36fb1a9d5682158891ef"
       },
       "spec-processing/source-manifests/wap-1.2.1-class-conformance.json": {
         "sha256": "b76605b2144b32965a857b848b2e9e522baada6fae9fe51012b9eaa664e85d86"
@@ -25,7 +25,7 @@
         "sha256": "654284270a068b427ab05166247cb8e0644a99cf6af511f9b9c477d18ea36faa"
       },
       "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json": {
-        "sha256": "4d05178d0d5b7c1e9c76119aa6d91df6f30e7b93e1e29b0c1b02529cb8d0d28f"
+        "sha256": "7e52675541e14ee97597507e7ecd42590e41bb88e06f40eef1c7e101ae946b89"
       }
     },
     "policy": "Canonical manifests remain authoritative; this graph and its Obsidian/context projections are generated views."

--- a/spec-processing/source-manifests/wap-1.2.1-wml-2-knowledge-graph.json
+++ b/spec-processing/source-manifests/wap-1.2.1-wml-2-knowledge-graph.json
@@ -13,7 +13,7 @@
     "generator": "spec-processing/scripts/generate-wap-knowledge-graph.mjs",
     "inputs": {
       "docs/waves/wap-1.2.1-compliance-program.json": {
-        "sha256": "e8076afef8391f966d8b1dcad1f1cbd3799efa1cf21034e95663bbc1af746614"
+        "sha256": "e7be2f0ac1198b749da58b2cc864651d8770b675092f36fb1a9d5682158891ef"
       },
       "spec-processing/source-manifests/wap-1.2.1-class-conformance.json": {
         "sha256": "b76605b2144b32965a857b848b2e9e522baada6fae9fe51012b9eaa664e85d86"
@@ -25,7 +25,7 @@
         "sha256": "654284270a068b427ab05166247cb8e0644a99cf6af511f9b9c477d18ea36faa"
       },
       "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json": {
-        "sha256": "4d05178d0d5b7c1e9c76119aa6d91df6f30e7b93e1e29b0c1b02529cb8d0d28f"
+        "sha256": "7e52675541e14ee97597507e7ecd42590e41bb88e06f40eef1c7e101ae946b89"
       }
     },
     "policy": "Canonical manifests remain authoritative; this graph and its Obsidian/context projections are generated views."
@@ -2311,7 +2311,7 @@
           "RQ-RMK-001",
           "RQ-RMK-004"
         ],
-        "implementationStatus": "not-assessed",
+        "implementationStatus": "implemented",
         "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented.",
         "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
       }
@@ -2350,7 +2350,7 @@
           "RQ-RMK-001",
           "RQ-RMK-004"
         ],
-        "implementationStatus": "not-assessed",
+        "implementationStatus": "implemented",
         "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented.",
         "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
       }
@@ -2421,7 +2421,7 @@
         "requirementIds": [
           "RQ-RMK-001"
         ],
-        "implementationStatus": "not-assessed",
+        "implementationStatus": "implemented",
         "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented.",
         "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
       }
@@ -2456,7 +2456,7 @@
         "requirementIds": [
           "RQ-RMK-001"
         ],
-        "implementationStatus": "not-assessed",
+        "implementationStatus": "implemented",
         "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented.",
         "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
       }
@@ -2492,7 +2492,7 @@
         "requirementIds": [
           "RQ-RMK-001"
         ],
-        "implementationStatus": "not-assessed",
+        "implementationStatus": "implemented",
         "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented.",
         "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
       }
@@ -2527,7 +2527,7 @@
         "requirementIds": [
           "RQ-RMK-001"
         ],
-        "implementationStatus": "not-assessed",
+        "implementationStatus": "implemented",
         "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented.",
         "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
       }
@@ -2597,7 +2597,7 @@
         "requirementIds": [
           "RQ-RMK-001"
         ],
-        "implementationStatus": "not-assessed",
+        "implementationStatus": "implemented",
         "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented.",
         "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
       }
@@ -2632,7 +2632,7 @@
         "requirementIds": [
           "RQ-RMK-001"
         ],
-        "implementationStatus": "not-assessed",
+        "implementationStatus": "implemented",
         "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented.",
         "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
       }
@@ -2667,7 +2667,7 @@
         "requirementIds": [
           "RQ-RMK-001"
         ],
-        "implementationStatus": "not-assessed",
+        "implementationStatus": "implemented",
         "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented.",
         "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
       }
@@ -2702,7 +2702,7 @@
         "requirementIds": [
           "RQ-RMK-001"
         ],
-        "implementationStatus": "not-assessed",
+        "implementationStatus": "implemented",
         "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented.",
         "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
       }
@@ -2737,7 +2737,7 @@
         "requirementIds": [
           "RQ-RMK-001"
         ],
-        "implementationStatus": "not-assessed",
+        "implementationStatus": "implemented",
         "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented.",
         "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
       }
@@ -2778,7 +2778,7 @@
           "RQ-RMK-003",
           "RQ-RMK-005"
         ],
-        "implementationStatus": "not-assessed",
+        "implementationStatus": "implemented",
         "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented.",
         "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
       }
@@ -3510,7 +3510,7 @@
       "title": "For multiple selection, dispatch onpick whenever the option is selected or deselected.",
       "properties": {
         "kind": "runtime",
-        "status": "planned",
+        "status": "implemented",
         "assertion": "For multiple selection, dispatch onpick whenever the option is selected or deselected.",
         "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
       }
@@ -3522,7 +3522,7 @@
       "title": "For single selection, dispatch onpick for the newly selected option but not for implicit deselection.",
       "properties": {
         "kind": "runtime",
-        "status": "planned",
+        "status": "implemented",
         "assertion": "For single selection, dispatch onpick for the newly selected option but not for implicit deselection.",
         "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
       }
@@ -3546,7 +3546,7 @@
       "title": "Choose initial selections in iname, ivalue, name, value, then single/multiple fallback order.",
       "properties": {
         "kind": "runtime",
-        "status": "planned",
+        "status": "implemented",
         "assertion": "Choose initial selections in iname, ivalue, name, value, then single/multiple fallback order.",
         "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
       }
@@ -3558,7 +3558,7 @@
       "title": "Validate selection indices by removing non-integers, out-of-range entries, and duplicates.",
       "properties": {
         "kind": "runtime",
-        "status": "planned",
+        "status": "implemented",
         "assertion": "Validate selection indices by removing non-integers, out-of-range entries, and duplicates.",
         "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
       }
@@ -3570,7 +3570,7 @@
       "title": "Initialize input and select controls in document order when entering the card.",
       "properties": {
         "kind": "runtime",
-        "status": "planned",
+        "status": "implemented",
         "assertion": "Initialize input and select controls in document order when entering the card.",
         "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
       }
@@ -3582,7 +3582,7 @@
       "title": "Serialize multiple results as semicolon-delimited lists with unique indices, duplicate non-empty values preserved, and no empty value entries.",
       "properties": {
         "kind": "runtime",
-        "status": "planned",
+        "status": "implemented",
         "assertion": "Serialize multiple results as semicolon-delimited lists with unique indices, duplicate non-empty values preserved, and no empty value entries.",
         "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
       }
@@ -3606,7 +3606,7 @@
       "title": "Deselect all options and then select every positive validated default index.",
       "properties": {
         "kind": "runtime",
-        "status": "planned",
+        "status": "implemented",
         "assertion": "Deselect all options and then select every positive validated default index.",
         "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
       }
@@ -3618,7 +3618,7 @@
       "title": "Allow one selected option by default and multiple selections only when multiple is true.",
       "properties": {
         "kind": "runtime",
-        "status": "planned",
+        "status": "implemented",
         "assertion": "Allow one selected option by default and multiple selections only when multiple is true.",
         "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
       }
@@ -3630,7 +3630,7 @@
       "title": "Require one or more option or optgroup children in each select element.",
       "properties": {
         "kind": "parser",
-        "status": "planned",
+        "status": "implemented",
         "assertion": "Require one or more option or optgroup children in each select element.",
         "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
       }
@@ -3642,7 +3642,7 @@
       "title": "Update name and iname after user selection changes and again before every task invocation.",
       "properties": {
         "kind": "runtime",
-        "status": "planned",
+        "status": "implemented",
         "assertion": "Update name and iname after user selection changes and again before every task invocation.",
         "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
       }
@@ -3654,7 +3654,7 @@
       "title": "Initialize name from selected option values and iname from the validated selected indices.",
       "properties": {
         "kind": "runtime",
-        "status": "planned",
+        "status": "implemented",
         "assertion": "Initialize name from selected option values and iname from the validated selected indices.",
         "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
       }
@@ -3666,7 +3666,7 @@
       "title": "Commit input and selection variables before invoking any task.",
       "properties": {
         "kind": "runtime",
-        "status": "planned",
+        "status": "implemented",
         "assertion": "Commit input and selection variables before invoking any task.",
         "source": "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
       }
@@ -4648,13 +4648,15 @@
           "C5-05"
         ],
         "outputs": [
-          "Complete field/control syntax and attribute validation"
+          "Complete field/control syntax and attribute validation",
+          "Source-derived select initialization, selection, serialization, and onpick runtime evidence"
         ],
         "acceptance": [
           "Input/select/option/optgroup/fieldset constraints, masks, defaults, and validation failures are deterministic."
         ],
         "evidence": [
-          "cargo test --manifest-path engine-wasm/engine/Cargo.toml"
+          "cargo test --manifest-path engine-wasm/engine/Cargo.toml",
+          "pnpm test:story WML-204"
         ],
         "source": "docs/waves/wap-1.2.1-compliance-program.json"
       }

--- a/spec-processing/source-manifests/wap-1.2.1-wml-scr.json
+++ b/spec-processing/source-manifests/wap-1.2.1-wml-scr.json
@@ -1655,7 +1655,7 @@
           "WML-204"
         ],
         "implementationStatus": "partial",
-        "assessmentNote": "Input now has deterministic DTD-derived syntax validation, Basic Latin format-mask and emptyok enforcement at commit, and literal name/value initialization in document order. Invalid masks fall back to *M; invalid existing/default values follow unset/fallback rules; rejected commits preserve the prior variable and active draft for retry; escaped literals remain part of accepted values. Size/tabindex behavior, vdata expansion, language-aware non-Basic-Latin mask repertoires, and interleaved select initialization remain incomplete.",
+        "assessmentNote": "Input now has deterministic DTD-derived syntax validation, Basic Latin format-mask and emptyok enforcement at commit, and name/value initialization interleaved with select controls in document order. Invalid masks fall back to *M; invalid existing/default values follow unset/fallback rules; rejected commits preserve the prior variable and active draft for retry; escaped literals remain part of accepted values. Size/tabindex behavior, general vdata validation/conversion, and language-aware non-Basic-Latin mask repertoires remain incomplete.",
         "implementationEvidence": [
           {
             "path": "engine-wasm/engine/src/parser/wml_parser/nodes.rs",
@@ -1669,10 +1669,10 @@
             "path": "engine-wasm/engine/src/engine_runtime_internal.rs",
             "symbol": "commit_focused_input_edit_internal"
           },
-          {
-            "path": "engine-wasm/engine/src/engine_runtime_internal.rs",
-            "symbol": "initialize_inputs_on_active_card"
-          }
+      {
+        "path": "engine-wasm/engine/src/engine_runtime_internal.rs",
+        "symbol": "initialize_controls_on_active_card"
+      }
         ],
         "testEvidence": [
           {
@@ -1714,6 +1714,11 @@
             "path": "engine-wasm/engine/src/engine_tests/actions_timers.rs",
             "test": "invalid_masked_input_blocks_task_without_navigation_side_effects",
             "command": "cd engine-wasm/engine && cargo test invalid_masked_input_blocks_task_without_navigation_side_effects"
+          },
+          {
+            "path": "engine-wasm/engine/src/engine_tests/select_semantics.rs",
+            "test": "wml_fx_select_init_order_precedence_validation_and_serialization",
+            "command": "cd engine-wasm/engine && cargo test wml_fx_select_init_order_precedence_validation_and_serialization"
           }
         ],
         "evidenceState": "direct-test-linked"
@@ -2104,7 +2109,7 @@
           "WML-204"
         ],
         "implementationStatus": "partial",
-        "assessmentNote": "Option content and allowed attributes now receive deterministic DTD-derived syntax validation, and empty or text labels plus value are represented. Onpick execution, title/xml:lang retention, and full selection initialization rules remain incomplete.",
+        "assessmentNote": "Option content and allowed attributes receive deterministic DTD-derived syntax validation; text labels, explicit empty values, evaluated value references, and onpick dispatch for single selection plus multiple selection/deselection are represented. Option title/xml:lang retention, onevent task forms, and general HREF conversion remain incomplete.",
         "implementationEvidence": [
           {
             "path": "engine-wasm/engine/src/parser/wml_parser/nodes.rs",
@@ -2121,6 +2126,21 @@
             "path": "engine-wasm/engine/src/parser/wml_parser/tests.rs",
             "test": "wml_fx_select_structure_rejects_invalid_syntax_deterministically",
             "command": "cd engine-wasm/engine && cargo test wml_fx_select_structure_rejects_invalid_syntax_deterministically"
+          },
+          {
+            "path": "engine-wasm/engine/src/engine_tests/select_semantics.rs",
+            "test": "wml_fx_select_value_and_ivalue_references_are_evaluated_before_assignment",
+            "command": "cd engine-wasm/engine && cargo test wml_fx_select_value_and_ivalue_references_are_evaluated_before_assignment"
+          },
+          {
+            "path": "engine-wasm/engine/src/engine_tests/select_semantics.rs",
+            "test": "wml_fx_option_onpick_single_updates_state_before_only_selected_task",
+            "command": "cd engine-wasm/engine && cargo test wml_fx_option_onpick_single_updates_state_before_only_selected_task"
+          },
+          {
+            "path": "engine-wasm/engine/src/engine_tests/select_semantics.rs",
+            "test": "wml_fx_option_onpick_multi_fires_for_deselection_after_state_update",
+            "command": "cd engine-wasm/engine && cargo test wml_fx_option_onpick_multi_fires_for_deselection_after_state_update"
           }
         ],
         "evidenceState": "direct-test-linked"
@@ -2215,7 +2235,7 @@
           "WML-204"
         ],
         "implementationStatus": "partial",
-        "assessmentNote": "Select now has deterministic DTD-derived child-content, allowed-attribute, NMTOKEN, boolean, and numeric syntax validation; single-choice selection commits to its name variable before card task execution. Optional optgroup modeling and multiple, iname/ivalue, tabindex, and complete initialization/runtime semantics remain absent.",
+        "assessmentNote": "Select has deterministic DTD-derived syntax validation, nested optgroup option ordering, source-order input/select initialization, complete iname/ivalue/name/value/fallback precedence, validated and deduplicated indices, single/multiple user selection, name/iname serialization, evaluated option values, task-time variable synchronization, and onpick dispatch. General vdata/HREF validation and conversion, tabindex behavior, no-implicit-refresh direct evidence, and optional optgroup capability declaration remain incomplete.",
         "implementationEvidence": [
           {
             "path": "engine-wasm/engine/src/parser/wml_parser/nodes.rs",
@@ -2224,6 +2244,14 @@
           {
             "path": "engine-wasm/engine/src/engine_runtime_internal/navigation.rs",
             "symbol": "execute_card_task_action"
+          },
+          {
+            "path": "engine-wasm/engine/src/engine_runtime_internal.rs",
+            "symbol": "initial_select_indices"
+          },
+          {
+            "path": "engine-wasm/engine/src/engine_runtime_internal.rs",
+            "symbol": "sync_select_variables"
           }
         ],
         "testEvidence": [
@@ -2241,6 +2269,21 @@
             "path": "engine-wasm/engine/src/engine_tests/actions_timers.rs",
             "test": "wml_fx_variable_commit_before_task_commits_active_select_before_accept",
             "command": "cd engine-wasm/engine && cargo test wml_fx_variable_commit_before_task_commits_active_select_before_accept"
+          },
+          {
+            "path": "engine-wasm/engine/src/engine_tests/select_semantics.rs",
+            "test": "wml_fx_select_default_precedence_covers_every_source_and_fallback",
+            "command": "cd engine-wasm/engine && cargo test wml_fx_select_default_precedence_covers_every_source_and_fallback"
+          },
+          {
+            "path": "engine-wasm/engine/src/engine_tests/select_semantics.rs",
+            "test": "wml_fx_select_init_order_precedence_validation_and_serialization",
+            "command": "cd engine-wasm/engine && cargo test wml_fx_select_init_order_precedence_validation_and_serialization"
+          },
+          {
+            "path": "engine-wasm/engine/src/engine_tests/select_semantics.rs",
+            "test": "wml_fx_select_variables_are_resynchronized_before_link_task_execution",
+            "command": "cd engine-wasm/engine && cargo test wml_fx_select_variables_are_resynchronized_before_link_task_execution"
           }
         ],
         "evidenceState": "direct-test-linked"


### PR DESCRIPTION
## Summary

- implement deterministic WML `select` initialization precedence and document-order control initialization
- support single and multiple selection, one-based index validation/deduplication, and `name`/`iname` serialization
- evaluate basic `value`/`ivalue` variable references and commit user state before task execution
- implement single- versus multiple-select `onpick` behavior with deterministic failure state
- parse and validate grouped controls, including nested `optgroup` flattening and `fieldset` grammar
- preserve native Rust/WASM parity and add a shared executable WML-204 story
- update canonical compliance evidence conservatively and regenerate knowledge-graph projections

## Why

WML-204 still lacked the core select-control state machine needed for authentic deck behavior. This slice adds the highest-value remaining semantics while keeping template/shadowing, broad rendering, and unsupported vdata modifiers out of scope.

## Impact

Select controls now initialize, serialize, update runtime variables, and invoke option tasks deterministically across native and WASM targets. WML-204 remains conservatively marked `todo` for the explicitly deferred gaps.

## Validation

- `cargo test --manifest-path engine-wasm/engine/Cargo.toml` — 245 passed
- `wasm-pack test --node` — 11 passed
- `wasm-pack build --target web --out-dir ../pkg`
- `pnpm test:story WML-204` — 1 passed
- knowledge-graph generation/check
- compliance-program, conformance-ledger, selected-clause, requirement-drift, and source-corpus checks
- pre-push engine/browser/transport formatting and clippy checks

## Remaining gaps

- complete vdata/HREF evaluation and conversion modifiers (`escape`, `noesc`, `unesc`)
- child `<onevent type="onpick">` task modeling
- direct no-implicit-refresh rendering evidence
- optional optgroup/fieldset presentation metadata and tabindex behavior
