### PR TITLE
TRN-702: implement constrained payload and IPv4 reassembly policy

### DIFF
--- a/docs/knowledge-graph/context-packs/TRN-7.md
+++ b/docs/knowledge-graph/context-packs/TRN-7.md
@@ -14,11 +14,11 @@
 ## Graph summary
 
 - Nodes: 214
-- Edges: 604
+- Edges: 613
 - Selected work items: 7
-- Direct normative clauses: 77
-- Work items without direct clause mappings: 5
-- Work items with unmapped declared normative families: 3
+- Direct normative clauses: 86
+- Work items without direct clause mappings: 4
+- Work items with unmapped declared normative families: 2
 
 ## Execution target
 
@@ -62,23 +62,30 @@ Evidence commands:
 
 ### TRN-702: WDP constrained-payload and segmentation/reassembly policy
 
-- Status: `todo`
+- Status: `done`
 - Owner layers: `transport-rust`, `qa`
 - Source families: `wdp`
 - Existing tickets: `T0-19`
-- Direct normative clauses: 0
+- Direct normative clauses: 9
 
 Outputs:
 
 - WDP constrained-payload and segmentation/reassembly policy
+- transport-rust/tests/fixtures/transport/wdp_constrained_payload_mapped/reassembly_fixture.json
 
 Acceptance:
 
-- Payload limits, truncation/rejection, segmentation applicability, and reassembly failure are deterministic for the selected bearer.
+- The nine adopted WAP-200 and RFC 791/768 obligations directly evidence deterministic payload limits, rejection without WDP unit-data truncation, no WDP segmentation header on CDPD/IPv4, and destination-IP reassembly below WDP.
+- Whole, fragmented, out-of-order, duplicate, malformed, overlapping, oversize, and incomplete-expiry inputs produce bounded deterministic outcomes for the selected 576-octet baseline profile.
 
 Evidence commands:
 
 - `cargo test --manifest-path transport-rust/Cargo.toml`
+- `cargo test --manifest-path transport-rust/Cargo.toml --test wdp_constrained_replay`
+- `node scripts/check-wap-selected-normative-clauses.mjs`
+- `node scripts/check-wap-transport-conformance-ledgers.mjs`
+- `node scripts/wap-context-pack.mjs TRN-702`
+- `node scripts/check-wap-knowledge-graph.mjs`
 
 ### TRN-703: WCMP generation/handling and error mapping
 
@@ -483,6 +490,63 @@ Evidence commands:
   - Requirements: `RQ-TRN-003`
   - Fixture: `WDP-FX-WAP-PORT-REGISTRY` (`transport-boundary`, `implemented`)
 
+### TRN-702
+
+- **WDP-CL-IP-MAPPING-FRAGMENTATION** — Rely on IPv4 fragmentation and reassembly below UDP rather than adding a second WDP segmentation header on the CDPD/IP path.
+  - Family: `wdp`; force: `implicit-must`; level: `required`
+  - Source: `WAP-200-WDP` §7.2 (7.2 Mapping of WDP for IP)
+  - Parents: `WDP-C-001`, `WDP-CT-C-002`, `WDP-NA-C-003`
+  - Requirements: `RQ-TRN-001`, `RQ-TRN-002`, `RQ-TRN-003`
+  - Fixture: `WDP-FX-IP-MAPPING-FRAGMENTATION` (`transport-boundary`, `implemented`)
+- **WDP-CL-IPV4-BASELINE-RECEIVE-SIZE** — Accept IPv4 datagrams up to 576 octets whether received whole or reassembled from fragments.
+  - Family: `wdp`; force: `explicit-must`; level: `required`
+  - Source: `rfc-791` §3.1 (3.1.  Internet Header Format)
+  - Parents: `WDP-CORE-C-001`, `WDP-NA-C-003`
+  - Requirements: `RQ-TRN-001`, `RQ-TRN-003`
+  - Fixture: `WDP-FX-IPV4-BASELINE-RECEIVE-SIZE` (`transport-boundary`, `implemented`)
+- **WDP-CL-IPV4-DONT-FRAGMENT** — Do not fragment a datagram whose DF bit is set; discard it when the route cannot carry it intact.
+  - Family: `wdp`; force: `explicit-must`; level: `required`
+  - Source: `rfc-791` §3.2 (3.2.  Discussion)
+  - Parents: `WDP-CORE-C-001`, `WDP-NA-C-003`
+  - Requirements: `RQ-TRN-001`, `RQ-TRN-003`
+  - Fixture: `WDP-FX-IPV4-DONT-FRAGMENT` (`error-policy`, `implemented`)
+- **WDP-CL-IPV4-FRAGMENT-REASSEMBLY-KEY** — Group IPv4 fragments by identification, source, destination, and protocol, then place data using fragment offsets and the final-fragment marker.
+  - Family: `wdp`; force: `implicit-must`; level: `required`
+  - Source: `rfc-791` §3.2 (3.2.  Discussion)
+  - Parents: `WDP-CORE-C-001`, `WDP-NA-C-003`
+  - Requirements: `RQ-TRN-001`, `RQ-TRN-003`
+  - Fixture: `WDP-FX-IPV4-FRAGMENT-REASSEMBLY-KEY` (`binary-decoder`, `implemented`)
+- **WDP-CL-IPV4-FRAGMENTATION-LOCATION** — Allow IPv4 fragmentation at gateways and reassemble fragments at the destination IP module below WDP.
+  - Family: `wdp`; force: `implicit-must`; level: `required`
+  - Source: `rfc-791` §3.2 (3.2.  Discussion)
+  - Parents: `WDP-CORE-C-001`, `WDP-NA-C-003`
+  - Requirements: `RQ-TRN-001`, `RQ-TRN-003`
+  - Fixture: `WDP-FX-IPV4-FRAGMENTATION-LOCATION` (`transport-boundary`, `implemented`)
+- **WDP-CL-IPV4-LARGE-SEND-GUARD** — Send an IPv4 datagram larger than 576 octets only with assurance that the destination can accept it.
+  - Family: `wdp`; force: `explicit-should`; level: `recommended`
+  - Source: `rfc-791` §3.1 (3.1.  Internet Header Format)
+  - Parents: `WDP-CORE-C-001`, `WDP-NA-C-003`
+  - Requirements: `RQ-TRN-001`, `RQ-TRN-003`
+  - Fixture: `WDP-FX-IPV4-LARGE-SEND-GUARD` (`transport-boundary`, `implemented`)
+- **WDP-CL-IPV4-TOTAL-LENGTH** — Interpret IPv4 total length as header plus payload octets with a maximum representable value of 65,535.
+  - Family: `wdp`; force: `implicit-must`; level: `required`
+  - Source: `rfc-791` §3.1 (3.1.  Internet Header Format)
+  - Parents: `WDP-CORE-C-001`, `WDP-NA-C-003`
+  - Requirements: `RQ-TRN-001`, `RQ-TRN-003`
+  - Fixture: `WDP-FX-IPV4-TOTAL-LENGTH` (`binary-decoder`, `implemented`)
+- **WDP-CL-UDP-LENGTH-BOUNDS** — Interpret UDP length as header plus data octets and reject values smaller than the eight-octet header.
+  - Family: `wdp`; force: `implicit-must`; level: `required`
+  - Source: `rfc-768` §fields (Fields)
+  - Parents: `WDP-CORE-C-001`
+  - Requirements: `RQ-TRN-001`
+  - Fixture: `WDP-FX-UDP-LENGTH-BOUNDS` (`binary-decoder`, `implemented`)
+- **WDP-CL-UNITDATA-CONTENT-TRANSPARENCY** — Transmit and deliver the complete service data unit without manipulating its content.
+  - Family: `wdp`; force: `implicit-must`; level: `required`
+  - Source: `WAP-200-WDP` §6.3.1.1 (6.3.1.1 T-DUnitdata)
+  - Parents: `WDP-CORE-C-001`, `WDP-PF-C-001`, `WDP-PF-C-002`
+  - Requirements: `RQ-TRN-001`
+  - Fixture: `WDP-FX-UNITDATA-CONTENT-TRANSPARENCY` (`transport-boundary`, `implemented`)
+
 ### TRN-703
 
 - **WCMP-CL-CLIENT-GENERAL-PROFILE** — Implement the general WCMP message branch used to report WDP processing errors on the selected non-ICMP profile.
@@ -656,7 +720,6 @@ Evidence commands:
 
 ## Explicit mapping gaps
 
-- `TRN-702` has no direct clause mapping in the canonical nested-clause manifest. Treat this as a planning/evidence gap, not as zero normative scope.
 - `TRN-704` has no direct clause mapping in the canonical nested-clause manifest. Treat this as a planning/evidence gap, not as zero normative scope.
 - `TRN-705` has no direct clause mapping in the canonical nested-clause manifest. Treat this as a planning/evidence gap, not as zero normative scope.
 - `TRN-706` has no direct clause mapping in the canonical nested-clause manifest. Treat this as a planning/evidence gap, not as zero normative scope.
@@ -664,7 +727,6 @@ Evidence commands:
 
 Declared-family gaps:
 
-- `TRN-702` declares `wdp` scope without a direct clause mapping from that family. Clauses from another family do not close this gap.
 - `TRN-706` declares `wdp` scope without a direct clause mapping from that family. Clauses from another family do not close this gap.
 - `TRN-707` declares `wcmp`, `wdp` scope without a direct clause mapping from that family. Clauses from another family do not close this gap.
 

--- a/docs/knowledge-graph/vault-TRN-7/_index.md
+++ b/docs/knowledge-graph/vault-TRN-7/_index.md
@@ -15,7 +15,7 @@ Target: [[sprints/TRN-7|TRN-7]]
 ## Graph summary
 
 - Nodes: 214
-- Edges: 604
+- Edges: 613
 
 - `clause`: 77
 - `fixture`: 77
@@ -31,7 +31,6 @@ Target: [[sprints/TRN-7|TRN-7]]
 
 ## Work items without direct normative-clause mappings
 
-- [[work-items/TRN-702|TRN-702]]
 - [[work-items/TRN-704|TRN-704]]
 - [[work-items/TRN-705|TRN-705]]
 - [[work-items/TRN-706|TRN-706]]
@@ -39,6 +38,5 @@ Target: [[sprints/TRN-7|TRN-7]]
 
 ## Declared normative families without direct clause mappings
 
-- [[work-items/TRN-702|TRN-702]]: `wdp`
 - [[work-items/TRN-706|TRN-706]]: `wdp`
 - [[work-items/TRN-707|TRN-707]]: `wcmp`, `wdp`

--- a/docs/knowledge-graph/vault-TRN-7/clauses/WDP-CL-IP-MAPPING-FRAGMENTATION.md
+++ b/docs/knowledge-graph/vault-TRN-7/clauses/WDP-CL-IP-MAPPING-FRAGMENTATION.md
@@ -19,6 +19,7 @@ tags:
 - `maps-to` → [[requirements/RQ-TRN-002|RQ-TRN-002]]
 - `maps-to` → [[requirements/RQ-TRN-003|RQ-TRN-003]]
 - `planned-by` → [[work-items/TRN-701|TRN-701]]
+- `planned-by` → [[work-items/TRN-702|TRN-702]]
 - `refines` → [[scr-rows/WDP-C-001|WDP-C-001]]
 - `refines` → [[scr-rows/WDP-CT-C-002|WDP-CT-C-002]]
 - `refines` → [[scr-rows/WDP-NA-C-003|WDP-NA-C-003]]
@@ -46,7 +47,8 @@ tags:
   "obligationSynopsis": "Rely on IPv4 fragmentation and reassembly below UDP rather than adding a second WDP segmentation header on the CDPD/IP path.",
   "workItems": [
     "T0-19",
-    "TRN-701"
+    "TRN-701",
+    "TRN-702"
   ],
   "ownerLayers": [
     "transport-rust"

--- a/docs/knowledge-graph/vault-TRN-7/clauses/WDP-CL-IPV4-BASELINE-RECEIVE-SIZE.md
+++ b/docs/knowledge-graph/vault-TRN-7/clauses/WDP-CL-IPV4-BASELINE-RECEIVE-SIZE.md
@@ -18,6 +18,7 @@ tags:
 - `maps-to` → [[requirements/RQ-TRN-001|RQ-TRN-001]]
 - `maps-to` → [[requirements/RQ-TRN-003|RQ-TRN-003]]
 - `planned-by` → [[work-items/TRN-701|TRN-701]]
+- `planned-by` → [[work-items/TRN-702|TRN-702]]
 - `refines` → [[scr-rows/WDP-CORE-C-001|WDP-CORE-C-001]]
 - `refines` → [[scr-rows/WDP-NA-C-003|WDP-NA-C-003]]
 - `sourced-from` → [[source-documents/rfc-791|rfc-791]]
@@ -43,7 +44,8 @@ tags:
   "obligationSynopsis": "Accept IPv4 datagrams up to 576 octets whether received whole or reassembled from fragments.",
   "workItems": [
     "T0-19",
-    "TRN-701"
+    "TRN-701",
+    "TRN-702"
   ],
   "ownerLayers": [
     "transport-rust"

--- a/docs/knowledge-graph/vault-TRN-7/clauses/WDP-CL-IPV4-DONT-FRAGMENT.md
+++ b/docs/knowledge-graph/vault-TRN-7/clauses/WDP-CL-IPV4-DONT-FRAGMENT.md
@@ -18,6 +18,7 @@ tags:
 - `maps-to` → [[requirements/RQ-TRN-001|RQ-TRN-001]]
 - `maps-to` → [[requirements/RQ-TRN-003|RQ-TRN-003]]
 - `planned-by` → [[work-items/TRN-701|TRN-701]]
+- `planned-by` → [[work-items/TRN-702|TRN-702]]
 - `refines` → [[scr-rows/WDP-CORE-C-001|WDP-CORE-C-001]]
 - `refines` → [[scr-rows/WDP-NA-C-003|WDP-NA-C-003]]
 - `sourced-from` → [[source-documents/rfc-791|rfc-791]]
@@ -43,7 +44,8 @@ tags:
   "obligationSynopsis": "Do not fragment a datagram whose DF bit is set; discard it when the route cannot carry it intact.",
   "workItems": [
     "T0-19",
-    "TRN-701"
+    "TRN-701",
+    "TRN-702"
   ],
   "ownerLayers": [
     "transport-rust"

--- a/docs/knowledge-graph/vault-TRN-7/clauses/WDP-CL-IPV4-FRAGMENT-REASSEMBLY-KEY.md
+++ b/docs/knowledge-graph/vault-TRN-7/clauses/WDP-CL-IPV4-FRAGMENT-REASSEMBLY-KEY.md
@@ -18,6 +18,7 @@ tags:
 - `maps-to` → [[requirements/RQ-TRN-001|RQ-TRN-001]]
 - `maps-to` → [[requirements/RQ-TRN-003|RQ-TRN-003]]
 - `planned-by` → [[work-items/TRN-701|TRN-701]]
+- `planned-by` → [[work-items/TRN-702|TRN-702]]
 - `refines` → [[scr-rows/WDP-CORE-C-001|WDP-CORE-C-001]]
 - `refines` → [[scr-rows/WDP-NA-C-003|WDP-NA-C-003]]
 - `sourced-from` → [[source-documents/rfc-791|rfc-791]]
@@ -43,7 +44,8 @@ tags:
   "obligationSynopsis": "Group IPv4 fragments by identification, source, destination, and protocol, then place data using fragment offsets and the final-fragment marker.",
   "workItems": [
     "T0-19",
-    "TRN-701"
+    "TRN-701",
+    "TRN-702"
   ],
   "ownerLayers": [
     "transport-rust"

--- a/docs/knowledge-graph/vault-TRN-7/clauses/WDP-CL-IPV4-FRAGMENTATION-LOCATION.md
+++ b/docs/knowledge-graph/vault-TRN-7/clauses/WDP-CL-IPV4-FRAGMENTATION-LOCATION.md
@@ -18,6 +18,7 @@ tags:
 - `maps-to` → [[requirements/RQ-TRN-001|RQ-TRN-001]]
 - `maps-to` → [[requirements/RQ-TRN-003|RQ-TRN-003]]
 - `planned-by` → [[work-items/TRN-701|TRN-701]]
+- `planned-by` → [[work-items/TRN-702|TRN-702]]
 - `refines` → [[scr-rows/WDP-CORE-C-001|WDP-CORE-C-001]]
 - `refines` → [[scr-rows/WDP-NA-C-003|WDP-NA-C-003]]
 - `sourced-from` → [[source-documents/rfc-791|rfc-791]]
@@ -43,7 +44,8 @@ tags:
   "obligationSynopsis": "Allow IPv4 fragmentation at gateways and reassemble fragments at the destination IP module below WDP.",
   "workItems": [
     "T0-19",
-    "TRN-701"
+    "TRN-701",
+    "TRN-702"
   ],
   "ownerLayers": [
     "transport-rust"

--- a/docs/knowledge-graph/vault-TRN-7/clauses/WDP-CL-IPV4-LARGE-SEND-GUARD.md
+++ b/docs/knowledge-graph/vault-TRN-7/clauses/WDP-CL-IPV4-LARGE-SEND-GUARD.md
@@ -18,6 +18,7 @@ tags:
 - `maps-to` → [[requirements/RQ-TRN-001|RQ-TRN-001]]
 - `maps-to` → [[requirements/RQ-TRN-003|RQ-TRN-003]]
 - `planned-by` → [[work-items/TRN-701|TRN-701]]
+- `planned-by` → [[work-items/TRN-702|TRN-702]]
 - `refines` → [[scr-rows/WDP-CORE-C-001|WDP-CORE-C-001]]
 - `refines` → [[scr-rows/WDP-NA-C-003|WDP-NA-C-003]]
 - `sourced-from` → [[source-documents/rfc-791|rfc-791]]
@@ -43,7 +44,8 @@ tags:
   "obligationSynopsis": "Send an IPv4 datagram larger than 576 octets only with assurance that the destination can accept it.",
   "workItems": [
     "T0-19",
-    "TRN-701"
+    "TRN-701",
+    "TRN-702"
   ],
   "ownerLayers": [
     "transport-rust"

--- a/docs/knowledge-graph/vault-TRN-7/clauses/WDP-CL-IPV4-TOTAL-LENGTH.md
+++ b/docs/knowledge-graph/vault-TRN-7/clauses/WDP-CL-IPV4-TOTAL-LENGTH.md
@@ -18,6 +18,7 @@ tags:
 - `maps-to` → [[requirements/RQ-TRN-001|RQ-TRN-001]]
 - `maps-to` → [[requirements/RQ-TRN-003|RQ-TRN-003]]
 - `planned-by` → [[work-items/TRN-701|TRN-701]]
+- `planned-by` → [[work-items/TRN-702|TRN-702]]
 - `refines` → [[scr-rows/WDP-CORE-C-001|WDP-CORE-C-001]]
 - `refines` → [[scr-rows/WDP-NA-C-003|WDP-NA-C-003]]
 - `sourced-from` → [[source-documents/rfc-791|rfc-791]]
@@ -43,7 +44,8 @@ tags:
   "obligationSynopsis": "Interpret IPv4 total length as header plus payload octets with a maximum representable value of 65,535.",
   "workItems": [
     "T0-19",
-    "TRN-701"
+    "TRN-701",
+    "TRN-702"
   ],
   "ownerLayers": [
     "transport-rust"

--- a/docs/knowledge-graph/vault-TRN-7/clauses/WDP-CL-UDP-LENGTH-BOUNDS.md
+++ b/docs/knowledge-graph/vault-TRN-7/clauses/WDP-CL-UDP-LENGTH-BOUNDS.md
@@ -17,6 +17,7 @@ tags:
 
 - `maps-to` → [[requirements/RQ-TRN-001|RQ-TRN-001]]
 - `planned-by` → [[work-items/TRN-701|TRN-701]]
+- `planned-by` → [[work-items/TRN-702|TRN-702]]
 - `refines` → [[scr-rows/WDP-CORE-C-001|WDP-CORE-C-001]]
 - `sourced-from` → [[source-documents/rfc-768|rfc-768]]
 - `verified-by` → [[fixtures/WDP-FX-UDP-LENGTH-BOUNDS|WDP-FX-UDP-LENGTH-BOUNDS]]
@@ -40,7 +41,8 @@ tags:
   "obligationSynopsis": "Interpret UDP length as header plus data octets and reject values smaller than the eight-octet header.",
   "workItems": [
     "T0-19",
-    "TRN-701"
+    "TRN-701",
+    "TRN-702"
   ],
   "ownerLayers": [
     "transport-rust"

--- a/docs/knowledge-graph/vault-TRN-7/clauses/WDP-CL-UNITDATA-CONTENT-TRANSPARENCY.md
+++ b/docs/knowledge-graph/vault-TRN-7/clauses/WDP-CL-UNITDATA-CONTENT-TRANSPARENCY.md
@@ -17,6 +17,7 @@ tags:
 
 - `maps-to` → [[requirements/RQ-TRN-001|RQ-TRN-001]]
 - `planned-by` → [[work-items/TRN-701|TRN-701]]
+- `planned-by` → [[work-items/TRN-702|TRN-702]]
 - `refines` → [[scr-rows/WDP-CORE-C-001|WDP-CORE-C-001]]
 - `refines` → [[scr-rows/WDP-PF-C-001|WDP-PF-C-001]]
 - `refines` → [[scr-rows/WDP-PF-C-002|WDP-PF-C-002]]
@@ -44,7 +45,8 @@ tags:
   "obligationSynopsis": "Transmit and deliver the complete service data unit without manipulating its content.",
   "workItems": [
     "T0-19",
-    "TRN-701"
+    "TRN-701",
+    "TRN-702"
   ],
   "ownerLayers": [
     "transport-rust"

--- a/docs/knowledge-graph/vault-TRN-7/work-items/TRN-702.md
+++ b/docs/knowledge-graph/vault-TRN-7/work-items/TRN-702.md
@@ -4,7 +4,7 @@ key: "TRN-702"
 type: "work-item"
 generated: true
 slice: "TRN-7"
-status: "todo"
+status: "done"
 tags:
   - "wap-knowledge-graph"
   - "wap-knowledge-graph/work-item"
@@ -20,13 +20,22 @@ tags:
 - `covers-family` → [[source-families/wdp|wdp]]
 - `owned-by` → [[owner-layers/qa|qa]]
 - `owned-by` → [[owner-layers/transport-rust|transport-rust]]
+- `planned-by` ← [[clauses/WDP-CL-IP-MAPPING-FRAGMENTATION|WDP-CL-IP-MAPPING-FRAGMENTATION]]
+- `planned-by` ← [[clauses/WDP-CL-IPV4-BASELINE-RECEIVE-SIZE|WDP-CL-IPV4-BASELINE-RECEIVE-SIZE]]
+- `planned-by` ← [[clauses/WDP-CL-IPV4-DONT-FRAGMENT|WDP-CL-IPV4-DONT-FRAGMENT]]
+- `planned-by` ← [[clauses/WDP-CL-IPV4-FRAGMENT-REASSEMBLY-KEY|WDP-CL-IPV4-FRAGMENT-REASSEMBLY-KEY]]
+- `planned-by` ← [[clauses/WDP-CL-IPV4-FRAGMENTATION-LOCATION|WDP-CL-IPV4-FRAGMENTATION-LOCATION]]
+- `planned-by` ← [[clauses/WDP-CL-IPV4-LARGE-SEND-GUARD|WDP-CL-IPV4-LARGE-SEND-GUARD]]
+- `planned-by` ← [[clauses/WDP-CL-IPV4-TOTAL-LENGTH|WDP-CL-IPV4-TOTAL-LENGTH]]
+- `planned-by` ← [[clauses/WDP-CL-UDP-LENGTH-BOUNDS|WDP-CL-UDP-LENGTH-BOUNDS]]
+- `planned-by` ← [[clauses/WDP-CL-UNITDATA-CONTENT-TRANSPARENCY|WDP-CL-UNITDATA-CONTENT-TRANSPARENCY]]
 - `relates-to` → [[legacy-tickets/T0-19|T0-19]]
 
 ## Data
 
 ```json
 {
-  "status": "todo",
+  "status": "done",
   "ownerLayers": [
     "transport-rust",
     "qa"
@@ -38,13 +47,20 @@ tags:
     "T0-19"
   ],
   "outputs": [
-    "WDP constrained-payload and segmentation/reassembly policy"
+    "WDP constrained-payload and segmentation/reassembly policy",
+    "transport-rust/tests/fixtures/transport/wdp_constrained_payload_mapped/reassembly_fixture.json"
   ],
   "acceptance": [
-    "Payload limits, truncation/rejection, segmentation applicability, and reassembly failure are deterministic for the selected bearer."
+    "The nine adopted WAP-200 and RFC 791/768 obligations directly evidence deterministic payload limits, rejection without WDP unit-data truncation, no WDP segmentation header on CDPD/IPv4, and destination-IP reassembly below WDP.",
+    "Whole, fragmented, out-of-order, duplicate, malformed, overlapping, oversize, and incomplete-expiry inputs produce bounded deterministic outcomes for the selected 576-octet baseline profile."
   ],
   "evidence": [
-    "cargo test --manifest-path transport-rust/Cargo.toml"
+    "cargo test --manifest-path transport-rust/Cargo.toml",
+    "cargo test --manifest-path transport-rust/Cargo.toml --test wdp_constrained_replay",
+    "node scripts/check-wap-selected-normative-clauses.mjs",
+    "node scripts/check-wap-transport-conformance-ledgers.mjs",
+    "node scripts/wap-context-pack.mjs TRN-702",
+    "node scripts/check-wap-knowledge-graph.mjs"
   ],
   "source": "docs/waves/wap-1.2.1-compliance-program.json"
 }

--- a/docs/waves/NETWORK_PROFILE_DECISION_RECORD.md
+++ b/docs/waves/NETWORK_PROFILE_DECISION_RECORD.md
@@ -37,12 +37,15 @@ Current caveat:
 - Native GET/POST ingress and smoke slices are landed, but exact
   WAP-203 connectionless conformance remains open under
   `WSP-801`/`802`/`804`/`805`; the selected WAP-200 and WAP-202 rows are
-  directly evidenced by `TRN-701` and `TRN-703`.
+  directly evidenced by `TRN-701`, the narrow constrained-payload policy by
+  `TRN-702`, and the WCMP core by `TRN-703`.
 
 Fixture lane:
 
 - `transport-rust/src/wsp_registry.rs` (assigned-number policy fixtures)
 - `transport-rust/src/wsp_capability.rs` (capability-bound fixtures)
+- `transport-rust/tests/fixtures/transport/wdp_constrained_payload_mapped/`
+  (bounded CDPD/IPv4 payload and lower-IP reassembly replay lane)
 - `transport-rust/tests/network/interop/` (promotion replay lane; tracked by `T0-22` and `T0-24`)
 
 ### `wap-net-ext` (target, gated)

--- a/docs/waves/WAP_1_2_1_NORMATIVE_CLAUSE_LEDGER.md
+++ b/docs/waves/WAP_1_2_1_NORMATIVE_CLAUSE_LEDGER.md
@@ -1,6 +1,6 @@
 # WAP 1.2.1 Selected Normative-Clause Ledger
 
-Version: v0.8
+Version: v0.9
 Status: `CONF-003` complete; all 201 selected Class C parents planned
 
 ## Purpose
@@ -82,13 +82,17 @@ Each clause records:
 - explicit force classification, including WML implicit-MUST rules;
 - a short project-authored obligation synopsis;
 - every selected SCR parent;
-- inherited owner layers, work items, requirements, and parent implementation
-  status;
-- one planned source-derived direct fixture.
+- inherited owner layers, requirements, parent implementation status, and
+  baseline work items;
+- any explicit slice-scoped `directWorkItems` additions adopted from the same
+  authoritative clause without widening its SCR parents;
+- one planned or implemented source-derived direct fixture.
 
-The fixture plan is not test evidence. Clause implementation status remains
-`not-assessed` until the planned fixture and direct code/test evidence are
-reviewed.
+A planned fixture is not test evidence. An implemented fixture must name its
+fixture path, test path, and command, and clause implementation status changes
+only after that direct evidence is reviewed. The validator currently
+allowlists the nine-clause `TRN-702` overlay so a broad parent-row mapping
+cannot silently substitute for slice adoption.
 
 ## Redistribution boundary
 
@@ -102,6 +106,7 @@ verbatim source text.
 ## `CONF-003` closure
 
 No selected family or parent row remains unexpanded. `CONF-003` is complete at
-the planning level; every clause still remains `not-assessed` until its
-source-derived fixture and direct code/test evidence are reviewed. WTP is
-added only if connection-oriented WSP becomes a claimed profile.
+the planning level. Most clauses remain `not-assessed` until source-derived
+fixture and direct code/test evidence are reviewed; implemented WDP, WCMP, and
+incremental WML clauses retain their explicit fixture evidence. WTP is added
+only if connection-oriented WSP becomes a claimed profile.

--- a/docs/waves/WAP_1_2_1_TRANSPORT_SCR_LEDGERS.md
+++ b/docs/waves/WAP_1_2_1_TRANSPORT_SCR_LEDGERS.md
@@ -95,10 +95,19 @@ WDP path:
 All nine selected rows and their 49 source-anchored WAP-200, RFC 768, and
 RFC 791 clauses link to the direct fixture at
 `transport-rust/tests/fixtures/transport/wdp_cdpd_ipv4_mapped/wdp_fixture.json`.
-IPv4 fragments are rejected with their reassembly key and must be reassembled
-by the destination IP module below WDP. This proves the TRN-701 adaptation
-boundary; it does not implement or close the separately unmapped TRN-702
-segmentation/reassembly policy.
+The stateless codec continues to reject raw IPv4 fragments with their
+reassembly key, preserving the TRN-701 adaptation boundary.
+
+TRN-702 adopts the narrow nine-clause subset governing content transparency,
+UDP/IPv4 length bounds, the 576-octet receive baseline, larger-send assurance,
+DF handling, and IPv4 fragmentation/reassembly location and identity. The
+bounded `Ipv4Reassembler` collects whole/out-of-order/duplicate fragments at
+the destination-IP module below WDP, rejects malformed/overlap/oversize input
+without truncating WDP unit data, and expires incomplete assemblies using
+simulated ticks. Direct replay evidence is in
+`transport-rust/tests/fixtures/transport/wdp_constrained_payload_mapped/reassembly_fixture.json`.
+No WDP segmentation header is introduced, and broader TRN-706 corpus status
+remains unchanged.
 
 ### WCMP
 
@@ -186,8 +195,9 @@ adapter.
 
 - `TRN-701` / `T0-19`: complete for the nine selected WDP rows, CDPD/IPv4
   capability declaration, and source-derived datagram fixtures.
-- `TRN-702`: remains open with no direct clause mapping; constrained-payload
-  and segmentation/reassembly policy must be adopted and evidenced separately.
+- `TRN-702`: complete for the adopted nine-clause constrained-payload subset,
+  deterministic lower-IPv4 reassembly policy, and direct simulated replay
+  evidence; additional bearers remain unclaimed.
 - `TRN-703` / `T0-17`: implement and test the five-row WCMP core, then
   capability-gate optional WCMP breadth.
 - `WSP-801`, `WSP-802`, `WSP-804`, `WSP-805`: close the eight-row

--- a/docs/waves/wap-1.2.1-compliance-program.json
+++ b/docs/waves/wap-1.2.1-compliance-program.json
@@ -968,18 +968,25 @@
         },
         {
           "id": "TRN-702",
-          "status": "todo",
+          "status": "done",
           "ownerLayers": ["transport-rust", "qa"],
           "sourceFamilies": ["wdp"],
           "existingTickets": ["T0-19"],
           "outputs": [
-            "WDP constrained-payload and segmentation/reassembly policy"
+            "WDP constrained-payload and segmentation/reassembly policy",
+            "transport-rust/tests/fixtures/transport/wdp_constrained_payload_mapped/reassembly_fixture.json"
           ],
           "acceptance": [
-            "Payload limits, truncation/rejection, segmentation applicability, and reassembly failure are deterministic for the selected bearer."
+            "The nine adopted WAP-200 and RFC 791/768 obligations directly evidence deterministic payload limits, rejection without WDP unit-data truncation, no WDP segmentation header on CDPD/IPv4, and destination-IP reassembly below WDP.",
+            "Whole, fragmented, out-of-order, duplicate, malformed, overlapping, oversize, and incomplete-expiry inputs produce bounded deterministic outcomes for the selected 576-octet baseline profile."
           ],
           "evidence": [
-            "cargo test --manifest-path transport-rust/Cargo.toml"
+            "cargo test --manifest-path transport-rust/Cargo.toml",
+            "cargo test --manifest-path transport-rust/Cargo.toml --test wdp_constrained_replay",
+            "node scripts/check-wap-selected-normative-clauses.mjs",
+            "node scripts/check-wap-transport-conformance-ledgers.mjs",
+            "node scripts/wap-context-pack.mjs TRN-702",
+            "node scripts/check-wap-knowledge-graph.mjs"
           ]
         },
         {

--- a/docs/waves/wdp-datagram-format.md
+++ b/docs/waves/wdp-datagram-format.md
@@ -84,10 +84,13 @@ Transport policy:
   all-zero UDP checksum omission;
 - accept IPv4 datagrams through the 576-octet baseline and require explicit
   destination assurance for larger sends;
+- treat `65,535` octets as the IPv4 protocol maximum and `65,507` octets as
+  the corresponding no-options UDP payload maximum;
 - discard TTL-zero, bad-header-checksum, malformed-length, bad non-zero UDP
   checksum, unsupported-protocol, and DF/path-MTU failures deterministically;
-- return unreassembled IPv4 fragments as an explicit lower-layer reassembly
-  requirement keyed by identification, source, destination, and protocol.
+- keep the stateless WDP/UDP decoder restricted to complete IPv4 datagrams;
+- collect fragments in the explicit destination-IP boundary below WDP,
+  keyed by identification, source, destination, and protocol.
 
 ### 4.2 SMS/USSD/other GSM bearers — deferred
 
@@ -102,10 +105,21 @@ Implementation is deferred but reserved in model:
 - the selected CDPD/IP path adds no WDP segmentation header;
 - IPv4 gateways may fragment and the destination IP module reassembles before
   delivery to WDP;
-- the codec does not perform fragment collection or reassembly;
-- `TRN-702` remains a declared zero-clause mapping gap for the broader
-  constrained-payload and segmentation/reassembly policy and is not closed by
-  the `TRN-701` evidence.
+- the stateless codec still returns `Ipv4FragmentRequiresReassembly` when it
+  is called directly with a fragment, preserving the `TRN-701` boundary;
+- `Ipv4Reassembler` owns bounded fragment collection at the destination-IP
+  boundary, outside the WDP datagram service;
+- the selected strict receive policy accepts complete/reassembled datagrams
+  through 576 octets, rejects larger units without truncating WDP user data,
+  and can be widened only by an explicit destination capability;
+- pending assemblies are bounded by datagram count, buffered bytes, total
+  datagram size, and deterministic simulated-time expiry;
+- duplicate fragments are idempotent, while conflicting overlaps, malformed
+  flags/lengths, oversize extents, and incomplete expiry are explicit outcomes.
+
+The optional generic `WdpSarPolicy::Enabled` path remains an inactive future
+bearer capability. It is not used to manufacture a WDP segmentation layer for
+CDPD/IPv4.
 
 ## 6) Error taxonomy
 
@@ -115,6 +129,10 @@ Minimum errors expected by upper layers:
 - `WdpError::AddressTypeUnsupported`
 - `WdpError::AddressUnresolvable`
 - `WdpError::PayloadOversize`
+- `WdpError::Ipv4FragmentMalformed`
+- `WdpError::Ipv4ReassemblyOversize`
+- `WdpError::Ipv4ReassemblyCapacityExceeded`
+- `WdpError::Ipv4ReassemblyBufferExceeded`
 - `WdpError::Timeout`
 - `WdpError::CorruptOrMalformed`
 
@@ -130,9 +148,18 @@ The direct fixture
 `transport-rust/tests/fixtures/transport/wdp_cdpd_ipv4_mapped/wdp_fixture.json`
 links the nine selected SCR rows and all 49 mapped TRN-701 clauses to exact
 profile constants, registered ports, positive wire packets, and deterministic
-malformed outcomes. Validate it with:
+malformed outcomes.
+
+The additive TRN-702 fixture
+`transport-rust/tests/fixtures/transport/wdp_constrained_payload_mapped/reassembly_fixture.json`
+maps the narrow nine-clause payload/fragment subset to whole, out-of-order,
+duplicate, malformed, overlap, oversize, and incomplete-expiry replays. This
+does not claim broader TRN-706 replay-corpus closure. Validate both with:
 
 ```sh
 cargo test --manifest-path transport-rust/Cargo.toml --lib network::wdp
+cargo test --manifest-path transport-rust/Cargo.toml --test wdp_constrained_replay
 node scripts/check-wap-transport-conformance-ledgers.mjs
+node scripts/check-wap-selected-normative-clauses.mjs
+node scripts/wap-context-pack.mjs TRN-702
 ```

--- a/scripts/check-requirement-status-drift.mjs
+++ b/scripts/check-requirement-status-drift.mjs
@@ -154,7 +154,7 @@ for (const sprint of program.sprints ?? []) {
 }
 if (
   JSON.stringify(programStatusCounts) !==
-  JSON.stringify({ done: 14, blocked: 1, 'in-progress': 9, todo: 54 })
+  JSON.stringify({ done: 15, blocked: 1, 'in-progress': 9, todo: 53 })
 ) {
   failures.push('compliance-program work-item status rollup drift');
 }

--- a/scripts/check-wap-compliance-program.mjs
+++ b/scripts/check-wap-compliance-program.mjs
@@ -403,12 +403,16 @@ const transportSprint = program.sprints.find(
 const wdpCore = transportSprint?.workItems.find(
   (workItem) => workItem.id === 'TRN-701'
 );
+const wdpConstrained = transportSprint?.workItems.find(
+  (workItem) => workItem.id === 'TRN-702'
+);
 const wcmpCore = transportSprint?.workItems.find(
   (workItem) => workItem.id === 'TRN-703'
 );
 if (
   transportSprint?.status !== 'in-progress' ||
   wdpCore?.status !== 'done' ||
+  wdpConstrained?.status !== 'done' ||
   wcmpCore?.status !== 'done' ||
   !wdpCore?.outputs?.includes(
     'spec-processing/source-manifests/wap-1.2.1-wdp-scr.json'
@@ -417,6 +421,17 @@ if (
     'spec-processing/source-manifests/wap-1.2.1-wcmp-scr.json'
   ) ||
   !wdpCore?.acceptance?.some((line) => line.includes('nine selected')) ||
+  !wdpConstrained?.acceptance?.some(
+    (line) =>
+      line.includes('nine adopted') &&
+      line.includes('destination-IP reassembly below WDP')
+  ) ||
+  !wdpConstrained?.evidence?.includes(
+    'cargo test --manifest-path transport-rust/Cargo.toml --test wdp_constrained_replay'
+  ) ||
+  !wdpConstrained?.evidence?.includes(
+    'node scripts/wap-context-pack.mjs TRN-702'
+  ) ||
   !wcmpCore?.acceptance?.some((line) => line.includes('five selected')) ||
   !transportSprint?.exitGates?.some((line) =>
     line.includes('only when connection-oriented WSP is claimed')

--- a/scripts/check-wap-knowledge-graph.mjs
+++ b/scripts/check-wap-knowledge-graph.mjs
@@ -196,9 +196,12 @@ const selectedWcmpRows = [
 if (
   trnGraph.target.sprint !== 'TRN-7' ||
   trnGraph.target.profile !== 'CCR-CLASSC-C-001' ||
+  !trnNodeIds.has('work-item:TRN-702') ||
   !trnNodeIds.has('work-item:TRN-703')
 ) {
-  failures.push('TRN-7 target must retain the selected Class C profile and TRN-703 work item');
+  failures.push(
+    'TRN-7 target must retain the selected Class C profile and adopted TRN-702/TRN-703 work items'
+  );
 }
 for (const row of selectedWcmpRows) {
   if (!trnNodeIds.has(`scr-row:${row}`)) {
@@ -213,6 +216,19 @@ if (
   !trn703Pack.includes('- Direct normative clauses: 28')
 ) {
   failures.push('TRN-703 context rendering must remain bounded to its 28 direct WCMP clauses');
+}
+const trn702Pack = renderContextPack(trnGraph, 'TRN-702');
+if (
+  !trn702Pack.startsWith('# TRN-702 AI Context Pack') ||
+  !trn702Pack.includes('### TRN-702:') ||
+  trn702Pack.includes('### TRN-701:') ||
+  !trn702Pack.includes('- Direct normative clauses: 9') ||
+  trnGraph.summary.workItemsWithoutDirectClauses.includes('TRN-702') ||
+  trnGraph.summary.unmappedNormativeFamiliesByWorkItem['TRN-702']
+) {
+  failures.push(
+    'TRN-702 context rendering must remain bounded to its nine adopted WDP clauses without a declared-family gap'
+  );
 }
 
 if (failures.length) {

--- a/scripts/check-wap-selected-normative-clauses.mjs
+++ b/scripts/check-wap-selected-normative-clauses.mjs
@@ -139,6 +139,17 @@ const expectedLevelByForce = {
   table: 'required',
   'error-condition': 'required'
 };
+const trn702ClauseIds = new Set([
+  'WDP-CL-UNITDATA-CONTENT-TRANSPARENCY',
+  'WDP-CL-IP-MAPPING-FRAGMENTATION',
+  'WDP-CL-UDP-LENGTH-BOUNDS',
+  'WDP-CL-IPV4-TOTAL-LENGTH',
+  'WDP-CL-IPV4-BASELINE-RECEIVE-SIZE',
+  'WDP-CL-IPV4-LARGE-SEND-GUARD',
+  'WDP-CL-IPV4-FRAGMENTATION-LOCATION',
+  'WDP-CL-IPV4-FRAGMENT-REASSEMBLY-KEY',
+  'WDP-CL-IPV4-DONT-FRAGMENT'
+]);
 const allowedFixtureKinds = new Set([
   'parser',
   'transport-boundary',
@@ -418,7 +429,10 @@ for (const family of ledger.families ?? []) {
       ...new Set(parents.flatMap((parent) => parent.mapping.ownerLayers))
     ].sort();
     const expectedWorkItems = [
-      ...new Set(parents.flatMap((parent) => parent.mapping.workItems))
+      ...new Set([
+        ...parents.flatMap((parent) => parent.mapping.workItems),
+        ...(trn702ClauseIds.has(candidate.id) ? ['TRN-702'] : [])
+      ])
     ].sort();
     const expectedRequirements = [
       ...new Set(parents.flatMap((parent) => parent.mapping.requirementIds))
@@ -434,6 +448,8 @@ for (const family of ledger.families ?? []) {
     const expectedFixtureStatus = directFixtureImplemented ? 'implemented' : 'planned';
     if (
       JSON.stringify(candidate.mapping?.ownerLayers) !== JSON.stringify(expectedOwners) ||
+      JSON.stringify(candidate.directWorkItems ?? []) !==
+        JSON.stringify(trn702ClauseIds.has(candidate.id) ? ['TRN-702'] : []) ||
       JSON.stringify(candidate.mapping?.workItems) !== JSON.stringify(expectedWorkItems) ||
       JSON.stringify(candidate.mapping?.requirementIds) !== JSON.stringify(expectedRequirements) ||
       JSON.stringify(candidate.mapping?.parentImplementationSnapshot) !==
@@ -452,15 +468,23 @@ for (const family of ledger.families ?? []) {
       candidate.fixturePlan.assertion !== candidate.obligationSynopsis ||
       ((candidate.family === 'wcmp' || candidate.family === 'wdp') &&
         (candidate.fixturePlan.evidence?.path !==
-          (candidate.family === 'wdp'
-            ? 'transport-rust/tests/fixtures/transport/wdp_cdpd_ipv4_mapped/wdp_fixture.json'
+          (trn702ClauseIds.has(candidate.id)
+            ? 'transport-rust/tests/fixtures/transport/wdp_constrained_payload_mapped/reassembly_fixture.json'
+            : candidate.family === 'wdp'
+              ? 'transport-rust/tests/fixtures/transport/wdp_cdpd_ipv4_mapped/wdp_fixture.json'
             : 'transport-rust/tests/fixtures/transport/wcmp_core_mapped/wcmp_fixture.json') ||
           candidate.fixturePlan.evidence?.testPath !==
-            (candidate.family === 'wdp'
-              ? 'transport-rust/src/network/wdp/tests.rs'
+            (trn702ClauseIds.has(candidate.id)
+              ? 'transport-rust/tests/wdp_constrained_replay.rs'
+              : candidate.family === 'wdp'
+                ? 'transport-rust/src/network/wdp/tests.rs'
               : 'transport-rust/src/network/wcmp/tests.rs') ||
           !candidate.fixturePlan.evidence?.command?.includes(
-            candidate.family === 'wdp' ? 'network::wdp' : 'network::wcmp'
+            trn702ClauseIds.has(candidate.id)
+              ? 'wdp_constrained_replay'
+              : candidate.family === 'wdp'
+                ? 'network::wdp'
+                : 'network::wcmp'
           ))) ||
       (implementedWmlClauseIds.has(candidate.id) &&
         (candidate.fixturePlan.evidence?.path !== candidate.fixturePlan.evidence?.testPath ||

--- a/scripts/wap-context-pack.mjs
+++ b/scripts/wap-context-pack.mjs
@@ -10,13 +10,14 @@ import {
 const target = process.argv[2];
 if (!target) {
   console.error(
-    'Usage: node scripts/wap-context-pack.mjs TRN-7|TRN-703|WML-2|WML-201|WML-202|WML-203|WML-204|WML-205'
+    'Usage: node scripts/wap-context-pack.mjs TRN-7|TRN-702|TRN-703|WML-2|WML-201|WML-202|WML-203|WML-204|WML-205'
   );
   process.exit(1);
 }
 
 const targetSprints = new Map([
   ['TRN-7', 'TRN-7'],
+  ['TRN-702', 'TRN-7'],
   ['TRN-703', 'TRN-7'],
   ['WML-2', 'WML-2'],
   ['WML-201', 'WML-2'],

--- a/spec-processing/scripts/generate-wap-selected-normative-clauses.mjs
+++ b/spec-processing/scripts/generate-wap-selected-normative-clauses.mjs
@@ -888,11 +888,20 @@ function clause(
   normativeForce,
   fixtureKind,
   obligationSynopsis,
-  anchorFamily = family
+  anchorFamily = family,
+  directWorkItems = []
 ) {
   const directFixtureImplemented = family === 'wcmp' || family === 'wdp';
+  const isTrn702Clause = directWorkItems.includes('TRN-702');
   const evidence =
-    family === 'wdp'
+    isTrn702Clause
+      ? {
+          path: 'transport-rust/tests/fixtures/transport/wdp_constrained_payload_mapped/reassembly_fixture.json',
+          testPath: 'transport-rust/tests/wdp_constrained_replay.rs',
+          command:
+            'cargo test --manifest-path transport-rust/Cargo.toml --test wdp_constrained_replay'
+        }
+      : family === 'wdp'
       ? {
           path: 'transport-rust/tests/fixtures/transport/wdp_cdpd_ipv4_mapped/wdp_fixture.json',
           testPath: 'transport-rust/src/network/wdp/tests.rs',
@@ -909,6 +918,7 @@ function clause(
     id: `${family.toUpperCase()}-CL-${key.toUpperCase().replaceAll('_', '-')}`,
     family,
     parentRows,
+    ...(directWorkItems.length ? { directWorkItems } : {}),
     sourceAnchor: sectionAnchors.get(`${anchorFamily}:${section}`),
     normativeForce,
     obligationLevel:
@@ -1360,10 +1370,10 @@ clause('wdp', 'destination_address_semantics', ['WDP-PF-C-001', 'WDP-PF-C-002', 
 clause('wdp', 'source_address_semantics', ['WDP-PF-C-001', 'WDP-PF-C-002', 'WDP-NA-C-000', 'WDP-NA-C-003'], '6.3.1.1', 'implicit-must', 'transport-boundary', 'Treat the source address as the unique network identity of the device issuing the transport request.');
 clause('wdp', 'destination_port_semantics', ['WDP-PF-C-001', 'WDP-PF-C-002', 'WDP-NA-C-006'], '6.3.1.1', 'implicit-must', 'transport-boundary', 'Bind the destination port to the destination application or upper-layer protocol for that communication instance.');
 clause('wdp', 'source_port_semantics', ['WDP-PF-C-001', 'WDP-PF-C-002', 'WDP-NA-C-007'], '6.3.1.1', 'implicit-must', 'transport-boundary', 'Bind the source port to the requesting application or upper-layer protocol for that communication instance.');
-clause('wdp', 'unitdata_content_transparency', ['WDP-CORE-C-001', 'WDP-PF-C-001', 'WDP-PF-C-002'], '6.3.1.1', 'implicit-must', 'transport-boundary', 'Transmit and deliver the complete service data unit without manipulating its content.');
+clause('wdp', 'unitdata_content_transparency', ['WDP-CORE-C-001', 'WDP-PF-C-001', 'WDP-PF-C-002'], '6.3.1.1', 'implicit-must', 'transport-boundary', 'Transmit and deliver the complete service data unit without manipulating its content.', 'wdp', ['TRN-702']);
 clause('wdp', 'protocol_required_port_fields', ['WDP-CORE-C-001', 'WDP-NA-C-006', 'WDP-NA-C-007'], '7.1', 'implicit-must', 'binary-decoder', 'Carry both destination and source port fields in the selected WDP protocol mapping.');
 clause('wdp', 'ip_mapping_is_udp', ['WDP-C-001', 'WDP-CT-C-002', 'WDP-NA-C-003'], '7.2', 'implicit-must', 'transport-boundary', 'Map WDP directly to UDP for every selected bearer on which IP routing is available.');
-clause('wdp', 'ip_mapping_fragmentation', ['WDP-C-001', 'WDP-CT-C-002', 'WDP-NA-C-003'], '7.2', 'implicit-must', 'transport-boundary', 'Rely on IPv4 fragmentation and reassembly below UDP rather than adding a second WDP segmentation header on the CDPD/IP path.');
+clause('wdp', 'ip_mapping_fragmentation', ['WDP-C-001', 'WDP-CT-C-002', 'WDP-NA-C-003'], '7.2', 'implicit-must', 'transport-boundary', 'Rely on IPv4 fragmentation and reassembly below UDP rather than adding a second WDP segmentation header on the CDPD/IP path.', 'wdp', ['TRN-702']);
 clause('wdp', 'wap_port_registry', ['WDP-NA-C-006', 'WDP-NA-C-007'], 'appendix-b', 'table', 'transport-boundary', 'Recognize the complete WAP port assignment table, including connectionless, session, secure, push, vCard, and vCalendar services.');
 clause('wdp', 'selected_wsp_port', ['WDP-C-001', 'WDP-NA-C-006'], 'appendix-b', 'table', 'transport-boundary', 'Use registered UDP/WDP port 9200 for the selected non-secure connectionless WSP session service.');
 clause('wdp', 'selected_bearer_assignment', ['WDP-CT-C-002', 'WDP-NA-C-003'], 'appendix-c', 'table', 'transport-boundary', 'Represent the AMPS/CDPD/IPv4 network-bearer-address combination with assigned bearer value 0x0D when that registry is carried.');
@@ -1372,7 +1382,7 @@ clause('wdp', 'udp_unreliable_datagrams', ['WDP-C-001', 'WDP-CORE-C-001'], 'intr
 clause('wdp', 'udp_header_layout', ['WDP-CORE-C-001', 'WDP-NA-C-006', 'WDP-NA-C-007'], 'format', 'grammar', 'binary-decoder', 'Encode and decode the UDP header as 16-bit source port, destination port, length, and checksum fields followed by data.', 'rfc-768');
 clause('wdp', 'udp_source_port_zero', ['WDP-NA-C-007'], 'fields', 'table', 'binary-decoder', 'Use source port zero when the sender does not supply a meaningful reply port, and otherwise preserve the selected source port.', 'rfc-768');
 clause('wdp', 'udp_destination_port_context', ['WDP-NA-C-006', 'WDP-NA-C-003'], 'fields', 'implicit-must', 'transport-boundary', 'Interpret a UDP destination port within the context of its destination IPv4 address.', 'rfc-768');
-clause('wdp', 'udp_length_bounds', ['WDP-CORE-C-001'], 'fields', 'implicit-must', 'binary-decoder', 'Interpret UDP length as header plus data octets and reject values smaller than the eight-octet header.', 'rfc-768');
+clause('wdp', 'udp_length_bounds', ['WDP-CORE-C-001'], 'fields', 'implicit-must', 'binary-decoder', 'Interpret UDP length as header plus data octets and reject values smaller than the eight-octet header.', 'rfc-768', ['TRN-702']);
 clause('wdp', 'udp_checksum_coverage', ['WDP-CORE-C-001', 'WDP-NA-C-003'], 'fields', 'implicit-must', 'binary-decoder', 'Compute the UDP checksum over the IPv4 pseudo-header, UDP header, and data using 16-bit ones-complement arithmetic.', 'rfc-768');
 clause('wdp', 'udp_checksum_padding', ['WDP-CORE-C-001'], 'fields', 'implicit-must', 'binary-decoder', 'Zero-pad an odd checksum input to a two-octet boundary without transmitting the padding octet.', 'rfc-768');
 clause('wdp', 'udp_checksum_zero_encoding', ['WDP-CORE-C-001'], 'fields', 'implicit-must', 'binary-decoder', 'Transmit an arithmetically computed zero UDP checksum as all one bits.', 'rfc-768');
@@ -1386,12 +1396,12 @@ clause('wdp', 'ipv4_independent_datagrams', ['WDP-C-001', 'WDP-CORE-C-001', 'WDP
 clause('wdp', 'ipv4_fixed_address_size', ['WDP-NA-C-000', 'WDP-NA-C-003'], '2.3', 'implicit-must', 'binary-decoder', 'Represent each selected IPv4 source or destination address as four octets.', 'rfc-791');
 clause('wdp', 'ipv4_header_layout', ['WDP-NA-C-003'], '3.1', 'grammar', 'binary-decoder', 'Decode the complete IPv4 header field order and widths before passing its UDP payload to WDP.', 'rfc-791');
 clause('wdp', 'ipv4_version_and_ihl', ['WDP-NA-C-003'], '3.1', 'table', 'binary-decoder', 'Require IPv4 version value 4 and use IHL in 32-bit words with a minimum valid value of five.', 'rfc-791');
-clause('wdp', 'ipv4_total_length', ['WDP-CORE-C-001', 'WDP-NA-C-003'], '3.1', 'implicit-must', 'binary-decoder', 'Interpret IPv4 total length as header plus payload octets with a maximum representable value of 65,535.', 'rfc-791');
-clause('wdp', 'ipv4_baseline_receive_size', ['WDP-CORE-C-001', 'WDP-NA-C-003'], '3.1', 'explicit-must', 'transport-boundary', 'Accept IPv4 datagrams up to 576 octets whether received whole or reassembled from fragments.', 'rfc-791');
-clause('wdp', 'ipv4_large_send_guard', ['WDP-CORE-C-001', 'WDP-NA-C-003'], '3.1', 'explicit-should', 'transport-boundary', 'Send an IPv4 datagram larger than 576 octets only with assurance that the destination can accept it.', 'rfc-791');
-clause('wdp', 'ipv4_fragmentation_location', ['WDP-CORE-C-001', 'WDP-NA-C-003'], '3.2', 'implicit-must', 'transport-boundary', 'Allow IPv4 fragmentation at gateways and reassemble fragments at the destination IP module below WDP.', 'rfc-791');
-clause('wdp', 'ipv4_fragment_reassembly_key', ['WDP-CORE-C-001', 'WDP-NA-C-003'], '3.2', 'implicit-must', 'binary-decoder', 'Group IPv4 fragments by identification, source, destination, and protocol, then place data using fragment offsets and the final-fragment marker.', 'rfc-791');
-clause('wdp', 'ipv4_dont_fragment', ['WDP-CORE-C-001', 'WDP-NA-C-003'], '3.2', 'explicit-must', 'error-policy', 'Do not fragment a datagram whose DF bit is set; discard it when the route cannot carry it intact.', 'rfc-791');
+clause('wdp', 'ipv4_total_length', ['WDP-CORE-C-001', 'WDP-NA-C-003'], '3.1', 'implicit-must', 'binary-decoder', 'Interpret IPv4 total length as header plus payload octets with a maximum representable value of 65,535.', 'rfc-791', ['TRN-702']);
+clause('wdp', 'ipv4_baseline_receive_size', ['WDP-CORE-C-001', 'WDP-NA-C-003'], '3.1', 'explicit-must', 'transport-boundary', 'Accept IPv4 datagrams up to 576 octets whether received whole or reassembled from fragments.', 'rfc-791', ['TRN-702']);
+clause('wdp', 'ipv4_large_send_guard', ['WDP-CORE-C-001', 'WDP-NA-C-003'], '3.1', 'explicit-should', 'transport-boundary', 'Send an IPv4 datagram larger than 576 octets only with assurance that the destination can accept it.', 'rfc-791', ['TRN-702']);
+clause('wdp', 'ipv4_fragmentation_location', ['WDP-CORE-C-001', 'WDP-NA-C-003'], '3.2', 'implicit-must', 'transport-boundary', 'Allow IPv4 fragmentation at gateways and reassemble fragments at the destination IP module below WDP.', 'rfc-791', ['TRN-702']);
+clause('wdp', 'ipv4_fragment_reassembly_key', ['WDP-CORE-C-001', 'WDP-NA-C-003'], '3.2', 'implicit-must', 'binary-decoder', 'Group IPv4 fragments by identification, source, destination, and protocol, then place data using fragment offsets and the final-fragment marker.', 'rfc-791', ['TRN-702']);
+clause('wdp', 'ipv4_dont_fragment', ['WDP-CORE-C-001', 'WDP-NA-C-003'], '3.2', 'explicit-must', 'error-policy', 'Do not fragment a datagram whose DF bit is set; discard it when the route cannot carry it intact.', 'rfc-791', ['TRN-702']);
 clause('wdp', 'ipv4_ttl_zero', ['WDP-NA-C-003'], '3.1', 'explicit-must', 'error-policy', 'Destroy an IPv4 datagram when its time-to-live value reaches zero.', 'rfc-791');
 clause('wdp', 'ipv4_header_checksum', ['WDP-NA-C-003'], '3.1', 'explicit-must', 'binary-decoder', 'Verify the ones-complement IPv4 header checksum and discard a datagram immediately when verification fails.', 'rfc-791');
 clause('wdp', 'ipv4_source_destination_fields', ['WDP-PF-C-001', 'WDP-PF-C-002', 'WDP-NA-C-003'], '3.1', 'table', 'binary-decoder', 'Preserve the 32-bit IPv4 source and destination header fields across the WDP request and indication boundary.', 'rfc-791');
@@ -2381,7 +2391,10 @@ const families = familyDefinitions.map((definition) => {
         ...new Set(parents.flatMap((parent) => parent.mapping.ownerLayers))
       ].sort(),
       workItems: [
-        ...new Set(parents.flatMap((parent) => parent.mapping.workItems))
+        ...new Set([
+          ...parents.flatMap((parent) => parent.mapping.workItems),
+          ...candidate.directWorkItems
+        ])
       ].sort(),
       requirementIds: [
         ...new Set(parents.flatMap((parent) => parent.mapping.requirementIds))

--- a/spec-processing/scripts/generate-wap-transport-scr-ledgers.mjs
+++ b/spec-processing/scripts/generate-wap-transport-scr-ledgers.mjs
@@ -809,7 +809,7 @@ function selectedEvidence(family, id) {
             'transport-rust/tests/fixtures/transport/wdp_cdpd_ipv4_mapped/wdp_fixture.json',
           evidenceClass: 'direct-normative',
           limitation:
-            'Closes only the nine selected CDPD/IPv4 WDP client rows and their mapped TRN-701 clauses; TRN-702 reassembly policy, alternate bearers, server rows, and optional services remain unclaimed.'
+            'Closes only the nine selected CDPD/IPv4 WDP client rows and their mapped TRN-701 clauses at SCR-row level; TRN-702 separately closes its adopted constrained-payload clause subset without widening row selection. Alternate bearers, server rows, and optional services remain unclaimed.'
         }
       ]
     };

--- a/spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json
+++ b/spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json
@@ -19693,7 +19693,7 @@
       "family": "wdp",
       "status": "nested-clauses-fixture-backed",
       "parentLedger": "spec-processing/source-manifests/wap-1.2.1-wdp-scr.json",
-      "parentLedgerSha256": "900f30373d63b8ba7764ded3211fe8074010f191a7f8119031f6be677be03253",
+      "parentLedgerSha256": "8cdd4055da1b4eb69770c74696aa6e1d9e71d8314bd4213f939d6378db7d3bfd",
       "effectiveSequence": [
         "WAP-200-WDP",
         "WAP-200_001-WDP",
@@ -20719,6 +20719,9 @@
             "WDP-PF-C-001",
             "WDP-PF-C-002"
           ],
+          "directWorkItems": [
+            "TRN-702"
+          ],
           "sourceAnchor": {
             "documentId": "WAP-200-WDP",
             "section": "6.3.1.1",
@@ -20734,9 +20737,9 @@
             "status": "implemented",
             "assertion": "Transmit and deliver the complete service data unit without manipulating its content.",
             "evidence": {
-              "path": "transport-rust/tests/fixtures/transport/wdp_cdpd_ipv4_mapped/wdp_fixture.json",
-              "testPath": "transport-rust/src/network/wdp/tests.rs",
-              "command": "cargo test --manifest-path transport-rust/Cargo.toml --lib network::wdp"
+              "path": "transport-rust/tests/fixtures/transport/wdp_constrained_payload_mapped/reassembly_fixture.json",
+              "testPath": "transport-rust/tests/wdp_constrained_replay.rs",
+              "command": "cargo test --manifest-path transport-rust/Cargo.toml --test wdp_constrained_replay"
             }
           },
           "mapping": {
@@ -20745,7 +20748,8 @@
             ],
             "workItems": [
               "T0-19",
-              "TRN-701"
+              "TRN-701",
+              "TRN-702"
             ],
             "requirementIds": [
               "RQ-TRN-001"
@@ -20866,6 +20870,9 @@
             "WDP-CT-C-002",
             "WDP-NA-C-003"
           ],
+          "directWorkItems": [
+            "TRN-702"
+          ],
           "sourceAnchor": {
             "documentId": "WAP-200-WDP",
             "section": "7.2",
@@ -20881,9 +20888,9 @@
             "status": "implemented",
             "assertion": "Rely on IPv4 fragmentation and reassembly below UDP rather than adding a second WDP segmentation header on the CDPD/IP path.",
             "evidence": {
-              "path": "transport-rust/tests/fixtures/transport/wdp_cdpd_ipv4_mapped/wdp_fixture.json",
-              "testPath": "transport-rust/src/network/wdp/tests.rs",
-              "command": "cargo test --manifest-path transport-rust/Cargo.toml --lib network::wdp"
+              "path": "transport-rust/tests/fixtures/transport/wdp_constrained_payload_mapped/reassembly_fixture.json",
+              "testPath": "transport-rust/tests/wdp_constrained_replay.rs",
+              "command": "cargo test --manifest-path transport-rust/Cargo.toml --test wdp_constrained_replay"
             }
           },
           "mapping": {
@@ -20892,7 +20899,8 @@
             ],
             "workItems": [
               "T0-19",
-              "TRN-701"
+              "TRN-701",
+              "TRN-702"
             ],
             "requirementIds": [
               "RQ-TRN-001",
@@ -21239,6 +21247,9 @@
           "parentRows": [
             "WDP-CORE-C-001"
           ],
+          "directWorkItems": [
+            "TRN-702"
+          ],
           "sourceAnchor": {
             "documentId": "rfc-768",
             "section": "fields",
@@ -21254,9 +21265,9 @@
             "status": "implemented",
             "assertion": "Interpret UDP length as header plus data octets and reject values smaller than the eight-octet header.",
             "evidence": {
-              "path": "transport-rust/tests/fixtures/transport/wdp_cdpd_ipv4_mapped/wdp_fixture.json",
-              "testPath": "transport-rust/src/network/wdp/tests.rs",
-              "command": "cargo test --manifest-path transport-rust/Cargo.toml --lib network::wdp"
+              "path": "transport-rust/tests/fixtures/transport/wdp_constrained_payload_mapped/reassembly_fixture.json",
+              "testPath": "transport-rust/tests/wdp_constrained_replay.rs",
+              "command": "cargo test --manifest-path transport-rust/Cargo.toml --test wdp_constrained_replay"
             }
           },
           "mapping": {
@@ -21265,7 +21276,8 @@
             ],
             "workItems": [
               "T0-19",
-              "TRN-701"
+              "TRN-701",
+              "TRN-702"
             ],
             "requirementIds": [
               "RQ-TRN-001"
@@ -21840,6 +21852,9 @@
             "WDP-CORE-C-001",
             "WDP-NA-C-003"
           ],
+          "directWorkItems": [
+            "TRN-702"
+          ],
           "sourceAnchor": {
             "documentId": "rfc-791",
             "section": "3.1",
@@ -21855,9 +21870,9 @@
             "status": "implemented",
             "assertion": "Interpret IPv4 total length as header plus payload octets with a maximum representable value of 65,535.",
             "evidence": {
-              "path": "transport-rust/tests/fixtures/transport/wdp_cdpd_ipv4_mapped/wdp_fixture.json",
-              "testPath": "transport-rust/src/network/wdp/tests.rs",
-              "command": "cargo test --manifest-path transport-rust/Cargo.toml --lib network::wdp"
+              "path": "transport-rust/tests/fixtures/transport/wdp_constrained_payload_mapped/reassembly_fixture.json",
+              "testPath": "transport-rust/tests/wdp_constrained_replay.rs",
+              "command": "cargo test --manifest-path transport-rust/Cargo.toml --test wdp_constrained_replay"
             }
           },
           "mapping": {
@@ -21866,7 +21881,8 @@
             ],
             "workItems": [
               "T0-19",
-              "TRN-701"
+              "TRN-701",
+              "TRN-702"
             ],
             "requirementIds": [
               "RQ-TRN-001",
@@ -21887,6 +21903,9 @@
             "WDP-CORE-C-001",
             "WDP-NA-C-003"
           ],
+          "directWorkItems": [
+            "TRN-702"
+          ],
           "sourceAnchor": {
             "documentId": "rfc-791",
             "section": "3.1",
@@ -21902,9 +21921,9 @@
             "status": "implemented",
             "assertion": "Accept IPv4 datagrams up to 576 octets whether received whole or reassembled from fragments.",
             "evidence": {
-              "path": "transport-rust/tests/fixtures/transport/wdp_cdpd_ipv4_mapped/wdp_fixture.json",
-              "testPath": "transport-rust/src/network/wdp/tests.rs",
-              "command": "cargo test --manifest-path transport-rust/Cargo.toml --lib network::wdp"
+              "path": "transport-rust/tests/fixtures/transport/wdp_constrained_payload_mapped/reassembly_fixture.json",
+              "testPath": "transport-rust/tests/wdp_constrained_replay.rs",
+              "command": "cargo test --manifest-path transport-rust/Cargo.toml --test wdp_constrained_replay"
             }
           },
           "mapping": {
@@ -21913,7 +21932,8 @@
             ],
             "workItems": [
               "T0-19",
-              "TRN-701"
+              "TRN-701",
+              "TRN-702"
             ],
             "requirementIds": [
               "RQ-TRN-001",
@@ -21934,6 +21954,9 @@
             "WDP-CORE-C-001",
             "WDP-NA-C-003"
           ],
+          "directWorkItems": [
+            "TRN-702"
+          ],
           "sourceAnchor": {
             "documentId": "rfc-791",
             "section": "3.1",
@@ -21949,9 +21972,9 @@
             "status": "implemented",
             "assertion": "Send an IPv4 datagram larger than 576 octets only with assurance that the destination can accept it.",
             "evidence": {
-              "path": "transport-rust/tests/fixtures/transport/wdp_cdpd_ipv4_mapped/wdp_fixture.json",
-              "testPath": "transport-rust/src/network/wdp/tests.rs",
-              "command": "cargo test --manifest-path transport-rust/Cargo.toml --lib network::wdp"
+              "path": "transport-rust/tests/fixtures/transport/wdp_constrained_payload_mapped/reassembly_fixture.json",
+              "testPath": "transport-rust/tests/wdp_constrained_replay.rs",
+              "command": "cargo test --manifest-path transport-rust/Cargo.toml --test wdp_constrained_replay"
             }
           },
           "mapping": {
@@ -21960,7 +21983,8 @@
             ],
             "workItems": [
               "T0-19",
-              "TRN-701"
+              "TRN-701",
+              "TRN-702"
             ],
             "requirementIds": [
               "RQ-TRN-001",
@@ -21981,6 +22005,9 @@
             "WDP-CORE-C-001",
             "WDP-NA-C-003"
           ],
+          "directWorkItems": [
+            "TRN-702"
+          ],
           "sourceAnchor": {
             "documentId": "rfc-791",
             "section": "3.2",
@@ -21996,9 +22023,9 @@
             "status": "implemented",
             "assertion": "Allow IPv4 fragmentation at gateways and reassemble fragments at the destination IP module below WDP.",
             "evidence": {
-              "path": "transport-rust/tests/fixtures/transport/wdp_cdpd_ipv4_mapped/wdp_fixture.json",
-              "testPath": "transport-rust/src/network/wdp/tests.rs",
-              "command": "cargo test --manifest-path transport-rust/Cargo.toml --lib network::wdp"
+              "path": "transport-rust/tests/fixtures/transport/wdp_constrained_payload_mapped/reassembly_fixture.json",
+              "testPath": "transport-rust/tests/wdp_constrained_replay.rs",
+              "command": "cargo test --manifest-path transport-rust/Cargo.toml --test wdp_constrained_replay"
             }
           },
           "mapping": {
@@ -22007,7 +22034,8 @@
             ],
             "workItems": [
               "T0-19",
-              "TRN-701"
+              "TRN-701",
+              "TRN-702"
             ],
             "requirementIds": [
               "RQ-TRN-001",
@@ -22028,6 +22056,9 @@
             "WDP-CORE-C-001",
             "WDP-NA-C-003"
           ],
+          "directWorkItems": [
+            "TRN-702"
+          ],
           "sourceAnchor": {
             "documentId": "rfc-791",
             "section": "3.2",
@@ -22043,9 +22074,9 @@
             "status": "implemented",
             "assertion": "Group IPv4 fragments by identification, source, destination, and protocol, then place data using fragment offsets and the final-fragment marker.",
             "evidence": {
-              "path": "transport-rust/tests/fixtures/transport/wdp_cdpd_ipv4_mapped/wdp_fixture.json",
-              "testPath": "transport-rust/src/network/wdp/tests.rs",
-              "command": "cargo test --manifest-path transport-rust/Cargo.toml --lib network::wdp"
+              "path": "transport-rust/tests/fixtures/transport/wdp_constrained_payload_mapped/reassembly_fixture.json",
+              "testPath": "transport-rust/tests/wdp_constrained_replay.rs",
+              "command": "cargo test --manifest-path transport-rust/Cargo.toml --test wdp_constrained_replay"
             }
           },
           "mapping": {
@@ -22054,7 +22085,8 @@
             ],
             "workItems": [
               "T0-19",
-              "TRN-701"
+              "TRN-701",
+              "TRN-702"
             ],
             "requirementIds": [
               "RQ-TRN-001",
@@ -22075,6 +22107,9 @@
             "WDP-CORE-C-001",
             "WDP-NA-C-003"
           ],
+          "directWorkItems": [
+            "TRN-702"
+          ],
           "sourceAnchor": {
             "documentId": "rfc-791",
             "section": "3.2",
@@ -22090,9 +22125,9 @@
             "status": "implemented",
             "assertion": "Do not fragment a datagram whose DF bit is set; discard it when the route cannot carry it intact.",
             "evidence": {
-              "path": "transport-rust/tests/fixtures/transport/wdp_cdpd_ipv4_mapped/wdp_fixture.json",
-              "testPath": "transport-rust/src/network/wdp/tests.rs",
-              "command": "cargo test --manifest-path transport-rust/Cargo.toml --lib network::wdp"
+              "path": "transport-rust/tests/fixtures/transport/wdp_constrained_payload_mapped/reassembly_fixture.json",
+              "testPath": "transport-rust/tests/wdp_constrained_replay.rs",
+              "command": "cargo test --manifest-path transport-rust/Cargo.toml --test wdp_constrained_replay"
             }
           },
           "mapping": {
@@ -22101,7 +22136,8 @@
             ],
             "workItems": [
               "T0-19",
-              "TRN-701"
+              "TRN-701",
+              "TRN-702"
             ],
             "requirementIds": [
               "RQ-TRN-001",

--- a/spec-processing/source-manifests/wap-1.2.1-trn-7-knowledge-graph.json
+++ b/spec-processing/source-manifests/wap-1.2.1-trn-7-knowledge-graph.json
@@ -13,7 +13,7 @@
     "generator": "spec-processing/scripts/generate-wap-knowledge-graph.mjs",
     "inputs": {
       "docs/waves/wap-1.2.1-compliance-program.json": {
-        "sha256": "5e76a03c6bdfb6790c219ca7758b308e6ad9a3ded50c92cbd417773f3bc1a572"
+        "sha256": "9890f45f67c2b6739941a87bdd88f111ba7d81d4560657090b0dced677ed1ada"
       },
       "spec-processing/source-manifests/wap-1.2.1-class-conformance.json": {
         "sha256": "b76605b2144b32965a857b848b2e9e522baada6fae9fe51012b9eaa664e85d86"
@@ -25,14 +25,14 @@
         "sha256": "654284270a068b427ab05166247cb8e0644a99cf6af511f9b9c477d18ea36faa"
       },
       "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json": {
-        "sha256": "c7e24ece1cdce7ad2f2fcce71cfe0b97528d1522f35955f2f56f873eb2b4d1ae"
+        "sha256": "fcb5278951c6cf0d1d1f03ca379b256bbd1610de8359c2615928ea498c3cf45c"
       }
     },
     "policy": "Canonical manifests remain authoritative; this graph and its Obsidian/context projections are generated views."
   },
   "summary": {
     "nodeCount": 214,
-    "edgeCount": 604,
+    "edgeCount": 613,
     "nodesByType": {
       "clause": 77,
       "fixture": 77,
@@ -56,7 +56,7 @@
       "effective-document": 12,
       "maps-to": 114,
       "owned-by": 15,
-      "planned-by": 91,
+      "planned-by": 100,
       "refines": 154,
       "relates-to": 8,
       "requires-family": 2,
@@ -67,7 +67,7 @@
     },
     "directClauseCountsByWorkItem": {
       "TRN-701": 49,
-      "TRN-702": 0,
+      "TRN-702": 9,
       "TRN-703": 28,
       "TRN-704": 0,
       "TRN-705": 0,
@@ -78,7 +78,9 @@
       "TRN-701": [
         "wdp"
       ],
-      "TRN-702": [],
+      "TRN-702": [
+        "wdp"
+      ],
       "TRN-703": [
         "wcmp"
       ],
@@ -88,9 +90,6 @@
       "TRN-707": []
     },
     "unmappedNormativeFamiliesByWorkItem": {
-      "TRN-702": [
-        "wdp"
-      ],
       "TRN-706": [
         "wdp"
       ],
@@ -100,7 +99,6 @@
       ]
     },
     "workItemsWithoutDirectClauses": [
-      "TRN-702",
       "TRN-704",
       "TRN-705",
       "TRN-706",
@@ -1390,7 +1388,8 @@
         "obligationSynopsis": "Rely on IPv4 fragmentation and reassembly below UDP rather than adding a second WDP segmentation header on the CDPD/IP path.",
         "workItems": [
           "T0-19",
-          "TRN-701"
+          "TRN-701",
+          "TRN-702"
         ],
         "ownerLayers": [
           "transport-rust"
@@ -1465,7 +1464,8 @@
         "obligationSynopsis": "Accept IPv4 datagrams up to 576 octets whether received whole or reassembled from fragments.",
         "workItems": [
           "T0-19",
-          "TRN-701"
+          "TRN-701",
+          "TRN-702"
         ],
         "ownerLayers": [
           "transport-rust"
@@ -1501,7 +1501,8 @@
         "obligationSynopsis": "Do not fragment a datagram whose DF bit is set; discard it when the route cannot carry it intact.",
         "workItems": [
           "T0-19",
-          "TRN-701"
+          "TRN-701",
+          "TRN-702"
         ],
         "ownerLayers": [
           "transport-rust"
@@ -1572,7 +1573,8 @@
         "obligationSynopsis": "Group IPv4 fragments by identification, source, destination, and protocol, then place data using fragment offsets and the final-fragment marker.",
         "workItems": [
           "T0-19",
-          "TRN-701"
+          "TRN-701",
+          "TRN-702"
         ],
         "ownerLayers": [
           "transport-rust"
@@ -1608,7 +1610,8 @@
         "obligationSynopsis": "Allow IPv4 fragmentation at gateways and reassemble fragments at the destination IP module below WDP.",
         "workItems": [
           "T0-19",
-          "TRN-701"
+          "TRN-701",
+          "TRN-702"
         ],
         "ownerLayers": [
           "transport-rust"
@@ -1749,7 +1752,8 @@
         "obligationSynopsis": "Send an IPv4 datagram larger than 576 octets only with assurance that the destination can accept it.",
         "workItems": [
           "T0-19",
-          "TRN-701"
+          "TRN-701",
+          "TRN-702"
         ],
         "ownerLayers": [
           "transport-rust"
@@ -1891,7 +1895,8 @@
         "obligationSynopsis": "Interpret IPv4 total length as header plus payload octets with a maximum representable value of 65,535.",
         "workItems": [
           "T0-19",
-          "TRN-701"
+          "TRN-701",
+          "TRN-702"
         ],
         "ownerLayers": [
           "transport-rust"
@@ -2498,7 +2503,8 @@
         "obligationSynopsis": "Interpret UDP length as header plus data octets and reject values smaller than the eight-octet header.",
         "workItems": [
           "T0-19",
-          "TRN-701"
+          "TRN-701",
+          "TRN-702"
         ],
         "ownerLayers": [
           "transport-rust"
@@ -2678,7 +2684,8 @@
         "obligationSynopsis": "Transmit and deliver the complete service data unit without manipulating its content.",
         "workItems": [
           "T0-19",
-          "TRN-701"
+          "TRN-701",
+          "TRN-702"
         ],
         "ownerLayers": [
           "transport-rust"
@@ -4668,7 +4675,7 @@
       "type": "work-item",
       "title": "WDP constrained-payload and segmentation/reassembly policy",
       "properties": {
-        "status": "todo",
+        "status": "done",
         "ownerLayers": [
           "transport-rust",
           "qa"
@@ -4680,13 +4687,20 @@
           "T0-19"
         ],
         "outputs": [
-          "WDP constrained-payload and segmentation/reassembly policy"
+          "WDP constrained-payload and segmentation/reassembly policy",
+          "transport-rust/tests/fixtures/transport/wdp_constrained_payload_mapped/reassembly_fixture.json"
         ],
         "acceptance": [
-          "Payload limits, truncation/rejection, segmentation applicability, and reassembly failure are deterministic for the selected bearer."
+          "The nine adopted WAP-200 and RFC 791/768 obligations directly evidence deterministic payload limits, rejection without WDP unit-data truncation, no WDP segmentation header on CDPD/IPv4, and destination-IP reassembly below WDP.",
+          "Whole, fragmented, out-of-order, duplicate, malformed, overlapping, oversize, and incomplete-expiry inputs produce bounded deterministic outcomes for the selected 576-octet baseline profile."
         ],
         "evidence": [
-          "cargo test --manifest-path transport-rust/Cargo.toml"
+          "cargo test --manifest-path transport-rust/Cargo.toml",
+          "cargo test --manifest-path transport-rust/Cargo.toml --test wdp_constrained_replay",
+          "node scripts/check-wap-selected-normative-clauses.mjs",
+          "node scripts/check-wap-transport-conformance-ledgers.mjs",
+          "node scripts/wap-context-pack.mjs TRN-702",
+          "node scripts/check-wap-knowledge-graph.mjs"
         ],
         "source": "docs/waves/wap-1.2.1-compliance-program.json"
       }
@@ -6819,6 +6833,15 @@
       ]
     },
     {
+      "id": "clause:WDP-CL-IP-MAPPING-FRAGMENTATION|planned-by|work-item:TRN-702",
+      "from": "clause:WDP-CL-IP-MAPPING-FRAGMENTATION",
+      "relation": "planned-by",
+      "to": "work-item:TRN-702",
+      "sourceRefs": [
+        "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
+      ]
+    },
+    {
       "id": "clause:WDP-CL-IP-MAPPING-FRAGMENTATION|refines|scr-row:WDP-C-001",
       "from": "clause:WDP-CL-IP-MAPPING-FRAGMENTATION",
       "relation": "refines",
@@ -6972,6 +6995,15 @@
       ]
     },
     {
+      "id": "clause:WDP-CL-IPV4-BASELINE-RECEIVE-SIZE|planned-by|work-item:TRN-702",
+      "from": "clause:WDP-CL-IPV4-BASELINE-RECEIVE-SIZE",
+      "relation": "planned-by",
+      "to": "work-item:TRN-702",
+      "sourceRefs": [
+        "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
+      ]
+    },
+    {
       "id": "clause:WDP-CL-IPV4-BASELINE-RECEIVE-SIZE|refines|scr-row:WDP-CORE-C-001",
       "from": "clause:WDP-CL-IPV4-BASELINE-RECEIVE-SIZE",
       "relation": "refines",
@@ -7030,6 +7062,15 @@
       "from": "clause:WDP-CL-IPV4-DONT-FRAGMENT",
       "relation": "planned-by",
       "to": "work-item:TRN-701",
+      "sourceRefs": [
+        "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
+      ]
+    },
+    {
+      "id": "clause:WDP-CL-IPV4-DONT-FRAGMENT|planned-by|work-item:TRN-702",
+      "from": "clause:WDP-CL-IPV4-DONT-FRAGMENT",
+      "relation": "planned-by",
+      "to": "work-item:TRN-702",
       "sourceRefs": [
         "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
       ]
@@ -7152,6 +7193,15 @@
       ]
     },
     {
+      "id": "clause:WDP-CL-IPV4-FRAGMENT-REASSEMBLY-KEY|planned-by|work-item:TRN-702",
+      "from": "clause:WDP-CL-IPV4-FRAGMENT-REASSEMBLY-KEY",
+      "relation": "planned-by",
+      "to": "work-item:TRN-702",
+      "sourceRefs": [
+        "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
+      ]
+    },
+    {
       "id": "clause:WDP-CL-IPV4-FRAGMENT-REASSEMBLY-KEY|refines|scr-row:WDP-CORE-C-001",
       "from": "clause:WDP-CL-IPV4-FRAGMENT-REASSEMBLY-KEY",
       "relation": "refines",
@@ -7210,6 +7260,15 @@
       "from": "clause:WDP-CL-IPV4-FRAGMENTATION-LOCATION",
       "relation": "planned-by",
       "to": "work-item:TRN-701",
+      "sourceRefs": [
+        "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
+      ]
+    },
+    {
+      "id": "clause:WDP-CL-IPV4-FRAGMENTATION-LOCATION|planned-by|work-item:TRN-702",
+      "from": "clause:WDP-CL-IPV4-FRAGMENTATION-LOCATION",
+      "relation": "planned-by",
+      "to": "work-item:TRN-702",
       "sourceRefs": [
         "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
       ]
@@ -7435,6 +7494,15 @@
       "from": "clause:WDP-CL-IPV4-LARGE-SEND-GUARD",
       "relation": "planned-by",
       "to": "work-item:TRN-701",
+      "sourceRefs": [
+        "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
+      ]
+    },
+    {
+      "id": "clause:WDP-CL-IPV4-LARGE-SEND-GUARD|planned-by|work-item:TRN-702",
+      "from": "clause:WDP-CL-IPV4-LARGE-SEND-GUARD",
+      "relation": "planned-by",
+      "to": "work-item:TRN-702",
       "sourceRefs": [
         "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
       ]
@@ -7669,6 +7737,15 @@
       "from": "clause:WDP-CL-IPV4-TOTAL-LENGTH",
       "relation": "planned-by",
       "to": "work-item:TRN-701",
+      "sourceRefs": [
+        "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
+      ]
+    },
+    {
+      "id": "clause:WDP-CL-IPV4-TOTAL-LENGTH|planned-by|work-item:TRN-702",
+      "from": "clause:WDP-CL-IPV4-TOTAL-LENGTH",
+      "relation": "planned-by",
+      "to": "work-item:TRN-702",
       "sourceRefs": [
         "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
       ]
@@ -8700,6 +8777,15 @@
       ]
     },
     {
+      "id": "clause:WDP-CL-UDP-LENGTH-BOUNDS|planned-by|work-item:TRN-702",
+      "from": "clause:WDP-CL-UDP-LENGTH-BOUNDS",
+      "relation": "planned-by",
+      "to": "work-item:TRN-702",
+      "sourceRefs": [
+        "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
+      ]
+    },
+    {
       "id": "clause:WDP-CL-UDP-LENGTH-BOUNDS|refines|scr-row:WDP-CORE-C-001",
       "from": "clause:WDP-CL-UDP-LENGTH-BOUNDS",
       "relation": "refines",
@@ -8992,6 +9078,15 @@
       "from": "clause:WDP-CL-UNITDATA-CONTENT-TRANSPARENCY",
       "relation": "planned-by",
       "to": "work-item:TRN-701",
+      "sourceRefs": [
+        "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
+      ]
+    },
+    {
+      "id": "clause:WDP-CL-UNITDATA-CONTENT-TRANSPARENCY|planned-by|work-item:TRN-702",
+      "from": "clause:WDP-CL-UNITDATA-CONTENT-TRANSPARENCY",
+      "relation": "planned-by",
+      "to": "work-item:TRN-702",
       "sourceRefs": [
         "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
       ]

--- a/spec-processing/source-manifests/wap-1.2.1-wdp-scr.json
+++ b/spec-processing/source-manifests/wap-1.2.1-wdp-scr.json
@@ -192,7 +192,7 @@
             "test": "source_derived_fixture_covers_selected_class_c_rows_and_clauses",
             "fixture": "transport-rust/tests/fixtures/transport/wdp_cdpd_ipv4_mapped/wdp_fixture.json",
             "evidenceClass": "direct-normative",
-            "limitation": "Closes only the nine selected CDPD/IPv4 WDP client rows and their mapped TRN-701 clauses; TRN-702 reassembly policy, alternate bearers, server rows, and optional services remain unclaimed."
+            "limitation": "Closes only the nine selected CDPD/IPv4 WDP client rows and their mapped TRN-701 clauses at SCR-row level; TRN-702 separately closes its adopted constrained-payload clause subset without widening row selection. Alternate bearers, server rows, and optional services remain unclaimed."
           }
         ],
         "evidenceState": "direct-normative-test-linked"
@@ -281,7 +281,7 @@
             "test": "selected_cdpd_ipv4_profile_preserves_exact_udp_ipv4_bytes",
             "fixture": "transport-rust/tests/fixtures/transport/wdp_cdpd_ipv4_mapped/wdp_fixture.json",
             "evidenceClass": "direct-normative",
-            "limitation": "Closes only the nine selected CDPD/IPv4 WDP client rows and their mapped TRN-701 clauses; TRN-702 reassembly policy, alternate bearers, server rows, and optional services remain unclaimed."
+            "limitation": "Closes only the nine selected CDPD/IPv4 WDP client rows and their mapped TRN-701 clauses at SCR-row level; TRN-702 separately closes its adopted constrained-payload clause subset without widening row selection. Alternate bearers, server rows, and optional services remain unclaimed."
           }
         ],
         "evidenceState": "direct-normative-test-linked"
@@ -370,7 +370,7 @@
             "test": "td_unitdata_request_and_indication_preserve_address_port_and_payload_semantics",
             "fixture": "transport-rust/tests/fixtures/transport/wdp_cdpd_ipv4_mapped/wdp_fixture.json",
             "evidenceClass": "direct-normative",
-            "limitation": "Closes only the nine selected CDPD/IPv4 WDP client rows and their mapped TRN-701 clauses; TRN-702 reassembly policy, alternate bearers, server rows, and optional services remain unclaimed."
+            "limitation": "Closes only the nine selected CDPD/IPv4 WDP client rows and their mapped TRN-701 clauses at SCR-row level; TRN-702 separately closes its adopted constrained-payload clause subset without widening row selection. Alternate bearers, server rows, and optional services remain unclaimed."
           }
         ],
         "evidenceState": "direct-normative-test-linked"
@@ -421,7 +421,7 @@
             "test": "td_unitdata_request_and_indication_preserve_address_port_and_payload_semantics",
             "fixture": "transport-rust/tests/fixtures/transport/wdp_cdpd_ipv4_mapped/wdp_fixture.json",
             "evidenceClass": "direct-normative",
-            "limitation": "Closes only the nine selected CDPD/IPv4 WDP client rows and their mapped TRN-701 clauses; TRN-702 reassembly policy, alternate bearers, server rows, and optional services remain unclaimed."
+            "limitation": "Closes only the nine selected CDPD/IPv4 WDP client rows and their mapped TRN-701 clauses at SCR-row level; TRN-702 separately closes its adopted constrained-payload clause subset without widening row selection. Alternate bearers, server rows, and optional services remain unclaimed."
           }
         ],
         "evidenceState": "direct-normative-test-linked"
@@ -662,7 +662,7 @@
             "test": "registered_port_and_bearer_profile_are_exact",
             "fixture": "transport-rust/tests/fixtures/transport/wdp_cdpd_ipv4_mapped/wdp_fixture.json",
             "evidenceClass": "direct-normative",
-            "limitation": "Closes only the nine selected CDPD/IPv4 WDP client rows and their mapped TRN-701 clauses; TRN-702 reassembly policy, alternate bearers, server rows, and optional services remain unclaimed."
+            "limitation": "Closes only the nine selected CDPD/IPv4 WDP client rows and their mapped TRN-701 clauses at SCR-row level; TRN-702 separately closes its adopted constrained-payload clause subset without widening row selection. Alternate bearers, server rows, and optional services remain unclaimed."
           }
         ],
         "evidenceState": "direct-normative-test-linked"
@@ -1549,7 +1549,7 @@
             "test": "td_unitdata_request_and_indication_preserve_address_port_and_payload_semantics",
             "fixture": "transport-rust/tests/fixtures/transport/wdp_cdpd_ipv4_mapped/wdp_fixture.json",
             "evidenceClass": "direct-normative",
-            "limitation": "Closes only the nine selected CDPD/IPv4 WDP client rows and their mapped TRN-701 clauses; TRN-702 reassembly policy, alternate bearers, server rows, and optional services remain unclaimed."
+            "limitation": "Closes only the nine selected CDPD/IPv4 WDP client rows and their mapped TRN-701 clauses at SCR-row level; TRN-702 separately closes its adopted constrained-payload clause subset without widening row selection. Alternate bearers, server rows, and optional services remain unclaimed."
           }
         ],
         "evidenceState": "direct-normative-test-linked"
@@ -1676,7 +1676,7 @@
             "test": "selected_cdpd_ipv4_profile_preserves_exact_udp_ipv4_bytes",
             "fixture": "transport-rust/tests/fixtures/transport/wdp_cdpd_ipv4_mapped/wdp_fixture.json",
             "evidenceClass": "direct-normative",
-            "limitation": "Closes only the nine selected CDPD/IPv4 WDP client rows and their mapped TRN-701 clauses; TRN-702 reassembly policy, alternate bearers, server rows, and optional services remain unclaimed."
+            "limitation": "Closes only the nine selected CDPD/IPv4 WDP client rows and their mapped TRN-701 clauses at SCR-row level; TRN-702 separately closes its adopted constrained-payload clause subset without widening row selection. Alternate bearers, server rows, and optional services remain unclaimed."
           }
         ],
         "evidenceState": "direct-normative-test-linked"
@@ -1803,7 +1803,7 @@
             "test": "registered_port_and_bearer_profile_are_exact",
             "fixture": "transport-rust/tests/fixtures/transport/wdp_cdpd_ipv4_mapped/wdp_fixture.json",
             "evidenceClass": "direct-normative",
-            "limitation": "Closes only the nine selected CDPD/IPv4 WDP client rows and their mapped TRN-701 clauses; TRN-702 reassembly policy, alternate bearers, server rows, and optional services remain unclaimed."
+            "limitation": "Closes only the nine selected CDPD/IPv4 WDP client rows and their mapped TRN-701 clauses at SCR-row level; TRN-702 separately closes its adopted constrained-payload clause subset without widening row selection. Alternate bearers, server rows, and optional services remain unclaimed."
           }
         ],
         "evidenceState": "direct-normative-test-linked"
@@ -1854,7 +1854,7 @@
             "test": "udp_source_port_zero_and_computed_zero_checksum_follow_rfc_768_encoding",
             "fixture": "transport-rust/tests/fixtures/transport/wdp_cdpd_ipv4_mapped/wdp_fixture.json",
             "evidenceClass": "direct-normative",
-            "limitation": "Closes only the nine selected CDPD/IPv4 WDP client rows and their mapped TRN-701 clauses; TRN-702 reassembly policy, alternate bearers, server rows, and optional services remain unclaimed."
+            "limitation": "Closes only the nine selected CDPD/IPv4 WDP client rows and their mapped TRN-701 clauses at SCR-row level; TRN-702 separately closes its adopted constrained-payload clause subset without widening row selection. Alternate bearers, server rows, and optional services remain unclaimed."
           }
         ],
         "evidenceState": "direct-normative-test-linked"

--- a/spec-processing/source-manifests/wap-1.2.1-wml-2-knowledge-graph.json
+++ b/spec-processing/source-manifests/wap-1.2.1-wml-2-knowledge-graph.json
@@ -13,7 +13,7 @@
     "generator": "spec-processing/scripts/generate-wap-knowledge-graph.mjs",
     "inputs": {
       "docs/waves/wap-1.2.1-compliance-program.json": {
-        "sha256": "5e76a03c6bdfb6790c219ca7758b308e6ad9a3ded50c92cbd417773f3bc1a572"
+        "sha256": "9890f45f67c2b6739941a87bdd88f111ba7d81d4560657090b0dced677ed1ada"
       },
       "spec-processing/source-manifests/wap-1.2.1-class-conformance.json": {
         "sha256": "b76605b2144b32965a857b848b2e9e522baada6fae9fe51012b9eaa664e85d86"
@@ -25,7 +25,7 @@
         "sha256": "654284270a068b427ab05166247cb8e0644a99cf6af511f9b9c477d18ea36faa"
       },
       "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json": {
-        "sha256": "c7e24ece1cdce7ad2f2fcce71cfe0b97528d1522f35955f2f56f873eb2b4d1ae"
+        "sha256": "fcb5278951c6cf0d1d1f03ca379b256bbd1610de8359c2615928ea498c3cf45c"
       }
     },
     "policy": "Canonical manifests remain authoritative; this graph and its Obsidian/context projections are generated views."

--- a/transport-rust/src/network/wdp/ipv4_reassembly.rs
+++ b/transport-rust/src/network/wdp/ipv4_reassembly.rs
@@ -1,0 +1,632 @@
+use crate::network::wdp::ipv4_udp::{
+    checksum, IPV4_FLAG_DONT_FRAGMENT, IPV4_FLAG_MORE_FRAGMENTS, IPV4_FRAGMENT_OFFSET_MASK,
+    IPV4_MIN_HEADER_BYTES,
+};
+use crate::network::wdp::profile::{
+    WDP_IPV4_BASELINE_DATAGRAM_BYTES, WDP_IPV4_MAX_DATAGRAM_BYTES, WDP_UDP_IPV4_PROTOCOL_NUMBER,
+};
+use crate::network::wdp::transport_trait::{WdpError, WdpResult};
+use std::collections::BTreeMap;
+
+const IPV4_FLAG_RESERVED: u16 = 0x8000;
+const IPV4_FRAGMENT_OFFSET_UNIT_BYTES: usize = 8;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Ipv4ReassemblyPolicy {
+    pub max_datagram_bytes: usize,
+    pub max_pending_datagrams: usize,
+    pub max_buffered_payload_bytes: usize,
+    pub timeout_ticks: u64,
+}
+
+impl Default for Ipv4ReassemblyPolicy {
+    fn default() -> Self {
+        Self {
+            max_datagram_bytes: WDP_IPV4_BASELINE_DATAGRAM_BYTES,
+            max_pending_datagrams: 8,
+            max_buffered_payload_bytes: 8 * WDP_IPV4_BASELINE_DATAGRAM_BYTES,
+            timeout_ticks: 30,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct Ipv4FragmentKey {
+    pub identification: u16,
+    pub source: [u8; 4],
+    pub destination: [u8; 4],
+    pub protocol: u8,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Ipv4ReassemblyPending {
+    pub key: Ipv4FragmentKey,
+    pub buffered_payload_bytes: usize,
+    pub expected_payload_bytes: Option<usize>,
+    pub expires_at_tick: u64,
+    pub duplicate: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Ipv4IncompleteReassembly {
+    pub key: Ipv4FragmentKey,
+    pub buffered_payload_bytes: usize,
+    pub expected_payload_bytes: Option<usize>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Ipv4ReassemblyOutcome {
+    Complete(Vec<u8>),
+    Pending(Ipv4ReassemblyPending),
+}
+
+#[derive(Debug)]
+struct ParsedFragment<'a> {
+    key: Ipv4FragmentKey,
+    header: &'a [u8],
+    payload: &'a [u8],
+    offset_bytes: usize,
+    more_fragments: bool,
+}
+
+#[derive(Debug)]
+struct PendingAssembly {
+    header: Option<Vec<u8>>,
+    fragments: BTreeMap<usize, Vec<u8>>,
+    final_payload_bytes: Option<usize>,
+    buffered_payload_bytes: usize,
+    last_activity_tick: u64,
+}
+
+#[derive(Debug)]
+pub struct Ipv4Reassembler {
+    policy: Ipv4ReassemblyPolicy,
+    pending: BTreeMap<Ipv4FragmentKey, PendingAssembly>,
+    buffered_payload_bytes: usize,
+}
+
+impl Ipv4Reassembler {
+    pub fn new(policy: Ipv4ReassemblyPolicy) -> WdpResult<Self> {
+        if policy.max_datagram_bytes < WDP_IPV4_BASELINE_DATAGRAM_BYTES
+            || policy.max_datagram_bytes > WDP_IPV4_MAX_DATAGRAM_BYTES
+            || policy.max_pending_datagrams == 0
+            || policy.max_buffered_payload_bytes < policy.max_datagram_bytes
+            || policy.timeout_ticks == 0
+        {
+            return Err(WdpError::Ipv4ReassemblyPolicyInvalid);
+        }
+        Ok(Self {
+            policy,
+            pending: BTreeMap::new(),
+            buffered_payload_bytes: 0,
+        })
+    }
+
+    pub fn policy(&self) -> Ipv4ReassemblyPolicy {
+        self.policy
+    }
+
+    pub fn pending_datagrams(&self) -> usize {
+        self.pending.len()
+    }
+
+    pub fn buffered_payload_bytes(&self) -> usize {
+        self.buffered_payload_bytes
+    }
+
+    pub fn ingest(&mut self, packet: &[u8], now_tick: u64) -> WdpResult<Ipv4ReassemblyOutcome> {
+        let fragment = parse_fragment(packet)?;
+        let fragment_total_bytes = fragment
+            .header
+            .len()
+            .checked_add(fragment.offset_bytes)
+            .and_then(|length| length.checked_add(fragment.payload.len()))
+            .ok_or(WdpError::Ipv4ReassemblyOversize {
+                actual: usize::MAX,
+                max: self.policy.max_datagram_bytes,
+            })?;
+        if fragment_total_bytes > self.policy.max_datagram_bytes {
+            return Err(WdpError::Ipv4ReassemblyOversize {
+                actual: fragment_total_bytes,
+                max: self.policy.max_datagram_bytes,
+            });
+        }
+
+        if fragment.offset_bytes == 0 && !fragment.more_fragments {
+            return Ok(Ipv4ReassemblyOutcome::Complete(packet.to_vec()));
+        }
+        if !self.pending.contains_key(&fragment.key)
+            && self.pending.len() >= self.policy.max_pending_datagrams
+        {
+            return Err(WdpError::Ipv4ReassemblyCapacityExceeded {
+                actual: self.pending.len() + 1,
+                max: self.policy.max_pending_datagrams,
+            });
+        }
+
+        let key = fragment.key;
+        let duplicate = {
+            let assembly = self.pending.entry(key).or_insert_with(|| PendingAssembly {
+                header: None,
+                fragments: BTreeMap::new(),
+                final_payload_bytes: None,
+                buffered_payload_bytes: 0,
+                last_activity_tick: now_tick,
+            });
+
+            if fragment.offset_bytes == 0 {
+                match &assembly.header {
+                    Some(existing) if existing.as_slice() != fragment.header => {
+                        self.discard(key);
+                        return Err(malformed("conflicting first-fragment headers"));
+                    }
+                    None => assembly.header = Some(fragment.header.to_vec()),
+                    Some(_) => {}
+                }
+            }
+
+            let fragment_end = fragment
+                .offset_bytes
+                .checked_add(fragment.payload.len())
+                .ok_or(WdpError::Ipv4ReassemblyOversize {
+                    actual: usize::MAX,
+                    max: self.policy.max_datagram_bytes,
+                })?;
+            if let Some(final_payload_bytes) = assembly.final_payload_bytes {
+                if fragment_end > final_payload_bytes {
+                    self.discard(key);
+                    return Err(malformed("fragment extends beyond final payload length"));
+                }
+            }
+
+            if !fragment.more_fragments {
+                match assembly.final_payload_bytes {
+                    Some(existing) if existing != fragment_end => {
+                        self.discard(key);
+                        return Err(malformed("conflicting final-fragment lengths"));
+                    }
+                    None => {
+                        if assembly.fragments.iter().any(|(offset, bytes)| {
+                            offset.saturating_add(bytes.len()) > fragment_end
+                        }) {
+                            self.discard(key);
+                            return Err(malformed("final fragment ends before buffered data"));
+                        }
+                        assembly.final_payload_bytes = Some(fragment_end);
+                    }
+                    Some(_) => {}
+                }
+            }
+
+            let duplicate = match assembly.fragments.get(&fragment.offset_bytes) {
+                Some(existing) if existing.as_slice() == fragment.payload => true,
+                Some(_) => {
+                    self.discard(key);
+                    return Err(malformed("conflicting fragments share an offset"));
+                }
+                None => {
+                    let overlaps = assembly.fragments.iter().any(|(offset, bytes)| {
+                        let existing_end = offset.saturating_add(bytes.len());
+                        fragment.offset_bytes < existing_end && *offset < fragment_end
+                    });
+                    if overlaps {
+                        self.discard(key);
+                        return Err(malformed("overlapping fragments are rejected"));
+                    }
+                    let next_buffered = self
+                        .buffered_payload_bytes
+                        .checked_add(fragment.payload.len())
+                        .ok_or(WdpError::Ipv4ReassemblyBufferExceeded {
+                            actual: usize::MAX,
+                            max: self.policy.max_buffered_payload_bytes,
+                        })?;
+                    if next_buffered > self.policy.max_buffered_payload_bytes {
+                        self.discard(key);
+                        return Err(WdpError::Ipv4ReassemblyBufferExceeded {
+                            actual: next_buffered,
+                            max: self.policy.max_buffered_payload_bytes,
+                        });
+                    }
+                    assembly
+                        .fragments
+                        .insert(fragment.offset_bytes, fragment.payload.to_vec());
+                    assembly.buffered_payload_bytes += fragment.payload.len();
+                    self.buffered_payload_bytes = next_buffered;
+                    false
+                }
+            };
+            assembly.last_activity_tick = now_tick;
+            duplicate
+        };
+
+        if let Some(packet) = self.try_complete(key)? {
+            return Ok(Ipv4ReassemblyOutcome::Complete(packet));
+        }
+        let assembly = self
+            .pending
+            .get(&key)
+            .ok_or_else(|| WdpError::Internal("pending IPv4 assembly disappeared".to_string()))?;
+        Ok(Ipv4ReassemblyOutcome::Pending(Ipv4ReassemblyPending {
+            key,
+            buffered_payload_bytes: assembly.buffered_payload_bytes,
+            expected_payload_bytes: assembly.final_payload_bytes,
+            expires_at_tick: now_tick.saturating_add(self.policy.timeout_ticks),
+            duplicate,
+        }))
+    }
+
+    pub fn expire(&mut self, now_tick: u64) -> Vec<Ipv4IncompleteReassembly> {
+        let expired_keys = self
+            .pending
+            .iter()
+            .filter_map(|(key, assembly)| {
+                (now_tick.saturating_sub(assembly.last_activity_tick) >= self.policy.timeout_ticks)
+                    .then_some(*key)
+            })
+            .collect::<Vec<_>>();
+        expired_keys
+            .into_iter()
+            .filter_map(|key| {
+                self.pending.remove(&key).map(|assembly| {
+                    self.buffered_payload_bytes = self
+                        .buffered_payload_bytes
+                        .saturating_sub(assembly.buffered_payload_bytes);
+                    Ipv4IncompleteReassembly {
+                        key,
+                        buffered_payload_bytes: assembly.buffered_payload_bytes,
+                        expected_payload_bytes: assembly.final_payload_bytes,
+                    }
+                })
+            })
+            .collect()
+    }
+
+    fn discard(&mut self, key: Ipv4FragmentKey) {
+        if let Some(assembly) = self.pending.remove(&key) {
+            self.buffered_payload_bytes = self
+                .buffered_payload_bytes
+                .saturating_sub(assembly.buffered_payload_bytes);
+        }
+    }
+
+    fn try_complete(&mut self, key: Ipv4FragmentKey) -> WdpResult<Option<Vec<u8>>> {
+        let Some(assembly) = self.pending.get(&key) else {
+            return Ok(None);
+        };
+        let (Some(header), Some(final_payload_bytes)) =
+            (&assembly.header, assembly.final_payload_bytes)
+        else {
+            return Ok(None);
+        };
+        let mut cursor = 0usize;
+        for (offset, bytes) in &assembly.fragments {
+            if *offset != cursor {
+                return Ok(None);
+            }
+            cursor = cursor
+                .checked_add(bytes.len())
+                .ok_or(WdpError::Ipv4ReassemblyOversize {
+                    actual: usize::MAX,
+                    max: self.policy.max_datagram_bytes,
+                })?;
+        }
+        if cursor != final_payload_bytes {
+            return Ok(None);
+        }
+
+        let total_length = header.len().checked_add(final_payload_bytes).ok_or(
+            WdpError::Ipv4ReassemblyOversize {
+                actual: usize::MAX,
+                max: self.policy.max_datagram_bytes,
+            },
+        )?;
+        if total_length > self.policy.max_datagram_bytes {
+            self.discard(key);
+            return Err(WdpError::Ipv4ReassemblyOversize {
+                actual: total_length,
+                max: self.policy.max_datagram_bytes,
+            });
+        }
+        let total_length_u16 =
+            u16::try_from(total_length).map_err(|_| WdpError::Ipv4ReassemblyOversize {
+                actual: total_length,
+                max: self.policy.max_datagram_bytes,
+            })?;
+
+        let mut packet = Vec::with_capacity(total_length);
+        packet.extend_from_slice(header);
+        for bytes in assembly.fragments.values() {
+            packet.extend_from_slice(bytes);
+        }
+        packet[2..4].copy_from_slice(&total_length_u16.to_be_bytes());
+        packet[6..8].copy_from_slice(&0u16.to_be_bytes());
+        packet[10..12].copy_from_slice(&0u16.to_be_bytes());
+        let header_checksum = checksum(&packet[..header.len()]);
+        packet[10..12].copy_from_slice(&header_checksum.to_be_bytes());
+        self.discard(key);
+        Ok(Some(packet))
+    }
+}
+
+fn malformed(reason: &str) -> WdpError {
+    WdpError::Ipv4FragmentMalformed {
+        reason: reason.to_string(),
+    }
+}
+
+fn parse_fragment(packet: &[u8]) -> WdpResult<ParsedFragment<'_>> {
+    if packet.len() < IPV4_MIN_HEADER_BYTES {
+        return Err(WdpError::Ipv4PacketTruncated {
+            actual: packet.len(),
+            minimum: IPV4_MIN_HEADER_BYTES,
+        });
+    }
+    let version = packet[0] >> 4;
+    if version != 4 {
+        return Err(WdpError::Ipv4VersionUnsupported(version));
+    }
+    let ihl = packet[0] & 0x0F;
+    if ihl < 5 {
+        return Err(WdpError::Ipv4HeaderLengthInvalid(ihl));
+    }
+    let header_length = usize::from(ihl) * 4;
+    if packet.len() < header_length {
+        return Err(WdpError::Ipv4PacketTruncated {
+            actual: packet.len(),
+            minimum: header_length,
+        });
+    }
+    let total_length = usize::from(u16::from_be_bytes([packet[2], packet[3]]));
+    if total_length < header_length || total_length != packet.len() {
+        return Err(WdpError::Ipv4TotalLengthInvalid {
+            declared: total_length,
+            actual: packet.len(),
+            header: header_length,
+        });
+    }
+    if checksum(&packet[..header_length]) != 0 {
+        return Err(WdpError::Ipv4HeaderChecksumInvalid);
+    }
+    if packet[8] == 0 {
+        return Err(WdpError::Ipv4TtlExpired);
+    }
+    if packet[9] != WDP_UDP_IPV4_PROTOCOL_NUMBER {
+        return Err(WdpError::Ipv4ProtocolUnsupported(packet[9]));
+    }
+
+    let flags_and_offset = u16::from_be_bytes([packet[6], packet[7]]);
+    if flags_and_offset & IPV4_FLAG_RESERVED != 0 {
+        return Err(malformed("reserved IPv4 flag is set"));
+    }
+    let fragment_offset_units = flags_and_offset & IPV4_FRAGMENT_OFFSET_MASK;
+    let more_fragments = flags_and_offset & IPV4_FLAG_MORE_FRAGMENTS != 0;
+    if flags_and_offset & IPV4_FLAG_DONT_FRAGMENT != 0
+        && (fragment_offset_units != 0 || more_fragments)
+    {
+        return Err(malformed("DF is set on a fragmented datagram"));
+    }
+    let payload = &packet[header_length..];
+    if more_fragments
+        && (payload.is_empty()
+            || !payload
+                .len()
+                .is_multiple_of(IPV4_FRAGMENT_OFFSET_UNIT_BYTES))
+    {
+        return Err(malformed(
+            "non-final fragment payload must be a non-empty multiple of eight octets",
+        ));
+    }
+    if fragment_offset_units != 0 && payload.is_empty() {
+        return Err(malformed("non-initial fragment payload is empty"));
+    }
+    let offset_bytes = usize::from(fragment_offset_units)
+        .checked_mul(IPV4_FRAGMENT_OFFSET_UNIT_BYTES)
+        .ok_or(WdpError::Ipv4ReassemblyOversize {
+            actual: usize::MAX,
+            max: WDP_IPV4_MAX_DATAGRAM_BYTES,
+        })?;
+
+    Ok(ParsedFragment {
+        key: Ipv4FragmentKey {
+            identification: u16::from_be_bytes([packet[4], packet[5]]),
+            source: [packet[12], packet[13], packet[14], packet[15]],
+            destination: [packet[16], packet[17], packet[18], packet[19]],
+            protocol: packet[9],
+        },
+        header: &packet[..header_length],
+        payload,
+        offset_bytes,
+        more_fragments,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::network::wdp::{
+        decode_cdpd_ipv4_udp, encode_cdpd_ipv4_udp, CdpdIpv4SendPolicy, UdpChecksumPolicy,
+        WdpAddress, WdpDatagram, WdpServicePort,
+    };
+
+    fn datagram(payload_len: usize) -> WdpDatagram {
+        WdpDatagram {
+            src_addr: WdpAddress::ipv4([192, 0, 2, 10]),
+            dst_addr: WdpAddress::ipv4([192, 0, 2, 7]),
+            src_port: 49_152,
+            dst_port: WdpServicePort::Connectionless as u16,
+            payload: vec![0xA5; payload_len],
+        }
+    }
+
+    fn fragment_packet(
+        identification: u16,
+        offset_units: u16,
+        more_fragments: bool,
+        payload: &[u8],
+    ) -> Vec<u8> {
+        let total_length = IPV4_MIN_HEADER_BYTES + payload.len();
+        let mut packet = vec![0u8; total_length];
+        packet[0] = 0x45;
+        packet[2..4].copy_from_slice(&(total_length as u16).to_be_bytes());
+        packet[4..6].copy_from_slice(&identification.to_be_bytes());
+        let flags_and_offset = if more_fragments {
+            IPV4_FLAG_MORE_FRAGMENTS
+        } else {
+            0
+        } | offset_units;
+        packet[6..8].copy_from_slice(&flags_and_offset.to_be_bytes());
+        packet[8] = 64;
+        packet[9] = WDP_UDP_IPV4_PROTOCOL_NUMBER;
+        packet[12..16].copy_from_slice(&[192, 0, 2, 10]);
+        packet[16..20].copy_from_slice(&[192, 0, 2, 7]);
+        packet[IPV4_MIN_HEADER_BYTES..].copy_from_slice(payload);
+        let header_checksum = checksum(&packet[..IPV4_MIN_HEADER_BYTES]);
+        packet[10..12].copy_from_slice(&header_checksum.to_be_bytes());
+        packet
+    }
+
+    #[test]
+    fn selected_policy_accepts_whole_baseline_and_rejects_larger_without_truncation() {
+        let mut reassembler =
+            Ipv4Reassembler::new(Ipv4ReassemblyPolicy::default()).expect("policy should be valid");
+        let baseline = encode_cdpd_ipv4_udp(
+            &datagram(548),
+            CdpdIpv4SendPolicy {
+                udp_checksum: UdpChecksumPolicy::Generate,
+                ..CdpdIpv4SendPolicy::default()
+            },
+        )
+        .expect("576-octet datagram should encode");
+        assert_eq!(baseline.len(), WDP_IPV4_BASELINE_DATAGRAM_BYTES);
+        assert!(matches!(
+            reassembler.ingest(&baseline, 0),
+            Ok(Ipv4ReassemblyOutcome::Complete(packet)) if packet == baseline
+        ));
+
+        let oversize = encode_cdpd_ipv4_udp(
+            &datagram(549),
+            CdpdIpv4SendPolicy {
+                destination_accepts_large_datagrams: true,
+                ..CdpdIpv4SendPolicy::default()
+            },
+        )
+        .expect("assured 577-octet datagram should encode");
+        assert_eq!(
+            reassembler.ingest(&oversize, 1),
+            Err(WdpError::Ipv4ReassemblyOversize {
+                actual: 577,
+                max: 576
+            })
+        );
+        assert_eq!(reassembler.pending_datagrams(), 0);
+    }
+
+    #[test]
+    fn policy_rejects_bounds_that_violate_the_ipv4_baseline() {
+        assert!(matches!(
+            Ipv4Reassembler::new(Ipv4ReassemblyPolicy {
+                max_datagram_bytes: 575,
+                ..Ipv4ReassemblyPolicy::default()
+            }),
+            Err(WdpError::Ipv4ReassemblyPolicyInvalid)
+        ));
+    }
+
+    #[test]
+    fn complete_reassembled_packet_is_accepted_by_the_wdp_udp_decoder() {
+        let user_data_bytes = 548;
+        let original = encode_cdpd_ipv4_udp(
+            &datagram(user_data_bytes),
+            CdpdIpv4SendPolicy {
+                identification: 0x1234,
+                ..CdpdIpv4SendPolicy::default()
+            },
+        )
+        .expect("packet should encode");
+        assert_eq!(original.len(), WDP_IPV4_BASELINE_DATAGRAM_BYTES);
+        let first_payload_bytes = 552;
+        let first_length = IPV4_MIN_HEADER_BYTES + first_payload_bytes;
+        let mut first = original[..first_length].to_vec();
+        first[2..4].copy_from_slice(&(first_length as u16).to_be_bytes());
+        first[6..8].copy_from_slice(&IPV4_FLAG_MORE_FRAGMENTS.to_be_bytes());
+        first[10..12].copy_from_slice(&0u16.to_be_bytes());
+        let first_checksum = checksum(&first[..IPV4_MIN_HEADER_BYTES]);
+        first[10..12].copy_from_slice(&first_checksum.to_be_bytes());
+
+        let mut second = original[..IPV4_MIN_HEADER_BYTES].to_vec();
+        second.extend_from_slice(&original[first_length..]);
+        let second_length = second.len() as u16;
+        second[2..4].copy_from_slice(&second_length.to_be_bytes());
+        let second_offset_units = (first_payload_bytes / IPV4_FRAGMENT_OFFSET_UNIT_BYTES) as u16;
+        second[6..8].copy_from_slice(&second_offset_units.to_be_bytes());
+        second[10..12].copy_from_slice(&0u16.to_be_bytes());
+        let second_checksum = checksum(&second[..IPV4_MIN_HEADER_BYTES]);
+        second[10..12].copy_from_slice(&second_checksum.to_be_bytes());
+
+        let mut reassembler =
+            Ipv4Reassembler::new(Ipv4ReassemblyPolicy::default()).expect("policy should be valid");
+        assert!(matches!(
+            reassembler.ingest(&second, 1),
+            Ok(Ipv4ReassemblyOutcome::Pending(_))
+        ));
+        let complete = match reassembler
+            .ingest(&first, 2)
+            .expect("fragments should reassemble")
+        {
+            Ipv4ReassemblyOutcome::Complete(packet) => packet,
+            Ipv4ReassemblyOutcome::Pending(_) => panic!("assembly should be complete"),
+        };
+        assert_eq!(complete, original);
+        assert_eq!(
+            decode_cdpd_ipv4_udp(&complete).expect("WDP should receive complete UDP data"),
+            datagram(user_data_bytes)
+        );
+    }
+
+    #[test]
+    fn pending_datagram_capacity_is_bounded_without_evicting_existing_state() {
+        let mut reassembler = Ipv4Reassembler::new(Ipv4ReassemblyPolicy {
+            max_pending_datagrams: 1,
+            max_buffered_payload_bytes: WDP_IPV4_BASELINE_DATAGRAM_BYTES,
+            ..Ipv4ReassemblyPolicy::default()
+        })
+        .expect("policy should be valid");
+        let first = fragment_packet(1, 0, true, &[0x11; 8]);
+        let second = fragment_packet(2, 0, true, &[0x22; 8]);
+        assert!(matches!(
+            reassembler.ingest(&first, 0),
+            Ok(Ipv4ReassemblyOutcome::Pending(_))
+        ));
+        assert_eq!(
+            reassembler.ingest(&second, 1),
+            Err(WdpError::Ipv4ReassemblyCapacityExceeded { actual: 2, max: 1 })
+        );
+        assert_eq!(reassembler.pending_datagrams(), 1);
+        assert_eq!(reassembler.buffered_payload_bytes(), 8);
+    }
+
+    #[test]
+    fn aggregate_buffer_limit_rejects_only_the_new_assembly() {
+        let mut reassembler = Ipv4Reassembler::new(Ipv4ReassemblyPolicy {
+            max_pending_datagrams: 2,
+            max_buffered_payload_bytes: WDP_IPV4_BASELINE_DATAGRAM_BYTES,
+            ..Ipv4ReassemblyPolicy::default()
+        })
+        .expect("policy should be valid");
+        let first = fragment_packet(1, 0, true, &[0x11; 552]);
+        let second = fragment_packet(2, 0, true, &[0x22; 32]);
+        assert!(matches!(
+            reassembler.ingest(&first, 0),
+            Ok(Ipv4ReassemblyOutcome::Pending(_))
+        ));
+        assert_eq!(
+            reassembler.ingest(&second, 1),
+            Err(WdpError::Ipv4ReassemblyBufferExceeded {
+                actual: 584,
+                max: 576
+            })
+        );
+        assert_eq!(reassembler.pending_datagrams(), 1);
+        assert_eq!(reassembler.buffered_payload_bytes(), 552);
+    }
+}

--- a/transport-rust/src/network/wdp/ipv4_udp.rs
+++ b/transport-rust/src/network/wdp/ipv4_udp.rs
@@ -6,11 +6,11 @@ use crate::network::wdp::profile::{
 };
 use crate::network::wdp::transport_trait::{WdpError, WdpResult};
 
-const IPV4_MIN_HEADER_BYTES: usize = 20;
+pub(super) const IPV4_MIN_HEADER_BYTES: usize = 20;
 const UDP_HEADER_BYTES: usize = 8;
-const IPV4_FLAG_DONT_FRAGMENT: u16 = 0x4000;
-const IPV4_FLAG_MORE_FRAGMENTS: u16 = 0x2000;
-const IPV4_FRAGMENT_OFFSET_MASK: u16 = 0x1FFF;
+pub(super) const IPV4_FLAG_DONT_FRAGMENT: u16 = 0x4000;
+pub(super) const IPV4_FLAG_MORE_FRAGMENTS: u16 = 0x2000;
+pub(super) const IPV4_FRAGMENT_OFFSET_MASK: u16 = 0x1FFF;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum UdpChecksumPolicy {
@@ -66,7 +66,7 @@ fn ones_complement_sum(bytes: &[u8]) -> u32 {
     sum
 }
 
-fn checksum(bytes: &[u8]) -> u16 {
+pub(super) fn checksum(bytes: &[u8]) -> u16 {
     !(ones_complement_sum(bytes) as u16)
 }
 

--- a/transport-rust/src/network/wdp/mod.rs
+++ b/transport-rust/src/network/wdp/mod.rs
@@ -2,6 +2,7 @@
 #![allow(unused_imports)]
 
 pub mod datagram;
+pub mod ipv4_reassembly;
 pub mod ipv4_udp;
 pub mod primitive;
 pub mod profile;
@@ -10,13 +11,17 @@ pub mod transport_trait;
 pub mod udp_adapter;
 
 pub use datagram::{WdpAddress, WdpAddressType, WdpDatagram, WdpServicePort};
+pub use ipv4_reassembly::{
+    Ipv4FragmentKey, Ipv4IncompleteReassembly, Ipv4Reassembler, Ipv4ReassemblyOutcome,
+    Ipv4ReassemblyPending, Ipv4ReassemblyPolicy,
+};
 pub use ipv4_udp::{
     decode_cdpd_ipv4_udp, encode_cdpd_ipv4_udp, CdpdIpv4SendPolicy, UdpChecksumPolicy,
 };
 pub use primitive::{TDUnitdataIndication, TDUnitdataRequest};
 pub use profile::{
     CdpdIpv4Profile, WDP_CDPD_IPV4_BEARER_TYPE, WDP_IPV4_BASELINE_DATAGRAM_BYTES,
-    WDP_UDP_IPV4_PROTOCOL_NUMBER,
+    WDP_IPV4_MAX_DATAGRAM_BYTES, WDP_UDP_IPV4_PROTOCOL_NUMBER,
 };
 pub use sar::{classify_sar_packet, WdpSarDecision, WdpSarPolicy, WdpSarTrace};
 pub use transport_trait::{DatagramTransport, WdpError, WdpResult};

--- a/transport-rust/src/network/wdp/profile.rs
+++ b/transport-rust/src/network/wdp/profile.rs
@@ -3,6 +3,7 @@ use crate::network::wdp::datagram::{WdpAddressType, WdpServicePort};
 pub const WDP_CDPD_IPV4_BEARER_TYPE: u8 = 0x0D;
 pub const WDP_UDP_IPV4_PROTOCOL_NUMBER: u8 = 17;
 pub const WDP_IPV4_BASELINE_DATAGRAM_BYTES: usize = 576;
+pub const WDP_IPV4_MAX_DATAGRAM_BYTES: usize = 65_535;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct CdpdIpv4Profile;
@@ -14,4 +15,5 @@ impl CdpdIpv4Profile {
     pub const IP_PROTOCOL: u8 = WDP_UDP_IPV4_PROTOCOL_NUMBER;
     pub const SELECTED_CONNECTIONLESS_WSP_PORT: u16 = WdpServicePort::Connectionless as u16;
     pub const WDP_SEGMENTATION_HEADER_PRESENT: bool = false;
+    pub const BASELINE_REASSEMBLY_LIMIT_BYTES: usize = WDP_IPV4_BASELINE_DATAGRAM_BYTES;
 }

--- a/transport-rust/src/network/wdp/transport_trait.rs
+++ b/transport-rust/src/network/wdp/transport_trait.rs
@@ -50,6 +50,22 @@ pub enum WdpError {
         actual: usize,
         mtu: usize,
     },
+    Ipv4FragmentMalformed {
+        reason: String,
+    },
+    Ipv4ReassemblyOversize {
+        actual: usize,
+        max: usize,
+    },
+    Ipv4ReassemblyCapacityExceeded {
+        actual: usize,
+        max: usize,
+    },
+    Ipv4ReassemblyBufferExceeded {
+        actual: usize,
+        max: usize,
+    },
+    Ipv4ReassemblyPolicyInvalid,
     UdpLengthInvalid {
         declared: usize,
         actual: usize,
@@ -141,6 +157,30 @@ impl std::fmt::Display for WdpError {
                     f,
                     "IPv4 datagram size {actual} exceeds path MTU {mtu} with DF set"
                 )
+            }
+            Self::Ipv4FragmentMalformed { reason } => {
+                write!(f, "malformed IPv4 fragment: {reason}")
+            }
+            Self::Ipv4ReassemblyOversize { actual, max } => {
+                write!(
+                    f,
+                    "IPv4 reassembly size {actual} exceeds configured limit {max}"
+                )
+            }
+            Self::Ipv4ReassemblyCapacityExceeded { actual, max } => {
+                write!(
+                    f,
+                    "IPv4 pending reassembly count {actual} exceeds configured limit {max}"
+                )
+            }
+            Self::Ipv4ReassemblyBufferExceeded { actual, max } => {
+                write!(
+                    f,
+                    "IPv4 reassembly buffer size {actual} exceeds configured limit {max}"
+                )
+            }
+            Self::Ipv4ReassemblyPolicyInvalid => {
+                write!(f, "invalid IPv4 reassembly policy")
             }
             Self::UdpLengthInvalid { declared, actual } => {
                 write!(

--- a/transport-rust/tests/fixtures/transport/wdp_constrained_payload_mapped/meta.toml
+++ b/transport-rust/tests/fixtures/transport/wdp_constrained_payload_mapped/meta.toml
@@ -1,0 +1,21 @@
+name = "wdp-constrained-payload-mapped"
+description = "Source-derived WAP-200 and RFC 791 evidence for the TRN-702 CDPD/IPv4 constrained-payload and lower-layer reassembly policy."
+mode = "mapped"
+work_items = ["TRN-702"]
+spec_items = [
+  "WDP-CORE-C-001",
+  "WDP-PF-C-001",
+  "WDP-PF-C-002",
+  "WDP-CT-C-002",
+  "WDP-NA-C-003",
+  "RQ-TRN-001",
+  "RQ-TRN-002",
+  "RQ-TRN-003",
+]
+testing_ac = [
+  "Keeps the selected CDPD/IPv4 WDP mapping as one UDP datagram with no WDP segmentation header.",
+  "Accepts complete or reassembled IPv4 datagrams through the 576-octet baseline and rejects larger unassured receive units without truncation.",
+  "Reassembles IPv4 fragments below WDP by identification, source, destination, protocol, offset, and final-fragment marker.",
+  "Delivers only complete UDP payloads to WDP and reports pending, expired-incomplete, malformed, overlap, and oversize outcomes deterministically.",
+  "Uses bounded pending-datagram, buffered-byte, datagram-size, and simulated-time policies without live-network dependencies.",
+]

--- a/transport-rust/tests/fixtures/transport/wdp_constrained_payload_mapped/reassembly_fixture.json
+++ b/transport-rust/tests/fixtures/transport/wdp_constrained_payload_mapped/reassembly_fixture.json
@@ -1,0 +1,138 @@
+{
+  "sourceDocuments": [
+    {
+      "id": "WAP-200-WDP",
+      "sections": ["6.3.1.1", "7.2"]
+    },
+    {
+      "id": "rfc-768",
+      "sections": ["fields"]
+    },
+    {
+      "id": "rfc-791",
+      "sections": ["3.1", "3.2"]
+    }
+  ],
+  "clauseIds": [
+    "WDP-CL-UNITDATA-CONTENT-TRANSPARENCY",
+    "WDP-CL-IP-MAPPING-FRAGMENTATION",
+    "WDP-CL-UDP-LENGTH-BOUNDS",
+    "WDP-CL-IPV4-TOTAL-LENGTH",
+    "WDP-CL-IPV4-BASELINE-RECEIVE-SIZE",
+    "WDP-CL-IPV4-LARGE-SEND-GUARD",
+    "WDP-CL-IPV4-FRAGMENTATION-LOCATION",
+    "WDP-CL-IPV4-FRAGMENT-REASSEMBLY-KEY",
+    "WDP-CL-IPV4-DONT-FRAGMENT"
+  ],
+  "profile": {
+    "bearer": "AMPS/CDPD/IPv4",
+    "ipv4BaselineDatagramBytes": 576,
+    "ipv4ProtocolMaximumDatagramBytes": 65535,
+    "udpMaximumPayloadBytes": 65507,
+    "wdpSegmentationHeaderPresent": false,
+    "oversizePolicy": "reject",
+    "truncationPolicy": "never-truncate-wdp-unitdata",
+    "reassemblyOwner": "destination-ip-module-below-wdp",
+    "maxPendingDatagrams": 8,
+    "maxBufferedPayloadBytes": 4608,
+    "timeoutTicks": 30
+  },
+  "completePacket": [69, 0, 0, 33, 18, 52, 0, 0, 64, 17, 228, 134, 192, 0, 2, 10, 192, 0, 2, 7, 192, 0, 35, 240, 0, 13, 249, 51, 222, 173, 190, 239, 1],
+  "expectedUserData": [222, 173, 190, 239, 1],
+  "replayCases": [
+    {
+      "name": "out-of-order-complete",
+      "steps": [
+        {
+          "tick": 0,
+          "packet": [69, 0, 0, 25, 18, 52, 0, 1, 64, 17, 228, 141, 192, 0, 2, 10, 192, 0, 2, 7, 222, 173, 190, 239, 1],
+          "expected": "pending",
+          "duplicate": false
+        },
+        {
+          "tick": 1,
+          "packet": [69, 0, 0, 28, 18, 52, 32, 0, 64, 17, 196, 139, 192, 0, 2, 10, 192, 0, 2, 7, 192, 0, 35, 240, 0, 13, 249, 51],
+          "expected": "complete"
+        }
+      ]
+    },
+    {
+      "name": "duplicate-is-idempotent",
+      "steps": [
+        {
+          "tick": 2,
+          "packet": [69, 0, 0, 28, 18, 52, 32, 0, 64, 17, 196, 139, 192, 0, 2, 10, 192, 0, 2, 7, 192, 0, 35, 240, 0, 13, 249, 51],
+          "expected": "pending",
+          "duplicate": false
+        },
+        {
+          "tick": 3,
+          "packet": [69, 0, 0, 28, 18, 52, 32, 0, 64, 17, 196, 139, 192, 0, 2, 10, 192, 0, 2, 7, 192, 0, 35, 240, 0, 13, 249, 51],
+          "expected": "pending",
+          "duplicate": true
+        },
+        {
+          "tick": 4,
+          "packet": [69, 0, 0, 25, 18, 52, 0, 1, 64, 17, 228, 141, 192, 0, 2, 10, 192, 0, 2, 7, 222, 173, 190, 239, 1],
+          "expected": "complete"
+        }
+      ]
+    },
+    {
+      "name": "incomplete-expires",
+      "steps": [
+        {
+          "tick": 10,
+          "packet": [69, 0, 0, 28, 18, 52, 32, 0, 64, 17, 196, 139, 192, 0, 2, 10, 192, 0, 2, 7, 192, 0, 35, 240, 0, 13, 249, 51],
+          "expected": "pending",
+          "duplicate": false
+        }
+      ],
+      "expireBeforeTick": 39,
+      "expireAtTick": 40,
+      "expectedExpiredBufferedBytes": 8
+    },
+    {
+      "name": "overlap-rejected-and-discarded",
+      "steps": [
+        {
+          "tick": 0,
+          "packet": [69, 0, 0, 36, 51, 51, 32, 0, 64, 17, 163, 132, 192, 0, 2, 10, 192, 0, 2, 7, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15],
+          "expected": "pending",
+          "duplicate": false
+        },
+        {
+          "tick": 1,
+          "packet": [69, 0, 0, 28, 51, 51, 0, 1, 64, 17, 195, 139, 192, 0, 2, 10, 192, 0, 2, 7, 100, 101, 102, 103, 104, 105, 106, 107],
+          "expected": "error",
+          "error": "malformed IPv4 fragment: overlapping fragments are rejected"
+        }
+      ],
+      "expectedPendingAfterError": 0
+    },
+    {
+      "name": "implied-reassembly-size-rejected",
+      "steps": [
+        {
+          "tick": 0,
+          "packet": [69, 0, 0, 21, 34, 34, 0, 70, 64, 17, 212, 94, 192, 0, 2, 10, 192, 0, 2, 7, 170],
+          "expected": "error",
+          "error": "IPv4 reassembly size 581 exceeds configured limit 576"
+        }
+      ],
+      "expectedPendingAfterError": 0
+    },
+    {
+      "name": "truncated-fragment-rejected",
+      "steps": [
+        {
+          "tick": 0,
+          "packet": [69, 0, 0, 28, 18, 52, 32, 0, 64, 17, 196, 139, 192, 0, 2, 10, 192, 0, 2, 7, 192, 0, 35, 240, 0, 13, 249],
+          "expected": "error",
+          "error": "invalid IPv4 total length 28 for header 20 and packet 27"
+        }
+      ],
+      "expectedPendingAfterError": 0
+    }
+  ]
+}

--- a/transport-rust/tests/wdp_constrained_replay.rs
+++ b/transport-rust/tests/wdp_constrained_replay.rs
@@ -1,0 +1,244 @@
+use lowband_transport_rust::network::wdp::{
+    classify_sar_packet, decode_cdpd_ipv4_udp, CdpdIpv4Profile, Ipv4Reassembler,
+    Ipv4ReassemblyOutcome, Ipv4ReassemblyPolicy, WdpSarDecision, WdpSarPolicy,
+    WDP_IPV4_BASELINE_DATAGRAM_BYTES, WDP_IPV4_MAX_DATAGRAM_BYTES,
+};
+use serde::Deserialize;
+
+const FIXTURE_SOURCE: &str =
+    include_str!("fixtures/transport/wdp_constrained_payload_mapped/reassembly_fixture.json");
+const CLAUSE_LEDGER_SOURCE: &str = include_str!(
+    "../../spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
+);
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct Fixture {
+    source_documents: Vec<SourceDocument>,
+    clause_ids: Vec<String>,
+    profile: Profile,
+    complete_packet: Vec<u8>,
+    expected_user_data: Vec<u8>,
+    replay_cases: Vec<ReplayCase>,
+}
+
+#[derive(Debug, Deserialize)]
+struct SourceDocument {
+    id: String,
+    sections: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct Profile {
+    bearer: String,
+    ipv4_baseline_datagram_bytes: usize,
+    ipv4_protocol_maximum_datagram_bytes: usize,
+    udp_maximum_payload_bytes: usize,
+    wdp_segmentation_header_present: bool,
+    oversize_policy: String,
+    truncation_policy: String,
+    reassembly_owner: String,
+    max_pending_datagrams: usize,
+    max_buffered_payload_bytes: usize,
+    timeout_ticks: u64,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ReplayCase {
+    name: String,
+    steps: Vec<ReplayStep>,
+    expire_before_tick: Option<u64>,
+    expire_at_tick: Option<u64>,
+    expected_expired_buffered_bytes: Option<usize>,
+    expected_pending_after_error: Option<usize>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ReplayStep {
+    tick: u64,
+    packet: Vec<u8>,
+    expected: String,
+    duplicate: Option<bool>,
+    error: Option<String>,
+}
+
+fn fixture() -> Fixture {
+    serde_json::from_str(FIXTURE_SOURCE).expect("TRN-702 fixture should parse")
+}
+
+fn policy(profile: &Profile) -> Ipv4ReassemblyPolicy {
+    Ipv4ReassemblyPolicy {
+        max_datagram_bytes: profile.ipv4_baseline_datagram_bytes,
+        max_pending_datagrams: profile.max_pending_datagrams,
+        max_buffered_payload_bytes: profile.max_buffered_payload_bytes,
+        timeout_ticks: profile.timeout_ticks,
+    }
+}
+
+#[test]
+fn trn_702_fixture_maps_only_the_adopted_authoritative_clause_subset() {
+    let fixture = fixture();
+    assert_eq!(
+        fixture
+            .source_documents
+            .iter()
+            .map(|source| source.id.as_str())
+            .collect::<Vec<_>>(),
+        ["WAP-200-WDP", "rfc-768", "rfc-791"]
+    );
+    assert!(fixture
+        .source_documents
+        .iter()
+        .all(|source| !source.sections.is_empty()));
+
+    let ledger: serde_json::Value =
+        serde_json::from_str(CLAUSE_LEDGER_SOURCE).expect("clause ledger should parse");
+    let adopted = ledger["families"]
+        .as_array()
+        .expect("families should be an array")
+        .iter()
+        .find(|family| family["family"] == "wdp")
+        .expect("WDP family should exist")["clauses"]
+        .as_array()
+        .expect("WDP clauses should be an array")
+        .iter()
+        .filter(|clause| {
+            clause["mapping"]["workItems"]
+                .as_array()
+                .is_some_and(|items| items.iter().any(|item| item == "TRN-702"))
+        })
+        .map(|clause| {
+            clause["id"]
+                .as_str()
+                .expect("adopted clause should have an ID")
+                .to_string()
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(fixture.clause_ids, adopted);
+}
+
+#[test]
+fn selected_cdpd_profile_exposes_bounded_ip_reassembly_without_wdp_sar() {
+    let fixture = fixture();
+    let profile = fixture.profile;
+    assert_eq!(profile.bearer, "AMPS/CDPD/IPv4");
+    assert_eq!(
+        profile.ipv4_baseline_datagram_bytes,
+        WDP_IPV4_BASELINE_DATAGRAM_BYTES
+    );
+    assert_eq!(
+        profile.ipv4_protocol_maximum_datagram_bytes,
+        WDP_IPV4_MAX_DATAGRAM_BYTES
+    );
+    assert_eq!(profile.udp_maximum_payload_bytes, 65_507);
+    assert_eq!(
+        profile.wdp_segmentation_header_present,
+        CdpdIpv4Profile::WDP_SEGMENTATION_HEADER_PRESENT
+    );
+    assert!(!profile.wdp_segmentation_header_present);
+    assert_eq!(profile.oversize_policy, "reject");
+    assert_eq!(profile.truncation_policy, "never-truncate-wdp-unitdata");
+    assert_eq!(profile.reassembly_owner, "destination-ip-module-below-wdp");
+
+    let (decision, trace) = classify_sar_packet(&WdpSarPolicy::Disabled, 65_508);
+    assert_eq!(decision, WdpSarDecision::OversizeRejected);
+    assert_eq!(trace.policy, WdpSarPolicy::Disabled);
+}
+
+#[test]
+fn source_derived_fragment_replays_are_deterministic() {
+    let fixture = fixture();
+    for case in &fixture.replay_cases {
+        let mut reassembler =
+            Ipv4Reassembler::new(policy(&fixture.profile)).expect("fixture policy should be valid");
+        for step in &case.steps {
+            match step.expected.as_str() {
+                "pending" => {
+                    let pending = match reassembler
+                        .ingest(&step.packet, step.tick)
+                        .unwrap_or_else(|error| panic!("case '{}' failed: {error}", case.name))
+                    {
+                        Ipv4ReassemblyOutcome::Pending(pending) => pending,
+                        Ipv4ReassemblyOutcome::Complete(_) => {
+                            panic!("case '{}' completed early", case.name)
+                        }
+                    };
+                    assert_eq!(
+                        pending.duplicate,
+                        step.duplicate.unwrap_or(false),
+                        "case '{}' duplicate classification",
+                        case.name
+                    );
+                }
+                "complete" => {
+                    let packet = match reassembler
+                        .ingest(&step.packet, step.tick)
+                        .unwrap_or_else(|error| panic!("case '{}' failed: {error}", case.name))
+                    {
+                        Ipv4ReassemblyOutcome::Complete(packet) => packet,
+                        Ipv4ReassemblyOutcome::Pending(_) => {
+                            panic!("case '{}' remained incomplete", case.name)
+                        }
+                    };
+                    assert_eq!(packet, fixture.complete_packet, "case '{}'", case.name);
+                    assert_eq!(
+                        decode_cdpd_ipv4_udp(&packet)
+                            .expect("complete reassembly should decode")
+                            .payload,
+                        fixture.expected_user_data,
+                        "case '{}'",
+                        case.name
+                    );
+                }
+                "error" => {
+                    let error = reassembler
+                        .ingest(&step.packet, step.tick)
+                        .expect_err("fixture expected a deterministic rejection");
+                    assert_eq!(
+                        error.to_string(),
+                        step.error.as_deref().expect("error text should be present"),
+                        "case '{}'",
+                        case.name
+                    );
+                }
+                other => panic!("case '{}' has unknown outcome '{other}'", case.name),
+            }
+        }
+
+        if let Some(before_tick) = case.expire_before_tick {
+            assert!(
+                reassembler.expire(before_tick).is_empty(),
+                "case '{}' expired early",
+                case.name
+            );
+        }
+        if let Some(expire_tick) = case.expire_at_tick {
+            let expired = reassembler.expire(expire_tick);
+            assert_eq!(expired.len(), 1, "case '{}' expiration count", case.name);
+            assert_eq!(
+                expired[0].buffered_payload_bytes,
+                case.expected_expired_buffered_bytes
+                    .expect("expiration fixture should declare buffered bytes"),
+                "case '{}'",
+                case.name
+            );
+            assert_eq!(expired[0].expected_payload_bytes, None);
+        }
+        if let Some(expected) = case.expected_pending_after_error {
+            assert_eq!(
+                reassembler.pending_datagrams(),
+                expected,
+                "case '{}' pending state after rejection",
+                case.name
+            );
+            assert_eq!(
+                reassembler.buffered_payload_bytes(),
+                0,
+                "case '{}' buffered state after rejection",
+                case.name
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- adopt the minimum authoritative WDP/IPv4 clause mappings needed to close TRN-702
- add a bounded IPv4 fragmentation/reassembly policy below WDP, with a strict 576-byte default receive profile and rejection rather than truncation
- make malformed, overlapping, oversize, capacity-bound, and incomplete reassembly outcomes deterministic
- add focused simulated replay fixtures and update canonical compliance, SCR, and knowledge-graph evidence

## Why

TRN-702 had no direct clause mapping or executable constrained-payload evidence. This slice establishes the narrow canonical graph support first, then implements the selected Class C CDPD/IPv4 behavior without inventing a WDP segmentation layer or broadening into connection-oriented WSP/WTP, live networking, or unsupported bearers.

## Behavior and scope

- IPv4 fragmentation and reassembly remain below WDP; only complete UDP datagrams reach the existing WDP decoder.
- The default policy accepts IPv4 datagrams through 576 bytes and rejects larger datagrams without truncation.
- Reassembly is bounded to 8 pending datagrams, 4608 buffered payload bytes, and a 30-tick deterministic expiry window.
- Exact duplicate fragments are idempotent; overlaps or conflicts reject and discard the assembly.
- The reassembly key uses source, destination, protocol, and identification.
- Existing #295 transport behavior remains covered.
- Alternate bearer profiles and broader TRN-706 replay/interop coverage remain explicitly open.

## Validation

- `make lint-rust-transport`
- `make test-rust-transport` — 198 passed, 3 ignored, 0 failed
- focused IPv4 reassembly unit tests — 5 passed
- focused TRN-702 replay tests — 3 passed
- existing interoperability replay/#295 regression
- selected normative clause, transport ledger, unified conformance, compliance-program, graph, requirement-status drift, and source-corpus drift checks
- focused `TRN-702` context pack — 9 clauses, 0 gaps
- repository pre-commit and pre-push hooks

## Known existing repository drift

`check-worklist-drift.mjs` still reports stale `M1-08` next-slice references in three files. Those files and the checker are unchanged from `main` and are outside this PR.
