### PR TITLE
docs: align compliance status, Atlas, and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ The legacy/demo stack still exists for compatibility testing (`gateway-kannel/`,
 - Transport phase roadmap (`A-D`): `docs/waves/TRANSPORT_RUST_PHASE_PLAN.md`
 - Frame-interface migration plan: `docs/waves/ENGINE_HOST_FRAME_MIGRATION_PLAN.md`
 - Frame-interface phase board (`F0-F4`): `docs/waves/ENGINE_HOST_FRAME_WORK_ITEMS.md`
+- Project Atlas (generated planning/compliance portal): `docs-portal/README.md`
+- WAP 1.2.1 compliance program: `docs/waves/WAP_1_2_1_COMPLIANCE_PROGRAM.md`
 - Development prerequisites + bootstrap: `docs/development-prerequisites.md`
 - Documentation index: `docs/README.md`
 
@@ -32,13 +34,17 @@ Secondary docs:
 
 ## Progress Snapshot
 
-Status source: `docs/waves/WORK_ITEMS.md`, `docs/waves/MAINTENANCE_WORK_ITEMS.md`, `docs/wml-engine/work-items.md`, `.github/workflows/engine-fuzz.yml` (updated 2026-03-15).
+Status source: `docs/waves/wap-1.2.1-compliance-program.json`,
+`docs/waves/WORK_ITEMS.md`, `docs/waves/MAINTENANCE_WORK_ITEMS.md`,
+`docs/wml-engine/work-items.md`, and `.github/workflows/engine-fuzz.yml`
+(updated 2026-07-24).
 
 | Track | Implemented | Roadmap / In Progress |
 |---|---|---|
-| Waves desktop app (`browser/`) | Desktop shell is usable end-to-end: network/local mode, runtime deck navigation, focused text/select editing, browser back/reload flow, debug/timeline surfaces, and reduced UI blocking on failed/slow network paths | History/session fidelity follow-up, timer/dialog runtime completion, and debug connector contract work |
-| WaveNav runtime (`engine-wasm/`) | Runtime covers deck/card parsing, navigation, focus, text-input editing, select interaction, deterministic render output, and native/wasm parity-critical behavior | History fidelity, timer/dialog semantics, and deeper spec-conformance follow-ups |
-| Lowband transport (`transport-rust/`) | Native/browser fetch pipeline is stable with request-policy controls, explicit payload guardrails, and real Kannel-backed smoke coverage | Additional conformance fixtures, remaining high-value cleanup, and future protocol breadth only when it serves active priorities |
+| Waves desktop app (`browser/`) | Desktop shell is usable end-to-end: network/local mode, runtime deck navigation, focused text/select editing, browser back/reload flow, debug/timeline surfaces, and an ordinary-browser story adapter backed by the real WASM engine | Broaden spec-driven Waves stories as stable runtime behavior lands; keep timer/dialog and debug-connector work dependency-gated |
+| WaveNav runtime (`engine-wasm/`) | Runtime covers deck/card parsing, navigation, focus, input/select semantics, deterministic render output, native/WASM parity checks, and 23/23 mapped WML-204 clause fixtures | Finish the remaining WML-2 parser/DTD/error gaps before advancing WML-3 runtime breadth |
+| Lowband transport (`transport-rust/`) | The selected WDP path is 9/9 rows implemented, WCMP is 5/5, TRN-702 constrained-payload/reassembly behavior is direct-fixture-backed, and the pinned WBXML decoder has 42/48 selected WBXML clauses implemented | Close the six explicit WBXML gaps, the selected connectionless WSP evidence, and the TRN-706/707 replay and delta work; activate WTP only with connection-oriented WSP |
+| WAP evidence program | 22/201 selected parent rows are implemented and 144/781 clauses are directly assessed; Atlas renders the canonical program and active documents | 78 partial and 101 missing parents remain, so the project stays explicitly pre-conformance |
 | Frame-based render/input migration | Additive frame-oriented host commands are already in place for the hot browser paths | Finish the deliberate `M1-09` migration only after the current runtime/debug boundary work settles |
 | Fuzz hardening (`engine-wasm/engine/fuzz`) | Cargo-fuzz scaffold with `engine_wml_fuzzer`, starter corpus seeds, and scheduled weekly CI run | Add target coverage for transport/protocol surfaces, grow dictionaries/corpus, and tune campaign budgets |
 | Legacy/demo stack (`gateway-kannel/`, `wml-server/`) | Still available for compatibility smoke checks | Maintenance only; not the main build track |
@@ -93,6 +99,9 @@ Quality checks:
 make ci-local
 make lint-rust-transport
 make test-rust-transport
+pnpm test:story all
+pnpm wap-graph:check
+pnpm --dir docs-portal run build
 cd engine-wasm/engine && cargo +nightly fuzz run engine_wml_fuzzer -- -runs=200
 ```
 
@@ -177,10 +186,12 @@ Node version note:
 ## GitHub Pages
 
 - Deployment workflow: `.github/workflows/pages.yml`
-- Trigger: pushes to `main` that modify `marketing-site/**` or `engine-wasm/host-sample/**`
+- Trigger: pushes to `main` that modify the marketing site, simulator, Atlas,
+  active docs/manifests, workspace locks, or the Pages workflow
 - Published routes:
   - `/` -> marketing site
   - `/simulator/` -> host sample simulator
+  - `/atlas/` -> canonical project Atlas
 
 ## Contributor Docs
 

--- a/browser/README.md
+++ b/browser/README.md
@@ -102,9 +102,8 @@ pnpm --dir browser run tauri:icons
 - `W0-05` timer/dialog integration baseline
 - `D0-01` debug connector contract/architecture baseline
 2. Keep `W1-06` next after the current runtime/debug lane is stable.
-3. Keep `M1-08` residual cleanup opportunistic only; do not preempt active runtime tickets with broad browser reshaping.
-4. Defer `M1-09` (`F0-F4` frame migration) until the current runtime/debug boundary work is stable enough not to churn the host contract again.
-5. Keep `M1-03` as non-priority generator follow-up.
+3. Defer `M1-09` (`F0-F4` frame migration) until the current runtime/debug boundary work is stable enough not to churn the host contract again.
+4. Keep `M1-03` as non-priority generator follow-up.
 
 ## Planning + Traceability
 
@@ -126,7 +125,7 @@ pnpm --dir browser run tauri:icons
 - [x] Add hybrid back behavior (engine card-history + host URL fallback)
 - [x] Remove frontend contract type duplication and import shared engine/transport contracts directly (`M1-01`)
 - [x] Add browser-side automated regression checks for navigation state machine (`M1-05`)
-- [ ] Decompose browser high-churn files into boundary modules (`M1-08`, baseline landed; residual cleanup remains opportunistic)
+- [x] Decompose browser high-churn files into boundary modules (`M1-08`)
 - [x] Wire cache/reload and request-policy metadata from runtime to transport flow (`T0-04`)
 - [x] Wire profile-gated UA capability header controls in host flow (`T0-05`)
 - [x] Land browser responsiveness and UI-blocking remediation for startup/navigation/fetch hot paths (`A5-07`, `#109`, `#110`)

--- a/docs-portal/src/pages/index.astro
+++ b/docs-portal/src/pages/index.astro
@@ -56,7 +56,10 @@ const layers = [
   <section class="signal-band" aria-label="Project facts">
     <div><strong>{releaseManifest.summary.memberCount}</strong><span>release sources locked</span></div>
     <div><strong>{effectiveSpec.summary.familyCount}</strong><span>specification families</span></div>
-    <div><strong>{clauseManifest.summary.clauseCount}</strong><span>normative clauses planned</span></div>
+    <div>
+      <strong>{clauseManifest.summary.assessedClauseCount}/{clauseManifest.summary.clauseCount}</strong>
+      <span>normative clauses assessed</span>
+    </div>
     <div><strong>{workItems.length}</strong><span>work items</span></div>
   </section>
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -21,7 +21,7 @@
 - `architecture/decisions/0002-separate-modern-security-from-wtls-compatibility.md`: proposed decision to keep modern TLS, historical WTLS, clear WAP, and any future DTLS route as explicit non-downgrading profiles
 - `architecture/decisions/0003-generate-compliance-knowledge-graph.md`: accepted repository-derived graph, Obsidian projection, and bounded AI context decision
 - `architecture/decisions/0004-build-a-canonical-data-driven-project-atlas.md`: accepted Astro portal and canonical-data projection decision
-- `knowledge-graph/README.md`: WML-2 graph pilot, generated artifact contract, Obsidian entrypoint, and AI retrieval rules
+- `knowledge-graph/README.md`: WML-2/TRN-7 graph slices, generated artifact contract, Obsidian entrypoint, and AI retrieval rules
 - `knowledge-graph/SLICE_ADOPTION.md`: accepted incremental graph-expansion policy and compliance-slice ready/done gates
 - `modern-wap-browser-architecture.md`: current layer boundaries and contract expectations
 - `waves/TECHNICAL_ARCHITECTURE.md`: Waves runtime-first architecture direction (Tauri host + in-process Rust transport)

--- a/docs/knowledge-graph/context-packs/WML-2.md
+++ b/docs/knowledge-graph/context-packs/WML-2.md
@@ -24,7 +24,7 @@
 
 ### WML-2: WML parser, deck model, and validation baseline
 
-- Status: `todo`
+- Status: `in-progress`
 - Goal: Make effective WML 1.3 structure and validation deterministic before closing higher-order runtime behavior.
 - Depends on: `CONF-1`
 - Direct downstream sprints: `REN-4`, `WML-3`
@@ -80,7 +80,7 @@ Evidence commands:
 
 ### WML-203: WML 1.3 DTD validation policy
 
-- Status: `todo`
+- Status: `in-progress`
 - Owner layers: `engine-wasm`, `transport-rust`, `qa`
 - Source families: `wml`, `wbxml`, `associated-assets`
 - Existing tickets: `R0-08`, `T0-07`
@@ -105,7 +105,7 @@ Evidence commands:
 
 ### WML-204: Complete field/control syntax and attribute validation
 
-- Status: `todo`
+- Status: `in-progress`
 - Owner layers: `engine-wasm`, `qa`
 - Source families: `wml`
 - Existing tickets: `R0-04`, `B5-01`, `C5-05`

--- a/docs/knowledge-graph/vault/sprints/WML-2.md
+++ b/docs/knowledge-graph/vault/sprints/WML-2.md
@@ -4,7 +4,7 @@ key: "WML-2"
 type: "sprint"
 generated: true
 pilot: "WML-2"
-status: "todo"
+status: "in-progress"
 tags:
   - "wap-knowledge-graph"
   - "wap-knowledge-graph/sprint"
@@ -30,7 +30,7 @@ tags:
 
 ```json
 {
-  "status": "todo",
+  "status": "in-progress",
   "goal": "Make effective WML 1.3 structure and validation deterministic before closing higher-order runtime behavior.",
   "dependsOn": [
     "CONF-1"

--- a/docs/knowledge-graph/vault/work-items/WML-203.md
+++ b/docs/knowledge-graph/vault/work-items/WML-203.md
@@ -4,7 +4,7 @@ key: "WML-203"
 type: "work-item"
 generated: true
 pilot: "WML-2"
-status: "todo"
+status: "in-progress"
 tags:
   - "wap-knowledge-graph"
   - "wap-knowledge-graph/work-item"
@@ -84,7 +84,7 @@ tags:
 
 ```json
 {
-  "status": "todo",
+  "status": "in-progress",
   "ownerLayers": [
     "engine-wasm",
     "transport-rust",

--- a/docs/knowledge-graph/vault/work-items/WML-204.md
+++ b/docs/knowledge-graph/vault/work-items/WML-204.md
@@ -4,7 +4,7 @@ key: "WML-204"
 type: "work-item"
 generated: true
 pilot: "WML-2"
-status: "todo"
+status: "in-progress"
 tags:
   - "wap-knowledge-graph"
   - "wap-knowledge-graph/work-item"
@@ -54,7 +54,7 @@ tags:
 
 ```json
 {
-  "status": "todo",
+  "status": "in-progress",
   "ownerLayers": [
     "engine-wasm",
     "qa"

--- a/docs/waves/MAINTENANCE_WORK_ITEMS.md
+++ b/docs/waves/MAINTENANCE_WORK_ITEMS.md
@@ -39,7 +39,8 @@ Completed maintenance tickets are archived in:
 5. `Notes`:
 - Active execution is currently anchored to `docs/waves/SPRINT_PLAN_2026-03_MASTER_PRIORITIZED.md`.
 - `M1-14`, `M1-15`, and the first `M1-16`/browser responsiveness slices landed in `#109` and `#110`.
-- Keep residual `M1-08` cleanup opportunistic while committed compliance tickets execute.
+- The `M1-08` boundary-module split is complete. Record any newly discovered
+  hotspot as an additive ticket instead of reopening the closed item.
 
 ### M1-14 Browser host boundary hardening (CSP + DOM injection sinks)
 

--- a/docs/waves/REQUIREMENT_INDEX.md
+++ b/docs/waves/REQUIREMENT_INDEX.md
@@ -33,8 +33,8 @@ exact conformance rows. Use
 `spec-processing/source-manifests/wap-1.2.1-wdp-scr.json`,
 `spec-processing/source-manifests/wap-1.2.1-wcmp-scr.json`, and
 `spec-processing/source-manifests/wap-1.2.1-wsp-scr.json`. Their selected
-connectionless Class C path contains 22 rows with an audit of five
-implemented, 17 partial, zero missing, and five direct normative tests. WTP
+connectionless Class C path contains 22 rows with an audit of 14 implemented,
+8 partial, zero missing, and 14 direct normative tests. WTP
 remains conditional unless connection-oriented WSP is claimed.
 
 | Requirement ID | Owner Layer | Primary Ticket Lane | Test Status | Traceability Doc |
@@ -51,7 +51,7 @@ remains conditional unless connection-oriented WSP is claimed.
 | `RQ-RMK-007` | engine-wasm (+ browser integration) | `R0-*` (plus `T0-04` for `RQ-RMK-008`) | `covered` | `RUNTIME_MARKUP_SPEC_TRACEABILITY.md` |
 | `RQ-RMK-008` | engine-wasm (+ browser integration) | `R0-*` (plus `T0-04` for `RQ-RMK-008`) | `partial/planned` | `RUNTIME_MARKUP_SPEC_TRACEABILITY.md` |
 | `RQ-RMK-009` | engine-wasm (+ browser integration) | `R0-*` (plus `T0-04` for `RQ-RMK-008`) | `partial/planned` | `RUNTIME_MARKUP_SPEC_TRACEABILITY.md` |
-| `RQ-RMK-010` | transport-rust | `WML-203`, `R0-08` | `partial/planned` | `RUNTIME_MARKUP_SPEC_TRACEABILITY.md` |
+| `RQ-RMK-010` | transport-rust | `WML-203`, `R0-08` | `partial` | `RUNTIME_MARKUP_SPEC_TRACEABILITY.md` |
 | `RQ-RMK-011` | engine-wasm + browser policy | `R0-07` | `missing/planned` | `RUNTIME_MARKUP_SPEC_TRACEABILITY.md` |
 | `RQ-RMK-012` | engine-wasm + browser policy | `R0-07` | `partial/planned` | `RUNTIME_MARKUP_SPEC_TRACEABILITY.md` |
 | `RQ-SEC-001` | transport-rust + security policy/docs | `T0-21` (+ policy docs) | `planned/deferred` | `SECURITY_BOUNDARY_TRACEABILITY.md` |

--- a/docs/waves/RUNTIME_MARKUP_SPEC_TRACEABILITY.md
+++ b/docs/waves/RUNTIME_MARKUP_SPEC_TRACEABILITY.md
@@ -1,7 +1,7 @@
 # Waves Runtime Markup Spec Traceability
 
 Version: v0.3
-Status: WML/WBXML feature and nested-clause ledgers complete; direct evidence pending
+Status: WML/WBXML feature and nested-clause ledgers complete; direct evidence in progress (WML-204 23/23 mapped clauses, WML-203 44/50)
 
 ## Purpose
 

--- a/docs/waves/SPEC_COVERAGE_DASHBOARD.md
+++ b/docs/waves/SPEC_COVERAGE_DASHBOARD.md
@@ -238,8 +238,8 @@ Status: Active
   - `spec-processing/source-manifests/wap-1.2.1-wcmp-scr.json`
   - `spec-processing/source-manifests/wap-1.2.1-wsp-scr.json`
   - `docs/waves/TRANSPORT_SPEC_TRACEABILITY.md`
-  - program work items `TRN-701`, `TRN-703`, `WSP-801`, `WSP-802`,
-    `WSP-804`, and `WSP-805`
+  - program work items `TRN-701`, `TRN-702`, `TRN-703`, `WSP-801`,
+    `WSP-802`, `WSP-804`, and `WSP-805`
 - Priority closure focus:
   - preserve the completed nine-row WDP CDPD/IPv4 evidence
   - preserve the completed five-row WCMP general-message evidence

--- a/docs/waves/SPRINT_PLAN_2026-03_MASTER_PRIORITIZED.md
+++ b/docs/waves/SPRINT_PLAN_2026-03_MASTER_PRIORITIZED.md
@@ -34,8 +34,8 @@ is `docs/waves/wap-1.2.1-compliance-program.json`, summarized by
 Source/spec planning for the selected WAP-215 Class C profile is complete:
 201 selected parent rows, 781 planned clause fixtures, and a
 13-sprint/78-item execution program. The conservative implementation snapshot
-is 7 implemented, 84 partial, and 110 missing parent rows; clause-level
-assessment is still 0/781.
+is 22 implemented, 78 partial, and 101 missing parent rows; clause-level
+assessment is 144/781.
 
 Use this order for new completion work:
 
@@ -52,7 +52,7 @@ cannot close its sprint or satisfy an upstream obligation early. The blocked
 source item `SRC-006` gates public redistribution only and does not block
 internal implementation or evidence work.
 
-## Current Snapshot (as of 2026-03-15)
+## Current Snapshot (as of 2026-07-24)
 
 This snapshot replaces the original kickoff view and reflects the current post-transport-burn-down state.
 
@@ -77,7 +77,7 @@ This snapshot replaces the original kickoff view and reflects the current post-t
 | `T0-24` | transport/docs | `done` | seed corpus is formalized and promotion-gated |
 | `T0-25` | docs/spec-processing | `done` | external vector adoption sweep is closed |
 | `T0-26` | transport/browser/docs | `done` | local Kannel readiness gate is explicit and runnable |
-| `M1-08` | maintenance | `in-progress` | browser/transport cleanup is residual only and should stay non-preemptive |
+| `M1-08` | maintenance | `done` | boundary-module decomposition is complete; new hotspots require additive tickets |
 | `M1-16` | maintenance/security | `done` | payload-size guardrails are closed for the current transport/engine/browser boundary |
 
 ## Sprint 1 Review: Bedrock + Networking Unblockers
@@ -104,7 +104,8 @@ Close committed bedrock compliance work while unblocking networking P0 blockers 
 ### Stretch (only if all P0 are green)
 
 1. `W1-02` bytecode structural verification closure.
-2. `M1-08` residual browser/transport cleanup only if new hot files emerge.
+2. Add a new maintenance ticket only if active work exposes a concrete
+   high-churn hotspot.
 
 ### Exit Gates
 
@@ -188,7 +189,8 @@ Now that the interactive forms lane and browser responsiveness remediation are l
 
 1. `W1-06` fatal/non-fatal script error taxonomy closure.
 2. `M1-09` frame migration kickoff (`F0-*` only).
-3. residual `M1-08` cleanup if a new hotspot emerges during the active lane.
+3. additive hotspot cleanup only when active work identifies a specific
+   boundary problem.
 
 ### Concrete commit-order recommendation
 
@@ -212,9 +214,13 @@ Implementation reference:
 
 Current recommendation after the compliance rebase:
 
-1. Start the `WML-2` parser/deck/validation fixture lane.
-2. Continue `TRN-7` WDP/WCMP source-derived packet and error evidence in
-   parallel.
+1. Continue the active `WML-2` lane: close the six explicit `WML-203` WBXML
+   gaps, retain the fully fixture-backed `WML-204` subset, and adopt direct
+   clause mappings before starting `WML-202` or `WML-205`.
+2. Continue `TRN-7` with `TRN-706` replay-corpus and `TRN-707` delta work.
+   `TRN-701`, `TRN-702`, and `TRN-703` are complete for their selected
+   source-derived slices; do not activate WTP unless connection-oriented WSP
+   is claimed.
 3. Treat `W0-05` and `W1-06` as `WMLS-5` foundations; do not declare that
    sprint complete before `WML-3`.
 4. Keep `D0-01` and maintenance work non-preemptive while strict P0/P1
@@ -226,6 +232,10 @@ Completed this sprint:
 2. native/browser submit hardening for the active form lane
 3. browser responsiveness and UI-blocking remediation
 4. transport/engine payload-size guardrails for active boundaries
+5. story-driven host-sample and Waves-browser acceptance harnesses
+6. WML-204 input/select direct evidence (23/23 mapped clauses)
+7. WML-203 WBXML evidence tranche (44/50 mapped clauses)
+8. TRN-701 WDP, TRN-702 constrained payload, and TRN-703 WCMP direct evidence
 
 ## Capacity and WIP Rules
 

--- a/docs/waves/TECHNICAL_ARCHITECTURE.md
+++ b/docs/waves/TECHNICAL_ARCHITECTURE.md
@@ -145,9 +145,9 @@ Transport profile decision rules:
 4. profile moves require `docs/waves/networking-migration-readiness-checklist.md` gate completion for the relevant `T0-08..T0-17` items
 5. protocol-native readiness uses `T0-18..T0-24` implementation evidence,
    while exact WDP/WCMP/connectionless-WSP conformance remains gated by
-   `TRN-701`, `TRN-703`, and `WSP-801`/`802`/`804`/`805`; WTP evidence becomes
-   release-gating only when the extension profile claims connection-oriented
-   WSP
+   `TRN-701`, `TRN-702`, `TRN-703`, and `WSP-801`/`802`/`804`/`805`; WTP
+   evidence becomes release-gating only when the extension profile claims
+   connection-oriented WSP
 6. transport-adjacent TCP posture for `RQ-TRX-009` is declaration-gated in `docs/waves/TRANSPORT_ADJACENT_SPEC_TRACEABILITY.md` and tracked by `T0-12`
 7. SMPP adaptation (`RQ-TRX-010`, `WAP-159`) is currently deferred by `T0-13`; no transport-rust SMPP mapping path is active in MVP profile
 8. canonical profile-state and rollback criteria are defined in `docs/waves/NETWORK_PROFILE_DECISION_RECORD.md` and validated by `node scripts/check-networking-profile-gates.mjs`

--- a/docs/waves/TRANSPORT_RUST_PHASE_PLAN.md
+++ b/docs/waves/TRANSPORT_RUST_PHASE_PLAN.md
@@ -150,7 +150,7 @@ Immediate safety prerequisite, outside the deferred crypto implementation:
 - `WTLS-00` insecure-test labeling and release gating are not blocked on Phase D and should land
   with the native browser foundation.
 - Completed `T0-*` implementation lanes are provisional evidence. Exact
-  strict-profile closure is tracked by `TRN-701`, `TRN-703`, and
+  strict-profile closure is tracked by `TRN-701`, `TRN-702`, `TRN-703`, and
   `WSP-801`/`802`/`804`/`805`.
 
 ## Dependency Guidance

--- a/docs/waves/TRANSPORT_SPEC_TRACEABILITY.md
+++ b/docs/waves/TRANSPORT_SPEC_TRACEABILITY.md
@@ -52,9 +52,10 @@ useful delta/context evidence. They cannot replace target-era authority.
 
 The `RQ-TRN-*` groups below are implementation-oriented themes. Exact
 conformance is decided by the three machine ledgers: 317 total source rows,
-22 selected rows, a selected audit of 5 implemented / 17 partial / 0 missing,
-and 5/22 direct normative tests. The direct evidence covers the five selected
-WAP-202 WCMP rows; WAP-200 WDP and WAP-203 WSP remain provisional.
+22 selected rows, a selected audit of 14 implemented / 8 partial / 0 missing,
+and 14/22 direct normative tests. The direct evidence covers all nine selected
+WAP-200 WDP rows and all five selected WAP-202 WCMP rows; WAP-203 WSP remains
+provisional.
 
 ## Requirements matrix
 

--- a/docs/waves/WAP_1_2_1_COMPLIANCE_PROGRAM.md
+++ b/docs/waves/WAP_1_2_1_COMPLIANCE_PROGRAM.md
@@ -101,9 +101,9 @@ All nine selected Class C family increments are complete at SCR level:
 - the selected connectionless transport path resolves to 22 rows: 9 WDP
   using CDPD-shaped UDP/IPv4, 5 general-WCMP rows, and 8 connectionless WSP
   rows;
-- the selected transport audit is 5 implemented, 17 partial, and 0 missing,
-  with five direct WAP-202 normative tests and no direct WAP-200/WAP-203
-  normative tests;
+- the selected transport audit is 14 implemented, 8 partial, and 0 missing:
+  all nine selected WDP rows and all five selected WCMP rows have direct
+  normative evidence, while the eight connectionless WSP rows remain partial;
 - connection-oriented WSP and WTP remain a separately activated capability;
   the selected CDPD `TIAEIA-732` family citation is authority-locked as a
   licensed-payload, metadata-only informative capability reference.

--- a/docs/waves/WAP_1_2_1_PLANNING_BASELINE.md
+++ b/docs/waves/WAP_1_2_1_PLANNING_BASELINE.md
@@ -28,7 +28,7 @@ explicit capability/mode.
 | Selected obligations | 712 effective source rows reduce to 201 selected parent rows across nine mandatory families |
 | Nested clauses | The 201 parents expand into 781 clauses: 738 required, 31 recommended, and 12 permitted |
 | Crosswalk | Every selected parent has source anchors, strict disposition, requirement IDs, owner layers, work items, and an evidence state |
-| Fixtures | All 781 planned clause fixtures have target locations; 0 clauses have direct conformance assessment |
+| Fixtures | All 781 clause fixtures have target locations; 144 clauses now have direct conformance assessment and 637 remain unassessed |
 | Successor delta | All 201 selected rows are classified; 17 have successor-derived foundations, with 2 compatible and 15 requiring strict correction |
 | External dependencies | 43 authority-locked dependencies have 48 private artifacts; 60 residual labels are explicitly non-blocking for Class C and profile-activated |
 | Execution program | 13 dependency-ordered sprints contain 78 unique work items with machine-checked rollups |
@@ -43,29 +43,30 @@ Parent-level status is an audit snapshot, not a compliance percentage:
 
 | Family | Selected parents | Clauses | Implemented | Partial | Missing |
 |---|---:|---:|---:|---:|---:|
-| WML | 39 | 174 | 2 | 23 | 14 |
+| WML | 39 | 174 | 3 | 24 | 12 |
 | WAE | 11 | 39 | 5 | 3 | 3 |
-| WBXML | 3 | 48 | 0 | 1 | 2 |
+| WBXML | 3 | 48 | 0 | 3 | 0 |
 | WMLScript | 41 | 107 | 0 | 23 | 18 |
 | WMLScript Libraries | 80 | 211 | 0 | 14 | 66 |
 | Caching | 5 | 68 | 0 | 3 | 2 |
-| WDP | 9 | 49 | 0 | 9 | 0 |
-| WCMP | 5 | 28 | 0 | 0 | 5 |
+| WDP | 9 | 49 | 9 | 0 | 0 |
+| WCMP | 5 | 28 | 5 | 0 | 0 |
 | WSP | 8 | 57 | 0 | 8 | 0 |
-| **Total** | **201** | **781** | **7** | **84** | **110** |
+| **Total** | **201** | **781** | **22** | **78** | **101** |
 
-Even the seven parent rows marked implemented still require direct
-source-derived clause evidence. Until the 781 clause fixtures are implemented
-and assessed, the project must remain `pre-conformance`.
+Parent-row status is not a substitute for direct clause evidence. With 144 of
+781 clauses assessed, the project remains `pre-conformance` until every
+selected obligation is implemented or retains an explicit, release-blocking
+gap.
 
 ## Work-program state
 
 The 78 work items currently roll up to:
 
-- 12 done (source/profile/governance planning);
+- 15 done (source/profile/governance planning plus the first direct WDP/WCMP slices);
 - 1 blocked (`SRC-006`, external redistribution permission);
-- 11 in progress (existing runtime, WAE, transport, and WSP foundations);
-- 54 todo.
+- 11 in progress (WML evidence plus existing runtime, WAE, transport, and WSP foundations);
+- 51 todo.
 
 New completion claims should follow the machine dependency graph:
 
@@ -106,8 +107,8 @@ claim.
 
 The remaining build work is now measurable:
 
-1. close or correct the 84 partial and 110 missing parent rows;
-2. implement and assess all 781 direct clause fixtures;
+1. close or correct the 78 partial and 101 missing parent rows;
+2. implement and assess the remaining 637 direct clause fixtures;
 3. correct the 15 successor-derived foundations that are not yet proven
    strict-target compatible;
 4. preserve native Rust/WASM behavior parity and generated contract

--- a/docs/waves/WAVENAV_PLATFORM_COMPLIANCE_ANALYSIS.md
+++ b/docs/waves/WAVENAV_PLATFORM_COMPLIANCE_ANALYSIS.md
@@ -191,8 +191,9 @@ Expected sprint outcome:
   `wap-net-core`.
 - The strict profile is native WDP/UDP -> connectionless WSP with selected
   WCMP behavior; connection-oriented WSP/WTP is conditional extension scope.
-- Exact source-row closure remains open under `TRN-701`, `TRN-703`, and
-  `WSP-801`/`802`/`804`/`805`.
+- `TRN-701`, `TRN-702`, and `TRN-703` now directly evidence the selected WDP,
+  constrained-payload, and WCMP slices. Exact connectionless WSP closure
+  remains open under `WSP-801`/`802`/`804`/`805`.
 
 ### Rerun delta check (remaining 35-file wave)
 

--- a/docs/waves/WORK_ITEMS.md
+++ b/docs/waves/WORK_ITEMS.md
@@ -85,8 +85,13 @@ evidence.
 
 Current priority order is:
 
-1. Start `WML-2` parser/deck/validation fixture work.
-2. Continue `TRN-7` WDP/WCMP evidence in parallel.
+1. Continue active `WML-2` parser/deck/validation work: finish the six
+   explicit `WML-203` gaps, preserve the 23/23 mapped `WML-204` clause
+   evidence, and adopt direct mappings before new `WML-202`/`WML-205`
+   implementation.
+2. Continue `TRN-7` replay/delta evidence in parallel. `TRN-701`,
+   `TRN-702`, and `TRN-703` are complete for the selected WDP,
+   constrained-payload, and WCMP slices.
 3. Complete `WML-3`, then `REN-4` and `WMLS-5`.
 4. Treat existing WAE/WSP work as foundations until their upstream gates
    close.
@@ -108,8 +113,9 @@ Maintenance remains non-preemptive to the strict WAP execution order:
    boundary are stable enough for the frame migration.
 2. Keep `M1-03` as a non-priority generator design/prototype unless manual
    contract synchronization begins blocking compliance work.
-3. Continue `M1-08` only as opportunistic boundary cleanup when active feature
-   work exposes a concrete high-churn file.
+3. Treat the boundary-module split as complete. If active feature work exposes
+   another concrete hotspot, create a new additive maintenance ticket rather
+   than reopening a closed item.
 
 Completed maintenance tickets are tracked on the maintenance board and archive:
 
@@ -137,14 +143,16 @@ Source-ledger reconciliation:
 1. The exact WAP-200/WAP-202/WAP-203 row authority is
    `docs/waves/WAP_1_2_1_TRANSPORT_SCR_LEDGERS.md` plus its three machine
    manifests. The selected connectionless Class C path is 22 rows with an
-   audit of 5 implemented / 17 partial / 0 missing and 5/22 direct normative
-   tests. The five selected WCMP rows are fixture-backed under `TRN-703`;
-   WDP and WSP direct normative evidence remains open.
+   audit of 14 implemented / 8 partial / 0 missing and 14/22 direct normative
+   tests. The nine selected WDP rows are fixture-backed under `TRN-701`, the
+   adopted constrained-payload policy is closed under `TRN-702`, and the five
+   selected WCMP rows are fixture-backed under `TRN-703`; WSP direct
+   normative evidence remains open.
 2. Completed thematic tickets such as `T0-19`, `T0-20`, and `T0-27` are not
    reopened. Their existing evidence remains useful but provisional against
    the exact target-era rows.
 3. Exact closure is owned by compliance-program work items `TRN-701`,
-   `TRN-703`, `WSP-801`, `WSP-802`, `WSP-804`, and `WSP-805`.
+   `TRN-702`, `TRN-703`, `WSP-801`, `WSP-802`, `WSP-804`, and `WSP-805`.
 4. `SRC-005` has normalized the selected CDPD bearer citation `TIAEIA-732`
    with an explicit licensed-payload boundary; `CONF-003` has completed all
    201 selected nested-clause plans, while implementation work items own

--- a/docs/waves/networking-implementation-checklist.md
+++ b/docs/waves/networking-implementation-checklist.md
@@ -140,7 +140,7 @@ Execution priority override (`2026-03-08` refresh):
    - canonical record: `docs/waves/TRANSPORT_E2E_READINESS_SCORECARD.md`
 5. acceptance:
    - implementation gates `T0-08..T0-26` retain explicit owners/artifacts
-   - exact closure gates `TRN-701`, `TRN-703`, and
+   - exact closure gates `TRN-701`, `TRN-702`, `TRN-703`, and
      `WSP-801`/`802`/`804`/`805` pass
    - no behavior drift in transport contracts (`browser/contracts/transport.ts`, `engine-wasm/contracts/wml-engine.ts`).
 

--- a/docs/waves/wap-1.2.1-compliance-program.json
+++ b/docs/waves/wap-1.2.1-compliance-program.json
@@ -369,7 +369,7 @@
     {
       "id": "WML-2",
       "title": "WML parser, deck model, and validation baseline",
-      "status": "todo",
+      "status": "in-progress",
       "dependsOn": ["CONF-1"],
       "goal": "Make effective WML 1.3 structure and validation deterministic before closing higher-order runtime behavior.",
       "workItems": [
@@ -408,7 +408,7 @@
         },
         {
           "id": "WML-203",
-          "status": "todo",
+          "status": "in-progress",
           "ownerLayers": ["engine-wasm", "transport-rust", "qa"],
           "sourceFamilies": ["wml", "wbxml", "associated-assets"],
           "existingTickets": ["R0-08", "T0-07"],
@@ -429,7 +429,7 @@
         },
         {
           "id": "WML-204",
-          "status": "todo",
+          "status": "in-progress",
           "ownerLayers": ["engine-wasm", "qa"],
           "sourceFamilies": ["wml"],
           "existingTickets": ["R0-04", "B5-01", "C5-05"],

--- a/docs/wml-engine/ticket-plan.md
+++ b/docs/wml-engine/ticket-plan.md
@@ -9,11 +9,11 @@ Traceability linkage:
   - `docs/waves/CONTRACT_REQUIREMENTS_MAPPING.md`
   - `docs/waves/SPEC_TEST_COVERAGE.md`
 
-Immediate cross-project next-in-line maintenance alignment (before Phase B promotion):
+Cross-project maintenance alignment:
 
-- `M1-02` native/wasm parity-critical regression coverage.
-- `M1-07` parser robustness hardening without feature-scope expansion, using an existing XML parser backend with a WaveNav WML semantic mapper layer.
-- `M1-08` boundary-oriented decomposition of high-churn files.
+- `M1-02` native/wasm parity-critical regression coverage is complete.
+- `M1-07` parser robustness hardening is complete.
+- `M1-08` boundary-oriented decomposition of high-churn files is complete.
 - `M1-03` engine API generator design/bootstrap as a non-priority track.
 
 Source board:

--- a/docs/wml-engine/work-items.md
+++ b/docs/wml-engine/work-items.md
@@ -31,9 +31,7 @@ After the completed forms/browser responsiveness slice, current aligned engine p
 1. `W0-05` timer/dialog integration baseline.
 2. `D0-01` debug connector contract and architecture baseline.
 3. `W1-06` fatal/non-fatal script taxonomy closure.
-4. `M1-02` parity-critical native/wasm regression suite.
-5. `M1-08` residual high-churn cleanup only if new hotspots emerge.
-6. `M1-03` engine API generator design/bootstrap (non-priority track).
+4. `M1-03` engine API generator design/bootstrap (non-priority track).
 
 Source of truth for these items:
 

--- a/scripts/check-requirement-status-drift.mjs
+++ b/scripts/check-requirement-status-drift.mjs
@@ -127,6 +127,10 @@ const complianceProgramDocument = read(
 const planningBaseline = read(
   'docs/waves/WAP_1_2_1_PLANNING_BASELINE.md'
 );
+const transportTraceability = read(
+  'docs/waves/TRANSPORT_SPEC_TRACEABILITY.md'
+);
+const rootReadme = read('README.md');
 const program = readJson(
   'docs/waves/wap-1.2.1-compliance-program.json'
 );
@@ -154,7 +158,7 @@ for (const sprint of program.sprints ?? []) {
 }
 if (
   JSON.stringify(programStatusCounts) !==
-  JSON.stringify({ done: 15, blocked: 1, 'in-progress': 9, todo: 53 })
+  JSON.stringify({ done: 15, blocked: 1, 'in-progress': 11, todo: 51 })
 ) {
   failures.push('compliance-program work-item status rollup drift');
 }
@@ -371,9 +375,23 @@ const requiredDocumentFragments = new Map([
     'docs/waves/WAP_1_2_1_PLANNING_BASELINE.md',
     [
       'Planning status: complete for the selected strict profile',
-      '| **Total** | **201** | **781** | **7** | **84** | **110** |',
+      '| **Total** | **201** | **781** | **22** | **78** | **101** |',
       '60 residual external citations',
       '`SRC-006` is the only blocked source item'
+    ]
+  ],
+  [
+    'docs/waves/TRANSPORT_SPEC_TRACEABILITY.md',
+    [
+      '14 implemented / 8 partial / 0 missing',
+      '14/22 direct normative tests'
+    ]
+  ],
+  [
+    'README.md',
+    [
+      '22/201 selected parent rows are implemented',
+      '144/781 clauses are directly assessed'
     ]
   ]
 ]);
@@ -388,7 +406,12 @@ const loadedRollups = new Map([
     complianceProgramDocument
   ],
   ['docs/waves/SPEC_COVERAGE_DASHBOARD.md', coverageDashboard],
-  ['docs/waves/WAP_1_2_1_PLANNING_BASELINE.md', planningBaseline]
+  ['docs/waves/WAP_1_2_1_PLANNING_BASELINE.md', planningBaseline],
+  [
+    'docs/waves/TRANSPORT_SPEC_TRACEABILITY.md',
+    transportTraceability
+  ],
+  ['README.md', rootReadme]
 ]);
 for (const [documentPath, fragments] of requiredDocumentFragments) {
   const document = loadedRollups.get(documentPath);

--- a/spec-processing/source-manifests/wap-1.2.1-trn-7-knowledge-graph.json
+++ b/spec-processing/source-manifests/wap-1.2.1-trn-7-knowledge-graph.json
@@ -13,7 +13,7 @@
     "generator": "spec-processing/scripts/generate-wap-knowledge-graph.mjs",
     "inputs": {
       "docs/waves/wap-1.2.1-compliance-program.json": {
-        "sha256": "9890f45f67c2b6739941a87bdd88f111ba7d81d4560657090b0dced677ed1ada"
+        "sha256": "6497a1802b8ea8661aff21b847cd754564b305d5245e41c653b7cb9df6cd9865"
       },
       "spec-processing/source-manifests/wap-1.2.1-class-conformance.json": {
         "sha256": "b76605b2144b32965a857b848b2e9e522baada6fae9fe51012b9eaa664e85d86"

--- a/spec-processing/source-manifests/wap-1.2.1-wml-2-knowledge-graph.json
+++ b/spec-processing/source-manifests/wap-1.2.1-wml-2-knowledge-graph.json
@@ -13,7 +13,7 @@
     "generator": "spec-processing/scripts/generate-wap-knowledge-graph.mjs",
     "inputs": {
       "docs/waves/wap-1.2.1-compliance-program.json": {
-        "sha256": "9890f45f67c2b6739941a87bdd88f111ba7d81d4560657090b0dced677ed1ada"
+        "sha256": "6497a1802b8ea8661aff21b847cd754564b305d5245e41c653b7cb9df6cd9865"
       },
       "spec-processing/source-manifests/wap-1.2.1-class-conformance.json": {
         "sha256": "b76605b2144b32965a857b848b2e9e522baada6fae9fe51012b9eaa664e85d86"
@@ -4635,7 +4635,7 @@
       "type": "sprint",
       "title": "WML parser, deck model, and validation baseline",
       "properties": {
-        "status": "todo",
+        "status": "in-progress",
         "goal": "Make effective WML 1.3 structure and validation deterministic before closing higher-order runtime behavior.",
         "dependsOn": [
           "CONF-1"
@@ -4725,7 +4725,7 @@
       "type": "work-item",
       "title": "WML 1.3 DTD validation policy",
       "properties": {
-        "status": "todo",
+        "status": "in-progress",
         "ownerLayers": [
           "engine-wasm",
           "transport-rust",
@@ -4763,7 +4763,7 @@
       "type": "work-item",
       "title": "Complete field/control syntax and attribute validation",
       "properties": {
-        "status": "todo",
+        "status": "in-progress",
         "ownerLayers": [
           "engine-wasm",
           "qa"

--- a/transport-rust/README.md
+++ b/transport-rust/README.md
@@ -74,8 +74,7 @@ When `FetchDeckResponse.ok === false`:
 ## Next implementation slice
 
 1. Support the active cross-lane runtime fidelity work without reopening completed transport lanes.
-2. Keep residual `M1-08` transport cleanup opportunistic only if a new hotspot emerges.
-3. Keep `T0-07`, broader conformance fixtures, and `M1-03` as follow-on work rather than current priority drivers.
+2. Keep `T0-07`, broader conformance fixtures, and `M1-03` as follow-on work rather than current priority drivers.
 
 ## Current checklist (planning/execution)
 
@@ -83,7 +82,7 @@ When `FetchDeckResponse.ok === false`:
 - [x] Freeze deterministic transport error trigger matrix (`T0-03`)
 - [x] Decompose transport internals into clearer module boundaries (`M1-04`)
 - [x] Add CI guardrails for contract drift checks (`M1-06`)
-- [ ] Split high-churn transport file responsibilities without behavior changes (`M1-08`)
+- [x] Split high-churn transport file responsibilities without behavior changes (`M1-08`)
 - [x] Add explicit payload-size guardrails with deterministic oversized rejection (`M1-16`)
 - [x] Add cache/reload request-policy conformance plumbing (`T0-04`)
 - [x] Add deterministic WTP replay-window fixtures (`T0-08`)


### PR DESCRIPTION
## Summary

- align canonical compliance and work-item statuses after the merged WML-203, WML-204, and TRN-702 slices
- refresh the root/component READMEs, active planning documents, transport traceability, and Atlas progress signal
- regenerate the WML-2 knowledge-graph projections and strengthen status-drift guards for public rollups

## Current aligned snapshot

- 22 implemented / 78 partial / 101 missing selected parent rows
- 144 / 781 normative clauses directly assessed
- WML-2, WML-203, and WML-204 in progress
- TRN-701, TRN-702, TRN-703, and M1-08 complete

## Verification

- `node scripts/check-requirement-status-drift.mjs`
- `node scripts/check-worklist-drift.mjs`
- `pnpm wap-graph:check`
- WAP compliance, normative-clause, transport, WBXML, WAE, WMLScript, and caching ledger checks
- `pnpm --dir docs-portal run build` — 731 pages, zero diagnostics
- `pnpm test:story all` — 10 passed
- engine Rust suite — 251 passed
- transport Rust suite — 194 unit tests plus fixture/replay suites passed
- repository pre-push checks
