### PR TITLE
Maintainability audit: dedupe transport/engine, add duplication + codegen steering policy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,7 @@ jobs:
       marketing_site: ${{ steps.filter.outputs.marketing_site }}
       docs_portal: ${{ steps.filter.outputs.docs_portal }}
       browser_shell: ${{ steps.filter.outputs.browser_shell }}
+      browser_frontend: ${{ steps.filter.outputs.browser_frontend }}
       wml_server: ${{ steps.filter.outputs.wml_server }}
     steps:
       - name: Checkout
@@ -83,6 +84,8 @@ jobs:
               - "engine-wasm/engine/**"
               - "transport-rust/**"
               - "browser/contracts/**"
+            browser_frontend:
+              - "browser/frontend/**"
             wml_server:
               - "wml-server/**"
 
@@ -463,5 +466,27 @@ jobs:
       - name: Node syntax check
         run: node --check wml-server/server.js
 
-  # Future jobs intentionally disabled until those layers are ready:
-  # - browser frontend lint/test
+  browser-frontend:
+    name: Browser Frontend Unit Tests
+    needs: [changes]
+    if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.ci == 'true' || needs.changes.outputs.browser_frontend == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
+
+      - name: Setup Node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: "pnpm"
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Install root Node deps
+        run: pnpm install --frozen-lockfile --ignore-scripts
+
+      - name: Browser frontend unit tests + coverage gate
+        run: pnpm --dir browser/frontend run test:coverage

--- a/browser/frontend/vitest.config.ts
+++ b/browser/frontend/vitest.config.ts
@@ -12,7 +12,11 @@ export default defineConfig({
       exclude: [
         'src/**/*.test.ts',
         'src/main.ts'
-      ]
+      ],
+      thresholds: {
+        lines: 80,
+        functions: 78
+      }
     }
   }
 });

--- a/docs/agents/AGENT_STANDARDS.md
+++ b/docs/agents/AGENT_STANDARDS.md
@@ -84,6 +84,68 @@ Target-specific glue is allowed only at serialization/binding boundaries.
 - Transport errors must remain structured and deterministic.
 - Runtime/script failures must trap without crashing host process.
 
+## Duplication Policy
+
+This is the canonical duplication policy, referenced by `docs/agents/RUST_ENGINE_STEERING.md` and
+`docs/agents/RUST_TRANSPORT_STEERING.md`. It exists because "keep changes localized, avoid broad
+refactors" (see Scope Control in `AGENTS.md`) was being read as license to copy-paste instead of
+share, across every layer of this repo. Sharing code is not a broad refactor when it stays inside
+the boundary you're already working in; it only becomes one when it would require touching files
+you would not otherwise touch for the task at hand. Three tiers, narrowest to widest:
+
+1. **Same file or module.** Before adding a new function, loop, or encode/decode block, grep the
+   file (and sibling files in the same directory) for a near-identical existing implementation. If
+   one exists, extract a shared helper and have both call sites use it — this is always in scope,
+   regardless of how small the requested change is.
+2. **Same language, different crate in this workspace** (e.g. `transport-rust` and
+   `engine-wasm/engine`, both Rust). If the same logic is genuinely needed in both, do not copy it
+   across the crate boundary; pull it into a small shared internal crate instead. This tier has not
+   come up yet in practice — the two crates currently have no overlapping logic — but the rule
+   exists so the first occurrence doesn't get copy-pasted by default.
+3. **Cross-language** (Rust and TypeScript). Single source of truth lives in Rust; the TypeScript
+   artifact is generated, never hand-maintained. This is already the house style for wire types
+   (`ts-rs`-derived contract types, drift-checked via `pnpm --dir browser run contracts:check`) and
+   for runtime behavior (`engine-wasm/engine` compiles once to both native and WASM targets rather
+   than reimplementing logic in TypeScript). It is not yet the house style for label/taxonomy
+   tables — see `docs/waves/MAINTENANCE_WORK_ITEMS.md` `M1-23` for the tracked gap. Any new
+   cross-language constant/label/taxonomy mapping should extend the existing codegen pipeline
+   rather than add another hand-copied table.
+
+When duplication is found but fixing it falls outside the current task's touched files (tier 2 or
+3, or a tier-1 case in a file you have no other reason to open), record it as a scoped
+`docs/waves/MAINTENANCE_WORK_ITEMS.md` entry instead of leaving it undocumented.
+
+## Codegen & Supported-Tooling Policy
+
+This exists because of `M1-18`: `transport-rust/src/native_fetch.rs` hand-rolled its own WSP wire
+codec instead of calling into the already-existing, spec-conformant `network::wsp` module —
+built one day apart by the same author, never wired together, and the drift sat unnoticed for
+months. Two related but distinct failure modes to guard against:
+
+1. **Hand-rolling a format/protocol implementation that already has a supported one.** Before
+   writing a new parser, encoder, decoder, or serializer for any wire format, file format, or data
+   shape, check whether this repo already has a module/crate for it, or whether the ecosystem has
+   a standard crate for it (e.g. `ts-rs` for Rust-to-TypeScript type generation, `wasm_bindgen` for
+   the WASM boundary, `network::wsp`'s codec for WSP framing). Use the existing one. If it's
+   missing a capability you need, extend it — don't build a second implementation "for now"; "for
+   now" is how `M1-18` happened, and it took an explicit owner override to unwind.
+2. **Data/logic that must stay in sync across languages or across multiple hand-authored call
+   sites should be generated from one source of truth, not hand-copied.** Ask three questions
+   before deciding: (a) does this need to exist in more than one place or language, (b) is there
+   already a canonical source of truth it could derive from (a Rust struct/enum, a spec, a
+   schema), (c) would hand-sync realistically drift given how infrequently this file gets touched
+   and by how many different contributors/agents. If yes to those, generate it — through the
+   repo's existing generator/derive infrastructure (`ts-rs`, `wasm_bindgen`,
+   `browser/scripts/generate-contract-wrappers.mjs`, drift-checked via
+   `pnpm --dir browser run contracts:check`) rather than inventing a parallel one-off script. If no
+   existing pipeline fits, design the new one deliberately and document it as a contract-first
+   surface per `AGENTS.md`, rather than bolting on an ad hoc generator nobody else knows exists.
+
+Shipping a hand-rolled reimplementation of something the repo already has a supported
+implementation for is not an acceptable "small, localized change" shortcut, even under Scope
+Control — flag the conflict and get an explicit decision (as happened with `M1-18`) rather than
+quietly duplicating.
+
 ## Agent Behavioral Rules
 
 Agents MUST:
@@ -94,6 +156,7 @@ Agents MUST:
 - keep completed backlog artifacts immutable; add linked follow-up tickets instead of rewriting `done` tickets when new compliance gaps are found
 - commit only from a feature branch; never commit on `main` or `gh-pages`
 - create a new branch name when the preferred feature-branch name already exists but is stale, unrelated, or otherwise unsuitable
+- dedupe near-identical logic within files/modules already being touched rather than deferring it — see `docs/agents/RUST_ENGINE_STEERING.md` / `docs/agents/RUST_TRANSPORT_STEERING.md` §0 for where in-scope dedup ends and an out-of-scope broad refactor begins
 
 Agents MUST NOT:
 

--- a/docs/agents/RUST_ENGINE_STEERING.md
+++ b/docs/agents/RUST_ENGINE_STEERING.md
@@ -4,6 +4,16 @@ Purpose: project-specific Rust rules for contributors and coding agents working 
 
 This file is intentionally prescriptive. When there is a conflict between "clever" and "predictable", choose predictable.
 
+## 0. Duplication Discipline (read first)
+
+Follow the canonical duplication policy in `docs/agents/AGENT_STANDARDS.md` ("Duplication
+Policy"). Tier 1 (same file/module) applies to nearly everything in this crate and is always in
+scope, no matter how small the requested change is.
+
+In this crate, watch especially for: tree/node lookups repeated across near-identical accessor
+functions, snapshot/rollback or other paired setup-teardown logic, wire-format encode/decode
+helpers, and thin wrapper functions that differ only in what they delegate to.
+
 ## 1. Scope
 
 Applies to:
@@ -76,6 +86,9 @@ Project rule: if an internal convention conflicts with these references, prefer 
 - Any boundary behavior change must update:
 - `engine-wasm/contracts/wml-engine.ts`
 - related docs under `docs/wml-engine/`
+- Before hand-writing a parser/encoder/decoder for a format this crate (or the Rust ecosystem)
+  already has a supported implementation for, use that instead of a parallel one — see
+  `docs/agents/AGENT_STANDARDS.md` ("Codegen & Supported-Tooling Policy") and `M1-18` for why.
 
 ## 5. API Design Rules
 

--- a/docs/agents/RUST_TRANSPORT_STEERING.md
+++ b/docs/agents/RUST_TRANSPORT_STEERING.md
@@ -7,6 +7,19 @@ This file is intentionally prescriptive. Transport code processes untrusted netw
 input, so protocol fidelity, bounded resource use, deterministic behavior, and explicit failures
 take priority over convenience.
 
+## 0. Duplication Discipline (read first)
+
+Follow the canonical duplication policy in `docs/agents/AGENT_STANDARDS.md` ("Duplication
+Policy"). Tier 1 (same file/module) applies to nearly everything in this crate and is always in
+scope, no matter how small the requested change is. Tier 2 (shared internal crate) is the relevant
+one if `transport-rust` and `engine-wasm/engine` ever need the same logic — do not copy it across
+that boundary.
+
+In this crate, watch especially for: wire-format encode/decode helpers reimplemented per call
+site, retry/attempt-loop scaffolding duplicated across transports, string-prefix-matched error
+classification instead of a typed error, and positional tuples/argument lists growing past 3-4
+members instead of a named struct.
+
 ## 1. Scope
 
 Applies to:
@@ -59,6 +72,11 @@ Transport must not:
 - bypass the contract generation and drift-check workflow
 
 ## 4. Contract source of truth
+
+Follow `docs/agents/AGENT_STANDARDS.md` ("Codegen & Supported-Tooling Policy") before hand-writing
+any parser/encoder/decoder in this crate. `M1-18` is the cautionary tale: `native_fetch.rs`
+hand-rolled a WSP codec instead of calling into the already-existing `network::wsp` module. Check
+for an existing module or standard crate first; extend it rather than building a parallel one.
 
 The exported Rust request/response types in `transport-rust/src/lib.rs` are the source of truth for
 the host transport contract.

--- a/docs/waves/MAINTENANCE_WORK_ITEMS.md
+++ b/docs/waves/MAINTENANCE_WORK_ITEMS.md
@@ -258,6 +258,26 @@ Completed maintenance tickets are archived in:
 - Error classification anywhere in `transport-rust` is by type/variant, never by message content.
 - `make lint-rust-transport` and `make test-rust-transport` stay green; public error codes and messages are unchanged.
 
+### M1-23 Script error taxonomy label table is hand-mirrored in TypeScript instead of generated (2026-07-24)
+
+1. `Status`: `todo`
+2. `Priority`: `P3`
+3. `Files`:
+- `browser/frontend/src/app/browser-presenter.ts` (`SCRIPT_ERROR_CATEGORY_LABELS`)
+- `engine-wasm/engine/src/engine_script_types.rs` (`ScriptErrorCategoryLiteral` / the category enum it mirrors)
+- `browser/scripts/generate-contract-wrappers.mjs`
+- `engine-wasm/contracts/wml-engine.ts`
+4. `Finding`:
+- `browser-presenter.ts` defines `SCRIPT_ERROR_CATEGORY_LABELS` as a hand-written `Record<string, string>` mapping each script-error category to a human-facing label, with a comment above it admitting it "mirrors the engine's `ScriptErrorCategoryLiteral` taxonomy." Nothing generates this table and nothing drift-checks it against the Rust enum it mirrors — it is exactly the cross-language duplication pattern `M1-11`/`M1-12` closed for wire *types*, but that codegen pipeline was never extended to cover human-facing label/taxonomy *tables*. A new script-error category added to the engine falls back to a generic label in the host UI until someone remembers to hand-edit this unrelated file.
+5. `Recommendation`:
+- Extend `browser/scripts/generate-contract-wrappers.mjs` (or a small sibling generator) to emit the label table from the Rust source of truth — either from doc comments/attributes on the enum variants, or from a small `#[derive]`-driven constant table exported alongside the existing `ts-rs` contract types — and have `browser-presenter.ts` import the generated table instead of hand-authoring it.
+- Cover this under `pnpm --dir browser run contracts:check` so a missing/stale label fails CI the same way a stale wire type does today.
+- This is a small, scoped codegen extension, not a new pipeline; do not build a second, parallel generator.
+6. `Accept`:
+- `SCRIPT_ERROR_CATEGORY_LABELS` (or its replacement) is generated, not hand-authored.
+- Adding a new script-error category on the Rust side and forgetting the TypeScript label fails `contracts:check` instead of silently falling back to a generic label.
+- No behavior change to today's rendered labels.
+
 ### M1-03 Engine API generator design and bootstrap (non-priority)
 
 1. `Status`: `todo`

--- a/docs/waves/MAINTENANCE_WORK_ITEMS.md
+++ b/docs/waves/MAINTENANCE_WORK_ITEMS.md
@@ -141,7 +141,7 @@ Completed maintenance tickets are archived in:
 
 ### M1-18 `network::wsp` codec is dead code relative to the live native fetch path (2026-07-23)
 
-1. `Status`: `todo`
+1. `Status`: `done`
 2. `Priority`: `P2`
 3. `Files`:
 - `transport-rust/src/network/wsp/pdu.rs`
@@ -178,6 +178,13 @@ Completed maintenance tickets are archived in:
 - `native_fetch.rs`'s WSP wire encode/decode calls into `network::wsp` instead of duplicating parsing logic.
 - `cargo test` stays green for `transport-rust`; native fetch behavior is unchanged for existing passing fixtures/smokes.
 - `docs/waves/NETWORK_PROFILE_DECISION_RECORD.md` / `TRANSPORT_RUST_PHASE_PLAN.md` updated to reflect that `wap-net-core` is genuinely live end-to-end, not just profile-gated.
+9. `Resolution` (2026-07-24): **Implemented in this pass, overriding the 2026-07-23 `Decision` to defer, per explicit repo-owner instruction.** The `Decision` and `Why the split exists` sections above are preserved as the historical record of why the split existed and why deferral was originally chosen; they are no longer the active call.
+- Added `transport-rust/src/network/wsp/connectionless.rs`, which owns the connectionless (session-less, WDP/UDP) WSP framing: `encode_connectionless_request`, `decode_connectionless_reply`, `encode_uintvar`/`decode_uintvar`, `decode_content_type_value`, `decode_text_string`, `decode_wsp_status_code`, plus typed `WspConnectionlessEncodeError`/`WspConnectionlessDecodeError` enums. It reuses `network::wsp::header_registry` assigned numbers (`encode_pdu_type`/`decode_pdu_type` for the `Get`/`Post`/`Reply` octets, `encode_header_field_name_on_page` for well-known header names) and the `network::wsp::header_block` types (`WspHeaderBlock`/`WspHeaderField`/`WspHeaderNameEncoding`) as its header representation. `network::wsp` is therefore on the live fetch path, no longer test-only.
+- Deleted the hand-rolled codec from `native_fetch.rs` (`encode_connectionless_request`, `encode_connectionless_request_headers`, `encode_connectionless_content_type`, `decode_connectionless_wsp_reply`, `encode_uintvar`, `decode_uintvar`, `decode_content_type_value`, `decode_text_string`, `decode_wsp_status_code`, `decode_well_known_media`, and the local `NativeReply` struct) along with the `NOTE(wsp-codec-duplication)` comment block that pointed at this entry. `native_fetch.rs` now owns no wire-format code: it keeps only fetch-level mapping (`encode_native_wap_request`, `negotiated_accept_media`, `connectionless_request_headers`, `build_kannel_request_uri`).
+- Scope note: `network::wsp::pdu`/`session` could **not** be called directly without changing bytes on the wire. Their fixture-defined framing is the connection-oriented form (no transaction id, single-octet block lengths, `u16` reply status, text-string header values), while the gateway path speaks the connectionless form (transaction id prefix, `uintvar` block lengths, single-octet assigned-number reply status, short-integer well-known values). Sharing happens at the assigned-number/header-model layer instead; `pdu.rs`/`session.rs` remain the connection-oriented reference implementation.
+- Fixed a latent encoder bug carried over from the deleted code: `encode_uintvar` set the continuation bit on the final octet for values >= 128, so any request URI or POST header section of 128+ bytes emitted a length field a conformant peer would mis-parse. The shared implementation sets the continuation bit only on non-final octets; covered by `uintvar_roundtrips_multi_octet_values_with_canonical_continuation_bits`.
+- Tests: codec-level cases moved into `connectionless.rs` (`get_request_uses_transaction_id_pdu_type_and_uintvar_uri_length`, `post_request_encodes_content_type_header_block_and_body`, `post_content_type_rejects_nul_bytes`, `decode_content_type_value_*`, `reply_*`, `status_code_mapping_covers_each_assigned_class`); `native_fetch.rs` keeps the fetch-level wire assertions and gains `encode_native_wap_request_rejects_unsupported_methods` and `connectionless_request_headers_negotiate_a_single_accept_media_type`. `make lint-rust-transport` and `make test-rust-transport` pass.
+- Not done here: `docs/waves/NETWORK_PROFILE_DECISION_RECORD.md` and `docs/waves/TRANSPORT_RUST_PHASE_PLAN.md` were left unchanged; the `wap-net-core` profile documentation refresh remains open.
 
 ### M1-19 `fetch_policy.rs` pre-flight destination check is shallow relative to the enforced check (2026-07-24)
 
@@ -227,6 +234,29 @@ Completed maintenance tickets are archived in:
 - A test demonstrates the gateway-fallback path cannot be redirected to an arbitrary non-configured host.
 7. `Resolution`: **Invariant confirmed to hold — no gap found.**
 - `WAVES_FETCH_TRANSPORT_FALLBACK` is a strict two-value enum switch (`disabled` | `gateway-bridged`) parsed in `default_fetch_transport_fallback()`; it carries no host/URL value itself and cannot smuggle one. When it selects the fallback, `fetch_deck_with_transport_executor` always retries with the hardcoded `FetchTransportProfile::GatewayBridged`, which routes through the same `build_gateway_request`/`GATEWAY_HTTP_BASE` machinery pinned by the M1-20 test — never a value derived from the fallback env var, request headers, or the original `wap://` URL's own host/port. Added `fetch_deck_command_gateway_fallback_cannot_be_redirected_by_fallback_env_value` in `browser/src-tauri/src/tests/fetch_commands.rs`, an end-to-end test using the real (unmocked) transport: a native attempt to an unreachable loopback port triggers the fallback, and the fallback is proven to land only on a local TCP listener bound to the test's `GATEWAY_HTTP_BASE`, receiving the original wap path unchanged. No enforcement logic changed.
+
+### M1-22 Residual ad hoc `Result<_, String>` on live transport paths (2026-07-24)
+
+1. `Status`: `todo`
+2. `Priority`: `P3`
+3. `Files`:
+- `transport-rust/src/gateway.rs` (`build_gateway_request`)
+- `transport-rust/src/fetch_body.rs` (`ReadBodyError::ReadFailed(String)`)
+- `transport-rust/src/wbxml_decoder.rs` (decoder returns `Result<String, String>` throughout)
+- `transport-rust/src/wbxml.rs` (`decode_wmlc`)
+- `transport-rust/src/native_fetch.rs` (`build_kannel_request_uri`)
+- `transport-rust/src/responses.rs` (`decode_textual_wml_payload`, `decode_utf16_payload`)
+4. `Finding`:
+- The live fetch modules historically used ad hoc `Result<_, String>` while the `network::` subsystem used per-module typed error enums. The M1-18/M1-19 pass (2026-07-24) converted the highest-value call sites it already touched: destination validation/resolution now returns `fetch_policy::FetchDestinationError` (classification is by variant, not by message prefix), and connectionless WSP encode/decode now returns `WspConnectionlessEncodeError`/`WspConnectionlessDecodeError`.
+- The remaining `Result<_, String>` surfaces above were deliberately left alone to keep that pass scoped. None of them currently drive a classification decision by string matching, so this is readability/robustness debt rather than a live defect — but each is one refactor away from becoming another string-matched boundary.
+5. `Recommendation`:
+- Convert the listed functions to typed errors module by module, smallest blast radius first (`gateway.rs`, then `fetch_body.rs`, then `native_fetch::build_kannel_request_uri`, then the WBXML decoder chain, which is the largest and should be its own change).
+- Preserve the exact rendered message text at every public boundary; the transport error codes and messages in `FetchDeckResponse` must not change.
+- Do not convert error strings that are already asserted verbatim by fixtures without updating the fixture in the same change.
+6. `Accept`:
+- No live transport module returns a bare `Result<_, String>` for a multi-variant failure.
+- Error classification anywhere in `transport-rust` is by type/variant, never by message content.
+- `make lint-rust-transport` and `make test-rust-transport` stay green; public error codes and messages are unchanged.
 
 ### M1-03 Engine API generator design and bootstrap (non-priority)
 

--- a/engine-wasm/contracts/wml-engine.ts
+++ b/engine-wasm/contracts/wml-engine.ts
@@ -137,14 +137,12 @@ export interface DrawLink {
   href: string;
 }
 
-export interface WmlEngineWasm {
+// Target-agnostic engine surface. Every method here must behave identically on
+// the WASM and native targets (see `WmlEngineCompatibilityRules`); only the
+// `loadDeckContext` argument shape is allowed to diverge, and that divergence
+// lives in the two target interfaces below.
+export interface WmlEngineCommon {
   loadDeck(xml: string): void;
-  loadDeckContext(
-    wmlXml: string,
-    baseUrl: string,
-    contentType: string,
-    rawBytesBase64?: string
-  ): void;
   render(): RenderList;
   handleKey(key: EngineKey): void;
   advanceTimeMs(deltaMs: number): void;
@@ -208,70 +206,20 @@ export interface WmlEngineWasm {
   clearTraceEntries(): void;
 }
 
-export interface WmlEngineNative {
-  loadDeck(xml: string): void;
+// WASM target: `loadDeckContext` takes positional arguments because the
+// wasm-bindgen boundary does not carry a structured input object.
+export interface WmlEngineWasm extends WmlEngineCommon {
+  loadDeckContext(
+    wmlXml: string,
+    baseUrl: string,
+    contentType: string,
+    rawBytesBase64?: string
+  ): void;
+}
+
+// Native target: `loadDeckContext` takes the structured `WmlDeckInput`.
+export interface WmlEngineNative extends WmlEngineCommon {
   loadDeckContext(input: WmlDeckInput): void;
-  render(): RenderList;
-  handleKey(key: EngineKey): void;
-  advanceTimeMs(deltaMs: number): void;
-  navigateToCard(id: string): void;
-  navigateBack(): boolean;
-  setViewportCols(cols: number): void;
-  activeCardId(): string;
-  focusedLinkIndex(): number;
-  baseUrl(): string;
-  contentType(): string;
-  getVar(name: string): string | undefined;
-  setVar(name: string, value: string): boolean;
-  beginFocusedInputEdit(): boolean;
-  setFocusedInputEditDraft(value: string): boolean;
-  commitFocusedInputEdit(): boolean;
-  cancelFocusedInputEdit(): boolean;
-  focusedInputEditName(): string | undefined;
-  focusedInputEditValue(): string | undefined;
-  beginFocusedSelectEdit(): boolean;
-  moveFocusedSelectEdit(delta: number): boolean;
-  commitFocusedSelectEdit(): boolean;
-  cancelFocusedSelectEdit(): boolean;
-  focusedSelectEditName(): string | undefined;
-  focusedSelectEditValue(): string | undefined;
-  externalNavigationIntent(): string | undefined;
-  externalNavigationRequestPolicy(): WmlGoRequestPolicy | undefined;
-  clearExternalNavigationIntent(): void;
-  executeScriptUnit(bytes: Uint8Array): ScriptExecutionOutcome;
-  registerScriptUnit(src: string, bytes: Uint8Array): void;
-  clearScriptUnits(): void;
-  registerScriptEntryPoint(src: string, functionName: string, entryPc: number): void;
-  clearScriptEntryPoints(): void;
-  invokeScriptRef(src: string): ScriptInvocationOutcome;
-  invokeScriptRefFunction(src: string, functionName: string): ScriptInvocationOutcome;
-  invokeScriptRefCall(
-    src: string,
-    functionName: string,
-    args: ScriptValueLiteral[]
-  ): ScriptInvocationOutcome;
-  executeScriptRef(src: string): ScriptExecutionOutcome;
-  executeScriptRefFunction(src: string, functionName: string): ScriptExecutionOutcome;
-  executeScriptRefCall(
-    src: string,
-    functionName: string,
-    args: ScriptValueLiteral[]
-  ): ScriptExecutionOutcome;
-  lastScriptExecutionTrap(): string | undefined;
-  lastScriptExecutionOk(): boolean | undefined;
-  lastScriptExecutionErrorClass(): 'none' | 'non-fatal' | 'fatal' | undefined;
-  lastScriptExecutionErrorCategory():
-    | 'none'
-    | 'computational'
-    | 'integrity'
-    | 'resource'
-    | 'host-binding'
-    | undefined;
-  lastScriptRequiresRefresh(): boolean | undefined;
-  lastScriptDialogRequests(): ScriptDialogRequest[];
-  lastScriptTimerRequests(): ScriptTimerRequest[];
-  traceEntries(): EngineTraceEntry[];
-  clearTraceEntries(): void;
 }
 
 export interface WmlEngineCompatibilityRules {

--- a/engine-wasm/engine/src/engine_public_api.rs
+++ b/engine-wasm/engine/src/engine_public_api.rs
@@ -376,16 +376,23 @@ impl WmlEngine {
         self.script_entrypoints.clear();
     }
 
-    /// Execute script reference without applying deferred runtime effects.
+    /// Run a script-execution entry point and settle the shared post-execution
+    /// state.
     ///
-    /// Wrapped in the panic-containment boundary (see [`catch_engine_panic`]).
-    /// This method has no `Result` in its public signature (kept stable per
-    /// the existing contract); a contained panic is reported through the
-    /// same `ScriptExecutionOutcome::fatal` shape already used for VM traps
-    /// (see `classify_vm_trap_outcome`), not a bespoke error shape.
-    pub fn execute_script_ref(&mut self, src: String) -> ScriptExecutionOutcome {
-        let outcome = catch_engine_panic(|| self.execute_script_ref_internal(&src, "main"))
-            .unwrap_or_else(contained_panic_script_outcome);
+    /// Shared by every `execute_script_ref*` method: run `execute` inside the
+    /// panic-containment boundary (see [`catch_engine_panic`]), record the
+    /// outcome, and drop the deferred effects that the non-applying `execute_*`
+    /// family deliberately does not run. These methods have no `Result` in
+    /// their public signature (kept stable per the existing contract); a
+    /// contained panic is reported through the same
+    /// `ScriptExecutionOutcome::fatal` shape already used for VM traps (see
+    /// `classify_vm_trap_outcome`), not a bespoke error shape.
+    fn execute_script_contained(
+        &mut self,
+        execute: impl FnOnce(&mut Self) -> ScriptExecutionOutcome,
+    ) -> ScriptExecutionOutcome {
+        let outcome =
+            catch_engine_panic(|| execute(self)).unwrap_or_else(contained_panic_script_outcome);
         self.last_script_outcome = Some(outcome.clone());
         self.pending_script_effects = ScriptRuntimeEffects::default();
         self.last_script_dialog_requests.clear();
@@ -393,26 +400,37 @@ impl WmlEngine {
         outcome
     }
 
-    /// Execute script function without applying deferred runtime effects.
+    /// Run a script invocation inside the panic-containment boundary.
     ///
-    /// Wrapped in the panic-containment boundary (see [`catch_engine_panic`]).
+    /// Shared by every `invoke_script_ref*` method. Unlike
+    /// [`Self::execute_script_contained`], the invoking family applies its
+    /// deferred runtime effects internally, so this only owns panic
+    /// containment: a defensive-programming bug in the VM or in re-entrant
+    /// navigation degrades to a typed error instead of crashing the host.
+    fn invoke_script_contained(
+        &mut self,
+        invoke: impl FnOnce(&mut Self) -> Result<ScriptInvocationOutcome, String>,
+    ) -> Result<ScriptInvocationOutcome, String> {
+        catch_engine_panic(|| invoke(self))?
+    }
+
+    /// Execute script reference without applying deferred runtime effects.
+    pub fn execute_script_ref(&mut self, src: String) -> ScriptExecutionOutcome {
+        self.execute_script_contained(|engine| engine.execute_script_ref_internal(&src, "main"))
+    }
+
+    /// Execute script function without applying deferred runtime effects.
     pub fn execute_script_ref_function(
         &mut self,
         src: String,
         function_name: String,
     ) -> ScriptExecutionOutcome {
-        let outcome = catch_engine_panic(|| self.execute_script_ref_internal(&src, &function_name))
-            .unwrap_or_else(contained_panic_script_outcome);
-        self.last_script_outcome = Some(outcome.clone());
-        self.pending_script_effects = ScriptRuntimeEffects::default();
-        self.last_script_dialog_requests.clear();
-        self.last_script_timer_requests.clear();
-        outcome
+        self.execute_script_contained(|engine| {
+            engine.execute_script_ref_internal(&src, &function_name)
+        })
     }
 
     /// Execute script function call without applying deferred runtime effects.
-    ///
-    /// Wrapped in the panic-containment boundary (see [`catch_engine_panic`]).
     pub fn execute_script_ref_call(
         &mut self,
         src: String,
@@ -420,41 +438,28 @@ impl WmlEngine {
         args: Vec<ScriptCallArgLiteral>,
     ) -> ScriptExecutionOutcome {
         let vm_args = convert_script_call_args(&args);
-        let outcome = catch_engine_panic(|| {
-            self.execute_script_ref_call_internal(&src, &function_name, &vm_args)
+        self.execute_script_contained(|engine| {
+            engine.execute_script_ref_call_internal(&src, &function_name, &vm_args)
         })
-        .unwrap_or_else(contained_panic_script_outcome);
-        self.last_script_outcome = Some(outcome.clone());
-        self.pending_script_effects = ScriptRuntimeEffects::default();
-        self.last_script_dialog_requests.clear();
-        self.last_script_timer_requests.clear();
-        outcome
     }
 
     /// Invoke script reference and apply deferred runtime effects at boundary.
-    ///
-    /// Wrapped in the panic-containment boundary (see [`catch_engine_panic`]):
-    /// this drives the WMLScript VM and can re-enter navigation, so a
-    /// defensive-programming bug here should degrade to a typed error, not
-    /// crash the host.
     pub fn invoke_script_ref(&mut self, src: String) -> Result<ScriptInvocationOutcome, String> {
-        catch_engine_panic(|| self.invoke_script_ref_internal(&src, "main", &[]))?
+        self.invoke_script_contained(|engine| engine.invoke_script_ref_internal(&src, "main", &[]))
     }
 
     /// Invoke script function and apply deferred runtime effects at boundary.
-    ///
-    /// Wrapped in the panic-containment boundary (see [`catch_engine_panic`]).
     pub fn invoke_script_ref_function(
         &mut self,
         src: String,
         function_name: String,
     ) -> Result<ScriptInvocationOutcome, String> {
-        catch_engine_panic(|| self.invoke_script_ref_internal(&src, &function_name, &[]))?
+        self.invoke_script_contained(|engine| {
+            engine.invoke_script_ref_internal(&src, &function_name, &[])
+        })
     }
 
     /// Invoke script function call and apply deferred runtime effects.
-    ///
-    /// Wrapped in the panic-containment boundary (see [`catch_engine_panic`]).
     pub fn invoke_script_ref_call(
         &mut self,
         src: String,
@@ -462,7 +467,9 @@ impl WmlEngine {
         args: Vec<ScriptCallArgLiteral>,
     ) -> Result<ScriptInvocationOutcome, String> {
         let vm_args = convert_script_call_args(&args);
-        catch_engine_panic(|| self.invoke_script_ref_internal(&src, &function_name, &vm_args))?
+        self.invoke_script_contained(|engine| {
+            engine.invoke_script_ref_internal(&src, &function_name, &vm_args)
+        })
     }
 
     /// Read last script trap message, if any.

--- a/engine-wasm/engine/src/engine_runtime_internal.rs
+++ b/engine-wasm/engine/src/engine_runtime_internal.rs
@@ -1,6 +1,7 @@
 use crate::*;
 
 mod navigation;
+mod node_lookup;
 mod script_effects;
 mod timers;
 mod trace;
@@ -276,76 +277,49 @@ impl WmlEngine {
             .and_then(|deck| deck.cards.get_mut(self.active_card_idx))
             .ok_or_else(|| "Active card not found".to_string())?;
 
-        for node in &mut card.nodes {
-            let runtime::node::Node::Paragraph(items) = node else {
-                continue;
+        for input in node_lookup::inputs_mut(card) {
+            let valid_existing = vars
+                .get(input.name)
+                .cloned()
+                .filter(|candidate| input_value_is_valid(input.mask, input.empty_ok, candidate));
+            let initial_value = if let Some(existing) = valid_existing {
+                Some(existing)
+            } else {
+                vars.remove(input.name);
+                input
+                    .default_value
+                    .as_deref()
+                    .map(|candidate| evaluate_vdata(candidate, vars))
+                    .filter(|candidate| input_value_is_valid(input.mask, input.empty_ok, candidate))
             };
-            for item in items {
-                match item {
-                    runtime::node::InlineNode::Input {
-                        name,
-                        value,
-                        default_value,
-                        mask,
-                        empty_ok,
-                        ..
-                    } => {
-                        let valid_existing = vars
-                            .get(name)
-                            .cloned()
-                            .filter(|candidate| input_value_is_valid(mask, *empty_ok, candidate));
-                        let initial_value = if let Some(existing) = valid_existing {
-                            Some(existing)
-                        } else {
-                            vars.remove(name);
-                            default_value
-                                .as_deref()
-                                .map(|candidate| evaluate_vdata(candidate, vars))
-                                .filter(|candidate| {
-                                    input_value_is_valid(mask, *empty_ok, candidate)
-                                })
-                        };
 
-                        if let Some(initial_value) = initial_value {
-                            vars.insert(name.clone(), initial_value.clone());
-                            *value = initial_value;
-                        } else {
-                            vars.remove(name);
-                            value.clear();
-                        }
-                    }
-                    runtime::node::InlineNode::Select {
-                        name,
-                        iname,
-                        default_value,
-                        default_index_value,
-                        multiple,
-                        options,
-                        selected_indices,
-                        ..
-                    } => {
-                        *selected_indices = initial_select_indices(
-                            name.as_deref(),
-                            iname.as_deref(),
-                            default_value.as_deref(),
-                            default_index_value.as_deref(),
-                            *multiple,
-                            options,
-                            vars,
-                        );
-                        sync_select_variables(
-                            vars,
-                            name.as_deref(),
-                            iname.as_deref(),
-                            *multiple,
-                            options,
-                            selected_indices,
-                        );
-                    }
-                    runtime::node::InlineNode::Text(_) | runtime::node::InlineNode::Link { .. } => {
-                    }
-                }
+            if let Some(initial_value) = initial_value {
+                vars.insert(input.name.to_string(), initial_value.clone());
+                *input.value = initial_value;
+            } else {
+                vars.remove(input.name);
+                input.value.clear();
             }
+        }
+
+        for select in node_lookup::selects_mut(card) {
+            *select.selected_indices = initial_select_indices(
+                select.name,
+                select.iname,
+                select.default_value,
+                select.default_index_value,
+                select.multiple,
+                select.options,
+                vars,
+            );
+            sync_select_variables(
+                vars,
+                select.name,
+                select.iname,
+                select.multiple,
+                select.options,
+                select.selected_indices,
+            );
         }
         Ok(())
     }
@@ -432,19 +406,7 @@ impl WmlEngine {
 
     fn input_value_on_active_card(&self, input_name: &str) -> Option<String> {
         let card = self.active_card_internal().ok()?;
-        for node in &card.nodes {
-            let runtime::node::Node::Paragraph(items) = node else {
-                continue;
-            };
-            for item in items {
-                if let runtime::node::InlineNode::Input { name, value, .. } = item {
-                    if name == input_name {
-                        return Some(value.clone());
-                    }
-                }
-            }
-        }
-        None
+        node_lookup::find_input(card, input_name).map(|input| input.value.to_string())
     }
 
     fn set_input_value_on_active_card(
@@ -453,30 +415,11 @@ impl WmlEngine {
         value: &str,
     ) -> Result<bool, String> {
         let card = self.active_card_internal_mut()?;
-        let mut updated = false;
-        for node in &mut card.nodes {
-            let runtime::node::Node::Paragraph(items) = node else {
-                continue;
-            };
-            for item in items {
-                if let runtime::node::InlineNode::Input {
-                    name,
-                    value: current_value,
-                    ..
-                } = item
-                {
-                    if name == input_name {
-                        *current_value = value.to_string();
-                        updated = true;
-                        break;
-                    }
-                }
-            }
-            if updated {
-                break;
-            }
-        }
-        Ok(updated)
+        let Some(input) = node_lookup::find_input_mut(card, input_name) else {
+            return Ok(false);
+        };
+        *input.value = value.to_string();
+        Ok(true)
     }
 
     pub(crate) fn apply_input_value_to_card(
@@ -485,68 +428,20 @@ impl WmlEngine {
         input_name: &str,
         value: &str,
     ) {
-        for node in &mut card.nodes {
-            let runtime::node::Node::Paragraph(items) = node else {
-                continue;
-            };
-            for item in items {
-                if let runtime::node::InlineNode::Input {
-                    name,
-                    value: current_value,
-                    ..
-                } = item
-                {
-                    if name == input_name {
-                        *current_value = value.to_string();
-                        return;
-                    }
-                }
-            }
+        if let Some(input) = node_lookup::find_input_mut(card, input_name) {
+            *input.value = value.to_string();
         }
     }
 
     pub(crate) fn select_selected_index_on_active_card(&self, select_name: &str) -> Option<usize> {
         let card = self.active_card_internal().ok()?;
-        for node in &card.nodes {
-            let runtime::node::Node::Paragraph(items) = node else {
-                continue;
-            };
-            for item in items {
-                if let runtime::node::InlineNode::Select {
-                    control_id,
-                    selected_indices,
-                    ..
-                } = item
-                {
-                    if control_id == select_name {
-                        return Some(selected_indices.first().copied().unwrap_or(0));
-                    }
-                }
-            }
-        }
-        None
+        node_lookup::find_select(card, select_name)
+            .map(|select| select.selected_indices.first().copied().unwrap_or(0))
     }
 
     pub(crate) fn select_option_count_on_active_card(&self, select_name: &str) -> Option<usize> {
         let card = self.active_card_internal().ok()?;
-        for node in &card.nodes {
-            let runtime::node::Node::Paragraph(items) = node else {
-                continue;
-            };
-            for item in items {
-                if let runtime::node::InlineNode::Select {
-                    control_id,
-                    options,
-                    ..
-                } = item
-                {
-                    if control_id == select_name {
-                        return Some(options.len());
-                    }
-                }
-            }
-        }
-        None
+        node_lookup::find_select(card, select_name).map(|select| select.options.len())
     }
 
     pub(crate) fn select_value_on_active_card(
@@ -555,26 +450,10 @@ impl WmlEngine {
         selected_index: usize,
     ) -> Option<String> {
         let card = self.active_card_internal().ok()?;
-        for node in &card.nodes {
-            let runtime::node::Node::Paragraph(items) = node else {
-                continue;
-            };
-            for item in items {
-                if let runtime::node::InlineNode::Select {
-                    control_id,
-                    options,
-                    ..
-                } = item
-                {
-                    if control_id == select_name {
-                        return options
-                            .get(selected_index)
-                            .map(|option| evaluate_vdata(&option.value, &self.vars));
-                    }
-                }
-            }
-        }
-        None
+        node_lookup::find_select(card, select_name)?
+            .options
+            .get(selected_index)
+            .map(|option| evaluate_vdata(&option.value, &self.vars))
     }
 
     pub(crate) fn set_select_selected_indices_on_active_card(
@@ -583,33 +462,16 @@ impl WmlEngine {
         selected_indices: &[usize],
     ) -> Result<bool, String> {
         let card = self.active_card_internal_mut()?;
-        let mut updated = false;
-        for node in &mut card.nodes {
-            let runtime::node::Node::Paragraph(items) = node else {
-                continue;
-            };
-            for item in items {
-                if let runtime::node::InlineNode::Select {
-                    control_id,
-                    options,
-                    selected_indices: current_indices,
-                    ..
-                } = item
-                {
-                    if control_id == select_name
-                        && selected_indices.iter().all(|index| *index < options.len())
-                    {
-                        *current_indices = selected_indices.to_vec();
-                        updated = true;
-                        break;
-                    }
-                }
-            }
-            if updated {
-                break;
+        for select in node_lookup::selects_with_control_id_mut(card, select_name) {
+            if selected_indices
+                .iter()
+                .all(|index| *index < select.options.len())
+            {
+                *select.selected_indices = selected_indices.to_vec();
+                return Ok(true);
             }
         }
-        Ok(updated)
+        Ok(false)
     }
 
     pub(crate) fn apply_select_index_to_card(
@@ -618,25 +480,11 @@ impl WmlEngine {
         select_name: &str,
         selected_index: usize,
     ) {
-        for node in &mut card.nodes {
-            let runtime::node::Node::Paragraph(items) = node else {
-                continue;
-            };
-            for item in items {
-                if let runtime::node::InlineNode::Select {
-                    control_id,
-                    options,
-                    multiple,
-                    selected_indices,
-                    ..
-                } = item
-                {
-                    if control_id == select_name && !*multiple && selected_index < options.len() {
-                        selected_indices.clear();
-                        selected_indices.push(selected_index);
-                        return;
-                    }
-                }
+        for select in node_lookup::selects_with_control_id_mut(card, select_name) {
+            if !select.multiple && selected_index < select.options.len() {
+                select.selected_indices.clear();
+                select.selected_indices.push(selected_index);
+                return;
             }
         }
     }
@@ -647,27 +495,13 @@ impl WmlEngine {
         selected_index: usize,
     ) -> Option<(bool, Vec<usize>, Option<String>)> {
         let card = self.active_card_internal().ok()?;
-        for node in &card.nodes {
-            let runtime::node::Node::Paragraph(items) = node else {
-                continue;
-            };
-            for item in items {
-                if let runtime::node::InlineNode::Select {
-                    control_id,
-                    multiple,
-                    options,
-                    selected_indices,
-                    ..
-                } = item
-                {
-                    if control_id == select_name {
-                        let option = options.get(selected_index)?;
-                        return Some((*multiple, selected_indices.clone(), option.onpick.clone()));
-                    }
-                }
-            }
-        }
-        None
+        let select = node_lookup::find_select(card, select_name)?;
+        let option = select.options.get(selected_index)?;
+        Some((
+            select.multiple,
+            select.selected_indices.to_vec(),
+            option.onpick.clone(),
+        ))
     }
 
     pub(crate) fn sync_select_variables_on_active_card(
@@ -679,36 +513,18 @@ impl WmlEngine {
             .as_ref()
             .and_then(|deck| deck.cards.get(self.active_card_idx))
             .ok_or_else(|| "Active card not found".to_string())?;
-        for node in &card.nodes {
-            let runtime::node::Node::Paragraph(items) = node else {
-                continue;
-            };
-            for item in items {
-                if let runtime::node::InlineNode::Select {
-                    control_id,
-                    name,
-                    iname,
-                    multiple,
-                    options,
-                    selected_indices,
-                    ..
-                } = item
-                {
-                    if control_id == select_name {
-                        sync_select_variables(
-                            vars,
-                            name.as_deref(),
-                            iname.as_deref(),
-                            *multiple,
-                            options,
-                            selected_indices,
-                        );
-                        return Ok(());
-                    }
-                }
-            }
-        }
-        Err(format!("Select '{select_name}' not found"))
+        let Some(select) = node_lookup::find_select(card, select_name) else {
+            return Err(format!("Select '{select_name}' not found"));
+        };
+        sync_select_variables(
+            vars,
+            select.name,
+            select.iname,
+            select.multiple,
+            select.options,
+            select.selected_indices,
+        );
+        Ok(())
     }
 
     pub(crate) fn sync_all_select_variables_on_active_card(&mut self) -> Result<(), String> {
@@ -717,52 +533,22 @@ impl WmlEngine {
             .as_ref()
             .and_then(|deck| deck.cards.get(self.active_card_idx))
             .ok_or_else(|| "Active card not found".to_string())?;
-        for node in &card.nodes {
-            let runtime::node::Node::Paragraph(items) = node else {
-                continue;
-            };
-            for item in items {
-                if let runtime::node::InlineNode::Select {
-                    name,
-                    iname,
-                    multiple,
-                    options,
-                    selected_indices,
-                    ..
-                } = item
-                {
-                    sync_select_variables(
-                        vars,
-                        name.as_deref(),
-                        iname.as_deref(),
-                        *multiple,
-                        options,
-                        selected_indices,
-                    );
-                }
-            }
+        for select in node_lookup::selects(card) {
+            sync_select_variables(
+                vars,
+                select.name,
+                select.iname,
+                select.multiple,
+                select.options,
+                select.selected_indices,
+            );
         }
         Ok(())
     }
 
     pub(crate) fn input_max_len_on_active_card(&self, input_name: &str) -> Option<usize> {
         let card = self.active_card_internal().ok()?;
-        for node in &card.nodes {
-            let runtime::node::Node::Paragraph(items) = node else {
-                continue;
-            };
-            for item in items {
-                if let runtime::node::InlineNode::Input {
-                    name, max_length, ..
-                } = item
-                {
-                    if name == input_name {
-                        return *max_length;
-                    }
-                }
-            }
-        }
-        None
+        node_lookup::find_input(card, input_name).and_then(|input| input.max_length)
     }
 
     fn input_constraints_on_active_card(
@@ -770,25 +556,7 @@ impl WmlEngine {
         input_name: &str,
     ) -> Option<(runtime::input_mask::InputMask, bool)> {
         let card = self.active_card_internal().ok()?;
-        for node in &card.nodes {
-            let runtime::node::Node::Paragraph(items) = node else {
-                continue;
-            };
-            for item in items {
-                if let runtime::node::InlineNode::Input {
-                    name,
-                    mask,
-                    empty_ok,
-                    ..
-                } = item
-                {
-                    if name == input_name {
-                        return Some((mask.clone(), *empty_ok));
-                    }
-                }
-            }
-        }
-        None
+        node_lookup::find_input(card, input_name).map(|input| (input.mask.clone(), input.empty_ok))
     }
 }
 

--- a/engine-wasm/engine/src/engine_runtime_internal/navigation.rs
+++ b/engine-wasm/engine/src/engine_runtime_internal/navigation.rs
@@ -33,42 +33,24 @@ impl WmlEngine {
             .card_index(id)
             .ok_or_else(|| "Card id not found".to_string())?;
 
-        let previous_idx = self.active_card_idx;
-        let previous_focus = self.focused_link_idx;
-        let previous_stack_len = self.nav_stack.len();
-        let previous_timer = self.active_timer.clone();
-        self.stop_active_timer_for_exit();
-        self.active_input_edit = None;
-        self.active_select_edit = None;
-        self.nav_stack.push(self.active_card_idx);
-        self.active_card_idx = next_idx;
-        self.focused_link_idx = 0;
-        if let Err(err) = self.initialize_controls_on_active_card() {
-            self.active_card_idx = previous_idx;
-            self.focused_link_idx = previous_focus;
-            self.nav_stack.truncate(previous_stack_len);
-            self.active_timer = previous_timer;
-            return Err(err);
-        }
-        if let Err(err) = self.run_onenterforward_for_active_card() {
-            // Roll back all state for deterministic failure behavior on entry-task failures.
-            // This also unwinds cleanly when a deeper recursive navigation trips the
-            // dispatch-depth guard above: each frame rolls back to its own prior state,
-            // so the engine ends up back on the last card that was fully, successfully
-            // entered before the cycle was detected.
-            self.active_card_idx = previous_idx;
-            self.focused_link_idx = previous_focus;
-            self.nav_stack.truncate(previous_stack_len);
-            self.active_timer = previous_timer;
-            return Err(err);
-        }
-        if let Err(err) = self.start_or_resume_timer_for_active_card(false) {
-            self.active_card_idx = previous_idx;
-            self.focused_link_idx = previous_focus;
-            self.nav_stack.truncate(previous_stack_len);
-            self.active_timer = previous_timer;
-            return Err(err);
-        }
+        // Every fallible entry step below rolls back all navigation state for
+        // deterministic failure behavior on entry-task failures. This also
+        // unwinds cleanly when a deeper recursive navigation trips the
+        // dispatch-depth guard above: each frame rolls back to its own prior
+        // state, so the engine ends up back on the last card that was fully,
+        // successfully entered before the cycle was detected.
+        let nav = NavRollbackGuard::forward(self);
+        nav.engine.stop_active_timer_for_exit();
+        nav.engine.active_input_edit = None;
+        nav.engine.active_select_edit = None;
+        let previous_idx = nav.engine.active_card_idx;
+        nav.engine.nav_stack.push(previous_idx);
+        nav.engine.active_card_idx = next_idx;
+        nav.engine.focused_link_idx = 0;
+        nav.engine.initialize_controls_on_active_card()?;
+        nav.engine.run_onenterforward_for_active_card()?;
+        nav.engine.start_or_resume_timer_for_active_card(false)?;
+        nav.commit();
         Ok(())
     }
 
@@ -86,44 +68,34 @@ impl WmlEngine {
     }
 
     fn navigate_back_internal_bounded(&mut self) -> bool {
-        let rollback_active_idx = self.active_card_idx;
-        let rollback_focus = self.focused_link_idx;
-        let rollback_stack = self.nav_stack.clone();
-        let rollback_timer = self.active_timer.clone();
-        let Some(back_target_idx) = self.nav_stack.pop() else {
-            self.push_trace("ACTION_BACK_EMPTY", String::new());
+        let nav = NavRollbackGuard::back(self);
+        let Some(back_target_idx) = nav.engine.nav_stack.pop() else {
+            nav.engine.push_trace("ACTION_BACK_EMPTY", String::new());
+            nav.commit();
             return false;
         };
 
-        self.stop_active_timer_for_exit();
-        self.active_input_edit = None;
-        self.active_select_edit = None;
-        self.active_card_idx = back_target_idx;
-        self.focused_link_idx = 0;
-        self.push_trace("ACTION_BACK", String::new());
-        if let Err(err) = self.initialize_controls_on_active_card() {
-            self.push_trace("INPUT_INIT_ERROR", err);
-            self.active_card_idx = rollback_active_idx;
-            self.focused_link_idx = rollback_focus;
-            self.nav_stack = rollback_stack;
-            self.active_timer = rollback_timer;
+        nav.engine.stop_active_timer_for_exit();
+        nav.engine.active_input_edit = None;
+        nav.engine.active_select_edit = None;
+        nav.engine.active_card_idx = back_target_idx;
+        nav.engine.focused_link_idx = 0;
+        nav.engine.push_trace("ACTION_BACK", String::new());
+        // Each fallible entry step traces first, then leaves the guard armed so
+        // the drop restores the pre-navigation state before returning.
+        if let Err(err) = nav.engine.initialize_controls_on_active_card() {
+            nav.engine.push_trace("INPUT_INIT_ERROR", err);
             return true;
         }
-        if let Err(err) = self.run_onenterbackward_for_active_card() {
-            self.push_trace("ACTION_ONENTERBACKWARD_ERROR", err);
-            self.active_card_idx = rollback_active_idx;
-            self.focused_link_idx = rollback_focus;
-            self.nav_stack = rollback_stack;
-            self.active_timer = rollback_timer;
+        if let Err(err) = nav.engine.run_onenterbackward_for_active_card() {
+            nav.engine.push_trace("ACTION_ONENTERBACKWARD_ERROR", err);
             return true;
         }
-        if let Err(err) = self.start_or_resume_timer_for_active_card(false) {
-            self.push_trace("ACTION_ONTIMER_ERROR", err);
-            self.active_card_idx = rollback_active_idx;
-            self.focused_link_idx = rollback_focus;
-            self.nav_stack = rollback_stack;
-            self.active_timer = rollback_timer;
+        if let Err(err) = nav.engine.start_or_resume_timer_for_active_card(false) {
+            nav.engine.push_trace("ACTION_ONTIMER_ERROR", err);
+            return true;
         }
+        nav.commit();
         true
     }
 
@@ -331,6 +303,86 @@ impl WmlEngine {
     }
 }
 
+/// Snapshot-and-restore guard for the state one navigation attempt may mutate.
+///
+/// Card entry has three fallible steps (input initialization, the `onenter*`
+/// task action, and timer start/resume). Rollback is all-or-nothing across
+/// them: a failure in any step must leave the engine exactly where it was
+/// before the attempt. The guard captures the affected fields up front and
+/// restores them on drop — including on `?` and early `return` paths — unless
+/// [`NavRollbackGuard::commit`] disarms it once the whole attempt succeeded.
+///
+/// While the guard is alive the engine is reached through its `engine` field,
+/// because the guard holds the `&mut WmlEngine` it must be able to restore.
+struct NavRollbackGuard<'a> {
+    engine: &'a mut WmlEngine,
+    rollback: Option<NavStateRollback>,
+}
+
+struct NavStateRollback {
+    active_card_idx: usize,
+    focused_link_idx: usize,
+    nav_stack: NavStackRollback,
+    active_timer: Option<CardTimerState>,
+}
+
+/// How to undo a navigation attempt's change to the history stack.
+enum NavStackRollback {
+    /// Forward navigation only pushes, so dropping entries added since the
+    /// snapshot restores the prior history.
+    TruncateTo(usize),
+    /// Back navigation pops, so the exact prior contents are restored.
+    Restore(Vec<usize>),
+}
+
+impl<'a> NavRollbackGuard<'a> {
+    fn forward(engine: &'a mut WmlEngine) -> Self {
+        let rollback = NavStateRollback {
+            active_card_idx: engine.active_card_idx,
+            focused_link_idx: engine.focused_link_idx,
+            nav_stack: NavStackRollback::TruncateTo(engine.nav_stack.len()),
+            active_timer: engine.active_timer.clone(),
+        };
+        Self {
+            engine,
+            rollback: Some(rollback),
+        }
+    }
+
+    fn back(engine: &'a mut WmlEngine) -> Self {
+        let rollback = NavStateRollback {
+            active_card_idx: engine.active_card_idx,
+            focused_link_idx: engine.focused_link_idx,
+            nav_stack: NavStackRollback::Restore(engine.nav_stack.clone()),
+            active_timer: engine.active_timer.clone(),
+        };
+        Self {
+            engine,
+            rollback: Some(rollback),
+        }
+    }
+
+    /// Disarm the guard: the navigation attempt is keeping its new state.
+    fn commit(mut self) {
+        self.rollback = None;
+    }
+}
+
+impl Drop for NavRollbackGuard<'_> {
+    fn drop(&mut self) {
+        let Some(rollback) = self.rollback.take() else {
+            return;
+        };
+        self.engine.active_card_idx = rollback.active_card_idx;
+        self.engine.focused_link_idx = rollback.focused_link_idx;
+        match rollback.nav_stack {
+            NavStackRollback::TruncateTo(len) => self.engine.nav_stack.truncate(len),
+            NavStackRollback::Restore(stack) => self.engine.nav_stack = stack,
+        }
+        self.engine.active_timer = rollback.active_timer;
+    }
+}
+
 #[derive(Debug, PartialEq, Eq)]
 pub(crate) struct ParsedScriptRef<'a> {
     pub(crate) src: &'a str,
@@ -354,4 +406,59 @@ pub(crate) fn parse_script_href(href: &str) -> Option<ParsedScriptRef<'_>> {
         return None;
     }
     Some(ParsedScriptRef { src, function_name })
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::WmlEngine;
+
+    /// Covers the third fallible step of back navigation (timer start/resume),
+    /// which the deck-level tests only exercise for forward navigation.
+    #[test]
+    fn ontimer_failure_on_back_entry_rolls_back_navigation_state() {
+        let mut engine = WmlEngine::new();
+        let xml = r##"
+        <wml>
+          <card id="home">
+            <a href="#timed">To timed</a>
+          </card>
+          <card id="timed">
+            <timer value="0"/>
+            <onevent type="ontimer"><go href="script:timer.wmlsc#main"/></onevent>
+            <a href="#next">To next</a>
+          </card>
+          <card id="next"><p>Next</p></card>
+        </wml>
+        "##;
+        engine.load_deck(xml).expect("deck should load");
+        // HALT-only unit: the ontimer task succeeds while the unit is registered.
+        engine.register_script_unit("timer.wmlsc".to_string(), vec![0x00]);
+
+        engine
+            .handle_key("enter".to_string())
+            .expect("home enter should navigate to timed card");
+        assert_eq!(engine.active_card_id().expect("active card"), "timed");
+        engine
+            .handle_key("enter".to_string())
+            .expect("timed enter should navigate to next card");
+        assert_eq!(engine.active_card_id().expect("active card"), "next");
+        assert_eq!(engine.nav_stack.len(), 2);
+
+        // Re-entering the timed card now fails inside the timer step.
+        engine.clear_script_units();
+        let handled = engine.navigate_back();
+
+        assert!(handled, "back should report handled when history exists");
+        assert_eq!(
+            engine.active_card_id().expect("active card"),
+            "next",
+            "failed entry timer task should roll back back-navigation state"
+        );
+        assert_eq!(engine.nav_stack.len(), 2);
+        assert_eq!(engine.focused_link_index(), 0);
+        assert!(engine
+            .trace_entries()
+            .iter()
+            .any(|entry| entry.kind == "ACTION_ONTIMER_ERROR"));
+    }
 }

--- a/engine-wasm/engine/src/engine_runtime_internal/node_lookup.rs
+++ b/engine-wasm/engine/src/engine_runtime_internal/node_lookup.rs
@@ -1,0 +1,393 @@
+//! Shared lookup helpers for named `<input>`/`<select>` controls on a card.
+//!
+//! Every runtime accessor that reads or mutates a control by name walks the
+//! same `Card -> Node::Paragraph -> InlineNode` tree. The traversal lives here
+//! once so callers keep only their own "what to do with the match" logic, and
+//! so lookup order stays deterministic (document order, first match wins).
+
+use crate::runtime::card::Card;
+use crate::runtime::input_mask::InputMask;
+use crate::runtime::node::{InlineNode, Node, SelectOption};
+
+/// Borrowed view of an [`InlineNode::Input`].
+pub(crate) struct InputRef<'a> {
+    pub(crate) name: &'a str,
+    pub(crate) value: &'a str,
+    pub(crate) max_length: Option<usize>,
+    pub(crate) mask: &'a InputMask,
+    pub(crate) empty_ok: bool,
+}
+
+/// Mutably borrowed view of an [`InlineNode::Input`].
+pub(crate) struct InputMut<'a> {
+    pub(crate) name: &'a str,
+    pub(crate) value: &'a mut String,
+    pub(crate) default_value: &'a Option<String>,
+    pub(crate) mask: &'a InputMask,
+    pub(crate) empty_ok: bool,
+}
+
+/// Borrowed view of an [`InlineNode::Select`], identified by `control_id`.
+///
+/// `control_id` defaults to `name` (or `iname`, or a parser-assigned
+/// `select-N` ordinal) when `name` is absent, and is what every runtime
+/// accessor keys lookups on — `name`/`iname` may be `None` or duplicated
+/// across sibling selects per WML-204 semantics, so they are not usable as a
+/// lookup key on their own.
+pub(crate) struct SelectRef<'a> {
+    pub(crate) control_id: &'a str,
+    pub(crate) name: Option<&'a str>,
+    pub(crate) iname: Option<&'a str>,
+    pub(crate) multiple: bool,
+    pub(crate) options: &'a [SelectOption],
+    pub(crate) selected_indices: &'a [usize],
+}
+
+/// Mutably borrowed view of an [`InlineNode::Select`], identified by `control_id`.
+pub(crate) struct SelectMut<'a> {
+    pub(crate) control_id: &'a str,
+    pub(crate) name: Option<&'a str>,
+    pub(crate) iname: Option<&'a str>,
+    pub(crate) default_value: Option<&'a str>,
+    pub(crate) default_index_value: Option<&'a str>,
+    pub(crate) multiple: bool,
+    pub(crate) options: &'a [SelectOption],
+    pub(crate) selected_indices: &'a mut Vec<usize>,
+}
+
+/// First input named `input_name`, in document order.
+pub(crate) fn find_input<'a>(card: &'a Card, input_name: &str) -> Option<InputRef<'a>> {
+    inline_nodes(card)
+        .filter_map(as_input)
+        .find(|input| input.name == input_name)
+}
+
+/// First input named `input_name`, in document order, for mutation.
+pub(crate) fn find_input_mut<'a>(card: &'a mut Card, input_name: &str) -> Option<InputMut<'a>> {
+    inputs_mut(card).find(|input| input.name == input_name)
+}
+
+/// Every input on the card, in document order, for mutation.
+pub(crate) fn inputs_mut<'a>(card: &'a mut Card) -> impl Iterator<Item = InputMut<'a>> + 'a {
+    inline_nodes_mut(card).filter_map(as_input_mut)
+}
+
+/// First select with `control_id`, in document order.
+pub(crate) fn find_select<'a>(card: &'a Card, control_id: &str) -> Option<SelectRef<'a>> {
+    inline_nodes(card)
+        .filter_map(as_select)
+        .find(|select| select.control_id == control_id)
+}
+
+/// Every select on the card, in document order.
+pub(crate) fn selects<'a>(card: &'a Card) -> impl Iterator<Item = SelectRef<'a>> + 'a {
+    inline_nodes(card).filter_map(as_select)
+}
+
+/// Every select on the card, in document order, for mutation.
+pub(crate) fn selects_mut<'a>(card: &'a mut Card) -> impl Iterator<Item = SelectMut<'a>> + 'a {
+    inline_nodes_mut(card).filter_map(as_select_mut)
+}
+
+/// Every select with `control_id`, in document order, for mutation.
+///
+/// `control_id` defaults to `name` when present, so sibling `<select>`
+/// elements sharing a `name` also share a `control_id`. Callers that only
+/// accept a match satisfying an extra condition (an in-range option index,
+/// for example) keep scanning later same-id selects, so this returns the
+/// full sequence instead of just the first match.
+pub(crate) fn selects_with_control_id_mut<'a>(
+    card: &'a mut Card,
+    control_id: &'a str,
+) -> impl Iterator<Item = SelectMut<'a>> + 'a {
+    inline_nodes_mut(card)
+        .filter_map(as_select_mut)
+        .filter(move |select| select.control_id == control_id)
+}
+
+fn inline_nodes(card: &Card) -> impl Iterator<Item = &InlineNode> + '_ {
+    card.nodes
+        .iter()
+        .filter_map(|node| match node {
+            Node::Paragraph(items) => Some(items.iter()),
+            Node::Break => None,
+        })
+        .flatten()
+}
+
+fn inline_nodes_mut(card: &mut Card) -> impl Iterator<Item = &mut InlineNode> + '_ {
+    card.nodes
+        .iter_mut()
+        .filter_map(|node| match node {
+            Node::Paragraph(items) => Some(items.iter_mut()),
+            Node::Break => None,
+        })
+        .flatten()
+}
+
+fn as_input(item: &InlineNode) -> Option<InputRef<'_>> {
+    match item {
+        InlineNode::Input {
+            name,
+            value,
+            max_length,
+            mask,
+            empty_ok,
+            ..
+        } => Some(InputRef {
+            name,
+            value,
+            max_length: *max_length,
+            mask,
+            empty_ok: *empty_ok,
+        }),
+        InlineNode::Text(_) | InlineNode::Link { .. } | InlineNode::Select { .. } => None,
+    }
+}
+
+fn as_input_mut(item: &mut InlineNode) -> Option<InputMut<'_>> {
+    match item {
+        InlineNode::Input {
+            name,
+            value,
+            default_value,
+            mask,
+            empty_ok,
+            ..
+        } => Some(InputMut {
+            name: name.as_str(),
+            value,
+            default_value: &*default_value,
+            mask: &*mask,
+            empty_ok: *empty_ok,
+        }),
+        InlineNode::Text(_) | InlineNode::Link { .. } | InlineNode::Select { .. } => None,
+    }
+}
+
+fn as_select(item: &InlineNode) -> Option<SelectRef<'_>> {
+    match item {
+        InlineNode::Select {
+            control_id,
+            name,
+            iname,
+            multiple,
+            options,
+            selected_indices,
+            ..
+        } => Some(SelectRef {
+            control_id,
+            name: name.as_deref(),
+            iname: iname.as_deref(),
+            multiple: *multiple,
+            options,
+            selected_indices,
+        }),
+        InlineNode::Text(_) | InlineNode::Link { .. } | InlineNode::Input { .. } => None,
+    }
+}
+
+fn as_select_mut(item: &mut InlineNode) -> Option<SelectMut<'_>> {
+    match item {
+        InlineNode::Select {
+            control_id,
+            name,
+            iname,
+            default_value,
+            default_index_value,
+            multiple,
+            options,
+            selected_indices,
+            ..
+        } => Some(SelectMut {
+            control_id: control_id.as_str(),
+            name: name.as_deref(),
+            iname: iname.as_deref(),
+            default_value: default_value.as_deref(),
+            default_index_value: default_index_value.as_deref(),
+            multiple: *multiple,
+            options: options.as_slice(),
+            selected_indices,
+        }),
+        InlineNode::Text(_) | InlineNode::Link { .. } | InlineNode::Input { .. } => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn input_node(name: &str, value: &str) -> InlineNode {
+        InlineNode::Input {
+            name: name.to_string(),
+            value: value.to_string(),
+            default_value: None,
+            is_password: false,
+            max_length: None,
+            mask: InputMask::default(),
+            empty_ok: true,
+        }
+    }
+
+    fn select_node(control_id: &str, option_labels: &[&str], selected_index: usize) -> InlineNode {
+        InlineNode::Select {
+            control_id: control_id.to_string(),
+            name: Some(control_id.to_string()),
+            iname: None,
+            title: None,
+            default_value: None,
+            default_index_value: None,
+            multiple: false,
+            options: option_labels
+                .iter()
+                .map(|label| SelectOption {
+                    label: (*label).to_string(),
+                    value: (*label).to_string(),
+                    onpick: None,
+                })
+                .collect(),
+            selected_indices: vec![selected_index],
+        }
+    }
+
+    fn card_with(nodes: Vec<Node>) -> Card {
+        Card {
+            id: "card".to_string(),
+            nodes,
+            accept_action: None,
+            onenterforward_action: None,
+            onenterbackward_action: None,
+            ontimer_action: None,
+            timer_value_ds: None,
+        }
+    }
+
+    #[test]
+    fn find_input_returns_first_match_across_paragraphs() {
+        let card = card_with(vec![
+            Node::Paragraph(vec![InlineNode::Text("label".to_string())]),
+            Node::Break,
+            Node::Paragraph(vec![input_node("name", "first")]),
+            Node::Paragraph(vec![input_node("name", "second")]),
+        ]);
+
+        let input = find_input(&card, "name").expect("input should be found");
+        assert_eq!(input.name, "name");
+        assert_eq!(input.value, "first");
+        assert_eq!(input.max_length, None);
+        assert!(input.empty_ok);
+    }
+
+    #[test]
+    fn find_input_returns_none_for_unknown_name() {
+        let card = card_with(vec![Node::Paragraph(vec![input_node("name", "value")])]);
+
+        assert!(find_input(&card, "other").is_none());
+    }
+
+    #[test]
+    fn find_input_ignores_same_named_select() {
+        let card = card_with(vec![Node::Paragraph(vec![select_node(
+            "choice",
+            &["a", "b"],
+            0,
+        )])]);
+
+        assert!(find_input(&card, "choice").is_none());
+    }
+
+    #[test]
+    fn find_input_mut_mutates_only_first_match() {
+        let mut card = card_with(vec![Node::Paragraph(vec![
+            input_node("name", "first"),
+            input_node("name", "second"),
+        ])]);
+
+        let input = find_input_mut(&mut card, "name").expect("input should be found");
+        *input.value = "updated".to_string();
+
+        let values: Vec<String> = inputs_mut(&mut card)
+            .map(|input| input.value.clone())
+            .collect();
+        assert_eq!(values, vec!["updated".to_string(), "second".to_string()]);
+    }
+
+    #[test]
+    fn inputs_mut_yields_every_input_in_document_order() {
+        let mut card = card_with(vec![
+            Node::Paragraph(vec![
+                input_node("a", "1"),
+                InlineNode::Link {
+                    text: "link".to_string(),
+                    href: "#next".to_string(),
+                },
+            ]),
+            Node::Break,
+            Node::Paragraph(vec![select_node("c", &["x"], 0), input_node("b", "2")]),
+        ]);
+
+        let names: Vec<String> = inputs_mut(&mut card)
+            .map(|input| input.name.to_string())
+            .collect();
+        assert_eq!(names, vec!["a".to_string(), "b".to_string()]);
+    }
+
+    #[test]
+    fn find_select_returns_first_match_and_ignores_other_node_types() {
+        let card = card_with(vec![
+            Node::Paragraph(vec![input_node("choice", "typed")]),
+            Node::Paragraph(vec![select_node("choice", &["a", "b"], 1)]),
+            Node::Paragraph(vec![select_node("choice", &["c"], 0)]),
+        ]);
+
+        let select = find_select(&card, "choice").expect("select should be found");
+        assert_eq!(select.control_id, "choice");
+        assert_eq!(select.name, Some("choice"));
+        assert_eq!(select.selected_indices, &[1]);
+        assert_eq!(select.options.len(), 2);
+        assert!(find_select(&card, "missing").is_none());
+    }
+
+    #[test]
+    fn selects_with_control_id_mut_yields_every_same_id_select() {
+        let mut card = card_with(vec![
+            Node::Paragraph(vec![select_node("choice", &["a"], 0)]),
+            Node::Paragraph(vec![select_node("other", &["a", "b"], 0)]),
+            Node::Paragraph(vec![select_node("choice", &["a", "b", "c"], 0)]),
+        ]);
+
+        let option_counts: Vec<usize> = selects_with_control_id_mut(&mut card, "choice")
+            .map(|select| select.options.len())
+            .collect();
+        assert_eq!(option_counts, vec![1, 3]);
+
+        for select in selects_with_control_id_mut(&mut card, "choice") {
+            if 2 < select.options.len() {
+                *select.selected_indices = vec![2];
+                break;
+            }
+        }
+
+        let indexes: Vec<Vec<usize>> = selects_with_control_id_mut(&mut card, "choice")
+            .map(|select| select.selected_indices.clone())
+            .collect();
+        assert_eq!(indexes, vec![vec![0], vec![2]]);
+    }
+
+    #[test]
+    fn selects_mut_yields_every_select_in_document_order() {
+        let mut card = card_with(vec![
+            Node::Paragraph(vec![
+                select_node("a", &["x"], 0),
+                input_node("typed", "value"),
+            ]),
+            Node::Break,
+            Node::Paragraph(vec![select_node("b", &["y", "z"], 0)]),
+        ]);
+
+        let ids: Vec<String> = selects_mut(&mut card)
+            .map(|select| select.control_id.to_string())
+            .collect();
+        assert_eq!(ids, vec!["a".to_string(), "b".to_string()]);
+    }
+}

--- a/engine-wasm/engine/src/engine_runtime_internal/timers.rs
+++ b/engine-wasm/engine/src/engine_runtime_internal/timers.rs
@@ -74,10 +74,15 @@ impl WmlEngine {
             return Ok(());
         }
         let (before, after) = {
+            // The guard above already proved `active_timer` is `Some`, but this
+            // path is reachable from untrusted script/host-driven time advance,
+            // so per the panic-vs-`Result` guidance in
+            // `docs/agents/RUST_ENGINE_STEERING.md` a broken invariant degrades
+            // to a structured error instead of panicking.
             let timer = self
                 .active_timer
                 .as_mut()
-                .expect("timer must exist after guard");
+                .ok_or_else(|| "timer: active timer missing after presence check".to_string())?;
             let before = timer.remaining_ms;
             timer.remaining_ms = timer.remaining_ms.saturating_sub(delta_ms);
             (before, timer.remaining_ms)

--- a/engine-wasm/engine/src/layout/flow_layout.rs
+++ b/engine-wasm/engine/src/layout/flow_layout.rs
@@ -15,6 +15,23 @@ pub enum FocusTarget {
     Select(String),
 }
 
+impl FocusTarget {
+    /// Encode this target as the `href` string carried by [`DrawCmd::Link`].
+    ///
+    /// This is the only place the `input:`/`select:` prefix encoding is
+    /// produced. The prefixes are part of the host-visible render-list shape
+    /// (see the `browser/src-tauri` render assertions), so the string form is
+    /// built once here at the output boundary rather than being round-tripped
+    /// back into a `FocusTarget` internally.
+    pub fn to_render_href(&self) -> String {
+        match self {
+            FocusTarget::Link(href) => href.clone(),
+            FocusTarget::Input(name) => format!("input:{name}"),
+            FocusTarget::Select(name) => format!("select:{name}"),
+        }
+    }
+}
+
 pub fn layout_card(card: &Card, viewport_cols: usize, focused_link_idx: usize) -> LayoutResult {
     let mut result = LayoutResult::default();
     let mut line = 0u32;
@@ -25,12 +42,12 @@ pub fn layout_card(card: &Card, viewport_cols: usize, focused_link_idx: usize) -
                 line += 1;
             }
             Node::Paragraph(inline) => {
-                let mut parts = Vec::new();
+                let mut parts: Vec<(String, Option<FocusTarget>)> = Vec::new();
                 for entry in inline {
                     match entry {
                         InlineNode::Text(text) => parts.push((text.clone(), None)),
                         InlineNode::Link { text, href } => {
-                            parts.push((text.clone(), Some(href.clone())));
+                            parts.push((text.clone(), Some(FocusTarget::Link(href.clone()))));
                         }
                         InlineNode::Input {
                             name,
@@ -45,7 +62,7 @@ pub fn layout_card(card: &Card, viewport_cols: usize, focused_link_idx: usize) -
                                 value.clone()
                             };
                             let rendered = format!("[{name}: {display_value}]");
-                            parts.push((rendered, Some(format!("input:{name}"))));
+                            parts.push((rendered, Some(FocusTarget::Input(name.clone()))));
                         }
                         InlineNode::Select {
                             control_id,
@@ -69,28 +86,23 @@ pub fn layout_card(card: &Card, viewport_cols: usize, focused_link_idx: usize) -
                                 .or_else(|| iname.clone())
                                 .unwrap_or_else(|| control_id.clone());
                             let rendered = format!("[{label}: {selected}]");
-                            parts.push((rendered, Some(format!("select:{control_id}"))));
+                            // Selects are looked up by `control_id` everywhere downstream
+                            // (WML-204 select semantics allow duplicate/absent `name`), so
+                            // the focus target must carry `control_id`, not `name`.
+                            parts.push((rendered, Some(FocusTarget::Select(control_id.clone()))));
                         }
                     }
                 }
 
-                for (segment, href) in parts {
+                for (segment, target) in parts {
                     let chunks = wrap_text(&segment, viewport_cols);
-                    let focus_index = href.as_ref().map(|target| {
+                    let focus_index = target.as_ref().map(|target| {
                         let idx = result.focus_targets.len();
-                        if let Some(input_name) = target.strip_prefix("input:") {
-                            result
-                                .focus_targets
-                                .push(FocusTarget::Input(input_name.to_string()));
-                        } else if let Some(select_name) = target.strip_prefix("select:") {
-                            result
-                                .focus_targets
-                                .push(FocusTarget::Select(select_name.to_string()));
-                        } else {
-                            result.focus_targets.push(FocusTarget::Link(target.clone()));
-                        }
+                        result.focus_targets.push(target.clone());
                         idx
                     });
+                    // Stringify once per segment, at the render-list boundary.
+                    let href = target.as_ref().map(FocusTarget::to_render_href);
 
                     for chunk in chunks {
                         match &href {

--- a/engine-wasm/engine/src/parser/wml_parser/actions.rs
+++ b/engine-wasm/engine/src/parser/wml_parser/actions.rs
@@ -1,7 +1,5 @@
 use crate::runtime::card::{CardPostField, CardTaskAction};
 
-#[cfg(test)]
-use super::xml::{extract_attr, find_tag_from};
 use super::xml::{XmlElement, XmlNode};
 use super::ParseBudget;
 
@@ -153,125 +151,6 @@ fn parse_timer_value_ds_xml(elements: &[&XmlElement]) -> Option<u32> {
     None
 }
 
-#[cfg(test)]
-pub(super) fn parse_do_accept_action(body: &str) -> Result<Option<CardTaskAction>, String> {
-    let mut cursor = 0usize;
-    while let Some(start) = find_tag_from(body, "do", cursor) {
-        let open_end = body[start..]
-            .find('>')
-            .map(|idx| start + idx)
-            .ok_or_else(|| "Malformed <do> opening tag".to_string())?;
-        let open_tag = &body[start..=open_end];
-        let close_start = body[open_end + 1..]
-            .find("</do>")
-            .map(|idx| open_end + 1 + idx)
-            .ok_or_else(|| "Missing closing </do> tag".to_string())?;
-        let do_body = &body[open_end + 1..close_start];
-
-        let do_type = extract_attr(open_tag, "type")
-            .unwrap_or_default()
-            .to_ascii_lowercase();
-        if do_type == "accept" {
-            if let Some(href) = extract_attr(open_tag, "href") {
-                if !href.is_empty() {
-                    return Ok(Some(CardTaskAction::Go {
-                        href,
-                        method: parse_go_method(open_tag),
-                        post_fields: parse_post_fields(do_body),
-                    }));
-                }
-            }
-            if let Some(action) = parse_first_task_action(do_body)? {
-                return Ok(Some(action));
-            }
-        }
-
-        cursor = close_start + "</do>".len();
-    }
-
-    Ok(None)
-}
-
-#[cfg(test)]
-pub(super) fn parse_onevent_action(
-    body: &str,
-    target_event_type: &str,
-) -> Result<Option<CardTaskAction>, String> {
-    let mut cursor = 0usize;
-    while let Some(start) = find_tag_from(body, "onevent", cursor) {
-        let open_end = body[start..]
-            .find('>')
-            .map(|idx| start + idx)
-            .ok_or_else(|| "Malformed <onevent> opening tag".to_string())?;
-        let open_tag = &body[start..=open_end];
-        let close_start = body[open_end + 1..]
-            .find("</onevent>")
-            .map(|idx| open_end + 1 + idx)
-            .ok_or_else(|| "Missing closing </onevent> tag".to_string())?;
-        let onevent_body = &body[open_end + 1..close_start];
-
-        let event_type = extract_attr(open_tag, "type")
-            .unwrap_or_default()
-            .to_ascii_lowercase();
-        if event_type == target_event_type {
-            return parse_first_task_action(onevent_body);
-        }
-
-        cursor = close_start + "</onevent>".len();
-    }
-
-    Ok(None)
-}
-
-#[cfg(test)]
-pub(super) fn parse_first_task_action(body: &str) -> Result<Option<CardTaskAction>, String> {
-    let mut cursor = 0usize;
-    while cursor < body.len() {
-        let next_go = find_tag_from(body, "go", cursor);
-        let next_prev = find_tag_from(body, "prev", cursor);
-        let next_refresh = find_tag_from(body, "refresh", cursor);
-        let next_noop = find_tag_from(body, "noop", cursor);
-        let Some((tag, start)) = choose_next_task_tag(next_go, next_prev, next_refresh, next_noop)
-        else {
-            break;
-        };
-
-        let open_end = body[start..]
-            .find('>')
-            .map(|idx| start + idx)
-            .ok_or_else(|| format!("Malformed <{tag}> tag"))?;
-        let open_tag = &body[start..=open_end];
-        match tag {
-            "go" => {
-                if let Some(href) = extract_attr(open_tag, "href") {
-                    if !href.is_empty() {
-                        let post_fields = if open_tag.trim_end().ends_with("/>") {
-                            Vec::new()
-                        } else {
-                            let close_start = body[open_end + 1..]
-                                .find("</go>")
-                                .map(|idx| open_end + 1 + idx)
-                                .unwrap_or(open_end + 1);
-                            parse_post_fields(&body[open_end + 1..close_start])
-                        };
-                        return Ok(Some(CardTaskAction::Go {
-                            href,
-                            method: parse_go_method(open_tag),
-                            post_fields,
-                        }));
-                    }
-                }
-            }
-            "prev" => return Ok(Some(CardTaskAction::Prev)),
-            "refresh" => return Ok(Some(CardTaskAction::Refresh)),
-            "noop" => return Ok(Some(CardTaskAction::Noop)),
-            _ => {}
-        }
-        cursor = open_end + 1;
-    }
-    Ok(None)
-}
-
 fn parse_go_method_xml(element: &XmlElement) -> Option<String> {
     normalize_go_method(element.attr("method"))
 }
@@ -299,78 +178,10 @@ fn collect_post_fields_xml(nodes: &[XmlNode], out: &mut Vec<CardPostField>) {
     }
 }
 
-#[cfg(test)]
-fn parse_go_method(open_tag: &str) -> Option<String> {
-    normalize_go_method(extract_attr(open_tag, "method").as_deref())
-}
-
 fn normalize_go_method(method: Option<&str>) -> Option<String> {
     let method = method?.trim();
     if method.is_empty() {
         return None;
     }
     Some(method.to_ascii_uppercase())
-}
-
-#[cfg(test)]
-fn parse_post_fields(body: &str) -> Vec<CardPostField> {
-    let mut out = Vec::new();
-    let mut cursor = 0usize;
-    while let Some(start) = find_tag_from(body, "postfield", cursor) {
-        let Some(open_end) = body[start..].find('>').map(|idx| start + idx) else {
-            break;
-        };
-        let open_tag = &body[start..=open_end];
-        if let Some(name) = extract_attr(open_tag, "name").filter(|value| !value.is_empty()) {
-            out.push(CardPostField {
-                name,
-                value: extract_attr(open_tag, "value").unwrap_or_default(),
-            });
-        }
-        cursor = open_end + 1;
-    }
-    out
-}
-
-#[cfg(test)]
-fn choose_next_task_tag(
-    next_go: Option<usize>,
-    next_prev: Option<usize>,
-    next_refresh: Option<usize>,
-    next_noop: Option<usize>,
-) -> Option<(&'static str, usize)> {
-    let mut candidate: Option<(&'static str, usize)> = None;
-    for (tag, pos) in [
-        ("go", next_go),
-        ("prev", next_prev),
-        ("refresh", next_refresh),
-        ("noop", next_noop),
-    ] {
-        if let Some(pos) = pos {
-            match candidate {
-                Some((_, current_pos)) if current_pos <= pos => {}
-                _ => candidate = Some((tag, pos)),
-            }
-        }
-    }
-    candidate
-}
-
-#[cfg(test)]
-pub(super) fn parse_timer_value_ds(body: &str) -> Result<Option<u32>, String> {
-    let mut cursor = 0usize;
-    while let Some(start) = find_tag_from(body, "timer", cursor) {
-        let open_end = body[start..]
-            .find('>')
-            .map(|idx| start + idx)
-            .ok_or_else(|| "Malformed <timer> tag".to_string())?;
-        let open_tag = &body[start..=open_end];
-        if let Some(raw) = extract_attr(open_tag, "value") {
-            if let Ok(value_ds) = raw.trim().parse::<u32>() {
-                return Ok(Some(value_ds));
-            }
-        }
-        cursor = open_end + 1;
-    }
-    Ok(None)
 }

--- a/engine-wasm/engine/src/parser/wml_parser/mod.rs
+++ b/engine-wasm/engine/src/parser/wml_parser/mod.rs
@@ -40,15 +40,6 @@ impl ParseBudget {
     }
 }
 
-#[cfg(test)]
-use actions::{
-    parse_do_accept_action, parse_first_task_action, parse_onevent_action, parse_timer_value_ds,
-};
-#[cfg(test)]
-use nodes::{parse_card_nodes, parse_inline_nodes};
-#[cfg(test)]
-use xml::extract_wml_body;
-
 pub fn parse_wml(xml: &str) -> Result<Deck, String> {
     let root = parse_xml_root(xml).map_err(map_xml_parse_error)?;
     if root.name != "wml" {

--- a/engine-wasm/engine/src/parser/wml_parser/nodes.rs
+++ b/engine-wasm/engine/src/parser/wml_parser/nodes.rs
@@ -1,8 +1,6 @@
 use crate::runtime::input_mask::InputMask;
 use crate::runtime::node::{InlineNode, Node, SelectOption};
 
-#[cfg(test)]
-use super::xml::{extract_attr, starts_with_tag_at};
 use super::xml::{normalize_text, XmlElement, XmlNode};
 use super::ParseBudget;
 
@@ -14,6 +12,53 @@ pub(super) fn parse_card_nodes_xml(
     let mut select_ordinal = 0usize;
     map_card_level_nodes(&card.children, &mut out, budget, 0, &mut select_ordinal)?;
     Ok(out)
+}
+
+/// What a tag from the shared inline tag set contributed to its walker.
+///
+/// The two walkers place the same inline content in different output models
+/// (`Node` for card level, `InlineNode` for paragraph level), so the shared
+/// dispatch reports *what* was produced and each walker decides *where* it
+/// goes.
+enum InlineTagOutcome {
+    /// A line break, rendered differently by each walker.
+    Break,
+    /// A concrete inline node to emit.
+    Node(InlineNode),
+    /// A recognized tag that intentionally contributes nothing (for example an
+    /// `<a>` without an `href`, or a `<select>` without a usable name).
+    Skip,
+}
+
+/// Handles the tags that both walkers treat identically (`a`, `br`, `input`,
+/// `select`, `option`).
+///
+/// Returns `Ok(None)` when `element` is not part of the shared set, leaving the
+/// caller to apply its own walker-specific handling (`<p>` at card level, or
+/// recursion into an unknown wrapper). Keeping this in one place means a new
+/// inline tag only has to be added here rather than in both walkers.
+///
+/// `child_depth` is the traversal depth used for `element`'s children, so the
+/// parse budget keeps counting nesting exactly as the callers do.
+fn map_shared_inline_tag(
+    element: &XmlElement,
+    budget: &mut ParseBudget,
+    child_depth: usize,
+    select_ordinal: &mut usize,
+) -> Result<Option<InlineTagOutcome>, String> {
+    let outcome = match element.name.as_str() {
+        "a" => parse_link_inline_node(element, budget, child_depth)?
+            .map_or(InlineTagOutcome::Skip, InlineTagOutcome::Node),
+        "br" => InlineTagOutcome::Break,
+        "input" => InlineTagOutcome::Node(parse_input_inline_node(element)?),
+        "select" => parse_select_inline_node(element, budget, child_depth, select_ordinal)?
+            .map_or(InlineTagOutcome::Skip, InlineTagOutcome::Node),
+        "option" => {
+            return Err("Invalid <option>: must be contained by <select> or <optgroup>".to_string())
+        }
+        _ => return Ok(None),
+    };
+    Ok(Some(outcome))
 }
 
 fn map_card_level_nodes(
@@ -33,39 +78,28 @@ fn map_card_level_nodes(
                     out.push(Node::Paragraph(vec![InlineNode::Text(text)]));
                 }
             }
-            XmlNode::Element(element) => match element.name.as_str() {
-                "br" => out.push(Node::Break),
-                "p" => {
+            XmlNode::Element(element) => {
+                if let Some(outcome) =
+                    map_shared_inline_tag(element, budget, depth + 1, select_ordinal)?
+                {
+                    match outcome {
+                        InlineTagOutcome::Break => out.push(Node::Break),
+                        InlineTagOutcome::Node(inline) => out.push(Node::Paragraph(vec![inline])),
+                        InlineTagOutcome::Skip => {}
+                    }
+                    continue;
+                }
+
+                if element.name == "p" {
                     let inline =
                         map_inline_nodes(&element.children, budget, depth + 1, select_ordinal)?;
                     if !inline.is_empty() {
                         out.push(Node::Paragraph(inline));
                     }
+                    continue;
                 }
-                "a" => {
-                    let href = element.attr("href").unwrap_or_default().to_string();
-                    if !href.is_empty() {
-                        let text = normalize_text(&inline_text_content(
-                            &element.children,
-                            budget,
-                            depth + 1,
-                        )?);
-                        let text = if text.is_empty() { href.clone() } else { text };
-                        out.push(Node::Paragraph(vec![InlineNode::Link { text, href }]));
-                    }
-                }
-                "input" => {
-                    let input_node = parse_input_inline_node(element)?;
-                    out.push(Node::Paragraph(vec![input_node]));
-                }
-                "select" => {
-                    if let Some(select_node) =
-                        parse_select_inline_node(element, budget, depth + 1, select_ordinal)?
-                    {
-                        out.push(Node::Paragraph(vec![select_node]));
-                    }
-                }
-                "fieldset" => {
+
+                if element.name == "fieldset" {
                     validate_fieldset_element(element)?;
                     map_card_level_nodes(
                         &element.children,
@@ -74,22 +108,18 @@ fn map_card_level_nodes(
                         depth + 1,
                         select_ordinal,
                     )?;
+                    continue;
                 }
-                "option" => {
-                    return Err(
-                        "Invalid <option>: must be contained by <select> or <optgroup>".to_string(),
-                    )
-                }
-                "optgroup" => {
+
+                if element.name == "optgroup" {
                     return Err(
                         "Invalid <optgroup>: must be contained by <select> or <optgroup>"
                             .to_string(),
-                    )
+                    );
                 }
-                _ => {
-                    map_card_level_nodes(&element.children, out, budget, depth + 1, select_ordinal)?
-                }
-            },
+
+                map_card_level_nodes(&element.children, out, budget, depth + 1, select_ordinal)?;
+            }
         }
     }
     Ok(())
@@ -128,39 +158,22 @@ fn map_inline_nodes_recursive(
         budget.visit_node("inline-node traversal")?;
         match node {
             XmlNode::Text(text) => pending_text.push_str(text),
-            XmlNode::Element(element) => match element.name.as_str() {
-                "a" => {
+            XmlNode::Element(element) => {
+                if let Some(outcome) =
+                    map_shared_inline_tag(element, budget, depth + 1, select_ordinal)?
+                {
+                    // Text accumulated before this tag has to be emitted first
+                    // so inline ordering is preserved.
                     flush_pending_inline_text(pending_text, out);
-                    let href = element.attr("href").unwrap_or_default().to_string();
-                    if !href.is_empty() {
-                        let text = normalize_text(&inline_text_content(
-                            &element.children,
-                            budget,
-                            depth + 1,
-                        )?);
-                        out.push(InlineNode::Link {
-                            text: if text.is_empty() { href.clone() } else { text },
-                            href,
-                        });
+                    match outcome {
+                        InlineTagOutcome::Break => out.push(InlineNode::Text(" ".to_string())),
+                        InlineTagOutcome::Node(inline) => out.push(inline),
+                        InlineTagOutcome::Skip => {}
                     }
+                    continue;
                 }
-                "br" => {
-                    flush_pending_inline_text(pending_text, out);
-                    out.push(InlineNode::Text(" ".to_string()));
-                }
-                "input" => {
-                    flush_pending_inline_text(pending_text, out);
-                    out.push(parse_input_inline_node(element)?);
-                }
-                "select" => {
-                    flush_pending_inline_text(pending_text, out);
-                    if let Some(select_node) =
-                        parse_select_inline_node(element, budget, depth + 1, select_ordinal)?
-                    {
-                        out.push(select_node);
-                    }
-                }
-                "fieldset" => {
+
+                if element.name == "fieldset" {
                     validate_fieldset_element(element)?;
                     map_inline_nodes_recursive(
                         &element.children,
@@ -170,30 +183,46 @@ fn map_inline_nodes_recursive(
                         depth + 1,
                         select_ordinal,
                     )?;
+                    continue;
                 }
-                "option" => {
-                    return Err(
-                        "Invalid <option>: must be contained by <select> or <optgroup>".to_string(),
-                    )
-                }
-                "optgroup" => {
+
+                if element.name == "optgroup" {
                     return Err(
                         "Invalid <optgroup>: must be contained by <select> or <optgroup>"
                             .to_string(),
-                    )
+                    );
                 }
-                _ => map_inline_nodes_recursive(
+
+                map_inline_nodes_recursive(
                     &element.children,
                     pending_text,
                     out,
                     budget,
                     depth + 1,
                     select_ordinal,
-                )?,
-            },
+                )?;
+            }
         }
     }
     Ok(())
+}
+
+fn parse_link_inline_node(
+    element: &XmlElement,
+    budget: &mut ParseBudget,
+    child_depth: usize,
+) -> Result<Option<InlineNode>, String> {
+    let href = element.attr("href").unwrap_or_default().to_string();
+    if href.is_empty() {
+        return Ok(None);
+    }
+    let text = normalize_text(&inline_text_content(
+        &element.children,
+        budget,
+        child_depth,
+    )?);
+    let text = if text.is_empty() { href.clone() } else { text };
+    Ok(Some(InlineNode::Link { text, href }))
 }
 
 fn flush_pending_inline_text(pending_text: &mut String, out: &mut Vec<InlineNode>) {
@@ -593,157 +622,4 @@ fn inline_text_content(
         }
     }
     Ok(out)
-}
-
-#[cfg(test)]
-pub(super) fn parse_card_nodes(body: &str) -> Result<Vec<Node>, String> {
-    let mut nodes = Vec::new();
-    let mut cursor = 0usize;
-
-    while cursor < body.len() {
-        if let Some(start) = body[cursor..].find('<') {
-            let tag_start = cursor + start;
-
-            if tag_start > cursor {
-                let text = normalize_text(&body[cursor..tag_start]);
-                if !text.is_empty() {
-                    nodes.push(Node::Paragraph(vec![InlineNode::Text(text)]));
-                }
-            }
-
-            if starts_with_tag_at(body, tag_start, "br") {
-                let end = body[tag_start..]
-                    .find('>')
-                    .map(|idx| tag_start + idx)
-                    .ok_or_else(|| "Malformed <br> tag".to_string())?;
-                nodes.push(Node::Break);
-                cursor = end + 1;
-                continue;
-            }
-
-            if starts_with_tag_at(body, tag_start, "p") {
-                let open_end = body[tag_start..]
-                    .find('>')
-                    .map(|idx| tag_start + idx)
-                    .ok_or_else(|| "Malformed <p> opening tag".to_string())?;
-                let close_start = body[open_end + 1..]
-                    .find("</p>")
-                    .map(|idx| open_end + 1 + idx)
-                    .ok_or_else(|| "Missing closing </p> tag".to_string())?;
-
-                let content = &body[open_end + 1..close_start];
-                let inline = parse_inline_nodes(content)?;
-                if !inline.is_empty() {
-                    nodes.push(Node::Paragraph(inline));
-                }
-                cursor = close_start + "</p>".len();
-                continue;
-            }
-
-            if starts_with_tag_at(body, tag_start, "a") {
-                let open_end = body[tag_start..]
-                    .find('>')
-                    .map(|idx| tag_start + idx)
-                    .ok_or_else(|| "Malformed <a> opening tag".to_string())?;
-                let open_tag = &body[tag_start..=open_end];
-                let href = extract_attr(open_tag, "href").unwrap_or_default();
-                let close_start = body[open_end + 1..]
-                    .find("</a>")
-                    .map(|idx| open_end + 1 + idx)
-                    .ok_or_else(|| "Missing closing </a> tag".to_string())?;
-
-                let link_text_raw = &body[open_end + 1..close_start];
-                let link_text = normalize_text(link_text_raw);
-                if !href.is_empty() {
-                    let text = if link_text.is_empty() {
-                        href.clone()
-                    } else {
-                        link_text
-                    };
-                    nodes.push(Node::Paragraph(vec![InlineNode::Link { text, href }]));
-                }
-                cursor = close_start + "</a>".len();
-                continue;
-            }
-
-            let end = body[tag_start..]
-                .find('>')
-                .map(|idx| tag_start + idx)
-                .ok_or_else(|| "Malformed tag".to_string())?;
-            cursor = end + 1;
-        } else {
-            let text = normalize_text(&body[cursor..]);
-            if !text.is_empty() {
-                nodes.push(Node::Paragraph(vec![InlineNode::Text(text)]));
-            }
-            break;
-        }
-    }
-
-    Ok(nodes)
-}
-
-#[cfg(test)]
-pub(super) fn parse_inline_nodes(content: &str) -> Result<Vec<InlineNode>, String> {
-    let mut nodes = Vec::new();
-    let mut cursor = 0usize;
-
-    while cursor < content.len() {
-        if let Some(start) = content[cursor..].find('<') {
-            let tag_start = cursor + start;
-            if tag_start > cursor {
-                let text = normalize_text(&content[cursor..tag_start]);
-                if !text.is_empty() {
-                    nodes.push(InlineNode::Text(text));
-                }
-            }
-
-            if starts_with_tag_at(content, tag_start, "a") {
-                let open_end = content[tag_start..]
-                    .find('>')
-                    .map(|idx| tag_start + idx)
-                    .ok_or_else(|| "Malformed inline <a> opening tag".to_string())?;
-                let open_tag = &content[tag_start..=open_end];
-                let href = extract_attr(open_tag, "href").unwrap_or_default();
-                let close_start = content[open_end + 1..]
-                    .find("</a>")
-                    .map(|idx| open_end + 1 + idx)
-                    .ok_or_else(|| "Missing closing inline </a> tag".to_string())?;
-                let raw_text = &content[open_end + 1..close_start];
-                let text = normalize_text(raw_text);
-                if !href.is_empty() {
-                    nodes.push(InlineNode::Link {
-                        text: if text.is_empty() { href.clone() } else { text },
-                        href,
-                    });
-                }
-                cursor = close_start + "</a>".len();
-                continue;
-            }
-
-            if starts_with_tag_at(content, tag_start, "br") {
-                let end = content[tag_start..]
-                    .find('>')
-                    .map(|idx| tag_start + idx)
-                    .ok_or_else(|| "Malformed inline <br> tag".to_string())?;
-                nodes.push(InlineNode::Text(" ".to_string()));
-                cursor = end + 1;
-                continue;
-            }
-
-            let end = content[tag_start..]
-                .find('>')
-                .map(|idx| tag_start + idx)
-                .ok_or_else(|| "Malformed inline tag".to_string())?;
-            cursor = end + 1;
-        } else {
-            let text = normalize_text(&content[cursor..]);
-            if !text.is_empty() {
-                nodes.push(InlineNode::Text(text));
-            }
-            break;
-        }
-    }
-
-    Ok(nodes)
 }

--- a/engine-wasm/engine/src/parser/wml_parser/tests.rs
+++ b/engine-wasm/engine/src/parser/wml_parser/tests.rs
@@ -1,8 +1,4 @@
-use super::{
-    extract_wml_body, parse_card_nodes, parse_do_accept_action, parse_first_task_action,
-    parse_inline_nodes, parse_onevent_action, parse_timer_value_ds, parse_wml, parse_xml_root,
-    MAX_PARSE_TREE_DEPTH,
-};
+use super::{parse_wml, parse_xml_root, MAX_PARSE_TREE_DEPTH};
 use crate::runtime::card::{CardPostField, CardTaskAction};
 use crate::runtime::node::{InlineNode, Node};
 
@@ -633,52 +629,96 @@ fn does_not_treat_prev_tag_as_paragraph_opening_tag() {
     );
 }
 
-#[test]
-fn helper_extract_wml_body_reports_root_errors() {
-    let malformed = extract_wml_body("<wml ").expect_err("malformed wml open tag must fail");
-    assert!(malformed.contains("Malformed <wml> opening tag"));
+// The tests below previously drove a second, string-scanning WML parser that
+// existed only under `#[cfg(test)]` and duplicated the production XML-tree
+// parser. That legacy scanner has been deleted; each test now asserts the same
+// observable behavior through the real `parse_wml` path.
 
-    let missing_close =
-        extract_wml_body("<wml><card id=\"x\"></card>").expect_err("missing wml close must fail");
-    assert!(missing_close.contains("Missing closing </wml> root element"));
+fn deck_with_card_body(body: &str) -> String {
+    format!("<wml><card id=\"home\">{body}</card></wml>")
+}
+
+fn accept_action_for(control: &str) -> Result<Option<CardTaskAction>, String> {
+    let xml = deck_with_card_body(&format!("<do type=\"accept\">{control}</do>"));
+    parse_wml(&xml).map(|deck| deck.cards[0].accept_action.clone())
+}
+
+fn onenterforward_action_for(control: &str) -> Result<Option<CardTaskAction>, String> {
+    let xml = deck_with_card_body(&format!(
+        "<onevent type=\"onenterforward\">{control}</onevent>"
+    ));
+    parse_wml(&xml).map(|deck| deck.cards[0].onenterforward_action.clone())
+}
+
+fn card_nodes_for(body: &str) -> Result<Vec<Node>, String> {
+    parse_wml(&deck_with_card_body(body)).map(|deck| deck.cards[0].nodes.clone())
+}
+
+fn paragraph_items_for(body: &str) -> Vec<InlineNode> {
+    let nodes = card_nodes_for(&format!("<p>{body}</p>")).expect("paragraph should parse");
+    match nodes.into_iter().next() {
+        Some(Node::Paragraph(items)) => items,
+        other => panic!("expected a leading paragraph, got: {other:?}"),
+    }
 }
 
 #[test]
-fn helper_parse_first_task_action_handles_go_prev_and_malformed() {
+fn parse_wml_rejects_malformed_and_unclosed_root_markup() {
+    let malformed = parse_wml("<wml ").expect_err("malformed <wml> opening tag must fail");
+    assert!(
+        malformed.contains("Malformed XML"),
+        "unexpected error: {malformed}"
+    );
+
+    let missing_close =
+        parse_wml("<wml><card id=\"x\"></card>").expect_err("missing </wml> must fail");
+    assert!(
+        missing_close.contains("unclosed tag"),
+        "unexpected error: {missing_close}"
+    );
+}
+
+#[test]
+fn parses_go_prev_refresh_and_noop_accept_tasks() {
     assert_eq!(
-        parse_first_task_action("<go href=\"#ok\"/>").expect("go should parse"),
+        accept_action_for("<go href=\"#ok\"/>").expect("go should parse"),
         Some(go_action("#ok"))
     );
     assert_eq!(
-        parse_first_task_action("<prev/>").expect("prev should parse"),
+        accept_action_for("<prev/>").expect("prev should parse"),
         Some(CardTaskAction::Prev)
     );
     assert_eq!(
-        parse_first_task_action("<refresh/>").expect("refresh should parse"),
+        accept_action_for("<refresh/>").expect("refresh should parse"),
         Some(CardTaskAction::Refresh)
     );
     assert_eq!(
-        parse_first_task_action("<go/><prev/>").expect("empty go should fall through"),
-        Some(CardTaskAction::Prev)
-    );
-    assert_eq!(
-        parse_first_task_action("<go/><refresh/>")
-            .expect("empty go should fall through to refresh"),
-        Some(CardTaskAction::Refresh)
-    );
-    assert_eq!(
-        parse_first_task_action("<noop/>").expect("noop should parse"),
+        accept_action_for("<noop/>").expect("noop should parse"),
         Some(CardTaskAction::Noop)
     );
+
+    // A <go> without an href does not claim the task; the next task wins.
+    assert_eq!(
+        accept_action_for("<go/><prev/>").expect("empty go should fall through"),
+        Some(CardTaskAction::Prev)
+    );
+    assert_eq!(
+        accept_action_for("<go/><refresh/>").expect("empty go should fall through to refresh"),
+        Some(CardTaskAction::Refresh)
+    );
+
     let malformed_go =
-        parse_first_task_action("<go href=\"#broken\"").expect_err("malformed go must fail");
-    assert!(malformed_go.contains("Malformed <go> tag"));
+        accept_action_for("<go href=\"#broken\"").expect_err("malformed go must fail");
+    assert!(
+        malformed_go.contains("Malformed XML"),
+        "unexpected error: {malformed_go}"
+    );
 }
 
 #[test]
-fn helper_parse_first_task_action_preserves_post_method_and_postfields() {
+fn preserves_go_post_method_and_postfields() {
     assert_eq!(
-        parse_first_task_action(
+        accept_action_for(
             "<go method=\"post\" href=\"/login\"><postfield name=\"username\" value=\"$(alias)\"/><postfield name=\"pin\" value=\"0000\"/></go>"
         )
         .expect("post go should parse"),
@@ -690,169 +730,135 @@ fn helper_parse_first_task_action_preserves_post_method_and_postfields() {
 }
 
 #[test]
-fn helper_parse_do_accept_action_exercises_direct_and_error_paths() {
-    assert_eq!(
-        parse_do_accept_action("<do type=\"accept\" href=\"#direct\"></do>")
-            .expect("direct href should parse"),
-        Some(go_action("#direct"))
-    );
+fn parses_do_accept_direct_href_and_nested_task_fallbacks() {
+    let direct = parse_wml(&deck_with_card_body(
+        "<do type=\"accept\" href=\"#direct\"></do>",
+    ))
+    .expect("direct href should parse");
+    assert_eq!(direct.cards[0].accept_action, Some(go_action("#direct")));
 
+    let fallback = parse_wml(&deck_with_card_body(
+        "<do type=\"accept\" href=\"\"><go href=\"#fallback\"/></do>",
+    ))
+    .expect("empty href should fall back to the nested task");
     assert_eq!(
-        parse_do_accept_action("<do type=\"accept\" href=\"\"><go href=\"#fallback\"/></do>")
-            .expect("fallback go href should parse"),
+        fallback.cards[0].accept_action,
         Some(go_action("#fallback"))
     );
 
-    assert_eq!(
-        parse_do_accept_action("<do type=\"accept\"><prev/></do>")
-            .expect("fallback prev should parse"),
-        Some(CardTaskAction::Prev)
-    );
-    assert_eq!(
-        parse_do_accept_action("<do type=\"accept\"><refresh/></do>")
-            .expect("fallback refresh should parse"),
-        Some(CardTaskAction::Refresh)
-    );
-    assert_eq!(
-        parse_do_accept_action("<do type=\"accept\"><noop/></do>")
-            .expect("fallback noop should parse"),
-        Some(CardTaskAction::Noop)
-    );
+    for (control, expected) in [
+        ("<prev/>", CardTaskAction::Prev),
+        ("<refresh/>", CardTaskAction::Refresh),
+        ("<noop/>", CardTaskAction::Noop),
+    ] {
+        assert_eq!(
+            accept_action_for(control).expect("nested task fallback should parse"),
+            Some(expected),
+            "unexpected accept action for {control}"
+        );
+    }
 
-    let malformed =
-        parse_do_accept_action("<do type=\"accept\"").expect_err("malformed do open tag must fail");
-    assert!(malformed.contains("Malformed <do> opening tag"));
-
-    let missing_close =
-        parse_do_accept_action("<do type=\"accept\">").expect_err("missing do close tag must fail");
-    assert!(missing_close.contains("Missing closing </do> tag"));
+    let missing_close = parse_wml(&deck_with_card_body("<do type=\"accept\">"))
+        .expect_err("unclosed <do> must fail");
+    assert!(
+        missing_close.contains("Malformed XML"),
+        "unexpected error: {missing_close}"
+    );
 }
 
 #[test]
-fn helper_parse_onevent_action_exercises_non_matching_and_error_paths() {
+fn parses_onevent_actions_and_ignores_non_matching_event_types() {
+    let deck = parse_wml(&deck_with_card_body(
+        "<onevent type=\"onenterbackward\"><go href=\"#skip\"/></onevent>",
+    ))
+    .expect("non-matching onevent should parse");
+    assert_eq!(deck.cards[0].onenterforward_action, None);
     assert_eq!(
-        parse_onevent_action(
-            "<onevent type=\"onenterbackward\"><go href=\"#skip\"/></onevent>",
-            "onenterforward"
-        )
-        .expect("non-matching onevent should parse"),
-        None
+        deck.cards[0].onenterbackward_action,
+        Some(go_action("#skip"))
     );
 
     assert_eq!(
-        parse_onevent_action(
-            "<onevent type=\"onenterforward\"><go href=\"#next\"/></onevent>",
-            "onenterforward"
-        )
-        .expect("matching onevent should parse"),
+        onenterforward_action_for("<go href=\"#next\"/>").expect("matching onevent should parse"),
         Some(go_action("#next"))
     );
 
-    assert_eq!(
-        parse_onevent_action(
-            "<onevent type=\"onenterbackward\"><go href=\"#prev\"/></onevent>",
-            "onenterbackward"
-        )
-        .expect("matching backward onevent should parse"),
-        Some(go_action("#prev"))
-    );
+    for (control, expected) in [
+        ("<prev/>", CardTaskAction::Prev),
+        ("<refresh/>", CardTaskAction::Refresh),
+        ("<noop/>", CardTaskAction::Noop),
+    ] {
+        assert_eq!(
+            onenterforward_action_for(control).expect("onevent task should parse"),
+            Some(expected),
+            "unexpected onenterforward action for {control}"
+        );
+    }
 
-    assert_eq!(
-        parse_onevent_action(
-            "<onevent type=\"onenterforward\"><prev/></onevent>",
-            "onenterforward"
-        )
-        .expect("prev task onevent should parse"),
-        Some(CardTaskAction::Prev)
+    let missing_close = parse_wml(&deck_with_card_body("<onevent type=\"onenterforward\">"))
+        .expect_err("unclosed <onevent> must fail");
+    assert!(
+        missing_close.contains("Malformed XML"),
+        "unexpected error: {missing_close}"
     );
-    assert_eq!(
-        parse_onevent_action(
-            "<onevent type=\"onenterforward\"><refresh/></onevent>",
-            "onenterforward"
-        )
-        .expect("refresh task onevent should parse"),
-        Some(CardTaskAction::Refresh)
-    );
-    assert_eq!(
-        parse_onevent_action(
-            "<onevent type=\"onenterforward\"><noop/></onevent>",
-            "onenterforward"
-        )
-        .expect("noop task onevent should parse"),
-        Some(CardTaskAction::Noop)
-    );
-
-    let malformed = parse_onevent_action("<onevent type=\"onenterforward\"", "onenterforward")
-        .expect_err("malformed onevent open tag must fail");
-    assert!(malformed.contains("Malformed <onevent> opening tag"));
-
-    let missing_close = parse_onevent_action("<onevent type=\"onenterforward\">", "onenterforward")
-        .expect_err("missing onevent close tag must fail");
-    assert!(missing_close.contains("Missing closing </onevent> tag"));
 }
 
 #[test]
-fn helper_parse_timer_value_ds_handles_valid_invalid_and_malformed() {
-    assert_eq!(
-        parse_timer_value_ds("<timer value=\"10\"/>").expect("timer should parse"),
-        Some(10)
+fn parses_timer_value_and_ignores_invalid_or_missing_timers() {
+    let deck =
+        parse_wml(&deck_with_card_body("<timer value=\"10\"/>")).expect("timer should parse");
+    assert_eq!(deck.cards[0].timer_value_ds, Some(10));
+
+    let deck = parse_wml(&deck_with_card_body("<timer value=\"x\"/>"))
+        .expect("invalid timer value should be ignored");
+    assert_eq!(deck.cards[0].timer_value_ds, None);
+
+    let deck = parse_wml(&deck_with_card_body("<p>No timer</p>"))
+        .expect("deck without a timer should parse");
+    assert_eq!(deck.cards[0].timer_value_ds, None);
+
+    let malformed = parse_wml(&deck_with_card_body("<timer value=\"3\""))
+        .expect_err("malformed <timer> must fail");
+    assert!(
+        malformed.contains("Malformed XML"),
+        "unexpected error: {malformed}"
     );
-    assert_eq!(
-        parse_timer_value_ds("<timer value=\"x\"/>").expect("invalid timer should be ignored"),
-        None
-    );
-    assert_eq!(
-        parse_timer_value_ds("<p>No timer</p>").expect("missing timer should parse"),
-        None
-    );
-    let malformed =
-        parse_timer_value_ds("<timer value=\"3\"").expect_err("malformed timer tag should fail");
-    assert!(malformed.contains("Malformed <timer> tag"));
 }
 
 #[test]
-fn helper_parse_card_nodes_reports_malformed_tags() {
-    let malformed_br = parse_card_nodes("<br").expect_err("malformed br should fail");
-    assert!(malformed_br.contains("Malformed <br> tag"));
-
-    let malformed_p = parse_card_nodes("<p").expect_err("malformed p open tag should fail");
-    assert!(malformed_p.contains("Malformed <p> opening tag"));
-
-    let missing_p_close = parse_card_nodes("<p>text").expect_err("unclosed p should fail");
-    assert!(missing_p_close.contains("Missing closing </p> tag"));
-
-    let malformed_a =
-        parse_card_nodes("<a href=\"#x\"").expect_err("malformed a open tag should fail");
-    assert!(malformed_a.contains("Malformed <a> opening tag"));
-
-    let missing_a_close = parse_card_nodes("<a href=\"#x\">X").expect_err("unclosed a should fail");
-    assert!(missing_a_close.contains("Missing closing </a> tag"));
-
-    let malformed_tag = parse_card_nodes("<foo").expect_err("malformed generic tag should fail");
-    assert!(malformed_tag.contains("Malformed tag"));
+fn parse_wml_rejects_malformed_card_level_markup() {
+    for control in [
+        "<br",
+        "<p",
+        "<p>text",
+        "<a href=\"#x\"",
+        "<a href=\"#x\">X",
+        "<foo",
+    ] {
+        let err = parse_wml(&deck_with_card_body(control))
+            .expect_err("malformed card-level markup must fail");
+        assert!(
+            err.contains("Malformed XML"),
+            "unexpected error for {control}: {err}"
+        );
+    }
 }
 
 #[test]
-fn helper_parse_inline_nodes_reports_malformed_tags() {
-    let malformed_a =
-        parse_inline_nodes("<a href=\"#x\"").expect_err("malformed inline a should fail");
-    assert!(malformed_a.contains("Malformed inline <a> opening tag"));
-
-    let missing_a_close =
-        parse_inline_nodes("<a href=\"#x\">X").expect_err("unclosed inline a should fail");
-    assert!(missing_a_close.contains("Missing closing inline </a> tag"));
-
-    let malformed_br = parse_inline_nodes("<br").expect_err("malformed inline br should fail");
-    assert!(malformed_br.contains("Malformed inline <br> tag"));
-
-    let malformed_tag =
-        parse_inline_nodes("<unknown").expect_err("malformed inline tag should fail");
-    assert!(malformed_tag.contains("Malformed inline tag"));
+fn parse_wml_rejects_malformed_inline_markup() {
+    for control in ["<a href=\"#x\"", "<a href=\"#x\">X", "<br", "<unknown"] {
+        let err = parse_wml(&deck_with_card_body(&format!("<p>{control}</p>")))
+            .expect_err("malformed inline markup must fail");
+        assert!(
+            err.contains("Malformed XML"),
+            "unexpected error for {control}: {err}"
+        );
+    }
 }
 
 #[test]
-fn helper_parse_card_nodes_parses_mixed_content_paths() {
-    let nodes = parse_card_nodes(
+fn parses_mixed_card_level_content_paths() {
+    let nodes = card_nodes_for(
         r##"lead<br/><p>one <a href="#a">A</a><br/>two <span>three</span></p><a href="#next"></a><a>NoHref</a><unknown attr="x">drop</unknown>tail"##,
     )
     .expect("mixed card nodes should parse");
@@ -881,11 +887,10 @@ fn helper_parse_card_nodes_parses_mixed_content_paths() {
 }
 
 #[test]
-fn helper_parse_inline_nodes_parses_text_links_break_and_unknown_wrappers() {
-    let items = parse_inline_nodes(
+fn parses_mixed_inline_text_links_break_and_unknown_wrappers() {
+    let items = paragraph_items_for(
         r##"pre <a href="#a">A</a> mid <br/> <span>wrapped</span> <a href="">skip</a> post"##,
-    )
-    .expect("mixed inline nodes should parse");
+    );
 
     assert!(matches!(&items[0], InlineNode::Text(t) if t == "pre"));
     assert!(matches!(

--- a/engine-wasm/engine/src/parser/wml_parser/xml.rs
+++ b/engine-wasm/engine/src/parser/wml_parser/xml.rs
@@ -221,66 +221,6 @@ fn attach_node(
     }
 }
 
-#[cfg(test)]
-pub(super) fn extract_wml_body(xml: &str) -> Result<&str, String> {
-    let open_start = find_tag_from(xml, "wml", 0)
-        .ok_or_else(|| "Missing required <wml> root element".to_string())?;
-
-    let open_end = xml[open_start..]
-        .find('>')
-        .map(|idx| open_start + idx)
-        .ok_or_else(|| "Malformed <wml> opening tag".to_string())?;
-
-    let close_start = xml[open_end + 1..]
-        .find("</wml>")
-        .map(|idx| open_end + 1 + idx)
-        .ok_or_else(|| "Missing closing </wml> root element".to_string())?;
-
-    Ok(&xml[open_end + 1..close_start])
-}
-
-#[cfg(test)]
-pub(super) fn find_tag_from(xml: &str, tag_name: &str, from: usize) -> Option<usize> {
-    let needle = format!("<{tag_name}");
-    let mut search = from;
-    while let Some(rel_idx) = xml[search..].find(&needle) {
-        let idx = search + rel_idx;
-        let next = xml[idx + needle.len()..].chars().next();
-        match next {
-            Some(ch) if ch.is_whitespace() || ch == '>' || ch == '/' => return Some(idx),
-            _ => {
-                search = idx + needle.len();
-            }
-        }
-    }
-    None
-}
-
-#[cfg(test)]
-pub(super) fn starts_with_tag_at(xml: &str, from: usize, tag_name: &str) -> bool {
-    if from >= xml.len() {
-        return false;
-    }
-    let tail = &xml[from..];
-    let needle = format!("<{tag_name}");
-    let Some(rest) = tail.strip_prefix(&needle) else {
-        return false;
-    };
-    match rest.chars().next() {
-        Some(ch) => ch.is_whitespace() || ch == '>' || ch == '/',
-        None => true,
-    }
-}
-
-#[cfg(test)]
-pub(super) fn extract_attr(tag: &str, attr: &str) -> Option<String> {
-    let needle = format!("{attr}=\"");
-    let start = tag.find(&needle)? + needle.len();
-    let rest = &tag[start..];
-    let end = rest.find('"')?;
-    Some(rest[..end].to_string())
-}
-
 pub(super) fn normalize_text(input: &str) -> String {
     let mut out = String::new();
     let mut saw_whitespace = false;

--- a/engine-wasm/engine/src/wavescript/decoder.rs
+++ b/engine-wasm/engine/src/wavescript/decoder.rs
@@ -1,16 +1,11 @@
 use std::collections::HashSet;
 
-pub const MAX_COMPILATION_UNIT_BYTES: usize = 64 * 1024;
+use super::opcodes::{
+    ADD_I32_OPCODE, CALL_HOST_OPCODE, CALL_OPCODE, HALT_OPCODE, LOAD_LOCAL_OPCODE,
+    PUSH_INT8_OPCODE, PUSH_STRING8_OPCODE, RET_OPCODE, STORE_LOCAL_OPCODE,
+};
 
-const HALT_OPCODE: u8 = 0x00;
-const PUSH_INT8_OPCODE: u8 = 0x01;
-const ADD_I32_OPCODE: u8 = 0x02;
-const PUSH_STRING8_OPCODE: u8 = 0x03;
-const STORE_LOCAL_OPCODE: u8 = 0x10;
-const LOAD_LOCAL_OPCODE: u8 = 0x11;
-const CALL_OPCODE: u8 = 0x12;
-const RET_OPCODE: u8 = 0x13;
-const CALL_HOST_OPCODE: u8 = 0x20;
+pub const MAX_COMPILATION_UNIT_BYTES: usize = 64 * 1024;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct DecodeLimits {

--- a/engine-wasm/engine/src/wavescript/mod.rs
+++ b/engine-wasm/engine/src/wavescript/mod.rs
@@ -1,4 +1,5 @@
 pub mod decoder;
+pub(crate) mod opcodes;
 pub mod stdlib;
 pub mod value;
 pub mod vm;

--- a/engine-wasm/engine/src/wavescript/opcodes.rs
+++ b/engine-wasm/engine/src/wavescript/opcodes.rs
@@ -1,0 +1,15 @@
+//! Single source of truth for WMLScript bytecode opcode values.
+//!
+//! Both the structural decoder (`super::decoder`) and the interpreter
+//! (`super::vm`) dispatch on these numbers, so they are defined once here to
+//! keep the two in lockstep.
+
+pub(crate) const HALT_OPCODE: u8 = 0x00;
+pub(crate) const PUSH_INT8_OPCODE: u8 = 0x01;
+pub(crate) const ADD_I32_OPCODE: u8 = 0x02;
+pub(crate) const PUSH_STRING8_OPCODE: u8 = 0x03;
+pub(crate) const STORE_LOCAL_OPCODE: u8 = 0x10;
+pub(crate) const LOAD_LOCAL_OPCODE: u8 = 0x11;
+pub(crate) const CALL_OPCODE: u8 = 0x12;
+pub(crate) const RET_OPCODE: u8 = 0x13;
+pub(crate) const CALL_HOST_OPCODE: u8 = 0x20;

--- a/engine-wasm/engine/src/wavescript/vm.rs
+++ b/engine-wasm/engine/src/wavescript/vm.rs
@@ -1,15 +1,9 @@
 use super::decoder::DecodedUnit;
+use super::opcodes::{
+    ADD_I32_OPCODE, CALL_HOST_OPCODE, CALL_OPCODE, HALT_OPCODE, LOAD_LOCAL_OPCODE,
+    PUSH_INT8_OPCODE, PUSH_STRING8_OPCODE, RET_OPCODE, STORE_LOCAL_OPCODE,
+};
 use super::value::ScriptValue;
-
-const HALT_OPCODE: u8 = 0x00;
-const PUSH_INT8_OPCODE: u8 = 0x01;
-const ADD_I32_OPCODE: u8 = 0x02;
-const PUSH_STRING8_OPCODE: u8 = 0x03;
-const STORE_LOCAL_OPCODE: u8 = 0x10;
-const LOAD_LOCAL_OPCODE: u8 = 0x11;
-const CALL_OPCODE: u8 = 0x12;
-const RET_OPCODE: u8 = 0x13;
-const CALL_HOST_OPCODE: u8 = 0x20;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ExecutionLimits {
@@ -192,7 +186,7 @@ impl Vm {
                 STORE_LOCAL_OPCODE => {
                     let idx = usize::from(read_u8(unit.bytes(), &mut pc, opcode)?);
                     let value = stack.pop().ok_or(VmTrap::StackUnderflow)?;
-                    let current = current_frame_mut(&mut frames);
+                    let current = current_frame_mut(&mut frames, idx)?;
                     let local = current
                         .locals
                         .get_mut(idx)
@@ -201,7 +195,7 @@ impl Vm {
                 }
                 LOAD_LOCAL_OPCODE => {
                     let idx = usize::from(read_u8(unit.bytes(), &mut pc, opcode)?);
-                    let current = current_frame(&frames);
+                    let current = current_frame(&frames, idx)?;
                     let value = current
                         .locals
                         .get(idx)
@@ -293,16 +287,31 @@ fn read_bytes<'a>(
     Ok(&bytes[start..start + len])
 }
 
-fn current_frame(frames: &[CallFrame]) -> &CallFrame {
+/// Borrow the active call frame for a local-slot access.
+///
+/// Execution always pushes a root frame before the dispatch loop starts and
+/// `RET_OPCODE` refuses to pop it, so an empty frame stack is an internal
+/// invariant break rather than something untrusted bytecode can request.
+/// Per the panic-vs-`Result` guidance in `docs/agents/RUST_ENGINE_STEERING.md`,
+/// this path is reachable from untrusted script execution and therefore
+/// degrades to a typed trap instead of panicking: with no frame the requested
+/// local slot is simply unresolvable, which is exactly what
+/// [`VmTrap::InvalidLocalIndex`] already reports.
+fn current_frame(frames: &[CallFrame], local_index: usize) -> Result<&CallFrame, VmTrap> {
     frames
         .last()
-        .expect("vm must always contain at least root call frame")
+        .ok_or(VmTrap::InvalidLocalIndex { index: local_index })
 }
 
-fn current_frame_mut(frames: &mut [CallFrame]) -> &mut CallFrame {
+/// Mutable counterpart of [`current_frame`]; see it for the invariant and the
+/// rationale for trapping rather than panicking.
+fn current_frame_mut(
+    frames: &mut [CallFrame],
+    local_index: usize,
+) -> Result<&mut CallFrame, VmTrap> {
     frames
         .last_mut()
-        .expect("vm must always contain at least root call frame")
+        .ok_or(VmTrap::InvalidLocalIndex { index: local_index })
 }
 
 fn push_stack(

--- a/transport-rust/src/fetch_policy.rs
+++ b/transport-rust/src/fetch_policy.rs
@@ -13,12 +13,64 @@ pub(crate) fn resolve_fetch_destination_policy(
         .unwrap_or(FetchDestinationPolicy::PublicOnly)
 }
 
+/// Typed failure reason for destination validation and resolution.
+///
+/// Classification must never be re-derived by string-matching the rendered
+/// message: `PolicyBlocked` is the only variant that maps to `INVALID_REQUEST`,
+/// every other variant is a transport-level failure. The message text is kept
+/// stable for logs and response payloads.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum FetchDestinationError {
+    UnsupportedScheme(String),
+    PolicyBlocked(String),
+    Unresolvable(String),
+}
+
+impl FetchDestinationError {
+    pub(crate) fn blocked_host(class: DestinationHostClass) -> Self {
+        Self::PolicyBlocked(format!(
+            "Destination blocked by fetch policy (public-only): {} host",
+            class.label()
+        ))
+    }
+
+    pub(crate) fn blocked_resolved_address(class: DestinationHostClass) -> Self {
+        Self::PolicyBlocked(format!(
+            "Destination blocked by fetch policy (public-only): resolved to {} address",
+            class.label()
+        ))
+    }
+
+    /// True when the failure is a policy decision (maps to `INVALID_REQUEST`)
+    /// rather than a transport/resolution failure.
+    pub(crate) fn is_policy_blocked(&self) -> bool {
+        matches!(self, Self::PolicyBlocked(_))
+    }
+}
+
+impl std::fmt::Display for FetchDestinationError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::UnsupportedScheme(scheme) => {
+                write!(formatter, "Unsupported URL scheme: {scheme}")
+            }
+            Self::PolicyBlocked(message) | Self::Unresolvable(message) => {
+                formatter.write_str(message)
+            }
+        }
+    }
+}
+
+impl std::error::Error for FetchDestinationError {}
+
 pub(crate) fn validate_fetch_destination(
     parsed_url: &Url,
     destination_policy: &FetchDestinationPolicy,
-) -> Result<(), String> {
+) -> Result<(), FetchDestinationError> {
     if !matches!(parsed_url.scheme(), "http" | "https" | "wap" | "waps") {
-        return Err(format!("Unsupported URL scheme: {}", parsed_url.scheme()));
+        return Err(FetchDestinationError::UnsupportedScheme(
+            parsed_url.scheme().to_string(),
+        ));
     }
     if matches!(destination_policy, FetchDestinationPolicy::AllowPrivate) {
         return Ok(());
@@ -26,10 +78,7 @@ pub(crate) fn validate_fetch_destination(
 
     match classify_destination_host(parsed_url) {
         None | Some(DestinationHostClass::Public) => Ok(()),
-        Some(class) => Err(format!(
-            "Destination blocked by fetch policy (public-only): {} host",
-            class.label()
-        )),
+        Some(class) => Err(FetchDestinationError::blocked_host(class)),
     }
 }
 
@@ -113,13 +162,19 @@ pub(crate) fn resolve_fetch_destination_addresses(
     host: &str,
     port: u16,
     destination_policy: &FetchDestinationPolicy,
-) -> Result<Vec<SocketAddr>, String> {
+) -> Result<Vec<SocketAddr>, FetchDestinationError> {
     let addresses = (host, port)
         .to_socket_addrs()
-        .map_err(|error| format!("failed to resolve destination {host}:{port}: {error}"))?
+        .map_err(|error| {
+            FetchDestinationError::Unresolvable(format!(
+                "failed to resolve destination {host}:{port}: {error}"
+            ))
+        })?
         .collect::<Vec<_>>();
     if addresses.is_empty() {
-        return Err(format!("failed to resolve destination {host}:{port}"));
+        return Err(FetchDestinationError::Unresolvable(format!(
+            "failed to resolve destination {host}:{port}"
+        )));
     }
     validate_resolved_destination_addresses(&addresses, destination_policy)?;
     Ok(addresses)
@@ -128,7 +183,7 @@ pub(crate) fn resolve_fetch_destination_addresses(
 pub(crate) fn validate_resolved_destination_addresses(
     addresses: &[SocketAddr],
     destination_policy: &FetchDestinationPolicy,
-) -> Result<(), String> {
+) -> Result<(), FetchDestinationError> {
     if matches!(destination_policy, FetchDestinationPolicy::AllowPrivate) {
         return Ok(());
     }
@@ -136,25 +191,26 @@ pub(crate) fn validate_resolved_destination_addresses(
     for address in addresses {
         let class = classify_ip(address.ip());
         if class != DestinationHostClass::Public {
-            return Err(format!(
-                "Destination blocked by fetch policy (public-only): resolved to {} address",
-                class.label()
-            ));
+            return Err(FetchDestinationError::blocked_resolved_address(class));
         }
     }
     Ok(())
+}
+
+/// Outcome of applying request policy to an outbound request.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct AppliedRequestPolicy {
+    pub(crate) method: String,
+    pub(crate) outbound_headers: HashMap<String, String>,
+    pub(crate) suppressed_same_deck_post_context: bool,
+    pub(crate) applied_ua_capability_profile: FetchUaCapabilityProfile,
 }
 
 pub(crate) fn apply_request_policy(
     method: String,
     mut outbound_headers: HashMap<String, String>,
     request_policy: Option<&FetchRequestPolicy>,
-) -> (
-    String,
-    HashMap<String, String>,
-    bool,
-    FetchUaCapabilityProfile,
-) {
+) -> AppliedRequestPolicy {
     let mut normalized_method = method;
     let mut suppressed_same_deck_post_context = false;
     let mut applied_ua_capability_profile = FetchUaCapabilityProfile::Disabled;
@@ -202,12 +258,12 @@ pub(crate) fn apply_request_policy(
         }
     }
 
-    (
-        normalized_method,
+    AppliedRequestPolicy {
+        method: normalized_method,
         outbound_headers,
         suppressed_same_deck_post_context,
         applied_ua_capability_profile,
-    )
+    }
 }
 
 fn apply_ua_capability_headers(

--- a/transport-rust/src/fetch_runtime.rs
+++ b/transport-rust/src/fetch_runtime.rs
@@ -46,12 +46,12 @@ pub(crate) fn fetch_deck_in_process_impl(
     let method = method
         .unwrap_or_else(|| "GET".to_string())
         .to_ascii_uppercase();
-    let (
-        method,
-        mut outbound_headers,
-        suppressed_same_deck_post_context,
-        applied_ua_capability_profile,
-    ) = apply_request_policy(method, headers.unwrap_or_default(), request_policy.as_ref());
+    let applied_policy =
+        apply_request_policy(method, headers.unwrap_or_default(), request_policy.as_ref());
+    let method = applied_policy.method;
+    let mut outbound_headers = applied_policy.outbound_headers;
+    let suppressed_same_deck_post_context = applied_policy.suppressed_same_deck_post_context;
+    let applied_ua_capability_profile = applied_policy.applied_ua_capability_profile;
     let native_method_supported = matches!(method.as_str(), "GET" | "POST")
         && matches!(parsed_scheme(&url), Some("wap" | "waps"));
     if method != "GET" && !native_method_supported {
@@ -73,8 +73,8 @@ pub(crate) fn fetch_deck_in_process_impl(
         }
     };
     let destination_policy = resolve_fetch_destination_policy(request_policy.as_ref());
-    if let Err(message) = validate_fetch_destination(&parsed, &destination_policy) {
-        return invalid_request_response(url, message, request_id.as_deref());
+    if let Err(error) = validate_fetch_destination(&parsed, &destination_policy) {
+        return invalid_request_response(url, error.to_string(), request_id.as_deref());
     }
 
     let attempts = retries.unwrap_or(1).clamp(0, 2) + 1;

--- a/transport-rust/src/fetch_runtime/execution.rs
+++ b/transport-rust/src/fetch_runtime/execution.rs
@@ -1,9 +1,12 @@
 use crate::fetch_body::{read_response_body_limited, ReadBodyError};
-use crate::fetch_policy::{resolve_fetch_destination_addresses, validate_fetch_destination};
-use crate::request_meta::log_transport_event;
+use crate::fetch_policy::{
+    resolve_fetch_destination_addresses, validate_fetch_destination, FetchDestinationError,
+};
+use crate::request_meta::{log_fetch_attempt_failure, log_transport_event};
 use crate::responses::{
-    invalid_request_response, map_success_payload_response, map_terminal_send_error,
-    normalize_content_type, payload_too_large_response, transport_unavailable_response,
+    invalid_request_response, map_success_payload_response, normalize_content_type,
+    payload_too_large_response, transport_unavailable_response, FetchAttemptFailure,
+    PayloadTooLargeParams, SuccessPayloadParams,
 };
 use crate::{FetchDeckResponse, FetchDestinationPolicy, MAX_RESPONSE_BODY_BYTES};
 use reqwest::blocking::{Client, ClientBuilder};
@@ -28,12 +31,14 @@ pub(super) struct FetchExecutionPlan {
     pub(super) destination_policy: FetchDestinationPolicy,
 }
 
+/// Carries a typed [`FetchDestinationError`] through `reqwest`'s boxed error
+/// wrapping so the classification survives to `destination_policy_error`.
 #[derive(Debug)]
-struct DestinationPolicyError(String);
+struct DestinationPolicyError(FetchDestinationError);
 
 impl fmt::Display for DestinationPolicyError {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        formatter.write_str(&self.0)
+        write!(formatter, "{}", self.0)
     }
 }
 
@@ -51,14 +56,12 @@ impl Resolve for PolicyDnsResolver {
         Box::pin(async move {
             match resolve_fetch_destination_addresses(&host, 0, &destination_policy) {
                 Ok(addresses) => Ok(Box::new(addresses.into_iter()) as Addrs),
-                Err(message) if message.starts_with("Destination blocked by fetch policy") => {
-                    Err(Box::new(DestinationPolicyError(message))
+                Err(error) if error.is_policy_blocked() => {
+                    Err(Box::new(DestinationPolicyError(error))
                         as Box<dyn std::error::Error + Send + Sync>)
                 }
-                Err(message) => {
-                    Err(Box::new(io::Error::other(message))
-                        as Box<dyn std::error::Error + Send + Sync>)
-                }
+                Err(error) => Err(Box::new(io::Error::other(error.to_string()))
+                    as Box<dyn std::error::Error + Send + Sync>),
             }
         })
     }
@@ -78,7 +81,7 @@ fn http_client_builder(
             }
             match validate_fetch_destination(attempt.url(), &redirect_destination_policy) {
                 Ok(()) => attempt.follow(),
-                Err(message) => attempt.error(DestinationPolicyError(message)),
+                Err(error) => attempt.error(DestinationPolicyError(error)),
             }
         }))
 }
@@ -114,9 +117,7 @@ pub(super) fn execute_fetch(plan: FetchExecutionPlan) -> FetchDeckResponse {
             );
         }
     };
-    let mut last_error = "Retries exhausted".to_string();
-    let mut last_elapsed_ms = 0.0_f64;
-    let mut last_is_timeout = false;
+    let mut failure = FetchAttemptFailure::default();
 
     for attempt in 1..=attempts {
         let start = Instant::now();
@@ -156,16 +157,16 @@ pub(super) fn execute_fetch(plan: FetchExecutionPlan) -> FetchDeckResponse {
                                 "error": message
                             }),
                         );
-                        return payload_too_large_response(
+                        return payload_too_large_response(PayloadTooLargeParams {
                             status,
                             final_url,
                             content_type,
-                            MAX_RESPONSE_BODY_BYTES,
-                            Some(content_len),
+                            limit_bytes: MAX_RESPONSE_BODY_BYTES,
+                            actual_bytes: Some(content_len),
                             attempt,
                             elapsed_ms,
-                            request_id.as_deref(),
-                        );
+                            request_id: request_id.as_deref(),
+                        });
                     }
                 }
 
@@ -202,16 +203,16 @@ pub(super) fn execute_fetch(plan: FetchExecutionPlan) -> FetchDeckResponse {
                                 "error": message
                             }),
                         );
-                        return payload_too_large_response(
+                        return payload_too_large_response(PayloadTooLargeParams {
                             status,
                             final_url,
                             content_type,
                             limit_bytes,
-                            None,
+                            actual_bytes: None,
                             attempt,
                             elapsed_ms,
-                            request_id.as_deref(),
-                        );
+                            request_id: request_id.as_deref(),
+                        });
                     }
                 };
                 log_transport_event(
@@ -227,74 +228,49 @@ pub(super) fn execute_fetch(plan: FetchExecutionPlan) -> FetchDeckResponse {
                         "elapsedMs": elapsed_ms
                     }),
                 );
-                return map_success_payload_response(
+                return map_success_payload_response(SuccessPayloadParams {
                     status,
                     is_wap_scheme,
-                    &url,
-                    &upstream_url,
+                    request_url: &url,
+                    upstream_url: &upstream_url,
                     final_url,
                     content_type,
-                    body.as_slice(),
+                    body: body.as_slice(),
                     attempt,
                     elapsed_ms,
-                    request_id.as_deref(),
-                );
+                    request_id: request_id.as_deref(),
+                });
             }
             Err(err) => {
-                if let Some(message) = destination_policy_error(&err) {
+                if let Some(policy_error) = destination_policy_error(&err) {
                     return invalid_request_response(
                         request_url.clone(),
-                        message,
+                        policy_error.to_string(),
                         request_id.as_deref(),
                     );
                 }
-                last_error = err.to_string();
-                last_is_timeout = err.is_timeout();
-                last_elapsed_ms = start.elapsed().as_secs_f64() * 1000.0;
-                if attempt < attempts {
-                    log_transport_event(
-                        "transport.fetch.retry",
-                        request_id.as_deref(),
-                        &url,
-                        serde_json::json!({
-                            "attempt": attempt,
-                            "nextAttempt": attempt + 1,
-                            "attempts": attempts,
-                            "isTimeout": last_is_timeout,
-                            "error": last_error,
-                            "elapsedMs": last_elapsed_ms
-                        }),
-                    );
-                } else {
-                    log_transport_event(
-                        "transport.fetch.failure",
-                        request_id.as_deref(),
-                        &url,
-                        serde_json::json!({
-                            "attempt": attempt,
-                            "attempts": attempts,
-                            "isTimeout": last_is_timeout,
-                            "error": last_error,
-                            "elapsedMs": last_elapsed_ms
-                        }),
-                    );
-                }
+                failure.record(
+                    err.to_string(),
+                    err.is_timeout(),
+                    start.elapsed().as_secs_f64() * 1000.0,
+                );
+                log_fetch_attempt_failure(
+                    request_id.as_deref(),
+                    &url,
+                    attempt,
+                    attempts,
+                    failure.is_timeout(),
+                    failure.message(),
+                    failure.elapsed_ms(),
+                );
             }
         }
     }
 
-    map_terminal_send_error(
-        url,
-        last_error,
-        attempts,
-        attempts,
-        last_is_timeout,
-        last_elapsed_ms,
-        request_id.as_deref(),
-    )
+    failure.into_terminal_response(url, attempts, attempts, request_id.as_deref())
 }
 
-fn destination_policy_error(error: &reqwest::Error) -> Option<String> {
+fn destination_policy_error(error: &reqwest::Error) -> Option<FetchDestinationError> {
     let mut current: Option<&(dyn std::error::Error + 'static)> = Some(error);
     while let Some(cause) = current {
         if let Some(policy_error) = cause.downcast_ref::<DestinationPolicyError>() {
@@ -323,8 +299,13 @@ mod tests {
             .send()
             .expect_err("private DNS answer must be rejected");
 
-        let message =
+        let policy_error =
             destination_policy_error(&error).expect("policy error should survive reqwest wrapping");
+        assert!(
+            policy_error.is_policy_blocked(),
+            "classification must come from the error type, not its message text"
+        );
+        let message = policy_error.to_string();
         assert!(message.contains("public-only"));
         assert!(message.contains("loopback"));
     }
@@ -353,8 +334,13 @@ mod tests {
             .expect_err("private redirect must be rejected");
         server.join().expect("redirect test server should exit");
 
-        let message =
+        let policy_error =
             destination_policy_error(&error).expect("policy error should survive reqwest wrapping");
+        assert!(
+            policy_error.is_policy_blocked(),
+            "classification must come from the error type, not its message text"
+        );
+        let message = policy_error.to_string();
         assert!(message.contains("public-only"));
         assert!(message.contains("loopback"));
     }

--- a/transport-rust/src/native_fetch.rs
+++ b/transport-rust/src/native_fetch.rs
@@ -1,12 +1,18 @@
-use crate::fetch_policy::resolve_fetch_destination_addresses;
+use crate::fetch_policy::{resolve_fetch_destination_addresses, FetchDestinationError};
 use crate::network::wdp::transport_trait::{DatagramTransport, WdpError};
 use crate::network::wdp::{
     UdpDatagramTransport, UdpDatagramTransportConfig, WdpAddress, WdpDatagram,
 };
+use crate::network::wsp::connectionless::{
+    decode_connectionless_reply, encode_connectionless_request, WspConnectionlessEncodeError,
+    WspConnectionlessMethod, WspConnectionlessRequest,
+};
+use crate::network::wsp::header_block::{WspHeaderBlock, WspHeaderField, WspHeaderNameEncoding};
+use crate::network::wsp::header_registry::DEFAULT_HEADER_CODE_PAGE;
 use crate::request_meta::log_transport_event;
 use crate::responses::{
     invalid_request_response, map_success_payload_response, map_terminal_send_error,
-    normalize_content_type,
+    normalize_content_type, FetchAttemptFailure, SuccessPayloadParams,
 };
 use crate::{FetchDeckResponse, FetchDestinationPolicy};
 use std::collections::HashMap;
@@ -38,11 +44,27 @@ pub(crate) struct NativeFetchPlan {
     pub(crate) destination_policy: FetchDestinationPolicy,
 }
 
+/// Media type this transport negotiates when the caller sends no `Accept`.
+const DEFAULT_ACCEPT_MEDIA: &str = "application/vnd.wap.wmlc";
+
+/// Failure while building the connectionless request for a native fetch plan.
 #[derive(Debug)]
-struct NativeReply {
-    status_code: u16,
-    content_type: String,
-    body: Vec<u8>,
+enum NativeRequestEncodeError {
+    UnsupportedMethod(String),
+    InvalidRequestUri(String),
+    Wsp(WspConnectionlessEncodeError),
+}
+
+impl std::fmt::Display for NativeRequestEncodeError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::UnsupportedMethod(method) => {
+                write!(formatter, "unsupported native WSP method: {method}")
+            }
+            Self::InvalidRequestUri(message) => formatter.write_str(message),
+            Self::Wsp(error) => write!(formatter, "{error}"),
+        }
+    }
 }
 
 pub(crate) fn active_transport_profile() -> TransportProfile {
@@ -134,7 +156,7 @@ pub(crate) fn execute_native_wap_request_with_transport(
     };
 
     let transaction_id = CONNECTIONLESS_INITIAL_TRANSACTION_ID;
-    let encoded_request = match encode_connectionless_request(
+    let encoded_request = match encode_native_wap_request(
         transaction_id,
         &plan.method,
         &parsed,
@@ -156,9 +178,7 @@ pub(crate) fn execute_native_wap_request_with_transport(
         }
     };
 
-    let mut last_error = "Retries exhausted".to_string();
-    let mut last_is_timeout = false;
-    let mut last_elapsed_ms = 0.0_f64;
+    let mut failure = FetchAttemptFailure::default();
 
     for attempt in 1..=plan.attempts {
         let send_start = Instant::now();
@@ -183,64 +203,63 @@ pub(crate) fn execute_native_wap_request_with_transport(
         );
 
         if let Err(error) = transport.send(&outbound) {
-            last_error = error.to_string();
-            last_is_timeout = matches!(error, WdpError::Timeout);
-            last_elapsed_ms = send_start.elapsed().as_secs_f64() * 1000.0;
+            failure.record(
+                error.to_string(),
+                matches!(error, WdpError::Timeout),
+                send_start.elapsed().as_secs_f64() * 1000.0,
+            );
             continue;
         }
 
         match transport.receive() {
             Ok(reply_datagram) => {
                 let elapsed_ms = send_start.elapsed().as_secs_f64() * 1000.0;
-                let reply = match decode_connectionless_wsp_reply(
-                    transaction_id,
-                    &reply_datagram.payload,
-                ) {
-                    Ok(reply) => reply,
-                    Err(error) => {
-                        return map_terminal_send_error(
-                            plan.request_url,
-                            format!(
-                                "failed to decode native WSP reply: {error} (payload={})",
-                                hex_bytes(&reply_datagram.payload)
-                            ),
-                            plan.attempts,
-                            attempt,
-                            false,
-                            elapsed_ms,
-                            plan.request_id.as_deref(),
-                        );
-                    }
-                };
+                let reply =
+                    match decode_connectionless_reply(transaction_id, &reply_datagram.payload) {
+                        Ok(reply) => reply,
+                        Err(error) => {
+                            return map_terminal_send_error(
+                                plan.request_url,
+                                format!(
+                                    "failed to decode native WSP reply: {error} (payload={})",
+                                    hex_bytes(&reply_datagram.payload)
+                                ),
+                                plan.attempts,
+                                attempt,
+                                false,
+                                elapsed_ms,
+                                plan.request_id.as_deref(),
+                            );
+                        }
+                    };
 
-                return map_success_payload_response(
-                    reply.status_code,
-                    true,
-                    &plan.request_url,
-                    &plan.request_url,
-                    plan.request_url.clone(),
-                    normalize_content_type(Some(reply.content_type.as_str())),
-                    &reply.body,
+                return map_success_payload_response(SuccessPayloadParams {
+                    status: reply.status_code,
+                    is_wap_scheme: true,
+                    request_url: &plan.request_url,
+                    upstream_url: &plan.request_url,
+                    final_url: plan.request_url.clone(),
+                    content_type: normalize_content_type(Some(reply.content_type.as_str())),
+                    body: &reply.body,
                     attempt,
                     elapsed_ms,
-                    plan.request_id.as_deref(),
-                );
+                    request_id: plan.request_id.as_deref(),
+                });
             }
             Err(error) => {
-                last_error = error.to_string();
-                last_is_timeout = matches!(error, WdpError::Timeout);
-                last_elapsed_ms = send_start.elapsed().as_secs_f64() * 1000.0;
+                failure.record(
+                    error.to_string(),
+                    matches!(error, WdpError::Timeout),
+                    send_start.elapsed().as_secs_f64() * 1000.0,
+                );
             }
         }
     }
 
-    map_terminal_send_error(
+    failure.into_terminal_response(
         plan.request_url,
-        last_error,
         plan.attempts,
         plan.attempts,
-        last_is_timeout,
-        last_elapsed_ms,
         plan.request_id.as_deref(),
     )
 }
@@ -256,29 +275,32 @@ fn default_bind_address(peer: &SocketAddr) -> String {
 fn resolve_destination_socket_addr(
     parsed: &Url,
     destination_policy: &FetchDestinationPolicy,
-) -> Result<SocketAddr, String> {
-    let host = parsed
-        .host_str()
-        .ok_or_else(|| "wap url must include a host".to_string())?;
+) -> Result<SocketAddr, FetchDestinationError> {
+    let host = parsed.host_str().ok_or_else(|| {
+        FetchDestinationError::Unresolvable("wap url must include a host".to_string())
+    })?;
     let port = parsed
         .port()
         .unwrap_or_else(|| default_service_port(parsed.scheme()));
     resolve_fetch_destination_addresses(host, port, destination_policy)?
         .into_iter()
         .next()
-        .ok_or_else(|| format!("failed to resolve wap host {host}:{port}"))
+        .ok_or_else(|| {
+            FetchDestinationError::Unresolvable(format!("failed to resolve wap host {host}:{port}"))
+        })
 }
 
 fn map_destination_resolution_error(
     request_url: String,
-    error: String,
+    error: FetchDestinationError,
     attempts: u8,
     request_id: Option<&str>,
 ) -> FetchDeckResponse {
-    if error.starts_with("Destination blocked by fetch policy") {
-        invalid_request_response(request_url, error, request_id)
+    let message = error.to_string();
+    if error.is_policy_blocked() {
+        invalid_request_response(request_url, message, request_id)
     } else {
-        map_terminal_send_error(request_url, error, attempts, 1, false, 0.0, request_id)
+        map_terminal_send_error(request_url, message, attempts, 1, false, 0.0, request_id)
     }
 }
 
@@ -332,239 +354,66 @@ fn default_http_port_for_host(host: &str) -> u16 {
     }
 }
 
-// NOTE(wsp-codec-duplication): The functions from here through
-// `decode_well_known_media` below are a hand-rolled, minimal WSP
-// uintvar/content-type/header/PDU codec used only by this native
-// connectionless fetch path. A separate, spec-conformant, fixture-tested
-// WSP codec already exists at `crate::network::wsp` (`pdu.rs`,
-// `header_block.rs`, `header_registry.rs`, `encoding_version.rs`,
-// `session.rs`, `decoder.rs`, `encoder.rs`) but is not called from here —
-// it is currently exercised only by its own `#[cfg(test)]` modules. This is
-// tracked drift, not an intentional permanent split: see
-// `docs/waves/MAINTENANCE_WORK_ITEMS.md` (entry dated 2026-07-23,
-// "network::wsp codec is dead code relative to the live native fetch
-// path") for the history and the recommendation to wire `network::wsp`
-// into this module in a future, dedicated change.
-fn encode_connectionless_request(
+/// Builds the connectionless WSP request wire bytes for a native fetch plan.
+///
+/// All wire-format concerns live in `crate::network::wsp::connectionless`; this
+/// function only maps fetch-level inputs (HTTP-style method, parsed URL, the
+/// outbound header map) onto that codec's inputs.
+fn encode_native_wap_request(
     transaction_id: u8,
     method: &str,
     parsed: &Url,
     headers: &HashMap<String, String>,
     post_content_type: Option<&str>,
     post_body: Option<&[u8]>,
-) -> Result<Vec<u8>, String> {
-    let uri = build_kannel_request_uri(parsed)?;
-    let uri_bytes = uri.as_bytes();
-    let encoded_headers = encode_connectionless_request_headers(headers);
-    let encoded_content_type = encode_connectionless_content_type(post_content_type)?;
-    let post_body = post_body.unwrap_or(&[]);
-    let mut wire = Vec::with_capacity(
-        uri_bytes.len() + encoded_content_type.len() + encoded_headers.len() + post_body.len() + 12,
-    );
-    wire.push(transaction_id);
-    wire.push(match method {
-        "GET" => 0x40,
-        "POST" => 0x60,
-        other => return Err(format!("unsupported native WSP method: {other}")),
-    });
-    if method == "GET" {
-        wire.extend_from_slice(&encode_uintvar(uri_bytes.len())?);
-        wire.extend_from_slice(uri_bytes);
-        wire.extend_from_slice(&encoded_headers);
-    } else {
-        let headers_len = encoded_content_type.len() + encoded_headers.len();
-        wire.extend_from_slice(&encode_uintvar(uri_bytes.len())?);
-        wire.extend_from_slice(&encode_uintvar(headers_len)?);
-        wire.extend_from_slice(uri_bytes);
-        wire.extend_from_slice(&encoded_content_type);
-        wire.extend_from_slice(&encoded_headers);
-        wire.extend_from_slice(post_body);
-    }
-    Ok(wire)
+) -> Result<Vec<u8>, NativeRequestEncodeError> {
+    let method = WspConnectionlessMethod::from_http_method(method)
+        .ok_or_else(|| NativeRequestEncodeError::UnsupportedMethod(method.to_string()))?;
+    let uri =
+        build_kannel_request_uri(parsed).map_err(NativeRequestEncodeError::InvalidRequestUri)?;
+    let header_block = connectionless_request_headers(headers);
+
+    encode_connectionless_request(&WspConnectionlessRequest {
+        transaction_id,
+        method,
+        uri: &uri,
+        headers: &header_block,
+        content_type: post_content_type,
+        body: post_body.unwrap_or(&[]),
+    })
+    .map_err(NativeRequestEncodeError::Wsp)
 }
 
-fn encode_connectionless_request_headers(headers: &HashMap<String, String>) -> Vec<u8> {
-    let mut out = Vec::new();
+/// Negotiates the single `Accept` media type this transport advertises.
+///
+/// Only the two WML media types are negotiable; anything else advertises
+/// nothing rather than forwarding an unrepresentable `Accept` value.
+fn negotiated_accept_media(headers: &HashMap<String, String>) -> Option<&'static str> {
     let accept_value = headers
         .get("Accept")
         .map(String::as_str)
-        .unwrap_or("application/vnd.wap.wmlc");
+        .unwrap_or(DEFAULT_ACCEPT_MEDIA);
     if accept_value.contains("application/vnd.wap.wmlc") {
-        out.extend_from_slice(&[0x80, 0x94]);
+        Some("application/vnd.wap.wmlc")
     } else if accept_value.contains("text/vnd.wap.wml") {
-        out.extend_from_slice(&[0x80, 0x88]);
-    }
-    out
-}
-
-fn encode_connectionless_content_type(content_type: Option<&str>) -> Result<Vec<u8>, String> {
-    let Some(content_type) = content_type
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-    else {
-        return Ok(Vec::new());
-    };
-
-    if content_type.as_bytes().contains(&0x00) {
-        return Err("native WSP POST content type must not contain NUL bytes".to_string());
-    }
-    let mut out = Vec::with_capacity(content_type.len() + 1);
-    out.extend_from_slice(content_type.as_bytes());
-    out.push(0x00);
-    Ok(out)
-}
-
-fn decode_connectionless_wsp_reply(
-    expected_transaction_id: u8,
-    payload: &[u8],
-) -> Result<NativeReply, String> {
-    let Some((&transaction_id, body)) = payload.split_first() else {
-        return Err("truncated native WSP reply: missing transaction id".to_string());
-    };
-    if transaction_id != expected_transaction_id {
-        return Err(format!(
-            "unexpected native WSP reply transaction id: expected {expected_transaction_id}, got {transaction_id}"
-        ));
-    }
-
-    let Some((&pdu_type, body)) = body.split_first() else {
-        return Err("truncated native WSP reply: missing pdu type".to_string());
-    };
-    if pdu_type != 0x04 {
-        return Err(format!(
-            "unexpected native WSP reply pdu type: expected 0x04, got 0x{pdu_type:02X}"
-        ));
-    }
-
-    let Some((&status, body)) = body.split_first() else {
-        return Err("truncated native WSP reply: missing status".to_string());
-    };
-    let (headers_len, body) = decode_uintvar(body)?;
-    if body.len() < headers_len {
-        return Err("truncated native WSP reply: headers section incomplete".to_string());
-    }
-    let (header_section, data) = body.split_at(headers_len);
-    let (content_type, content_type_len) = decode_content_type_value(header_section)?;
-    if content_type_len > header_section.len() {
-        return Err("truncated native WSP reply: content type overruns header section".to_string());
-    }
-
-    Ok(NativeReply {
-        status_code: decode_wsp_status_code(status)?,
-        content_type,
-        body: data.to_vec(),
-    })
-}
-
-fn encode_uintvar(value: usize) -> Result<Vec<u8>, String> {
-    if value > 0x0FFF_FFFF {
-        return Err(format!("value too large for uintvar encoding: {value}"));
-    }
-    let mut chunks = [0u8; 5];
-    let mut cursor = chunks.len();
-    let mut remaining = value;
-    loop {
-        cursor -= 1;
-        chunks[cursor] = (remaining & 0x7F) as u8;
-        remaining >>= 7;
-        if remaining == 0 {
-            break;
-        }
-        chunks[cursor] |= 0x80;
-    }
-    let mut out = chunks[cursor..].to_vec();
-    for index in 0..out.len().saturating_sub(1) {
-        out[index] |= 0x80;
-    }
-    Ok(out)
-}
-
-fn decode_uintvar(input: &[u8]) -> Result<(usize, &[u8]), String> {
-    let mut value = 0usize;
-    for (index, byte) in input.iter().copied().enumerate().take(5) {
-        value = (value << 7) | usize::from(byte & 0x7F);
-        if byte & 0x80 == 0 {
-            return Ok((value, &input[index + 1..]));
-        }
-    }
-    Err("truncated uintvar".to_string())
-}
-
-fn decode_content_type_value(input: &[u8]) -> Result<(String, usize), String> {
-    let Some((&first, _)) = input.split_first() else {
-        return Err("truncated native WSP reply: missing content type".to_string());
-    };
-    if first & 0x80 != 0 {
-        let media = decode_well_known_media(first & 0x7F)
-            .ok_or_else(|| format!("unsupported well-known media type: 0x{:02X}", first & 0x7F))?;
-        return Ok((media.to_string(), 1));
-    }
-    if first <= 31 {
-        let length = usize::from(first);
-        if input.len() < 1 + length {
-            return Err(
-                "truncated native WSP reply: content type general form incomplete".to_string(),
-            );
-        }
-        let (media, _consumed) = decode_text_string(&input[1..1 + length])?;
-        return Ok((media, 1 + length));
-    }
-    // General form: `decode_text_string` reports exactly how many bytes of
-    // `input` it consumed (terminating NUL included), which is the only
-    // correct source for the returned length here. Do not reconstruct it
-    // from `media.len() + 1` — when the string is quoted with a leading
-    // 0x7F byte (RFC 2045 quoted-string escape used by WSP token-text),
-    // `decode_text_string` strips that leading byte from `media`, so
-    // `media.len()` undercounts the raw bytes consumed by exactly one.
-    let (media, consumed) = decode_text_string(input)?;
-    Ok((media, consumed))
-}
-
-/// Decodes a NUL-terminated WSP text-string, returning the decoded text and
-/// the number of bytes consumed from `input` (including the leading 0x7F
-/// quote byte, if present, and the terminating NUL). The returned length is
-/// intentionally not derivable from `text.len() + 1` alone: a leading 0x7F
-/// is stripped from the returned text but still counts toward consumed
-/// bytes, so quoted and unquoted strings of the same visible length consume
-/// different amounts of input.
-fn decode_text_string(input: &[u8]) -> Result<(String, usize), String> {
-    let terminator = input
-        .iter()
-        .position(|byte| *byte == 0x00)
-        .ok_or_else(|| "truncated native WSP text string".to_string())?;
-    let content = if input.first().copied() == Some(0x7F) {
-        &input[1..terminator]
+        Some("text/vnd.wap.wml")
     } else {
-        &input[..terminator]
-    };
-    let text = String::from_utf8(content.to_vec())
-        .map_err(|error| format!("invalid utf-8 in native WSP text string: {error}"))?;
-    Ok((text, terminator + 1))
-}
-
-fn decode_wsp_status_code(status: u8) -> Result<u16, String> {
-    match status {
-        0x10 => Ok(100),
-        0x11 => Ok(101),
-        0x20..=0x26 => Ok(200 + u16::from(status - 0x20)),
-        0x30..=0x37 => Ok(300 + u16::from(status - 0x30)),
-        0x40..=0x51 => Ok(400 + u16::from(status - 0x40)),
-        0x60..=0x65 => Ok(500 + u16::from(status - 0x60)),
-        _ => Err(format!(
-            "unsupported native WSP status code: 0x{status:02X}"
-        )),
+        None
     }
 }
 
-fn decode_well_known_media(code: u8) -> Option<&'static str> {
-    match code {
-        0x03 => Some("text/plain"),
-        0x08 => Some("text/vnd.wap.wml"),
-        0x14 => Some("application/vnd.wap.wmlc"),
-        0x28 => Some("text/xml"),
-        0x29 => Some("application/xml"),
-        _ => None,
+fn connectionless_request_headers(headers: &HashMap<String, String>) -> WspHeaderBlock {
+    let mut block = WspHeaderBlock::default();
+    if let Some(media) = negotiated_accept_media(headers) {
+        block.headers.push(WspHeaderField {
+            name: "Accept".to_string(),
+            value: media.to_string(),
+            name_encoding: WspHeaderNameEncoding::Binary {
+                page: DEFAULT_HEADER_CODE_PAGE,
+            },
+        });
     }
+    block
 }
 
 fn hex_bytes(bytes: &[u8]) -> String {
@@ -581,7 +430,9 @@ fn hex_bytes(bytes: &[u8]) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::fetch_policy::DestinationHostClass;
     use crate::network::wdp::transport_trait::WdpResult;
+    use crate::network::wsp::connectionless::{decode_uintvar, encode_uintvar};
     use std::sync::{Mutex, OnceLock};
 
     struct FakeDatagramTransport {
@@ -787,7 +638,7 @@ mod tests {
     #[test]
     fn native_connectionless_wire_format_prefixes_transaction_id() {
         let parsed = Url::parse("wap://localhost/").expect("url should parse");
-        let encoded = encode_connectionless_request(
+        let encoded = encode_native_wap_request(
             CONNECTIONLESS_INITIAL_TRANSACTION_ID,
             "GET",
             &parsed,
@@ -836,11 +687,67 @@ mod tests {
     }
 
     #[test]
-    fn encode_connectionless_content_type_rejects_nul_bytes() {
-        let error = encode_connectionless_content_type(Some("text/plain\0oops"))
-            .expect_err("content type with NUL should fail");
+    fn encode_native_wap_request_rejects_content_type_with_nul_bytes() {
+        let parsed = Url::parse("wap://localhost/login").expect("url should parse");
 
-        assert!(error.contains("must not contain NUL bytes"));
+        let error = encode_native_wap_request(
+            CONNECTIONLESS_INITIAL_TRANSACTION_ID,
+            "POST",
+            &parsed,
+            &HashMap::new(),
+            Some("text/plain\0oops"),
+            Some(b"a=1"),
+        )
+        .expect_err("content type with NUL should fail");
+
+        assert!(error.to_string().contains("must not contain NUL bytes"));
+    }
+
+    #[test]
+    fn encode_native_wap_request_rejects_unsupported_methods() {
+        let parsed = Url::parse("wap://localhost/").expect("url should parse");
+
+        let error = encode_native_wap_request(
+            CONNECTIONLESS_INITIAL_TRANSACTION_ID,
+            "HEAD",
+            &parsed,
+            &HashMap::new(),
+            None,
+            None,
+        )
+        .expect_err("HEAD is not a connectionless method this transport encodes");
+
+        assert_eq!(error.to_string(), "unsupported native WSP method: HEAD");
+    }
+
+    #[test]
+    fn connectionless_request_headers_negotiate_a_single_accept_media_type() {
+        assert_eq!(
+            negotiated_accept_media(&HashMap::new()),
+            Some("application/vnd.wap.wmlc"),
+            "missing Accept must fall back to the compiled WML media type"
+        );
+        assert_eq!(
+            negotiated_accept_media(&HashMap::from([(
+                "Accept".to_string(),
+                "text/vnd.wap.wml".to_string()
+            )])),
+            Some("text/vnd.wap.wml")
+        );
+        assert_eq!(
+            negotiated_accept_media(&HashMap::from([(
+                "Accept".to_string(),
+                "application/json".to_string()
+            )])),
+            None,
+            "unrepresentable Accept values advertise nothing"
+        );
+        assert!(connectionless_request_headers(&HashMap::from([(
+            "Accept".to_string(),
+            "application/json".to_string()
+        )]))
+        .headers
+        .is_empty());
     }
 
     #[test]
@@ -867,16 +774,16 @@ mod tests {
         let error = resolve_destination_socket_addr(&wap, &FetchDestinationPolicy::PublicOnly)
             .expect_err("public-only must reject a resolved loopback peer");
 
-        assert!(error.contains("public-only"));
-        assert!(error.contains("loopback"));
+        assert!(error.is_policy_blocked());
+        assert!(error.to_string().contains("public-only"));
+        assert!(error.to_string().contains("loopback"));
     }
 
     #[test]
     fn native_destination_policy_failure_maps_invalid_request() {
         let response = map_destination_resolution_error(
             "wap://private.test/".to_string(),
-            "Destination blocked by fetch policy (public-only): resolved to private address"
-                .to_string(),
+            FetchDestinationError::blocked_resolved_address(DestinationHostClass::Private),
             1,
             Some("req-native-policy"),
         );
@@ -892,9 +799,25 @@ mod tests {
     }
 
     #[test]
+    fn native_destination_resolution_failure_maps_transport_error() {
+        let response = map_destination_resolution_error(
+            "wap://unknown.invalid/".to_string(),
+            FetchDestinationError::Unresolvable("failed to resolve wap host x:9200".to_string()),
+            2,
+            Some("req-native-dns"),
+        );
+
+        assert_eq!(
+            response.error.as_ref().map(|error| error.code.as_str()),
+            Some("TRANSPORT_UNAVAILABLE"),
+            "non-policy resolution failures must not be classified as INVALID_REQUEST"
+        );
+    }
+
+    #[test]
     fn native_connectionless_post_wire_format_encodes_header_block_and_body() {
         let parsed = Url::parse("wap://localhost/login").expect("url should parse");
-        let encoded = encode_connectionless_request(
+        let encoded = encode_native_wap_request(
             CONNECTIONLESS_INITIAL_TRANSACTION_ID,
             "POST",
             &parsed,
@@ -937,7 +860,7 @@ mod tests {
         ];
 
         for payload in payloads {
-            let encoded = encode_connectionless_request(
+            let encoded = encode_native_wap_request(
                 CONNECTIONLESS_INITIAL_TRANSACTION_ID,
                 "POST",
                 &parsed,
@@ -969,74 +892,49 @@ mod tests {
     }
 
     #[test]
-    fn native_connectionless_reply_rejects_transaction_id_mismatch() {
-        let encoded = build_connectionless_reply_wire(9, 0x20, 0x08, &[]);
+    fn native_connectionless_reply_mismatch_maps_terminal_transport_error() {
+        // Codec-level reply decoding is covered in
+        // `crate::network::wsp::connectionless`; this pins how a decode failure
+        // surfaces through the fetch path.
+        let reply_datagram = WdpDatagram {
+            src_addr: WdpAddress::ipv4([127, 0, 0, 1]),
+            dst_addr: WdpAddress::ipv4([127, 0, 0, 1]),
+            src_port: 9200,
+            dst_port: 49152,
+            payload: build_connectionless_reply_wire(9, 0x20, 0x08, &[]),
+        };
+        let mut transport = FakeDatagramTransport {
+            sent: Vec::new(),
+            next_receive: Ok(reply_datagram),
+        };
 
-        let error =
-            decode_connectionless_wsp_reply(CONNECTIONLESS_INITIAL_TRANSACTION_ID, &encoded)
-                .expect_err("transaction-id mismatch should fail");
+        let response = execute_native_wap_request_with_transport(
+            &mut transport,
+            "127.0.0.1:9200".parse().expect("literal should parse"),
+            NativeFetchPlan {
+                request_url: "wap://127.0.0.1/".to_string(),
+                method: "GET".to_string(),
+                outbound_headers: HashMap::new(),
+                post_body: None,
+                post_content_type: None,
+                timeout_ms: 200,
+                attempts: 1,
+                request_id: Some("req-native-mismatch".to_string()),
+                destination_policy: FetchDestinationPolicy::AllowPrivate,
+            },
+        );
 
-        assert!(error.contains("unexpected native WSP reply transaction id"));
-    }
-
-    #[test]
-    fn decode_content_type_value_general_form_matches_len_plus_one() {
-        // Unquoted general-form text-string: no leading 0x7F is stripped,
-        // so the consumed byte count legitimately equals `media.len() + 1`
-        // (the string bytes plus the terminating NUL). This is the
-        // non-quoted case the fix must leave unchanged.
-        let input = b"text/html\x00";
-
-        let (media, consumed) = decode_content_type_value(input).expect("value should decode");
-
-        assert_eq!(media, "text/html");
-        assert_eq!(consumed, media.len() + 1);
-        assert_eq!(consumed, input.len());
-    }
-
-    #[test]
-    fn decode_content_type_value_quoted_general_form_counts_quote_byte() {
-        // Quoted general-form text-string (leading 0x7F escape byte, per
-        // WSP token-text quoting): `decode_text_string` strips the leading
-        // 0x7F from the returned media string, so `media.len() + 1` alone
-        // undercounts the consumed bytes by exactly one. Regression test
-        // for that off-by-one.
-        let input = b"\x7Ftext/html\x00";
-
-        let (media, consumed) = decode_content_type_value(input).expect("value should decode");
-
-        assert_eq!(media, "text/html");
+        assert!(!response.ok);
         assert_eq!(
-            consumed,
-            input.len(),
-            "quoted content type must count the leading 0x7F byte as consumed"
+            response.error.as_ref().map(|error| error.code.as_str()),
+            Some("TRANSPORT_UNAVAILABLE")
         );
-        assert_ne!(
-            consumed,
-            media.len() + 1,
-            "regression guard: consumed length must not be derived from media.len() + 1 \
-             when the value was quoted"
-        );
-    }
-
-    #[test]
-    fn native_connectionless_reply_decodes_quoted_general_form_content_type() {
-        // Exercises the real downstream caller of `decode_content_type_value`
-        // (`decode_connectionless_wsp_reply`'s `content_type_len >
-        // header_section.len()` sanity check) with a quoted general-form
-        // content type, proving the corrected byte count still passes that
-        // check and yields the right decoded reply.
-        let content_type = b"\x7Ftext/html\x00";
-        let headers_len = encode_uintvar(content_type.len()).expect("headers len should encode");
-        let mut wire = vec![CONNECTIONLESS_INITIAL_TRANSACTION_ID, 0x04, 0x20];
-        wire.extend_from_slice(&headers_len);
-        wire.extend_from_slice(content_type);
-
-        let reply = decode_connectionless_wsp_reply(CONNECTIONLESS_INITIAL_TRANSACTION_ID, &wire)
-            .expect("quoted content type reply should decode");
-
-        assert_eq!(reply.content_type, "text/html");
-        assert_eq!(reply.status_code, 200);
-        assert!(reply.body.is_empty());
+        assert!(response
+            .error
+            .as_ref()
+            .map(|error| error
+                .message
+                .contains("unexpected native WSP reply transaction id"))
+            .unwrap_or(false));
     }
 }

--- a/transport-rust/src/network/wsp.rs
+++ b/transport-rust/src/network/wsp.rs
@@ -1,5 +1,6 @@
 #![allow(unused_imports)]
 
+pub mod connectionless;
 pub mod decoder;
 pub mod encoder;
 pub mod encoding_version;

--- a/transport-rust/src/network/wsp/connectionless.rs
+++ b/transport-rust/src/network/wsp/connectionless.rs
@@ -1,0 +1,768 @@
+//! Connectionless (session-less) WSP framing used by the live native fetch path.
+//!
+//! WAP-230-WSP defines two framings for the same PDU set. The
+//! connection-oriented framing modelled by [`crate::network::wsp::pdu`] carries
+//! no transaction id and length-prefixes its blocks with a single octet. The
+//! connectionless framing used over WDP/UDP — the one the `wap-net-core`
+//! transport profile actually speaks to the gateway — prefixes every PDU with a
+//! transaction id and length-prefixes the request URI and header section with
+//! `uintvar` values, and encodes reply status as a single assigned-number octet.
+//!
+//! The two framings are therefore not byte-compatible, which is why this module
+//! exists instead of `native_fetch.rs` calling [`crate::network::wsp::pdu::encode_wsp_pdu`]
+//! directly. What is shared is everything that is genuinely common: the assigned
+//! number tables in [`crate::network::wsp::header_registry`] (PDU types, header
+//! field names) and the header representation in
+//! [`crate::network::wsp::header_block`] ([`WspHeaderBlock`] / `WspHeaderField`).
+//! `native_fetch.rs` owns no wire-format code of its own.
+
+use crate::network::wsp::header_block::{WspHeaderBlock, WspHeaderNameEncoding};
+use crate::network::wsp::header_registry::{
+    decode_pdu_type, encode_header_field_name_on_page, encode_pdu_type, WspAssignedNumberPolicy,
+    DEFAULT_HEADER_CODE_PAGE,
+};
+
+/// High bit marking a well-known (binary) WSP field name or short-integer value.
+const WELL_KNOWN_MARKER: u8 = 0x80;
+/// Largest value representable by the five-octet `uintvar` form.
+const MAX_UINTVAR_VALUE: usize = 0x0FFF_FFFF;
+/// Highest first octet still interpreted as a content-type short-length prefix.
+const MAX_SHORT_LENGTH: u8 = 31;
+/// RFC 2045 quoted-string escape byte used by WSP token-text.
+const TEXT_STRING_QUOTE: u8 = 0x7F;
+/// Assigned-number name of the reply PDU this transport expects back.
+const REPLY_PDU_TYPE_NAME: &str = "Reply";
+
+/// Well-known media types this transport can encode/decode in short-integer form.
+const WELL_KNOWN_MEDIA_TYPES: &[(u8, &str)] = &[
+    (0x03, "text/plain"),
+    (0x08, "text/vnd.wap.wml"),
+    (0x14, "application/vnd.wap.wmlc"),
+    (0x28, "text/xml"),
+    (0x29, "application/xml"),
+];
+
+/// Header field names whose values may be compacted to a well-known media octet.
+const MEDIA_VALUED_HEADER_NAMES: &[&str] = &["Accept", "Content-Type"];
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum WspConnectionlessMethod {
+    Get,
+    Post,
+}
+
+impl WspConnectionlessMethod {
+    pub(crate) fn from_http_method(method: &str) -> Option<Self> {
+        match method {
+            "GET" => Some(Self::Get),
+            "POST" => Some(Self::Post),
+            _ => None,
+        }
+    }
+
+    fn pdu_type_name(self) -> &'static str {
+        match self {
+            Self::Get => "Get",
+            Self::Post => "Post",
+        }
+    }
+}
+
+pub(crate) struct WspConnectionlessRequest<'a> {
+    pub(crate) transaction_id: u8,
+    pub(crate) method: WspConnectionlessMethod,
+    pub(crate) uri: &'a str,
+    pub(crate) headers: &'a WspHeaderBlock,
+    pub(crate) content_type: Option<&'a str>,
+    pub(crate) body: &'a [u8],
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct WspConnectionlessReply {
+    pub(crate) status_code: u16,
+    pub(crate) content_type: String,
+    pub(crate) body: Vec<u8>,
+}
+
+/// A decoded WSP text-string plus the number of raw input bytes it consumed.
+///
+/// The two values are deliberately not derivable from one another: a leading
+/// [`TEXT_STRING_QUOTE`] byte is stripped from `text` but still counts toward
+/// `consumed_bytes`, so quoted and unquoted strings of the same visible length
+/// consume different amounts of input. Fields are private so a caller cannot
+/// reconstruct a length from `text.len()` and get it wrong.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct DecodedWspText {
+    text: String,
+    consumed_bytes: usize,
+}
+
+impl DecodedWspText {
+    fn new(text: String, consumed_bytes: usize) -> Self {
+        Self {
+            text,
+            consumed_bytes,
+        }
+    }
+
+    pub(crate) fn text(&self) -> &str {
+        &self.text
+    }
+
+    pub(crate) fn consumed_bytes(&self) -> usize {
+        self.consumed_bytes
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum WspConnectionlessEncodeError {
+    UnassignedPduType(&'static str),
+    ContentTypeContainsNul,
+    LengthExceedsUintvarRange(usize),
+}
+
+impl std::fmt::Display for WspConnectionlessEncodeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::UnassignedPduType(name) => write!(f, "unassigned WSP PDU type: {name}"),
+            Self::ContentTypeContainsNul => {
+                write!(f, "native WSP POST content type must not contain NUL bytes")
+            }
+            Self::LengthExceedsUintvarRange(value) => {
+                write!(f, "value too large for uintvar encoding: {value}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for WspConnectionlessEncodeError {}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum WspConnectionlessDecodeError {
+    MissingTransactionId,
+    TransactionIdMismatch { expected: u8, actual: u8 },
+    MissingPduType,
+    UnexpectedPduType(u8),
+    MissingStatus,
+    TruncatedUintvar,
+    TruncatedHeaderSection,
+    MissingContentType,
+    TruncatedContentType,
+    ContentTypeOverrunsHeaderSection,
+    UnsupportedWellKnownMedia(u8),
+    TruncatedTextString,
+    InvalidTextStringUtf8(String),
+    UnsupportedStatusCode(u8),
+}
+
+impl std::fmt::Display for WspConnectionlessDecodeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::MissingTransactionId => {
+                write!(f, "truncated native WSP reply: missing transaction id")
+            }
+            Self::TransactionIdMismatch { expected, actual } => write!(
+                f,
+                "unexpected native WSP reply transaction id: expected {expected}, got {actual}"
+            ),
+            Self::MissingPduType => write!(f, "truncated native WSP reply: missing pdu type"),
+            Self::UnexpectedPduType(code) => write!(
+                f,
+                "unexpected native WSP reply pdu type: expected 0x04, got 0x{code:02X}"
+            ),
+            Self::MissingStatus => write!(f, "truncated native WSP reply: missing status"),
+            Self::TruncatedUintvar => write!(f, "truncated uintvar"),
+            Self::TruncatedHeaderSection => {
+                write!(f, "truncated native WSP reply: headers section incomplete")
+            }
+            Self::MissingContentType => {
+                write!(f, "truncated native WSP reply: missing content type")
+            }
+            Self::TruncatedContentType => write!(
+                f,
+                "truncated native WSP reply: content type general form incomplete"
+            ),
+            Self::ContentTypeOverrunsHeaderSection => write!(
+                f,
+                "truncated native WSP reply: content type overruns header section"
+            ),
+            Self::UnsupportedWellKnownMedia(code) => {
+                write!(f, "unsupported well-known media type: 0x{code:02X}")
+            }
+            Self::TruncatedTextString => write!(f, "truncated native WSP text string"),
+            Self::InvalidTextStringUtf8(error) => {
+                write!(f, "invalid utf-8 in native WSP text string: {error}")
+            }
+            Self::UnsupportedStatusCode(status) => {
+                write!(f, "unsupported native WSP status code: 0x{status:02X}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for WspConnectionlessDecodeError {}
+
+/// Encodes a connectionless WSP `Get`/`Post` request onto the wire.
+pub(crate) fn encode_connectionless_request(
+    request: &WspConnectionlessRequest<'_>,
+) -> Result<Vec<u8>, WspConnectionlessEncodeError> {
+    let pdu_type = encode_pdu_type(request.method.pdu_type_name()).ok_or(
+        WspConnectionlessEncodeError::UnassignedPduType(request.method.pdu_type_name()),
+    )?;
+    let uri_bytes = request.uri.as_bytes();
+    let encoded_headers = encode_connectionless_header_block(request.headers);
+    let encoded_content_type = encode_content_type_field(request.content_type)?;
+
+    let mut wire = Vec::with_capacity(
+        uri_bytes.len()
+            + encoded_content_type.len()
+            + encoded_headers.len()
+            + request.body.len()
+            + 12,
+    );
+    wire.push(request.transaction_id);
+    wire.push(pdu_type);
+    match request.method {
+        WspConnectionlessMethod::Get => {
+            wire.extend_from_slice(&encode_uintvar(uri_bytes.len())?);
+            wire.extend_from_slice(uri_bytes);
+            wire.extend_from_slice(&encoded_headers);
+        }
+        WspConnectionlessMethod::Post => {
+            let headers_len = encoded_content_type.len() + encoded_headers.len();
+            wire.extend_from_slice(&encode_uintvar(uri_bytes.len())?);
+            wire.extend_from_slice(&encode_uintvar(headers_len)?);
+            wire.extend_from_slice(uri_bytes);
+            wire.extend_from_slice(&encoded_content_type);
+            wire.extend_from_slice(&encoded_headers);
+            wire.extend_from_slice(request.body);
+        }
+    }
+    Ok(wire)
+}
+
+/// Decodes a connectionless WSP `Reply` PDU addressed to `expected_transaction_id`.
+///
+/// Only the content type is lifted out of the header section; the remaining
+/// header bytes are intentionally left unparsed, because the gateway encodes
+/// them with value forms this fetch path does not need and must not fail on.
+pub(crate) fn decode_connectionless_reply(
+    expected_transaction_id: u8,
+    payload: &[u8],
+) -> Result<WspConnectionlessReply, WspConnectionlessDecodeError> {
+    let Some((&transaction_id, body)) = payload.split_first() else {
+        return Err(WspConnectionlessDecodeError::MissingTransactionId);
+    };
+    if transaction_id != expected_transaction_id {
+        return Err(WspConnectionlessDecodeError::TransactionIdMismatch {
+            expected: expected_transaction_id,
+            actual: transaction_id,
+        });
+    }
+
+    let Some((&pdu_type, body)) = body.split_first() else {
+        return Err(WspConnectionlessDecodeError::MissingPduType);
+    };
+    let decoded_pdu_type = decode_pdu_type(pdu_type, WspAssignedNumberPolicy::STRICT)
+        .ok()
+        .flatten();
+    if decoded_pdu_type != Some(REPLY_PDU_TYPE_NAME) {
+        return Err(WspConnectionlessDecodeError::UnexpectedPduType(pdu_type));
+    }
+
+    let Some((&status, body)) = body.split_first() else {
+        return Err(WspConnectionlessDecodeError::MissingStatus);
+    };
+    let (headers_len, body) = decode_uintvar(body)?;
+    if body.len() < headers_len {
+        return Err(WspConnectionlessDecodeError::TruncatedHeaderSection);
+    }
+    let (header_section, data) = body.split_at(headers_len);
+    let content_type = decode_content_type_value(header_section)?;
+    if content_type.consumed_bytes() > header_section.len() {
+        return Err(WspConnectionlessDecodeError::ContentTypeOverrunsHeaderSection);
+    }
+
+    Ok(WspConnectionlessReply {
+        status_code: decode_wsp_status_code(status)?,
+        content_type: content_type.text().to_string(),
+        body: data.to_vec(),
+    })
+}
+
+/// Encodes a header block in the binary connectionless form.
+///
+/// Field names registered on the default code page are emitted as well-known
+/// octets from [`crate::network::wsp::header_registry`]; anything else falls
+/// back to the text form. Media-typed values are compacted to well-known media
+/// octets when possible.
+fn encode_connectionless_header_block(block: &WspHeaderBlock) -> Vec<u8> {
+    let mut out = Vec::new();
+    for header in &block.headers {
+        let page = match header.name_encoding {
+            WspHeaderNameEncoding::Binary { page } => page,
+            WspHeaderNameEncoding::Text => DEFAULT_HEADER_CODE_PAGE,
+        };
+        match encode_header_field_name_on_page(&header.name, page)
+            .filter(|_| page == DEFAULT_HEADER_CODE_PAGE)
+        {
+            Some(code) => out.push(WELL_KNOWN_MARKER | code),
+            None => {
+                out.extend_from_slice(header.name.as_bytes());
+                out.push(0x00);
+            }
+        }
+
+        let media_code = MEDIA_VALUED_HEADER_NAMES
+            .iter()
+            .any(|name| name.eq_ignore_ascii_case(&header.name))
+            .then(|| well_known_media_code(&header.value))
+            .flatten();
+        match media_code {
+            Some(code) => out.push(WELL_KNOWN_MARKER | code),
+            None => {
+                out.extend_from_slice(header.value.as_bytes());
+                out.push(0x00);
+            }
+        }
+    }
+    out
+}
+
+/// Encodes the `ContentType` field that precedes a `Post` header section.
+fn encode_content_type_field(
+    content_type: Option<&str>,
+) -> Result<Vec<u8>, WspConnectionlessEncodeError> {
+    let Some(content_type) = content_type
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    else {
+        return Ok(Vec::new());
+    };
+
+    if content_type.as_bytes().contains(&0x00) {
+        return Err(WspConnectionlessEncodeError::ContentTypeContainsNul);
+    }
+    let mut out = Vec::with_capacity(content_type.len() + 1);
+    out.extend_from_slice(content_type.as_bytes());
+    out.push(0x00);
+    Ok(out)
+}
+
+pub(crate) fn encode_uintvar(value: usize) -> Result<Vec<u8>, WspConnectionlessEncodeError> {
+    if value > MAX_UINTVAR_VALUE {
+        return Err(WspConnectionlessEncodeError::LengthExceedsUintvarRange(
+            value,
+        ));
+    }
+    let mut groups = [0u8; 5];
+    let mut cursor = groups.len();
+    let mut remaining = value;
+    loop {
+        cursor -= 1;
+        groups[cursor] = (remaining & 0x7F) as u8;
+        remaining >>= 7;
+        if remaining == 0 {
+            break;
+        }
+    }
+    let mut out = groups[cursor..].to_vec();
+    // Continuation bit is set on every octet except the final one.
+    for index in 0..out.len().saturating_sub(1) {
+        out[index] |= WELL_KNOWN_MARKER;
+    }
+    Ok(out)
+}
+
+pub(crate) fn decode_uintvar(input: &[u8]) -> Result<(usize, &[u8]), WspConnectionlessDecodeError> {
+    let mut value = 0usize;
+    for (index, byte) in input.iter().copied().enumerate().take(5) {
+        value = (value << 7) | usize::from(byte & 0x7F);
+        if byte & WELL_KNOWN_MARKER == 0 {
+            return Ok((value, &input[index + 1..]));
+        }
+    }
+    Err(WspConnectionlessDecodeError::TruncatedUintvar)
+}
+
+pub(crate) fn decode_content_type_value(
+    input: &[u8],
+) -> Result<DecodedWspText, WspConnectionlessDecodeError> {
+    let Some((&first, _)) = input.split_first() else {
+        return Err(WspConnectionlessDecodeError::MissingContentType);
+    };
+    if first & WELL_KNOWN_MARKER != 0 {
+        let code = first & 0x7F;
+        let media = well_known_media_name(code).ok_or(
+            WspConnectionlessDecodeError::UnsupportedWellKnownMedia(code),
+        )?;
+        return Ok(DecodedWspText::new(media.to_string(), 1));
+    }
+    if first <= MAX_SHORT_LENGTH {
+        let length = usize::from(first);
+        if input.len() < 1 + length {
+            return Err(WspConnectionlessDecodeError::TruncatedContentType);
+        }
+        let media = decode_text_string(&input[1..1 + length])?;
+        return Ok(DecodedWspText::new(media.text().to_string(), 1 + length));
+    }
+    decode_text_string(input)
+}
+
+/// Decodes a NUL-terminated WSP text-string.
+///
+/// A leading [`TEXT_STRING_QUOTE`] byte is stripped from the returned text but
+/// still counted in [`DecodedWspText::consumed_bytes`].
+pub(crate) fn decode_text_string(
+    input: &[u8],
+) -> Result<DecodedWspText, WspConnectionlessDecodeError> {
+    let terminator = input
+        .iter()
+        .position(|byte| *byte == 0x00)
+        .ok_or(WspConnectionlessDecodeError::TruncatedTextString)?;
+    let content = if input.first().copied() == Some(TEXT_STRING_QUOTE) {
+        &input[1..terminator]
+    } else {
+        &input[..terminator]
+    };
+    let text = String::from_utf8(content.to_vec())
+        .map_err(|error| WspConnectionlessDecodeError::InvalidTextStringUtf8(error.to_string()))?;
+    Ok(DecodedWspText::new(text, terminator + 1))
+}
+
+pub(crate) fn decode_wsp_status_code(status: u8) -> Result<u16, WspConnectionlessDecodeError> {
+    match status {
+        0x10 => Ok(100),
+        0x11 => Ok(101),
+        0x20..=0x26 => Ok(200 + u16::from(status - 0x20)),
+        0x30..=0x37 => Ok(300 + u16::from(status - 0x30)),
+        0x40..=0x51 => Ok(400 + u16::from(status - 0x40)),
+        0x60..=0x65 => Ok(500 + u16::from(status - 0x60)),
+        _ => Err(WspConnectionlessDecodeError::UnsupportedStatusCode(status)),
+    }
+}
+
+fn well_known_media_name(code: u8) -> Option<&'static str> {
+    WELL_KNOWN_MEDIA_TYPES
+        .iter()
+        .find(|(entry_code, _)| *entry_code == code)
+        .map(|(_, name)| *name)
+}
+
+fn well_known_media_code(media: &str) -> Option<u8> {
+    WELL_KNOWN_MEDIA_TYPES
+        .iter()
+        .find(|(_, name)| name.eq_ignore_ascii_case(media))
+        .map(|(code, _)| *code)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::network::wsp::header_block::WspHeaderField;
+
+    const TRANSACTION_ID: u8 = 1;
+
+    fn accept_block(media: &str) -> WspHeaderBlock {
+        WspHeaderBlock {
+            headers: vec![WspHeaderField {
+                name: "Accept".to_string(),
+                value: media.to_string(),
+                name_encoding: WspHeaderNameEncoding::Binary {
+                    page: DEFAULT_HEADER_CODE_PAGE,
+                },
+            }],
+            encoding_version_headers: Vec::new(),
+        }
+    }
+
+    fn reply_wire(transaction_id: u8, status: u8, content_type: u8, body: &[u8]) -> Vec<u8> {
+        let headers_len = encode_uintvar(1).expect("single-octet content type should encode");
+        let mut wire = vec![transaction_id, 0x04, status];
+        wire.extend_from_slice(&headers_len);
+        wire.push(content_type | WELL_KNOWN_MARKER);
+        wire.extend_from_slice(body);
+        wire
+    }
+
+    #[test]
+    fn get_request_uses_transaction_id_pdu_type_and_uintvar_uri_length() {
+        let block = accept_block("application/vnd.wap.wmlc");
+        let encoded = encode_connectionless_request(&WspConnectionlessRequest {
+            transaction_id: TRANSACTION_ID,
+            method: WspConnectionlessMethod::Get,
+            uri: "http://localhost:13002/",
+            headers: &block,
+            content_type: None,
+            body: &[],
+        })
+        .expect("request should encode");
+
+        assert_eq!(encoded.first().copied(), Some(TRANSACTION_ID));
+        assert_eq!(encoded.get(1).copied(), Some(0x40));
+        let (uri_len, rest) = decode_uintvar(&encoded[2..]).expect("uri len should decode");
+        assert_eq!(
+            std::str::from_utf8(&rest[..uri_len]).expect("uri should decode"),
+            "http://localhost:13002/"
+        );
+        assert_eq!(&rest[uri_len..], &[0x80, 0x94]);
+    }
+
+    #[test]
+    fn get_request_encodes_wml_accept_as_well_known_media_octet() {
+        let block = accept_block("text/vnd.wap.wml");
+        let encoded = encode_connectionless_request(&WspConnectionlessRequest {
+            transaction_id: TRANSACTION_ID,
+            method: WspConnectionlessMethod::Get,
+            uri: "/",
+            headers: &block,
+            content_type: None,
+            body: &[],
+        })
+        .expect("request should encode");
+
+        assert_eq!(&encoded[encoded.len() - 2..], &[0x80, 0x88]);
+    }
+
+    #[test]
+    fn post_request_encodes_content_type_header_block_and_body() {
+        let block = accept_block("text/vnd.wap.wml");
+        let encoded = encode_connectionless_request(&WspConnectionlessRequest {
+            transaction_id: TRANSACTION_ID,
+            method: WspConnectionlessMethod::Post,
+            uri: "http://localhost:13002/login",
+            headers: &block,
+            content_type: Some("application/x-www-form-urlencoded"),
+            body: b"username=alice&pin=0000",
+        })
+        .expect("post request should encode");
+
+        assert_eq!(encoded.get(1).copied(), Some(0x60));
+        let (uri_len, remainder) = decode_uintvar(&encoded[2..]).expect("uri len should decode");
+        let (headers_len, remainder) =
+            decode_uintvar(remainder).expect("headers len should decode");
+        assert_eq!(
+            std::str::from_utf8(&remainder[..uri_len]).expect("uri should decode"),
+            "http://localhost:13002/login"
+        );
+        let remainder = &remainder[uri_len..];
+        assert_eq!(headers_len, 36);
+        assert_eq!(
+            &remainder[..headers_len],
+            &[
+                b'a', b'p', b'p', b'l', b'i', b'c', b'a', b't', b'i', b'o', b'n', b'/', b'x', b'-',
+                b'w', b'w', b'w', b'-', b'f', b'o', b'r', b'm', b'-', b'u', b'r', b'l', b'e', b'n',
+                b'c', b'o', b'd', b'e', b'd', 0x00, 0x80, 0x88,
+            ]
+        );
+        assert_eq!(&remainder[headers_len..], b"username=alice&pin=0000");
+    }
+
+    #[test]
+    fn post_content_type_rejects_nul_bytes() {
+        let block = WspHeaderBlock::default();
+        let error = encode_connectionless_request(&WspConnectionlessRequest {
+            transaction_id: TRANSACTION_ID,
+            method: WspConnectionlessMethod::Post,
+            uri: "/",
+            headers: &block,
+            content_type: Some("text/plain\0oops"),
+            body: &[],
+        })
+        .expect_err("content type with NUL should fail");
+
+        assert_eq!(error, WspConnectionlessEncodeError::ContentTypeContainsNul);
+        assert!(error.to_string().contains("must not contain NUL bytes"));
+    }
+
+    #[test]
+    fn uintvar_roundtrips_multi_octet_values_with_canonical_continuation_bits() {
+        // Only the non-final octets carry the continuation bit; a trailing octet
+        // with 0x80 set would make a peer swallow the byte that follows the
+        // length field.
+        for value in [0usize, 1, 127, 128, 200, 16_383, 16_384, MAX_UINTVAR_VALUE] {
+            let encoded = encode_uintvar(value).expect("value should encode");
+            assert_eq!(
+                encoded.last().copied().map(|byte| byte & 0x80),
+                Some(0),
+                "final uintvar octet must not set the continuation bit for {value}"
+            );
+            let mut wire = encoded.clone();
+            wire.push(0xAA);
+            let (decoded, rest) = decode_uintvar(&wire).expect("value should decode");
+            assert_eq!(decoded, value);
+            assert_eq!(rest, &[0xAA], "decode must stop at the final octet");
+        }
+        assert_eq!(
+            encode_uintvar(200).expect("200 should encode"),
+            [0x81, 0x48]
+        );
+    }
+
+    #[test]
+    fn uintvar_rejects_values_outside_the_encodable_range() {
+        let error = encode_uintvar(MAX_UINTVAR_VALUE + 1).expect_err("value should be rejected");
+        assert_eq!(
+            error,
+            WspConnectionlessEncodeError::LengthExceedsUintvarRange(MAX_UINTVAR_VALUE + 1)
+        );
+    }
+
+    #[test]
+    fn decode_uintvar_rejects_unterminated_sequences() {
+        let error = decode_uintvar(&[0x80, 0x80, 0x80, 0x80, 0x80])
+            .expect_err("uintvar should be rejected");
+        assert_eq!(error, WspConnectionlessDecodeError::TruncatedUintvar);
+    }
+
+    #[test]
+    fn decode_content_type_value_general_form_matches_len_plus_one() {
+        // Unquoted general-form text-string: no leading 0x7F is stripped, so the
+        // consumed byte count legitimately equals `text.len() + 1` (the string
+        // bytes plus the terminating NUL).
+        let input = b"text/html\x00";
+
+        let decoded = decode_content_type_value(input).expect("value should decode");
+
+        assert_eq!(decoded.text(), "text/html");
+        assert_eq!(decoded.consumed_bytes(), decoded.text().len() + 1);
+        assert_eq!(decoded.consumed_bytes(), input.len());
+    }
+
+    #[test]
+    fn decode_content_type_value_quoted_general_form_counts_quote_byte() {
+        // Quoted general-form text-string (leading 0x7F escape byte, per WSP
+        // token-text quoting): the quote byte is stripped from the text but must
+        // still be counted as consumed, so `text.len() + 1` undercounts by one.
+        let input = b"\x7Ftext/html\x00";
+
+        let decoded = decode_content_type_value(input).expect("value should decode");
+
+        assert_eq!(decoded.text(), "text/html");
+        assert_eq!(
+            decoded.consumed_bytes(),
+            input.len(),
+            "quoted content type must count the leading 0x7F byte as consumed"
+        );
+        assert_ne!(
+            decoded.consumed_bytes(),
+            decoded.text().len() + 1,
+            "regression guard: consumed length must not be derived from text.len() + 1 \
+             when the value was quoted"
+        );
+    }
+
+    #[test]
+    fn decode_content_type_value_maps_well_known_media_octets() {
+        let decoded = decode_content_type_value(&[0x94]).expect("well-known media should decode");
+        assert_eq!(decoded.text(), "application/vnd.wap.wmlc");
+        assert_eq!(decoded.consumed_bytes(), 1);
+
+        let error = decode_content_type_value(&[0xFF]).expect_err("unknown media should fail");
+        assert_eq!(
+            error,
+            WspConnectionlessDecodeError::UnsupportedWellKnownMedia(0x7F)
+        );
+    }
+
+    #[test]
+    fn reply_rejects_transaction_id_mismatch() {
+        let encoded = reply_wire(9, 0x20, 0x08, &[]);
+
+        let error = decode_connectionless_reply(TRANSACTION_ID, &encoded)
+            .expect_err("transaction-id mismatch should fail");
+
+        assert_eq!(
+            error,
+            WspConnectionlessDecodeError::TransactionIdMismatch {
+                expected: TRANSACTION_ID,
+                actual: 9,
+            }
+        );
+        assert!(error
+            .to_string()
+            .contains("unexpected native WSP reply transaction id"));
+    }
+
+    #[test]
+    fn reply_rejects_non_reply_pdu_types() {
+        let mut encoded = reply_wire(TRANSACTION_ID, 0x20, 0x08, &[]);
+        encoded[1] = 0x40;
+
+        let error = decode_connectionless_reply(TRANSACTION_ID, &encoded)
+            .expect_err("a Get PDU is not a valid reply");
+
+        assert_eq!(error, WspConnectionlessDecodeError::UnexpectedPduType(0x40));
+    }
+
+    #[test]
+    fn reply_decodes_status_content_type_and_body() {
+        let encoded = reply_wire(TRANSACTION_ID, 0x20, 0x08, b"<wml/>");
+
+        let reply =
+            decode_connectionless_reply(TRANSACTION_ID, &encoded).expect("reply should decode");
+
+        assert_eq!(reply.status_code, 200);
+        assert_eq!(reply.content_type, "text/vnd.wap.wml");
+        assert_eq!(reply.body, b"<wml/>".to_vec());
+    }
+
+    #[test]
+    fn reply_decodes_quoted_general_form_content_type() {
+        // Exercises the `consumed_bytes > header_section.len()` sanity check with
+        // a quoted general-form content type.
+        let content_type = b"\x7Ftext/html\x00";
+        let headers_len = encode_uintvar(content_type.len()).expect("headers len should encode");
+        let mut wire = vec![TRANSACTION_ID, 0x04, 0x20];
+        wire.extend_from_slice(&headers_len);
+        wire.extend_from_slice(content_type);
+
+        let reply = decode_connectionless_reply(TRANSACTION_ID, &wire)
+            .expect("quoted content type reply should decode");
+
+        assert_eq!(reply.content_type, "text/html");
+        assert_eq!(reply.status_code, 200);
+        assert!(reply.body.is_empty());
+    }
+
+    #[test]
+    fn reply_rejects_truncated_frames() {
+        assert_eq!(
+            decode_connectionless_reply(TRANSACTION_ID, &[]).expect_err("empty payload"),
+            WspConnectionlessDecodeError::MissingTransactionId
+        );
+        assert_eq!(
+            decode_connectionless_reply(TRANSACTION_ID, &[TRANSACTION_ID])
+                .expect_err("missing pdu type"),
+            WspConnectionlessDecodeError::MissingPduType
+        );
+        assert_eq!(
+            decode_connectionless_reply(TRANSACTION_ID, &[TRANSACTION_ID, 0x04])
+                .expect_err("missing status"),
+            WspConnectionlessDecodeError::MissingStatus
+        );
+        assert_eq!(
+            decode_connectionless_reply(TRANSACTION_ID, &[TRANSACTION_ID, 0x04, 0x20, 0x05])
+                .expect_err("short header section"),
+            WspConnectionlessDecodeError::TruncatedHeaderSection
+        );
+    }
+
+    #[test]
+    fn status_code_mapping_covers_each_assigned_class() {
+        assert_eq!(decode_wsp_status_code(0x10), Ok(100));
+        assert_eq!(decode_wsp_status_code(0x11), Ok(101));
+        assert_eq!(decode_wsp_status_code(0x20), Ok(200));
+        assert_eq!(decode_wsp_status_code(0x26), Ok(206));
+        assert_eq!(decode_wsp_status_code(0x30), Ok(300));
+        assert_eq!(decode_wsp_status_code(0x37), Ok(307));
+        assert_eq!(decode_wsp_status_code(0x40), Ok(400));
+        assert_eq!(decode_wsp_status_code(0x51), Ok(417));
+        assert_eq!(decode_wsp_status_code(0x60), Ok(500));
+        assert_eq!(decode_wsp_status_code(0x65), Ok(505));
+        assert_eq!(
+            decode_wsp_status_code(0x00),
+            Err(WspConnectionlessDecodeError::UnsupportedStatusCode(0x00))
+        );
+    }
+}

--- a/transport-rust/src/request_meta.rs
+++ b/transport-rust/src/request_meta.rs
@@ -47,3 +47,46 @@ pub(crate) fn log_transport_event(
     entry.insert("payload".to_string(), payload);
     println!("{}", Value::Object(entry));
 }
+
+/// Emits the retry-or-failure event for a consumed fetch attempt.
+///
+/// Attempts before the last one are logged as retries (carrying the next
+/// attempt number); the final attempt is logged as a failure.
+pub(crate) fn log_fetch_attempt_failure(
+    request_id: Option<&str>,
+    request_url: &str,
+    attempt: u8,
+    attempts: u8,
+    is_timeout: bool,
+    error: &str,
+    elapsed_ms: f64,
+) {
+    if attempt < attempts {
+        log_transport_event(
+            "transport.fetch.retry",
+            request_id,
+            request_url,
+            serde_json::json!({
+                "attempt": attempt,
+                "nextAttempt": attempt + 1,
+                "attempts": attempts,
+                "isTimeout": is_timeout,
+                "error": error,
+                "elapsedMs": elapsed_ms
+            }),
+        );
+    } else {
+        log_transport_event(
+            "transport.fetch.failure",
+            request_id,
+            request_url,
+            serde_json::json!({
+                "attempt": attempt,
+                "attempts": attempts,
+                "isTimeout": is_timeout,
+                "error": error,
+                "elapsedMs": elapsed_ms
+            }),
+        );
+    }
+}

--- a/transport-rust/src/responses.rs
+++ b/transport-rust/src/responses.rs
@@ -9,66 +9,17 @@ use crate::{
     FETCH_ERROR_CODE_PAYLOAD_TOO_LARGE, MAX_RESPONSE_BODY_BYTES,
 };
 
-pub(crate) fn transport_unavailable_response(
-    url: String,
-    message: String,
-    request_id: Option<&str>,
-) -> FetchDeckResponse {
-    FetchDeckResponse {
-        ok: false,
-        status: 0,
-        final_url: url,
-        content_type: "text/plain".to_string(),
-        wml: None,
-        error: Some(FetchErrorInfo {
-            code: "TRANSPORT_UNAVAILABLE".to_string(),
-            message,
-            details: details_with_request_id(request_id, None),
-        }),
-        timing_ms: FetchTiming {
-            encode: 0.0,
-            udp_rtt: 0.0,
-            decode: 0.0,
-        },
-        engine_deck_input: None,
-    }
-}
-
-pub(crate) fn invalid_request_response(
-    url: String,
-    message: String,
-    request_id: Option<&str>,
-) -> FetchDeckResponse {
-    FetchDeckResponse {
-        ok: false,
-        status: 0,
-        final_url: url,
-        content_type: "text/plain".to_string(),
-        wml: None,
-        error: Some(FetchErrorInfo {
-            code: "INVALID_REQUEST".to_string(),
-            message,
-            details: details_with_request_id(request_id, None),
-        }),
-        timing_ms: FetchTiming {
-            encode: 0.0,
-            udp_rtt: 0.0,
-            decode: 0.0,
-        },
-        engine_deck_input: None,
-    }
-}
-
-#[allow(clippy::too_many_arguments)]
-pub(crate) fn payload_too_large_response(
+/// Builds the shared shape of every failed `FetchDeckResponse`.
+///
+/// Every error path differs only in status, final URL, content type, error info
+/// and round-trip timing; `ok`, `wml`, `engine_deck_input` and the encode/decode
+/// timings are invariant across all of them.
+fn error_response(
     status: u16,
     final_url: String,
     content_type: String,
-    limit_bytes: usize,
-    actual_bytes: Option<u64>,
-    attempt: u8,
+    error: FetchErrorInfo,
     elapsed_ms: f64,
-    request_id: Option<&str>,
 ) -> FetchDeckResponse {
     FetchDeckResponse {
         ok: false,
@@ -76,7 +27,80 @@ pub(crate) fn payload_too_large_response(
         final_url,
         content_type,
         wml: None,
-        error: Some(FetchErrorInfo {
+        error: Some(error),
+        timing_ms: FetchTiming {
+            encode: 0.0,
+            udp_rtt: elapsed_ms,
+            decode: 0.0,
+        },
+        engine_deck_input: None,
+    }
+}
+
+pub(crate) fn transport_unavailable_response(
+    url: String,
+    message: String,
+    request_id: Option<&str>,
+) -> FetchDeckResponse {
+    error_response(
+        0,
+        url,
+        "text/plain".to_string(),
+        FetchErrorInfo {
+            code: "TRANSPORT_UNAVAILABLE".to_string(),
+            message,
+            details: details_with_request_id(request_id, None),
+        },
+        0.0,
+    )
+}
+
+pub(crate) fn invalid_request_response(
+    url: String,
+    message: String,
+    request_id: Option<&str>,
+) -> FetchDeckResponse {
+    error_response(
+        0,
+        url,
+        "text/plain".to_string(),
+        FetchErrorInfo {
+            code: "INVALID_REQUEST".to_string(),
+            message,
+            details: details_with_request_id(request_id, None),
+        },
+        0.0,
+    )
+}
+
+/// Inputs for [`payload_too_large_response`].
+pub(crate) struct PayloadTooLargeParams<'a> {
+    pub(crate) status: u16,
+    pub(crate) final_url: String,
+    pub(crate) content_type: String,
+    pub(crate) limit_bytes: usize,
+    pub(crate) actual_bytes: Option<u64>,
+    pub(crate) attempt: u8,
+    pub(crate) elapsed_ms: f64,
+    pub(crate) request_id: Option<&'a str>,
+}
+
+pub(crate) fn payload_too_large_response(params: PayloadTooLargeParams<'_>) -> FetchDeckResponse {
+    let PayloadTooLargeParams {
+        status,
+        final_url,
+        content_type,
+        limit_bytes,
+        actual_bytes,
+        attempt,
+        elapsed_ms,
+        request_id,
+    } = params;
+    error_response(
+        status,
+        final_url,
+        content_type,
+        FetchErrorInfo {
             code: FETCH_ERROR_CODE_PAYLOAD_TOO_LARGE.to_string(),
             message: match actual_bytes {
                 Some(actual) => {
@@ -92,14 +116,9 @@ pub(crate) fn payload_too_large_response(
                     "actualBytes": actual_bytes
                 })),
             ),
-        }),
-        timing_ms: FetchTiming {
-            encode: 0.0,
-            udp_rtt: elapsed_ms,
-            decode: 0.0,
         },
-        engine_deck_input: None,
-    }
+        elapsed_ms,
+    )
 }
 
 pub(crate) fn normalize_content_type(content_type: Option<&str>) -> String {
@@ -121,44 +140,57 @@ pub(crate) fn is_supported_wml_content_type(content_type: &str) -> bool {
     )
 }
 
-#[allow(clippy::too_many_arguments)]
-pub(crate) fn map_success_payload_response(
-    status: u16,
-    is_wap_scheme: bool,
-    request_url: &str,
-    upstream_url: &str,
-    final_url: String,
-    content_type: String,
-    body: &[u8],
-    attempt: u8,
-    elapsed_ms: f64,
-    request_id: Option<&str>,
-) -> FetchDeckResponse {
+/// Inputs for [`map_success_payload_response`].
+pub(crate) struct SuccessPayloadParams<'a> {
+    pub(crate) status: u16,
+    pub(crate) is_wap_scheme: bool,
+    pub(crate) request_url: &'a str,
+    pub(crate) upstream_url: &'a str,
+    pub(crate) final_url: String,
+    pub(crate) content_type: String,
+    pub(crate) body: &'a [u8],
+    pub(crate) attempt: u8,
+    pub(crate) elapsed_ms: f64,
+    pub(crate) request_id: Option<&'a str>,
+}
+
+pub(crate) fn map_success_payload_response(params: SuccessPayloadParams<'_>) -> FetchDeckResponse {
+    let SuccessPayloadParams {
+        status,
+        is_wap_scheme,
+        request_url,
+        upstream_url,
+        final_url,
+        content_type,
+        body,
+        attempt,
+        elapsed_ms,
+        request_id,
+    } = params;
+
     if body.len() > MAX_RESPONSE_BODY_BYTES {
-        return payload_too_large_response(
+        return payload_too_large_response(PayloadTooLargeParams {
             status,
             final_url,
             content_type,
-            MAX_RESPONSE_BODY_BYTES,
-            Some(body.len() as u64),
+            limit_bytes: MAX_RESPONSE_BODY_BYTES,
+            actual_bytes: Some(body.len() as u64),
             attempt,
             elapsed_ms,
             request_id,
-        );
+        });
     }
 
     if status >= 400 {
-        return FetchDeckResponse {
-            ok: false,
+        return error_response(
             status,
-            final_url: if is_wap_scheme {
+            if is_wap_scheme {
                 request_url.to_string()
             } else {
                 upstream_url.to_string()
             },
-            content_type: "text/plain".to_string(),
-            wml: None,
-            error: Some(FetchErrorInfo {
+            "text/plain".to_string(),
+            FetchErrorInfo {
                 code: "PROTOCOL_ERROR".to_string(),
                 message: format!("Upstream HTTP error: {status}"),
                 details: details_with_request_id(
@@ -168,14 +200,9 @@ pub(crate) fn map_success_payload_response(
                         "attempt": attempt
                     })),
                 ),
-            }),
-            timing_ms: FetchTiming {
-                encode: 0.0,
-                udp_rtt: elapsed_ms,
-                decode: 0.0,
             },
-            engine_deck_input: None,
-        };
+            elapsed_ms,
+        );
     }
 
     let raw_b64 = BASE64.encode(body);
@@ -201,78 +228,57 @@ pub(crate) fn map_success_payload_response(
                     raw_bytes_base64: Some(raw_b64),
                 }),
             },
-            Err(err) => FetchDeckResponse {
-                ok: false,
+            Err(err) => error_response(
                 status,
                 final_url,
                 content_type,
-                wml: None,
-                error: Some(FetchErrorInfo {
+                FetchErrorInfo {
                     code: "WBXML_DECODE_FAILED".to_string(),
                     message: err,
                     details: details_with_request_id(
                         request_id,
                         Some(serde_json::json!({ "attempt": attempt })),
                     ),
-                }),
-                timing_ms: FetchTiming {
-                    encode: 0.0,
-                    udp_rtt: elapsed_ms,
-                    decode: 0.0,
                 },
-                engine_deck_input: None,
-            },
+                elapsed_ms,
+            ),
         };
     }
 
     if !is_supported_wml_content_type(&content_type) {
-        return FetchDeckResponse {
-            ok: false,
+        return error_response(
             status,
             final_url,
-            content_type: content_type.clone(),
-            wml: None,
-            error: Some(FetchErrorInfo {
+            content_type.clone(),
+            FetchErrorInfo {
                 code: "UNSUPPORTED_CONTENT_TYPE".to_string(),
                 message: format!("Unsupported content type: {content_type}"),
                 details: details_with_request_id(
                     request_id,
                     Some(serde_json::json!({ "attempt": attempt })),
                 ),
-            }),
-            timing_ms: FetchTiming {
-                encode: 0.0,
-                udp_rtt: elapsed_ms,
-                decode: 0.0,
             },
-            engine_deck_input: None,
-        };
+            elapsed_ms,
+        );
     }
 
     let wml = match decode_textual_wml_payload(body) {
         Ok(wml) => wml,
         Err(message) => {
-            return FetchDeckResponse {
-                ok: false,
+            return error_response(
                 status,
                 final_url,
                 content_type,
-                wml: None,
-                error: Some(FetchErrorInfo {
+                FetchErrorInfo {
                     code: "PROTOCOL_ERROR".to_string(),
                     message,
                     details: details_with_request_id(
                         request_id,
                         Some(serde_json::json!({ "attempt": attempt })),
                     ),
-                }),
-                timing_ms: FetchTiming {
-                    encode: 0.0,
-                    udp_rtt: elapsed_ms,
-                    decode: 0.0,
                 },
-                engine_deck_input: None,
-            };
+                elapsed_ms,
+            );
         }
     };
     FetchDeckResponse {
@@ -336,13 +342,11 @@ pub(crate) fn map_terminal_send_error(
     elapsed_ms: f64,
     request_id: Option<&str>,
 ) -> FetchDeckResponse {
-    FetchDeckResponse {
-        ok: false,
-        status: 0,
-        final_url: request_url,
-        content_type: "text/plain".to_string(),
-        wml: None,
-        error: Some(FetchErrorInfo {
+    error_response(
+        0,
+        request_url,
+        "text/plain".to_string(),
+        FetchErrorInfo {
             code: if is_timeout {
                 "GATEWAY_TIMEOUT".to_string()
             } else {
@@ -356,12 +360,68 @@ pub(crate) fn map_terminal_send_error(
                     "lastAttempt": attempt
                 })),
             ),
-        }),
-        timing_ms: FetchTiming {
-            encode: 0.0,
-            udp_rtt: elapsed_ms,
-            decode: 0.0,
         },
-        engine_deck_input: None,
+        elapsed_ms,
+    )
+}
+
+/// Last-failure accumulator shared by the HTTP and native transport retry loops.
+///
+/// Both loops previously carried three parallel `last_*` locals and re-derived
+/// the same terminal-response mapping. The actual send/receive mechanics stay
+/// with each transport; only this bookkeeping is shared.
+pub(crate) struct FetchAttemptFailure {
+    message: String,
+    is_timeout: bool,
+    elapsed_ms: f64,
+}
+
+impl Default for FetchAttemptFailure {
+    fn default() -> Self {
+        Self {
+            message: "Retries exhausted".to_string(),
+            is_timeout: false,
+            elapsed_ms: 0.0,
+        }
+    }
+}
+
+impl FetchAttemptFailure {
+    pub(crate) fn record(&mut self, message: String, is_timeout: bool, elapsed_ms: f64) {
+        self.message = message;
+        self.is_timeout = is_timeout;
+        self.elapsed_ms = elapsed_ms;
+    }
+
+    pub(crate) fn message(&self) -> &str {
+        &self.message
+    }
+
+    pub(crate) fn is_timeout(&self) -> bool {
+        self.is_timeout
+    }
+
+    pub(crate) fn elapsed_ms(&self) -> f64 {
+        self.elapsed_ms
+    }
+
+    /// Maps the recorded failure to the terminal `FetchDeckResponse` returned
+    /// once every attempt has been consumed.
+    pub(crate) fn into_terminal_response(
+        self,
+        request_url: String,
+        attempts: u8,
+        last_attempt: u8,
+        request_id: Option<&str>,
+    ) -> FetchDeckResponse {
+        map_terminal_send_error(
+            request_url,
+            self.message,
+            attempts,
+            last_attempt,
+            self.is_timeout,
+            self.elapsed_ms,
+            request_id,
+        )
     }
 }

--- a/transport-rust/src/tests/fetch_mapping.rs
+++ b/transport-rust/src/tests/fetch_mapping.rs
@@ -90,18 +90,18 @@ fn transport_fetch_accepts_url_at_1024_octet_boundary() {
 fn transport_map_success_payload_http_success_builds_engine_deck_input() {
     let base = "http://example.test/index.wml".to_string();
     let body = b"<wml><card id=\"home\"><p>ok</p></card></wml>";
-    let response = map_success_payload_response(
-        200,
-        false,
-        &base,
-        &base,
-        base.clone(),
-        "text/vnd.wap.wml".to_string(),
+    let response = map_success_payload_response(SuccessPayloadParams {
+        status: 200,
+        is_wap_scheme: false,
+        request_url: &base,
+        upstream_url: &base,
+        final_url: base.clone(),
+        content_type: "text/vnd.wap.wml".to_string(),
         body,
-        1,
-        3.5,
-        None,
-    );
+        attempt: 1,
+        elapsed_ms: 3.5,
+        request_id: None,
+    });
     assert!(response.ok);
     assert_eq!(response.status, 200);
     assert_eq!(response.content_type, "text/vnd.wap.wml");
@@ -128,18 +128,18 @@ fn transport_map_success_payload_http_success_builds_engine_deck_input() {
 fn transport_map_success_payload_rejects_oversized_body() {
     let base = "http://example.test/index.wml".to_string();
     let body = vec![b'a'; MAX_RESPONSE_BODY_BYTES + 1];
-    let response = map_success_payload_response(
-        200,
-        false,
-        &base,
-        &base,
-        base.clone(),
-        "text/vnd.wap.wml".to_string(),
-        body.as_slice(),
-        1,
-        3.5,
-        Some("req-oversized-body"),
-    );
+    let response = map_success_payload_response(SuccessPayloadParams {
+        status: 200,
+        is_wap_scheme: false,
+        request_url: &base,
+        upstream_url: &base,
+        final_url: base.clone(),
+        content_type: "text/vnd.wap.wml".to_string(),
+        body: body.as_slice(),
+        attempt: 1,
+        elapsed_ms: 3.5,
+        request_id: Some("req-oversized-body"),
+    });
 
     assert!(!response.ok);
     assert_eq!(response.status, 200);
@@ -159,18 +159,18 @@ fn transport_map_success_payload_rejects_oversized_body() {
 fn transport_map_success_payload_accepts_body_at_limit() {
     let base = "http://example.test/index.wml".to_string();
     let body = vec![b'a'; MAX_RESPONSE_BODY_BYTES];
-    let response = map_success_payload_response(
-        200,
-        false,
-        &base,
-        &base,
-        base.clone(),
-        "text/vnd.wap.wml".to_string(),
-        body.as_slice(),
-        1,
-        3.5,
-        Some("req-body-at-limit"),
-    );
+    let response = map_success_payload_response(SuccessPayloadParams {
+        status: 200,
+        is_wap_scheme: false,
+        request_url: &base,
+        upstream_url: &base,
+        final_url: base.clone(),
+        content_type: "text/vnd.wap.wml".to_string(),
+        body: body.as_slice(),
+        attempt: 1,
+        elapsed_ms: 3.5,
+        request_id: Some("req-body-at-limit"),
+    });
 
     assert!(response.ok, "body at hard limit should map successfully");
     assert_eq!(response.status, 200);
@@ -193,18 +193,18 @@ fn transport_map_success_payload_utf16le_textual_wml_maps_ok() {
         0xFF, 0xFE, b'<', 0x00, b'w', 0x00, b'm', 0x00, b'l', 0x00, b'>', 0x00, b'<', 0x00, b'/',
         0x00, b'w', 0x00, b'm', 0x00, b'l', 0x00, b'>', 0x00,
     ];
-    let response = map_success_payload_response(
-        200,
-        false,
-        &base,
-        &base,
-        base.clone(),
-        "text/vnd.wap.wml".to_string(),
-        &utf16le_body,
-        1,
-        3.5,
-        None,
-    );
+    let response = map_success_payload_response(SuccessPayloadParams {
+        status: 200,
+        is_wap_scheme: false,
+        request_url: &base,
+        upstream_url: &base,
+        final_url: base.clone(),
+        content_type: "text/vnd.wap.wml".to_string(),
+        body: &utf16le_body,
+        attempt: 1,
+        elapsed_ms: 3.5,
+        request_id: None,
+    });
     assert!(response.ok);
     assert_eq!(response.wml.as_deref(), Some("<wml></wml>"));
 }
@@ -213,18 +213,18 @@ fn transport_map_success_payload_utf16le_textual_wml_maps_ok() {
 fn transport_map_success_payload_utf16_odd_length_maps_protocol_error() {
     let base = "http://example.test/index.wml".to_string();
     let invalid_utf16_body: Vec<u8> = vec![0xFF, 0xFE, b'<', 0x00, b'w'];
-    let response = map_success_payload_response(
-        200,
-        false,
-        &base,
-        &base,
-        base.clone(),
-        "text/vnd.wap.wml".to_string(),
-        &invalid_utf16_body,
-        1,
-        3.5,
-        Some("req-utf16-invalid"),
-    );
+    let response = map_success_payload_response(SuccessPayloadParams {
+        status: 200,
+        is_wap_scheme: false,
+        request_url: &base,
+        upstream_url: &base,
+        final_url: base.clone(),
+        content_type: "text/vnd.wap.wml".to_string(),
+        body: &invalid_utf16_body,
+        attempt: 1,
+        elapsed_ms: 3.5,
+        request_id: Some("req-utf16-invalid"),
+    });
     assert!(!response.ok);
     assert_eq!(
         response.error.as_ref().map(|err| err.code.as_str()),
@@ -238,18 +238,18 @@ fn transport_map_success_payload_utf16_odd_length_maps_protocol_error() {
 
 #[test]
 fn transport_map_success_payload_http_error_maps_protocol_error() {
-    let response = map_success_payload_response(
-        502,
-        false,
-        "http://request.example",
-        "http://upstream.example",
-        "http://request.example".to_string(),
-        "text/plain".to_string(),
-        b"upstream fail",
-        2,
-        9.1,
-        Some("req-protocol"),
-    );
+    let response = map_success_payload_response(SuccessPayloadParams {
+        status: 502,
+        is_wap_scheme: false,
+        request_url: "http://request.example",
+        upstream_url: "http://upstream.example",
+        final_url: "http://request.example".to_string(),
+        content_type: "text/plain".to_string(),
+        body: b"upstream fail",
+        attempt: 2,
+        elapsed_ms: 9.1,
+        request_id: Some("req-protocol"),
+    });
     assert!(!response.ok);
     assert_eq!(response.status, 502);
     assert_eq!(
@@ -264,18 +264,18 @@ fn transport_map_success_payload_http_error_maps_protocol_error() {
 
 #[test]
 fn transport_map_success_payload_unsupported_content_type_maps_error() {
-    let response = map_success_payload_response(
-        200,
-        false,
-        "http://request.example",
-        "http://upstream.example",
-        "http://request.example".to_string(),
-        "application/json".to_string(),
-        br#"{"ok":true}"#,
-        1,
-        2.0,
-        Some("req-content"),
-    );
+    let response = map_success_payload_response(SuccessPayloadParams {
+        status: 200,
+        is_wap_scheme: false,
+        request_url: "http://request.example",
+        upstream_url: "http://upstream.example",
+        final_url: "http://request.example".to_string(),
+        content_type: "application/json".to_string(),
+        body: br#"{"ok":true}"#,
+        attempt: 1,
+        elapsed_ms: 2.0,
+        request_id: Some("req-content"),
+    });
     assert!(!response.ok);
     assert_eq!(
         response.error.as_ref().map(|err| err.code.as_str()),
@@ -294,18 +294,18 @@ fn transport_fixture_mapped_unsupported_content_type() {
     let expected: FixtureExpected =
         read_json_fixture("unsupported_content_type_mapped", "expected.json");
     let body = input.body_bytes();
-    let response = map_success_payload_response(
-        input.status,
-        input.is_wap_scheme,
-        &input.request_url,
-        &input.upstream_url,
-        input.final_url,
-        input.content_type,
-        &body,
-        input.attempt,
-        input.elapsed_ms,
-        None,
-    );
+    let response = map_success_payload_response(SuccessPayloadParams {
+        status: input.status,
+        is_wap_scheme: input.is_wap_scheme,
+        request_url: &input.request_url,
+        upstream_url: &input.upstream_url,
+        final_url: input.final_url,
+        content_type: input.content_type,
+        body: &body,
+        attempt: input.attempt,
+        elapsed_ms: input.elapsed_ms,
+        request_id: None,
+    });
     assert_eq!(response.ok, expected.ok);
     assert_eq!(response.status, expected.status);
     assert_eq!(response.final_url, expected.final_url);
@@ -321,18 +321,18 @@ fn transport_fixture_mapped_unsupported_content_type() {
 
 #[test]
 fn transport_map_success_payload_wmlc_decode_failure_maps_error() {
-    let response = map_success_payload_response(
-        200,
-        false,
-        "http://request.example",
-        "http://upstream.example",
-        "http://request.example".to_string(),
-        "application/vnd.wap.wmlc".to_string(),
-        b"\x03\x01\x6a\x00",
-        1,
-        2.0,
-        Some("req-wbxml"),
-    );
+    let response = map_success_payload_response(SuccessPayloadParams {
+        status: 200,
+        is_wap_scheme: false,
+        request_url: "http://request.example",
+        upstream_url: "http://upstream.example",
+        final_url: "http://request.example".to_string(),
+        content_type: "application/vnd.wap.wmlc".to_string(),
+        body: b"\x03\x01\x6a\x00",
+        attempt: 1,
+        elapsed_ms: 2.0,
+        request_id: Some("req-wbxml"),
+    });
     assert!(!response.ok);
     assert_eq!(
         response.error.as_ref().map(|err| err.code.as_str()),
@@ -347,18 +347,18 @@ fn transport_map_success_payload_wmlc_decode_failure_maps_error() {
 #[test]
 fn transport_map_success_payload_wmlc_decode_success_maps_ok() {
     let body = b"\x03\x0a\x6a\x00\x7f\x67\x60\x03hello\x00\x01\x01\x01";
-    let response = map_success_payload_response(
-        200,
-        false,
-        "http://request.example",
-        "http://upstream.example",
-        "http://request.example".to_string(),
-        "application/vnd.wap.wmlc".to_string(),
+    let response = map_success_payload_response(SuccessPayloadParams {
+        status: 200,
+        is_wap_scheme: false,
+        request_url: "http://request.example",
+        upstream_url: "http://upstream.example",
+        final_url: "http://request.example".to_string(),
+        content_type: "application/vnd.wap.wmlc".to_string(),
         body,
-        1,
-        2.0,
-        None,
-    );
+        attempt: 1,
+        elapsed_ms: 2.0,
+        request_id: None,
+    });
     assert!(response.ok);
     assert_eq!(response.status, 200);
     assert_eq!(
@@ -387,18 +387,18 @@ fn transport_map_success_payload_wmlc_decode_success_maps_ok() {
 
 #[test]
 fn transport_map_success_payload_wap_protocol_error_uses_original_url() {
-    let response = map_success_payload_response(
-        500,
-        true,
-        "wap://example.test/start.wml",
-        "http://gateway.local/start.wml",
-        "wap://example.test/start.wml".to_string(),
-        "text/plain".to_string(),
-        b"bad gateway",
-        1,
-        4.0,
-        None,
-    );
+    let response = map_success_payload_response(SuccessPayloadParams {
+        status: 500,
+        is_wap_scheme: true,
+        request_url: "wap://example.test/start.wml",
+        upstream_url: "http://gateway.local/start.wml",
+        final_url: "wap://example.test/start.wml".to_string(),
+        content_type: "text/plain".to_string(),
+        body: b"bad gateway",
+        attempt: 1,
+        elapsed_ms: 4.0,
+        request_id: None,
+    });
     assert!(!response.ok);
     assert_eq!(response.final_url, "wap://example.test/start.wml");
 }
@@ -408,18 +408,18 @@ fn transport_fixture_mapped_protocol_error_5xx() {
     let input: FixtureMapInput = read_json_fixture("protocol_error_5xx_mapped", "map_input.json");
     let expected: FixtureExpected = read_json_fixture("protocol_error_5xx_mapped", "expected.json");
     let body = input.body_bytes();
-    let response = map_success_payload_response(
-        input.status,
-        input.is_wap_scheme,
-        &input.request_url,
-        &input.upstream_url,
-        input.final_url,
-        input.content_type,
-        &body,
-        input.attempt,
-        input.elapsed_ms,
-        None,
-    );
+    let response = map_success_payload_response(SuccessPayloadParams {
+        status: input.status,
+        is_wap_scheme: input.is_wap_scheme,
+        request_url: &input.request_url,
+        upstream_url: &input.upstream_url,
+        final_url: input.final_url,
+        content_type: input.content_type,
+        body: &body,
+        attempt: input.attempt,
+        elapsed_ms: input.elapsed_ms,
+        request_id: None,
+    });
     assert_eq!(response.ok, expected.ok);
     assert_eq!(response.status, expected.status);
     assert_eq!(response.final_url, expected.final_url);
@@ -439,18 +439,18 @@ fn transport_fixture_mapped_utf16le_textual_wml_ok() {
     let expected: FixtureExpected =
         read_json_fixture("utf16le_textual_wml_mapped", "expected.json");
     let body = input.body_bytes();
-    let response = map_success_payload_response(
-        input.status,
-        input.is_wap_scheme,
-        &input.request_url,
-        &input.upstream_url,
-        input.final_url,
-        input.content_type,
-        &body,
-        input.attempt,
-        input.elapsed_ms,
-        None,
-    );
+    let response = map_success_payload_response(SuccessPayloadParams {
+        status: input.status,
+        is_wap_scheme: input.is_wap_scheme,
+        request_url: &input.request_url,
+        upstream_url: &input.upstream_url,
+        final_url: input.final_url,
+        content_type: input.content_type,
+        body: &body,
+        attempt: input.attempt,
+        elapsed_ms: input.elapsed_ms,
+        request_id: None,
+    });
     assert_eq!(response.ok, expected.ok);
     assert_eq!(response.status, expected.status);
     assert_eq!(response.final_url, expected.final_url);
@@ -471,18 +471,18 @@ fn transport_fixture_mapped_utf16_odd_length_protocol_error() {
     let expected: FixtureExpected =
         read_json_fixture("utf16_odd_length_protocol_error_mapped", "expected.json");
     let body = input.body_bytes();
-    let response = map_success_payload_response(
-        input.status,
-        input.is_wap_scheme,
-        &input.request_url,
-        &input.upstream_url,
-        input.final_url,
-        input.content_type,
-        &body,
-        input.attempt,
-        input.elapsed_ms,
-        None,
-    );
+    let response = map_success_payload_response(SuccessPayloadParams {
+        status: input.status,
+        is_wap_scheme: input.is_wap_scheme,
+        request_url: &input.request_url,
+        upstream_url: &input.upstream_url,
+        final_url: input.final_url,
+        content_type: input.content_type,
+        body: &body,
+        attempt: input.attempt,
+        elapsed_ms: input.elapsed_ms,
+        request_id: None,
+    });
     assert_eq!(response.ok, expected.ok);
     assert_eq!(response.status, expected.status);
     assert_eq!(response.final_url, expected.final_url);
@@ -618,8 +618,9 @@ fn transport_destination_policy_rejects_loopback_without_override() {
     let parsed = Url::parse("http://127.0.0.1:8080/deck.wml").expect("url should parse");
     let err = validate_fetch_destination(&parsed, &FetchDestinationPolicy::PublicOnly)
         .expect_err("loopback destination should be blocked");
-    assert!(err.contains("public-only"));
-    assert!(err.contains("loopback"));
+    assert!(err.is_policy_blocked());
+    assert!(err.to_string().contains("public-only"));
+    assert!(err.to_string().contains("loopback"));
 }
 
 #[test]
@@ -627,7 +628,8 @@ fn transport_destination_policy_rejects_private_without_override() {
     let parsed = Url::parse("http://10.0.0.8/deck.wml").expect("url should parse");
     let err = validate_fetch_destination(&parsed, &FetchDestinationPolicy::PublicOnly)
         .expect_err("private destination should be blocked");
-    assert!(err.contains("private"));
+    assert!(err.is_policy_blocked());
+    assert!(err.to_string().contains("private"));
 }
 
 #[test]
@@ -642,7 +644,11 @@ fn transport_destination_policy_rejects_unsupported_scheme() {
     let parsed = Url::parse("ftp://example.test/deck.wml").expect("url should parse");
     let err = validate_fetch_destination(&parsed, &FetchDestinationPolicy::PublicOnly)
         .expect_err("unsupported scheme should be rejected");
-    assert!(err.contains("Unsupported URL scheme"));
+    assert!(
+        !err.is_policy_blocked(),
+        "an unsupported scheme is a request-shape failure, not a policy block"
+    );
+    assert!(err.to_string().contains("Unsupported URL scheme"));
 }
 
 #[test]
@@ -650,7 +656,8 @@ fn transport_destination_policy_rejects_localhost_domains_without_override() {
     let parsed = Url::parse("http://api.localhost/deck.wml").expect("url should parse");
     let err = validate_fetch_destination(&parsed, &FetchDestinationPolicy::PublicOnly)
         .expect_err("localhost domain should be blocked");
-    assert!(err.contains("loopback"));
+    assert!(err.is_policy_blocked());
+    assert!(err.to_string().contains("loopback"));
 }
 
 #[test]
@@ -729,8 +736,9 @@ fn transport_destination_policy_rejects_private_resolved_addresses() {
         validate_resolved_destination_addresses(&addresses, &FetchDestinationPolicy::PublicOnly)
             .expect_err("mixed public and loopback answers must be rejected");
 
-    assert!(error.contains("public-only"));
-    assert!(error.contains("loopback"));
+    assert!(error.is_policy_blocked());
+    assert!(error.to_string().contains("public-only"));
+    assert!(error.to_string().contains("loopback"));
 }
 
 #[test]
@@ -791,8 +799,12 @@ fn transport_resolution_time_check_blocks_private_answer_that_shallow_preflight_
         &FetchDestinationPolicy::PublicOnly,
     )
     .expect_err("resolution-time layer must block the private resolved address");
-    assert!(error.contains("public-only"));
-    assert!(error.contains("private"));
+    assert!(
+        error.is_policy_blocked(),
+        "classification must be carried by the error type, not matched from its message"
+    );
+    assert!(error.to_string().contains("public-only"));
+    assert!(error.to_string().contains("private"));
 }
 
 #[test]
@@ -838,16 +850,16 @@ fn transport_invalid_request_response_helper() {
 
 #[test]
 fn transport_payload_too_large_response_with_known_actual_bytes() {
-    let response = payload_too_large_response(
-        200,
-        "http://example.test/deck.wml".to_string(),
-        "text/vnd.wap.wml".to_string(),
-        512 * 1024,
-        Some(700_000),
-        1,
-        5.0,
-        Some("req-too-large"),
-    );
+    let response = payload_too_large_response(PayloadTooLargeParams {
+        status: 200,
+        final_url: "http://example.test/deck.wml".to_string(),
+        content_type: "text/vnd.wap.wml".to_string(),
+        limit_bytes: 512 * 1024,
+        actual_bytes: Some(700_000),
+        attempt: 1,
+        elapsed_ms: 5.0,
+        request_id: Some("req-too-large"),
+    });
     assert!(!response.ok);
     assert_eq!(
         response.error.as_ref().map(|error| error.code.as_str()),
@@ -867,16 +879,16 @@ fn transport_payload_too_large_response_with_known_actual_bytes() {
 
 #[test]
 fn transport_payload_too_large_response_without_actual_bytes() {
-    let response = payload_too_large_response(
-        200,
-        "http://example.test/deck.wml".to_string(),
-        "text/vnd.wap.wml".to_string(),
-        512 * 1024,
-        None,
-        2,
-        9.0,
-        None,
-    );
+    let response = payload_too_large_response(PayloadTooLargeParams {
+        status: 200,
+        final_url: "http://example.test/deck.wml".to_string(),
+        content_type: "text/vnd.wap.wml".to_string(),
+        limit_bytes: 512 * 1024,
+        actual_bytes: None,
+        attempt: 2,
+        elapsed_ms: 9.0,
+        request_id: None,
+    });
     assert!(!response.ok);
     let message = response
         .error
@@ -906,48 +918,48 @@ fn transport_error_code_trigger_matrix_is_deterministic() {
         },
         Case {
             name: "payload-too-large",
-            response: payload_too_large_response(
-                200,
-                "http://example.test/deck.wml".to_string(),
-                "text/vnd.wap.wml".to_string(),
-                512 * 1024,
-                Some(700_000),
-                1,
-                1.0,
-                None,
-            ),
+            response: payload_too_large_response(PayloadTooLargeParams {
+                status: 200,
+                final_url: "http://example.test/deck.wml".to_string(),
+                content_type: "text/vnd.wap.wml".to_string(),
+                limit_bytes: 512 * 1024,
+                actual_bytes: Some(700_000),
+                attempt: 1,
+                elapsed_ms: 1.0,
+                request_id: None,
+            }),
             expected_code: "PAYLOAD_TOO_LARGE",
         },
         Case {
             name: "protocol-error-5xx",
-            response: map_success_payload_response(
-                502,
-                false,
-                "http://request.example",
-                "http://upstream.example",
-                "http://request.example".to_string(),
-                "text/plain".to_string(),
-                b"upstream fail",
-                1,
-                1.0,
-                None,
-            ),
+            response: map_success_payload_response(SuccessPayloadParams {
+                status: 502,
+                is_wap_scheme: false,
+                request_url: "http://request.example",
+                upstream_url: "http://upstream.example",
+                final_url: "http://request.example".to_string(),
+                content_type: "text/plain".to_string(),
+                body: b"upstream fail",
+                attempt: 1,
+                elapsed_ms: 1.0,
+                request_id: None,
+            }),
             expected_code: "PROTOCOL_ERROR",
         },
         Case {
             name: "unsupported-content-type",
-            response: map_success_payload_response(
-                200,
-                false,
-                "http://request.example",
-                "http://upstream.example",
-                "http://request.example".to_string(),
-                "application/json".to_string(),
-                br#"{"ok":true}"#,
-                1,
-                1.0,
-                None,
-            ),
+            response: map_success_payload_response(SuccessPayloadParams {
+                status: 200,
+                is_wap_scheme: false,
+                request_url: "http://request.example",
+                upstream_url: "http://upstream.example",
+                final_url: "http://request.example".to_string(),
+                content_type: "application/json".to_string(),
+                body: br#"{"ok":true}"#,
+                attempt: 1,
+                elapsed_ms: 1.0,
+                request_id: None,
+            }),
             expected_code: "UNSUPPORTED_CONTENT_TYPE",
         },
         Case {

--- a/transport-rust/src/tests/mod.rs
+++ b/transport-rust/src/tests/mod.rs
@@ -23,7 +23,8 @@ pub(super) use super::{
 };
 pub(super) use crate::fetch_policy::{
     apply_request_policy, classify_destination_host, classify_ip, resolve_fetch_destination_policy,
-    validate_fetch_destination, validate_resolved_destination_addresses, DestinationHostClass,
+    validate_fetch_destination, validate_resolved_destination_addresses, AppliedRequestPolicy,
+    DestinationHostClass,
 };
 pub(super) use crate::gateway::build_gateway_request;
 pub(super) use crate::request_meta::{
@@ -32,6 +33,7 @@ pub(super) use crate::request_meta::{
 pub(super) use crate::responses::{
     invalid_request_response, is_supported_wml_content_type, map_success_payload_response,
     map_terminal_send_error, normalize_content_type, payload_too_large_response,
+    PayloadTooLargeParams, SuccessPayloadParams,
 };
 pub(super) use crate::wbxml::decode_wmlc;
 pub(super) use base64::engine::general_purpose::STANDARD as BASE64;

--- a/transport-rust/src/tests/request_gateway_policy.rs
+++ b/transport-rust/src/tests/request_gateway_policy.rs
@@ -204,8 +204,13 @@ fn apply_request_policy_adds_no_cache_headers_and_referer() {
         ua_capability_profile: None,
     };
 
-    let (method, mapped_headers, suppressed, ua_profile) =
-        apply_request_policy("GET".to_string(), headers, Some(&policy));
+    let AppliedRequestPolicy {
+        method,
+        outbound_headers: mapped_headers,
+        suppressed_same_deck_post_context: suppressed,
+        applied_ua_capability_profile: ua_profile,
+        ..
+    } = apply_request_policy("GET".to_string(), headers, Some(&policy));
     assert_eq!(method, "GET");
     assert!(!suppressed);
     assert_eq!(ua_profile, FetchUaCapabilityProfile::Disabled);
@@ -240,8 +245,12 @@ fn apply_request_policy_keeps_same_deck_post_when_payload_present() {
         }),
         ua_capability_profile: None,
     };
-    let (method, _mapped_headers, suppressed, ua_profile) =
-        apply_request_policy("POST".to_string(), HashMap::new(), Some(&policy));
+    let AppliedRequestPolicy {
+        method,
+        suppressed_same_deck_post_context: suppressed,
+        applied_ua_capability_profile: ua_profile,
+        ..
+    } = apply_request_policy("POST".to_string(), HashMap::new(), Some(&policy));
     assert_eq!(method, "POST");
     assert!(!suppressed);
     assert_eq!(ua_profile, FetchUaCapabilityProfile::Disabled);
@@ -260,8 +269,12 @@ fn apply_request_policy_suppresses_same_deck_post_when_payload_missing() {
         }),
         ua_capability_profile: None,
     };
-    let (method, _mapped_headers, suppressed, ua_profile) =
-        apply_request_policy("POST".to_string(), HashMap::new(), Some(&policy));
+    let AppliedRequestPolicy {
+        method,
+        suppressed_same_deck_post_context: suppressed,
+        applied_ua_capability_profile: ua_profile,
+        ..
+    } = apply_request_policy("POST".to_string(), HashMap::new(), Some(&policy));
     assert_eq!(method, "GET");
     assert!(suppressed);
     assert_eq!(ua_profile, FetchUaCapabilityProfile::Disabled);
@@ -280,8 +293,13 @@ fn apply_request_policy_keeps_post_when_no_cache_is_set() {
         }),
         ua_capability_profile: None,
     };
-    let (method, mapped_headers, suppressed, ua_profile) =
-        apply_request_policy("POST".to_string(), HashMap::new(), Some(&policy));
+    let AppliedRequestPolicy {
+        method,
+        outbound_headers: mapped_headers,
+        suppressed_same_deck_post_context: suppressed,
+        applied_ua_capability_profile: ua_profile,
+        ..
+    } = apply_request_policy("POST".to_string(), HashMap::new(), Some(&policy));
     assert_eq!(method, "POST");
     assert!(!suppressed);
     assert_eq!(ua_profile, FetchUaCapabilityProfile::Disabled);
@@ -300,8 +318,13 @@ fn apply_request_policy_wap_baseline_profile_adds_capability_headers() {
         post_context: None,
         ua_capability_profile: Some(FetchUaCapabilityProfile::WapBaseline),
     };
-    let (method, mapped_headers, suppressed, ua_profile) =
-        apply_request_policy("GET".to_string(), HashMap::new(), Some(&policy));
+    let AppliedRequestPolicy {
+        method,
+        outbound_headers: mapped_headers,
+        suppressed_same_deck_post_context: suppressed,
+        applied_ua_capability_profile: ua_profile,
+        ..
+    } = apply_request_policy("GET".to_string(), HashMap::new(), Some(&policy));
     assert_eq!(method, "GET");
     assert!(!suppressed);
     assert_eq!(ua_profile, FetchUaCapabilityProfile::WapBaseline);
@@ -334,8 +357,10 @@ fn apply_request_policy_wap_baseline_profile_keeps_existing_capability_headers()
         post_context: None,
         ua_capability_profile: Some(FetchUaCapabilityProfile::WapBaseline),
     };
-    let (_method, mapped_headers, _suppressed, _ua_profile) =
-        apply_request_policy("GET".to_string(), headers, Some(&policy));
+    let AppliedRequestPolicy {
+        outbound_headers: mapped_headers,
+        ..
+    } = apply_request_policy("GET".to_string(), headers, Some(&policy));
     assert_eq!(
         mapped_headers.get("Accept-Language").map(String::as_str),
         Some("fr-ca")
@@ -351,8 +376,11 @@ fn apply_request_policy_disabled_profile_does_not_add_capability_headers() {
         post_context: None,
         ua_capability_profile: Some(FetchUaCapabilityProfile::Disabled),
     };
-    let (_method, mapped_headers, _suppressed, ua_profile) =
-        apply_request_policy("GET".to_string(), HashMap::new(), Some(&policy));
+    let AppliedRequestPolicy {
+        outbound_headers: mapped_headers,
+        applied_ua_capability_profile: ua_profile,
+        ..
+    } = apply_request_policy("GET".to_string(), HashMap::new(), Some(&policy));
     assert_eq!(ua_profile, FetchUaCapabilityProfile::Disabled);
     assert!(!mapped_headers.contains_key("Accept"));
     assert!(!mapped_headers.contains_key("Accept-Charset"));


### PR DESCRIPTION
## Summary

Maintainability audit across all four canonical layers (`transport-rust`, `engine-wasm`, `browser`, `gateway-kannel`/scripts), followed by fixing the two highest-debt layers and reworking the steering docs that let the debt accumulate.

**`transport-rust`** (7 approved findings fixed):
- Wired `network::wsp` header/assigned-number model into `native_fetch.rs`, retiring the hand-rolled connectionless codec (`M1-18`, explicit owner override of its prior "defer" decision). Found and fixed a real uintvar continuation-bit bug in the process — the old encoding would have mis-encoded any URI/header section ≥128 bytes.
- Typed `FetchDestinationError`/`Wsp*Error` replace string-prefix error matching.
- Param structs + shared `error_response()` helper replace `responses.rs` god-functions (`#[allow(clippy::too_many_arguments)]` removed crate-wide).
- Shared `FetchAttemptFailure` accumulator between HTTP/native retry loops (kept divergent logging untouched — unifying further would change observable transport events).
- `AppliedRequestPolicy` struct replaces an unlabeled 4-tuple; `DecodedWspText` type-enforces a previously-prose-only invariant.
- Opens `M1-22` for the remaining `Result<_, String>` surface.

**`engine-wasm`** (10 findings, all fixed):
- New `node_lookup.rs` collapses ~11 near-identical `Card`→`Paragraph`→`InlineNode` traversals into shared helpers.
- `NavRollbackGuard` (RAII) replaces 6 hand-rolled snapshot/restore blocks in navigation; added a missing rollback regression test in the process.
- Deleted ~640 lines of a test-only string-scanning WML parser duplicating the real XML-tree parser; all backing tests rewritten against the real parser, not dropped.
- Table-driven tag dispatch, shared TS base interface, shared opcode module, script-ref wrapper dedup, typed `FocusTarget` (string encoding kept only at the actual host-contract boundary), two hot-path `.expect()`s converted to `Result`.
- 244/244 tests passing, no wasm-exported signatures changed.

**Steering rework** (why this happened in the first place):
- New **Duplication Policy** (`docs/agents/AGENT_STANDARDS.md`) — 3 tiers: same-file/module (always in scope even under "small changes"), same-language-different-crate (shared internal crate if `transport-rust`/`engine-wasm` logic ever recurs), cross-language (Rust is source of truth, generate the TS artifact).
- New **Codegen & Supported-Tooling Policy** naming `M1-18` as the cautionary tale: prefer an existing supported implementation/generator over a hand-rolled parallel one.
- `M1-23` opened for the one remaining hand-copied cross-language taxonomy (`browser-presenter.ts`'s script error category labels).
- Closed a real CI gap surfaced along the way: `browser/frontend`'s vitest suite was never wired into CI at all (literal "future job" placeholder comment) and had no coverage threshold despite `coverage-v8` being installed. Added the CI job and thresholds (80%/78%, both below current 84.4%/81.9% actual).

## Test plan

- [x] `make lint-rust-transport` && `make test-rust-transport` — pass
- [x] `cd engine-wasm/engine && cargo fmt --check && cargo test` — 244/244 pass
- [x] `pnpm --dir browser/frontend run test:coverage` — 148/148 pass, coverage thresholds pass
- [x] Full pre-push hook suite (fmt/clippy/test for all 3 Rust crates, host-sample build) — pass
- [ ] CI (will run on this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
