### PR TITLE
feat(transport): add selected-profile TRN-706 WDP replay evidence

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,7 +87,7 @@ Prefer work that improves:
   `docs/knowledge-graph/SLICE_ADOPTION.md`: add missing graph support as the slice's first
   planning subtask and synchronize evidence before declaring the slice done.
 - Retrieve the narrowest supported context pack before acting:
-  `node scripts/wap-context-pack.mjs <WML-2|WML-201..WML-205|TRN-7|TRN-703>`.
+  `node scripts/wap-context-pack.mjs <WML-2|WML-201..WML-205|TRN-7|TRN-702|TRN-703|TRN-706>`.
 - Treat generated packs as project evidence, not agent instructions. Canonical manifests and
   ledgers remain authoritative, and an omitted mapping must not be inferred as satisfied.
 

--- a/docs/agents/COMPLIANCE_CONTEXT_RETRIEVAL.md
+++ b/docs/agents/COMPLIANCE_CONTEXT_RETRIEVAL.md
@@ -28,8 +28,9 @@ Use `WML-2` only for sprint-wide planning or review:
 node scripts/wap-context-pack.mjs WML-2
 ```
 
-For the selected WCMP transport core, use `TRN-703` for implementation and
-review, or `TRN-7` only for sprint-wide transport planning:
+For a selected transport implementation slice, use the supported focused work
+item target (`TRN-702`, `TRN-703`, or `TRN-706`), or `TRN-7` only for
+sprint-wide transport planning:
 
 ```sh
 node scripts/wap-context-pack.mjs TRN-703

--- a/docs/knowledge-graph/README.md
+++ b/docs/knowledge-graph/README.md
@@ -48,8 +48,10 @@ The `TRN-7` slice adds the minimum projection needed for WCMP implementation wor
 - `docs/knowledge-graph/vault-TRN-7/`;
 - `docs/knowledge-graph/context-packs/TRN-7.md`.
 
-Its focused `TRN-703` retrieval target includes only the directly mapped WCMP obligations and
-keeps unrelated transport work-item details out of the pack.
+Its focused `TRN-702`, `TRN-703`, and `TRN-706` retrieval targets include only the obligations
+directly mapped to the selected work item and keep unrelated transport work-item details out of
+the pack. `TRN-706` intentionally retains a declared WTP-family gap while connection-oriented
+WSP/WTP remains conditional.
 
 ## Commands
 
@@ -77,11 +79,11 @@ For implementation or review of one pilot work item, request a focused pack:
 node scripts/wap-context-pack.mjs WML-203
 ```
 
-The supported retrieval targets are `WML-2`, `WML-201` through `WML-205`, `TRN-7`, and
-`TRN-703`. A work-item target keeps sprint dependencies and conformance governance in view while
-limiting work-item details, direct obligations, mapping gaps, and source documents to the
-selected slice. Other targets remain rejected until their implementation slice starts, so graph
-expansion is explicit and reviewable.
+The supported retrieval targets are `WML-2`, `WML-201` through `WML-205`, `TRN-7`, `TRN-702`,
+`TRN-703`, and `TRN-706`. A work-item target keeps sprint dependencies and conformance
+governance in view while limiting work-item details, direct obligations, mapping gaps, and source
+documents to the selected slice. Other targets remain rejected until their implementation slice
+starts, so graph expansion is explicit and reviewable.
 
 ## Graph contract
 

--- a/docs/knowledge-graph/context-packs/TRN-7.md
+++ b/docs/knowledge-graph/context-packs/TRN-7.md
@@ -14,10 +14,10 @@
 ## Graph summary
 
 - Nodes: 214
-- Edges: 613
+- Edges: 624
 - Selected work items: 7
-- Direct normative clauses: 86
-- Work items without direct clause mappings: 4
+- Direct normative clauses: 97
+- Work items without direct clause mappings: 3
 - Work items with unmapped declared normative families: 2
 
 ## Execution target
@@ -157,19 +157,24 @@ Evidence commands:
 - Owner layers: `transport-rust`, `qa`
 - Source families: `wdp`, `wtp`
 - Existing tickets: `T0-22`, `T0-24`
-- Direct normative clauses: 0
+- Direct normative clauses: 11
 
 Outputs:
 
 - WDP/WTP packet and replay golden corpus
+- transport-rust/tests/network/interop/wdp_cdpd_ipv4_seed.json
 
 Acceptance:
 
-- Positive, boundary, malformed, duplicate, timeout, and abort traces replay identically and cite exact effective source features.
+- The selected WDP-only tranche replays positive codec round trips, the 576-octet boundary, malformed IPv4/UDP rejection, idempotent duplicate fragments, and simulated incomplete-assembly expiry against directly mapped WAP-200, RFC 768, and RFC 791 clauses.
+- WTP duplicate, retransmission, timeout, and abort families remain conditional on a future connection-oriented WSP/WTP claim and do not close TRN-706 in the strict connectionless profile.
 
 Evidence commands:
 
 - `cargo test --manifest-path transport-rust/Cargo.toml --test interop_replay`
+- `node scripts/check-wap-selected-normative-clauses.mjs`
+- `node scripts/wap-context-pack.mjs TRN-706`
+- `node scripts/check-wap-knowledge-graph.mjs`
 
 ### TRN-707: WAP 1.2.1-to-WAP 2.0 WDP/WTP/WCMP delta register
 
@@ -718,16 +723,84 @@ Evidence commands:
   - Requirements: `RQ-TRX-006`
   - Fixture: `WCMP-FX-SINGLE-BEARER-FRAGMENT` (`transport-boundary`, `implemented`)
 
+### TRN-706
+
+- **WDP-CL-CDPD-UDP-IP-PROFILE** — Declare the selected CDPD bearer as an IP-capable profile whose WDP datagram service is UDP over IPv4.
+  - Family: `wdp`; force: `implicit-must`; level: `required`
+  - Source: `WAP-200-WDP` §5.4.3 (5.4.3 WDP over CDPD)
+  - Parents: `WDP-CT-C-002`, `WDP-NA-C-003`
+  - Requirements: `RQ-TRN-002`, `RQ-TRN-003`
+  - Fixture: `WDP-FX-CDPD-UDP-IP-PROFILE` (`transport-boundary`, `implemented`)
+- **WDP-CL-IP-MAPPING-FRAGMENTATION** — Rely on IPv4 fragmentation and reassembly below UDP rather than adding a second WDP segmentation header on the CDPD/IP path.
+  - Family: `wdp`; force: `implicit-must`; level: `required`
+  - Source: `WAP-200-WDP` §7.2 (7.2 Mapping of WDP for IP)
+  - Parents: `WDP-C-001`, `WDP-CT-C-002`, `WDP-NA-C-003`
+  - Requirements: `RQ-TRN-001`, `RQ-TRN-002`, `RQ-TRN-003`
+  - Fixture: `WDP-FX-IP-MAPPING-FRAGMENTATION` (`transport-boundary`, `implemented`)
+- **WDP-CL-IPV4-BASELINE-RECEIVE-SIZE** — Accept IPv4 datagrams up to 576 octets whether received whole or reassembled from fragments.
+  - Family: `wdp`; force: `explicit-must`; level: `required`
+  - Source: `rfc-791` §3.1 (3.1.  Internet Header Format)
+  - Parents: `WDP-CORE-C-001`, `WDP-NA-C-003`
+  - Requirements: `RQ-TRN-001`, `RQ-TRN-003`
+  - Fixture: `WDP-FX-IPV4-BASELINE-RECEIVE-SIZE` (`transport-boundary`, `implemented`)
+- **WDP-CL-IPV4-FRAGMENT-REASSEMBLY-KEY** — Group IPv4 fragments by identification, source, destination, and protocol, then place data using fragment offsets and the final-fragment marker.
+  - Family: `wdp`; force: `implicit-must`; level: `required`
+  - Source: `rfc-791` §3.2 (3.2.  Discussion)
+  - Parents: `WDP-CORE-C-001`, `WDP-NA-C-003`
+  - Requirements: `RQ-TRN-001`, `RQ-TRN-003`
+  - Fixture: `WDP-FX-IPV4-FRAGMENT-REASSEMBLY-KEY` (`binary-decoder`, `implemented`)
+- **WDP-CL-IPV4-FRAGMENTATION-LOCATION** — Allow IPv4 fragmentation at gateways and reassemble fragments at the destination IP module below WDP.
+  - Family: `wdp`; force: `implicit-must`; level: `required`
+  - Source: `rfc-791` §3.2 (3.2.  Discussion)
+  - Parents: `WDP-CORE-C-001`, `WDP-NA-C-003`
+  - Requirements: `RQ-TRN-001`, `RQ-TRN-003`
+  - Fixture: `WDP-FX-IPV4-FRAGMENTATION-LOCATION` (`transport-boundary`, `implemented`)
+- **WDP-CL-IPV4-HEADER-CHECKSUM** — Verify the ones-complement IPv4 header checksum and discard a datagram immediately when verification fails.
+  - Family: `wdp`; force: `explicit-must`; level: `required`
+  - Source: `rfc-791` §3.1 (3.1.  Internet Header Format)
+  - Parents: `WDP-NA-C-003`
+  - Requirements: `RQ-TRN-003`
+  - Fixture: `WDP-FX-IPV4-HEADER-CHECKSUM` (`binary-decoder`, `implemented`)
+- **WDP-CL-IPV4-HEADER-LAYOUT** — Decode the complete IPv4 header field order and widths before passing its UDP payload to WDP.
+  - Family: `wdp`; force: `grammar`; level: `required`
+  - Source: `rfc-791` §3.1 (3.1.  Internet Header Format)
+  - Parents: `WDP-NA-C-003`
+  - Requirements: `RQ-TRN-003`
+  - Fixture: `WDP-FX-IPV4-HEADER-LAYOUT` (`binary-decoder`, `implemented`)
+- **WDP-CL-IPV4-SOURCE-DESTINATION-FIELDS** — Preserve the 32-bit IPv4 source and destination header fields across the WDP request and indication boundary.
+  - Family: `wdp`; force: `table`; level: `required`
+  - Source: `rfc-791` §3.1 (3.1.  Internet Header Format)
+  - Parents: `WDP-PF-C-001`, `WDP-PF-C-002`, `WDP-NA-C-003`
+  - Requirements: `RQ-TRN-001`, `RQ-TRN-003`
+  - Fixture: `WDP-FX-IPV4-SOURCE-DESTINATION-FIELDS` (`binary-decoder`, `implemented`)
+- **WDP-CL-UDP-HEADER-LAYOUT** — Encode and decode the UDP header as 16-bit source port, destination port, length, and checksum fields followed by data.
+  - Family: `wdp`; force: `grammar`; level: `required`
+  - Source: `rfc-768` §format (Format)
+  - Parents: `WDP-CORE-C-001`, `WDP-NA-C-006`, `WDP-NA-C-007`
+  - Requirements: `RQ-TRN-001`, `RQ-TRN-003`
+  - Fixture: `WDP-FX-UDP-HEADER-LAYOUT` (`binary-decoder`, `implemented`)
+- **WDP-CL-UDP-LENGTH-BOUNDS** — Interpret UDP length as header plus data octets and reject values smaller than the eight-octet header.
+  - Family: `wdp`; force: `implicit-must`; level: `required`
+  - Source: `rfc-768` §fields (Fields)
+  - Parents: `WDP-CORE-C-001`
+  - Requirements: `RQ-TRN-001`
+  - Fixture: `WDP-FX-UDP-LENGTH-BOUNDS` (`binary-decoder`, `implemented`)
+- **WDP-CL-UNITDATA-CONTENT-TRANSPARENCY** — Transmit and deliver the complete service data unit without manipulating its content.
+  - Family: `wdp`; force: `implicit-must`; level: `required`
+  - Source: `WAP-200-WDP` §6.3.1.1 (6.3.1.1 T-DUnitdata)
+  - Parents: `WDP-CORE-C-001`, `WDP-PF-C-001`, `WDP-PF-C-002`
+  - Requirements: `RQ-TRN-001`
+  - Fixture: `WDP-FX-UNITDATA-CONTENT-TRANSPARENCY` (`transport-boundary`, `implemented`)
+
 ## Explicit mapping gaps
 
 - `TRN-704` has no direct clause mapping in the canonical nested-clause manifest. Treat this as a planning/evidence gap, not as zero normative scope.
 - `TRN-705` has no direct clause mapping in the canonical nested-clause manifest. Treat this as a planning/evidence gap, not as zero normative scope.
-- `TRN-706` has no direct clause mapping in the canonical nested-clause manifest. Treat this as a planning/evidence gap, not as zero normative scope.
 - `TRN-707` has no direct clause mapping in the canonical nested-clause manifest. Treat this as a planning/evidence gap, not as zero normative scope.
 
 Declared-family gaps:
 
-- `TRN-706` declares `wdp` scope without a direct clause mapping from that family. Clauses from another family do not close this gap.
+- `TRN-706` declares `wtp` scope without a direct clause mapping from that family. Clauses from another family do not close this gap.
 - `TRN-707` declares `wcmp`, `wdp` scope without a direct clause mapping from that family. Clauses from another family do not close this gap.
 
 ## Source documents

--- a/docs/knowledge-graph/vault-TRN-7/_index.md
+++ b/docs/knowledge-graph/vault-TRN-7/_index.md
@@ -15,7 +15,7 @@ Target: [[sprints/TRN-7|TRN-7]]
 ## Graph summary
 
 - Nodes: 214
-- Edges: 613
+- Edges: 624
 
 - `clause`: 77
 - `fixture`: 77
@@ -33,10 +33,9 @@ Target: [[sprints/TRN-7|TRN-7]]
 
 - [[work-items/TRN-704|TRN-704]]
 - [[work-items/TRN-705|TRN-705]]
-- [[work-items/TRN-706|TRN-706]]
 - [[work-items/TRN-707|TRN-707]]
 
 ## Declared normative families without direct clause mappings
 
-- [[work-items/TRN-706|TRN-706]]: `wdp`
+- [[work-items/TRN-706|TRN-706]]: `wtp`
 - [[work-items/TRN-707|TRN-707]]: `wcmp`, `wdp`

--- a/docs/knowledge-graph/vault-TRN-7/clauses/WDP-CL-CDPD-UDP-IP-PROFILE.md
+++ b/docs/knowledge-graph/vault-TRN-7/clauses/WDP-CL-CDPD-UDP-IP-PROFILE.md
@@ -18,6 +18,7 @@ tags:
 - `maps-to` → [[requirements/RQ-TRN-002|RQ-TRN-002]]
 - `maps-to` → [[requirements/RQ-TRN-003|RQ-TRN-003]]
 - `planned-by` → [[work-items/TRN-701|TRN-701]]
+- `planned-by` → [[work-items/TRN-706|TRN-706]]
 - `refines` → [[scr-rows/WDP-CT-C-002|WDP-CT-C-002]]
 - `refines` → [[scr-rows/WDP-NA-C-003|WDP-NA-C-003]]
 - `sourced-from` → [[source-documents/WAP-200-WDP|WAP-200-WDP]]
@@ -43,7 +44,8 @@ tags:
   "obligationSynopsis": "Declare the selected CDPD bearer as an IP-capable profile whose WDP datagram service is UDP over IPv4.",
   "workItems": [
     "T0-19",
-    "TRN-701"
+    "TRN-701",
+    "TRN-706"
   ],
   "ownerLayers": [
     "transport-rust"

--- a/docs/knowledge-graph/vault-TRN-7/clauses/WDP-CL-IP-MAPPING-FRAGMENTATION.md
+++ b/docs/knowledge-graph/vault-TRN-7/clauses/WDP-CL-IP-MAPPING-FRAGMENTATION.md
@@ -20,6 +20,7 @@ tags:
 - `maps-to` → [[requirements/RQ-TRN-003|RQ-TRN-003]]
 - `planned-by` → [[work-items/TRN-701|TRN-701]]
 - `planned-by` → [[work-items/TRN-702|TRN-702]]
+- `planned-by` → [[work-items/TRN-706|TRN-706]]
 - `refines` → [[scr-rows/WDP-C-001|WDP-C-001]]
 - `refines` → [[scr-rows/WDP-CT-C-002|WDP-CT-C-002]]
 - `refines` → [[scr-rows/WDP-NA-C-003|WDP-NA-C-003]]
@@ -48,7 +49,8 @@ tags:
   "workItems": [
     "T0-19",
     "TRN-701",
-    "TRN-702"
+    "TRN-702",
+    "TRN-706"
   ],
   "ownerLayers": [
     "transport-rust"

--- a/docs/knowledge-graph/vault-TRN-7/clauses/WDP-CL-IPV4-BASELINE-RECEIVE-SIZE.md
+++ b/docs/knowledge-graph/vault-TRN-7/clauses/WDP-CL-IPV4-BASELINE-RECEIVE-SIZE.md
@@ -19,6 +19,7 @@ tags:
 - `maps-to` → [[requirements/RQ-TRN-003|RQ-TRN-003]]
 - `planned-by` → [[work-items/TRN-701|TRN-701]]
 - `planned-by` → [[work-items/TRN-702|TRN-702]]
+- `planned-by` → [[work-items/TRN-706|TRN-706]]
 - `refines` → [[scr-rows/WDP-CORE-C-001|WDP-CORE-C-001]]
 - `refines` → [[scr-rows/WDP-NA-C-003|WDP-NA-C-003]]
 - `sourced-from` → [[source-documents/rfc-791|rfc-791]]
@@ -45,7 +46,8 @@ tags:
   "workItems": [
     "T0-19",
     "TRN-701",
-    "TRN-702"
+    "TRN-702",
+    "TRN-706"
   ],
   "ownerLayers": [
     "transport-rust"

--- a/docs/knowledge-graph/vault-TRN-7/clauses/WDP-CL-IPV4-FRAGMENT-REASSEMBLY-KEY.md
+++ b/docs/knowledge-graph/vault-TRN-7/clauses/WDP-CL-IPV4-FRAGMENT-REASSEMBLY-KEY.md
@@ -19,6 +19,7 @@ tags:
 - `maps-to` → [[requirements/RQ-TRN-003|RQ-TRN-003]]
 - `planned-by` → [[work-items/TRN-701|TRN-701]]
 - `planned-by` → [[work-items/TRN-702|TRN-702]]
+- `planned-by` → [[work-items/TRN-706|TRN-706]]
 - `refines` → [[scr-rows/WDP-CORE-C-001|WDP-CORE-C-001]]
 - `refines` → [[scr-rows/WDP-NA-C-003|WDP-NA-C-003]]
 - `sourced-from` → [[source-documents/rfc-791|rfc-791]]
@@ -45,7 +46,8 @@ tags:
   "workItems": [
     "T0-19",
     "TRN-701",
-    "TRN-702"
+    "TRN-702",
+    "TRN-706"
   ],
   "ownerLayers": [
     "transport-rust"

--- a/docs/knowledge-graph/vault-TRN-7/clauses/WDP-CL-IPV4-FRAGMENTATION-LOCATION.md
+++ b/docs/knowledge-graph/vault-TRN-7/clauses/WDP-CL-IPV4-FRAGMENTATION-LOCATION.md
@@ -19,6 +19,7 @@ tags:
 - `maps-to` → [[requirements/RQ-TRN-003|RQ-TRN-003]]
 - `planned-by` → [[work-items/TRN-701|TRN-701]]
 - `planned-by` → [[work-items/TRN-702|TRN-702]]
+- `planned-by` → [[work-items/TRN-706|TRN-706]]
 - `refines` → [[scr-rows/WDP-CORE-C-001|WDP-CORE-C-001]]
 - `refines` → [[scr-rows/WDP-NA-C-003|WDP-NA-C-003]]
 - `sourced-from` → [[source-documents/rfc-791|rfc-791]]
@@ -45,7 +46,8 @@ tags:
   "workItems": [
     "T0-19",
     "TRN-701",
-    "TRN-702"
+    "TRN-702",
+    "TRN-706"
   ],
   "ownerLayers": [
     "transport-rust"

--- a/docs/knowledge-graph/vault-TRN-7/clauses/WDP-CL-IPV4-HEADER-CHECKSUM.md
+++ b/docs/knowledge-graph/vault-TRN-7/clauses/WDP-CL-IPV4-HEADER-CHECKSUM.md
@@ -17,6 +17,7 @@ tags:
 
 - `maps-to` → [[requirements/RQ-TRN-003|RQ-TRN-003]]
 - `planned-by` → [[work-items/TRN-701|TRN-701]]
+- `planned-by` → [[work-items/TRN-706|TRN-706]]
 - `refines` → [[scr-rows/WDP-NA-C-003|WDP-NA-C-003]]
 - `sourced-from` → [[source-documents/rfc-791|rfc-791]]
 - `verified-by` → [[fixtures/WDP-FX-IPV4-HEADER-CHECKSUM|WDP-FX-IPV4-HEADER-CHECKSUM]]
@@ -40,7 +41,8 @@ tags:
   "obligationSynopsis": "Verify the ones-complement IPv4 header checksum and discard a datagram immediately when verification fails.",
   "workItems": [
     "T0-19",
-    "TRN-701"
+    "TRN-701",
+    "TRN-706"
   ],
   "ownerLayers": [
     "transport-rust"

--- a/docs/knowledge-graph/vault-TRN-7/clauses/WDP-CL-IPV4-HEADER-LAYOUT.md
+++ b/docs/knowledge-graph/vault-TRN-7/clauses/WDP-CL-IPV4-HEADER-LAYOUT.md
@@ -17,6 +17,7 @@ tags:
 
 - `maps-to` → [[requirements/RQ-TRN-003|RQ-TRN-003]]
 - `planned-by` → [[work-items/TRN-701|TRN-701]]
+- `planned-by` → [[work-items/TRN-706|TRN-706]]
 - `refines` → [[scr-rows/WDP-NA-C-003|WDP-NA-C-003]]
 - `sourced-from` → [[source-documents/rfc-791|rfc-791]]
 - `verified-by` → [[fixtures/WDP-FX-IPV4-HEADER-LAYOUT|WDP-FX-IPV4-HEADER-LAYOUT]]
@@ -40,7 +41,8 @@ tags:
   "obligationSynopsis": "Decode the complete IPv4 header field order and widths before passing its UDP payload to WDP.",
   "workItems": [
     "T0-19",
-    "TRN-701"
+    "TRN-701",
+    "TRN-706"
   ],
   "ownerLayers": [
     "transport-rust"

--- a/docs/knowledge-graph/vault-TRN-7/clauses/WDP-CL-IPV4-SOURCE-DESTINATION-FIELDS.md
+++ b/docs/knowledge-graph/vault-TRN-7/clauses/WDP-CL-IPV4-SOURCE-DESTINATION-FIELDS.md
@@ -18,6 +18,7 @@ tags:
 - `maps-to` → [[requirements/RQ-TRN-001|RQ-TRN-001]]
 - `maps-to` → [[requirements/RQ-TRN-003|RQ-TRN-003]]
 - `planned-by` → [[work-items/TRN-701|TRN-701]]
+- `planned-by` → [[work-items/TRN-706|TRN-706]]
 - `refines` → [[scr-rows/WDP-NA-C-003|WDP-NA-C-003]]
 - `refines` → [[scr-rows/WDP-PF-C-001|WDP-PF-C-001]]
 - `refines` → [[scr-rows/WDP-PF-C-002|WDP-PF-C-002]]
@@ -45,7 +46,8 @@ tags:
   "obligationSynopsis": "Preserve the 32-bit IPv4 source and destination header fields across the WDP request and indication boundary.",
   "workItems": [
     "T0-19",
-    "TRN-701"
+    "TRN-701",
+    "TRN-706"
   ],
   "ownerLayers": [
     "transport-rust"

--- a/docs/knowledge-graph/vault-TRN-7/clauses/WDP-CL-UDP-HEADER-LAYOUT.md
+++ b/docs/knowledge-graph/vault-TRN-7/clauses/WDP-CL-UDP-HEADER-LAYOUT.md
@@ -18,6 +18,7 @@ tags:
 - `maps-to` → [[requirements/RQ-TRN-001|RQ-TRN-001]]
 - `maps-to` → [[requirements/RQ-TRN-003|RQ-TRN-003]]
 - `planned-by` → [[work-items/TRN-701|TRN-701]]
+- `planned-by` → [[work-items/TRN-706|TRN-706]]
 - `refines` → [[scr-rows/WDP-CORE-C-001|WDP-CORE-C-001]]
 - `refines` → [[scr-rows/WDP-NA-C-006|WDP-NA-C-006]]
 - `refines` → [[scr-rows/WDP-NA-C-007|WDP-NA-C-007]]
@@ -45,7 +46,8 @@ tags:
   "obligationSynopsis": "Encode and decode the UDP header as 16-bit source port, destination port, length, and checksum fields followed by data.",
   "workItems": [
     "T0-19",
-    "TRN-701"
+    "TRN-701",
+    "TRN-706"
   ],
   "ownerLayers": [
     "transport-rust"

--- a/docs/knowledge-graph/vault-TRN-7/clauses/WDP-CL-UDP-LENGTH-BOUNDS.md
+++ b/docs/knowledge-graph/vault-TRN-7/clauses/WDP-CL-UDP-LENGTH-BOUNDS.md
@@ -18,6 +18,7 @@ tags:
 - `maps-to` → [[requirements/RQ-TRN-001|RQ-TRN-001]]
 - `planned-by` → [[work-items/TRN-701|TRN-701]]
 - `planned-by` → [[work-items/TRN-702|TRN-702]]
+- `planned-by` → [[work-items/TRN-706|TRN-706]]
 - `refines` → [[scr-rows/WDP-CORE-C-001|WDP-CORE-C-001]]
 - `sourced-from` → [[source-documents/rfc-768|rfc-768]]
 - `verified-by` → [[fixtures/WDP-FX-UDP-LENGTH-BOUNDS|WDP-FX-UDP-LENGTH-BOUNDS]]
@@ -42,7 +43,8 @@ tags:
   "workItems": [
     "T0-19",
     "TRN-701",
-    "TRN-702"
+    "TRN-702",
+    "TRN-706"
   ],
   "ownerLayers": [
     "transport-rust"

--- a/docs/knowledge-graph/vault-TRN-7/clauses/WDP-CL-UNITDATA-CONTENT-TRANSPARENCY.md
+++ b/docs/knowledge-graph/vault-TRN-7/clauses/WDP-CL-UNITDATA-CONTENT-TRANSPARENCY.md
@@ -18,6 +18,7 @@ tags:
 - `maps-to` → [[requirements/RQ-TRN-001|RQ-TRN-001]]
 - `planned-by` → [[work-items/TRN-701|TRN-701]]
 - `planned-by` → [[work-items/TRN-702|TRN-702]]
+- `planned-by` → [[work-items/TRN-706|TRN-706]]
 - `refines` → [[scr-rows/WDP-CORE-C-001|WDP-CORE-C-001]]
 - `refines` → [[scr-rows/WDP-PF-C-001|WDP-PF-C-001]]
 - `refines` → [[scr-rows/WDP-PF-C-002|WDP-PF-C-002]]
@@ -46,7 +47,8 @@ tags:
   "workItems": [
     "T0-19",
     "TRN-701",
-    "TRN-702"
+    "TRN-702",
+    "TRN-706"
   ],
   "ownerLayers": [
     "transport-rust"

--- a/docs/knowledge-graph/vault-TRN-7/work-items/TRN-706.md
+++ b/docs/knowledge-graph/vault-TRN-7/work-items/TRN-706.md
@@ -21,6 +21,17 @@ tags:
 - `covers-family` → [[source-families/wtp|wtp]]
 - `owned-by` → [[owner-layers/qa|qa]]
 - `owned-by` → [[owner-layers/transport-rust|transport-rust]]
+- `planned-by` ← [[clauses/WDP-CL-CDPD-UDP-IP-PROFILE|WDP-CL-CDPD-UDP-IP-PROFILE]]
+- `planned-by` ← [[clauses/WDP-CL-IP-MAPPING-FRAGMENTATION|WDP-CL-IP-MAPPING-FRAGMENTATION]]
+- `planned-by` ← [[clauses/WDP-CL-IPV4-BASELINE-RECEIVE-SIZE|WDP-CL-IPV4-BASELINE-RECEIVE-SIZE]]
+- `planned-by` ← [[clauses/WDP-CL-IPV4-FRAGMENT-REASSEMBLY-KEY|WDP-CL-IPV4-FRAGMENT-REASSEMBLY-KEY]]
+- `planned-by` ← [[clauses/WDP-CL-IPV4-FRAGMENTATION-LOCATION|WDP-CL-IPV4-FRAGMENTATION-LOCATION]]
+- `planned-by` ← [[clauses/WDP-CL-IPV4-HEADER-CHECKSUM|WDP-CL-IPV4-HEADER-CHECKSUM]]
+- `planned-by` ← [[clauses/WDP-CL-IPV4-HEADER-LAYOUT|WDP-CL-IPV4-HEADER-LAYOUT]]
+- `planned-by` ← [[clauses/WDP-CL-IPV4-SOURCE-DESTINATION-FIELDS|WDP-CL-IPV4-SOURCE-DESTINATION-FIELDS]]
+- `planned-by` ← [[clauses/WDP-CL-UDP-HEADER-LAYOUT|WDP-CL-UDP-HEADER-LAYOUT]]
+- `planned-by` ← [[clauses/WDP-CL-UDP-LENGTH-BOUNDS|WDP-CL-UDP-LENGTH-BOUNDS]]
+- `planned-by` ← [[clauses/WDP-CL-UNITDATA-CONTENT-TRANSPARENCY|WDP-CL-UNITDATA-CONTENT-TRANSPARENCY]]
 - `relates-to` → [[legacy-tickets/T0-22|T0-22]]
 - `relates-to` → [[legacy-tickets/T0-24|T0-24]]
 
@@ -37,18 +48,26 @@ tags:
     "wdp",
     "wtp"
   ],
+  "explicitUnmappedFamilies": [
+    "wtp"
+  ],
   "existingTickets": [
     "T0-22",
     "T0-24"
   ],
   "outputs": [
-    "WDP/WTP packet and replay golden corpus"
+    "WDP/WTP packet and replay golden corpus",
+    "transport-rust/tests/network/interop/wdp_cdpd_ipv4_seed.json"
   ],
   "acceptance": [
-    "Positive, boundary, malformed, duplicate, timeout, and abort traces replay identically and cite exact effective source features."
+    "The selected WDP-only tranche replays positive codec round trips, the 576-octet boundary, malformed IPv4/UDP rejection, idempotent duplicate fragments, and simulated incomplete-assembly expiry against directly mapped WAP-200, RFC 768, and RFC 791 clauses.",
+    "WTP duplicate, retransmission, timeout, and abort families remain conditional on a future connection-oriented WSP/WTP claim and do not close TRN-706 in the strict connectionless profile."
   ],
   "evidence": [
-    "cargo test --manifest-path transport-rust/Cargo.toml --test interop_replay"
+    "cargo test --manifest-path transport-rust/Cargo.toml --test interop_replay",
+    "node scripts/check-wap-selected-normative-clauses.mjs",
+    "node scripts/wap-context-pack.mjs TRN-706",
+    "node scripts/check-wap-knowledge-graph.mjs"
   ],
   "source": "docs/waves/wap-1.2.1-compliance-program.json"
 }

--- a/docs/waves/NETWORK_PROFILE_DECISION_RECORD.md
+++ b/docs/waves/NETWORK_PROFILE_DECISION_RECORD.md
@@ -46,6 +46,8 @@ Fixture lane:
 - `transport-rust/src/wsp_capability.rs` (capability-bound fixtures)
 - `transport-rust/tests/fixtures/transport/wdp_constrained_payload_mapped/`
   (bounded CDPD/IPv4 payload and lower-IP reassembly replay lane)
+- `transport-rust/tests/network/interop/wdp_cdpd_ipv4_seed.json`
+  (directly mapped TRN-706 selected-profile WDP replay lane)
 - `transport-rust/tests/network/interop/` (promotion replay lane; tracked by `T0-22` and `T0-24`)
 
 ### `wap-net-ext` (target, gated)

--- a/docs/waves/TRANSPORT_SPEC_TRACEABILITY.md
+++ b/docs/waves/TRANSPORT_SPEC_TRACEABILITY.md
@@ -323,6 +323,20 @@ Legend:
 - Migration dependency lock: `T0-08`..`T0-14` must be closed before production profile move in `TECHNICAL_ARCHITECTURE.md`.
 - Profile-gate evidence reference (`T0-14`): `docs/waves/NETWORK_PROFILE_DECISION_RECORD.md` + `node scripts/check-networking-profile-gates.mjs`.
 
+## Selected-profile replay evidence
+
+`TRN-706` has a bounded WDP-only replay lane at
+`transport-rust/tests/network/interop/wdp_cdpd_ipv4_seed.json`, executed by
+`cargo test --manifest-path transport-rust/Cargo.toml --test interop_replay`.
+The fixture self-checks its eleven direct clause IDs against the selected
+normative-clause manifest and exercises the existing CDPD/UDP/IPv4 codec and
+lower-IP reassembler. It does not claim connection-oriented WSP/WTP.
+
+The simulated incomplete-assembly timeout is deterministic resource-policy
+evidence for the existing reassembler. The source mapping supports lower-IP
+fragment identity and reassembly placement, but no source-defined timer value
+is inferred.
+
 ## Adjacent transport-context watchlist
 
 The transport stack will remain stable while adjacent networking specs are explicitly deferred:

--- a/docs/waves/WAP_1_2_1_TRANSPORT_SCR_LEDGERS.md
+++ b/docs/waves/WAP_1_2_1_TRANSPORT_SCR_LEDGERS.md
@@ -106,8 +106,17 @@ the destination-IP module below WDP, rejects malformed/overlap/oversize input
 without truncating WDP unit data, and expires incomplete assemblies using
 simulated ticks. Direct replay evidence is in
 `transport-rust/tests/fixtures/transport/wdp_constrained_payload_mapped/reassembly_fixture.json`.
-No WDP segmentation header is introduced, and broader TRN-706 corpus status
-remains unchanged.
+No WDP segmentation header is introduced.
+
+TRN-706 now adds a selected-profile WDP-only golden replay tranche at
+`transport-rust/tests/network/interop/wdp_cdpd_ipv4_seed.json`. Eleven WDP
+clauses directly map byte-exact codec round trip, the 576-octet IPv4 boundary,
+IPv4 checksum and UDP-length rejection, idempotent duplicate fragments, and
+lower-IP reassembly completion. Incomplete assembly expiry uses deterministic
+simulated ticks as a bounded implementation policy; no exact WAP timer value
+is inferred. The declared WTP family remains an explicit conditional mapping
+gap, so this tranche does not activate connection-oriented WSP/WTP or complete
+TRN-706.
 
 ### WCMP
 
@@ -200,6 +209,9 @@ adapter.
   evidence; additional bearers remain unclaimed.
 - `TRN-703` / `T0-17`: implement and test the five-row WCMP core, then
   capability-gate optional WCMP breadth.
+- `TRN-706`: in progress; the eleven-clause selected WDP replay tranche is
+  directly evidenced, while the conditional WTP family and full
+  timeout/abort corpus remain open.
 - `WSP-801`, `WSP-802`, `WSP-804`, `WSP-805`: close the eight-row
   connectionless WSP path, exact WAP-203 registries, and browser GET/POST
   ingress.

--- a/docs/waves/wap-1.2.1-compliance-program.json
+++ b/docs/waves/wap-1.2.1-compliance-program.json
@@ -1046,15 +1046,21 @@
           "status": "in-progress",
           "ownerLayers": ["transport-rust", "qa"],
           "sourceFamilies": ["wdp", "wtp"],
+          "explicitUnmappedFamilies": ["wtp"],
           "existingTickets": ["T0-22", "T0-24"],
           "outputs": [
-            "WDP/WTP packet and replay golden corpus"
+            "WDP/WTP packet and replay golden corpus",
+            "transport-rust/tests/network/interop/wdp_cdpd_ipv4_seed.json"
           ],
           "acceptance": [
-            "Positive, boundary, malformed, duplicate, timeout, and abort traces replay identically and cite exact effective source features."
+            "The selected WDP-only tranche replays positive codec round trips, the 576-octet boundary, malformed IPv4/UDP rejection, idempotent duplicate fragments, and simulated incomplete-assembly expiry against directly mapped WAP-200, RFC 768, and RFC 791 clauses.",
+            "WTP duplicate, retransmission, timeout, and abort families remain conditional on a future connection-oriented WSP/WTP claim and do not close TRN-706 in the strict connectionless profile."
           ],
           "evidence": [
-            "cargo test --manifest-path transport-rust/Cargo.toml --test interop_replay"
+            "cargo test --manifest-path transport-rust/Cargo.toml --test interop_replay",
+            "node scripts/check-wap-selected-normative-clauses.mjs",
+            "node scripts/wap-context-pack.mjs TRN-706",
+            "node scripts/check-wap-knowledge-graph.mjs"
           ]
         },
         {

--- a/scripts/check-wap-compliance-program.mjs
+++ b/scripts/check-wap-compliance-program.mjs
@@ -409,6 +409,9 @@ const wdpConstrained = transportSprint?.workItems.find(
 const wcmpCore = transportSprint?.workItems.find(
   (workItem) => workItem.id === 'TRN-703'
 );
+const replayCorpus = transportSprint?.workItems.find(
+  (workItem) => workItem.id === 'TRN-706'
+);
 if (
   transportSprint?.status !== 'in-progress' ||
   wdpCore?.status !== 'done' ||
@@ -433,6 +436,24 @@ if (
     'node scripts/wap-context-pack.mjs TRN-702'
   ) ||
   !wcmpCore?.acceptance?.some((line) => line.includes('five selected')) ||
+  replayCorpus?.status !== 'in-progress' ||
+  JSON.stringify(replayCorpus?.explicitUnmappedFamilies) !==
+    JSON.stringify(['wtp']) ||
+  !replayCorpus?.outputs?.includes(
+    'transport-rust/tests/network/interop/wdp_cdpd_ipv4_seed.json'
+  ) ||
+  !replayCorpus?.acceptance?.some(
+    (line) => line.includes('selected WDP-only tranche') && line.includes('576-octet')
+  ) ||
+  !replayCorpus?.acceptance?.some(
+    (line) =>
+      line.includes('WTP') &&
+      line.includes('conditional') &&
+      line.includes('do not close TRN-706')
+  ) ||
+  !replayCorpus?.evidence?.includes(
+    'node scripts/wap-context-pack.mjs TRN-706'
+  ) ||
   !transportSprint?.exitGates?.some((line) =>
     line.includes('only when connection-oriented WSP is claimed')
   )

--- a/scripts/check-wap-knowledge-graph.mjs
+++ b/scripts/check-wap-knowledge-graph.mjs
@@ -197,10 +197,11 @@ if (
   trnGraph.target.sprint !== 'TRN-7' ||
   trnGraph.target.profile !== 'CCR-CLASSC-C-001' ||
   !trnNodeIds.has('work-item:TRN-702') ||
-  !trnNodeIds.has('work-item:TRN-703')
+  !trnNodeIds.has('work-item:TRN-703') ||
+  !trnNodeIds.has('work-item:TRN-706')
 ) {
   failures.push(
-    'TRN-7 target must retain the selected Class C profile and adopted TRN-702/TRN-703 work items'
+    'TRN-7 target must retain the selected Class C profile and adopted TRN-702/TRN-703/TRN-706 work items'
   );
 }
 for (const row of selectedWcmpRows) {
@@ -228,6 +229,20 @@ if (
 ) {
   failures.push(
     'TRN-702 context rendering must remain bounded to its nine adopted WDP clauses without a declared-family gap'
+  );
+}
+const trn706Pack = renderContextPack(trnGraph, 'TRN-706');
+if (
+  !trn706Pack.startsWith('# TRN-706 AI Context Pack') ||
+  !trn706Pack.includes('### TRN-706:') ||
+  trn706Pack.includes('### TRN-703:') ||
+  !trn706Pack.includes('- Direct normative clauses: 11') ||
+  trnGraph.summary.workItemsWithoutDirectClauses.includes('TRN-706') ||
+  JSON.stringify(trnGraph.summary.unmappedNormativeFamiliesByWorkItem['TRN-706']) !==
+    JSON.stringify(['wtp'])
+) {
+  failures.push(
+    'TRN-706 context rendering must remain bounded to its eleven selected WDP clauses and preserve the conditional WTP family gap'
   );
 }
 

--- a/scripts/check-wap-selected-normative-clauses.mjs
+++ b/scripts/check-wap-selected-normative-clauses.mjs
@@ -150,6 +150,19 @@ const trn702ClauseIds = new Set([
   'WDP-CL-IPV4-FRAGMENT-REASSEMBLY-KEY',
   'WDP-CL-IPV4-DONT-FRAGMENT'
 ]);
+const trn706ClauseIds = new Set([
+  'WDP-CL-CDPD-UDP-IP-PROFILE',
+  'WDP-CL-UNITDATA-CONTENT-TRANSPARENCY',
+  'WDP-CL-IP-MAPPING-FRAGMENTATION',
+  'WDP-CL-UDP-HEADER-LAYOUT',
+  'WDP-CL-UDP-LENGTH-BOUNDS',
+  'WDP-CL-IPV4-HEADER-LAYOUT',
+  'WDP-CL-IPV4-BASELINE-RECEIVE-SIZE',
+  'WDP-CL-IPV4-FRAGMENTATION-LOCATION',
+  'WDP-CL-IPV4-FRAGMENT-REASSEMBLY-KEY',
+  'WDP-CL-IPV4-HEADER-CHECKSUM',
+  'WDP-CL-IPV4-SOURCE-DESTINATION-FIELDS'
+]);
 const allowedFixtureKinds = new Set([
   'parser',
   'transport-boundary',
@@ -437,9 +450,14 @@ for (const family of ledger.families ?? []) {
     const expectedWorkItems = [
       ...new Set([
         ...parents.flatMap((parent) => parent.mapping.workItems),
-        ...(trn702ClauseIds.has(candidate.id) ? ['TRN-702'] : [])
+        ...(trn702ClauseIds.has(candidate.id) ? ['TRN-702'] : []),
+        ...(trn706ClauseIds.has(candidate.id) ? ['TRN-706'] : [])
       ])
     ].sort();
+    const expectedDirectWorkItems = [
+      ...(trn702ClauseIds.has(candidate.id) ? ['TRN-702'] : []),
+      ...(trn706ClauseIds.has(candidate.id) ? ['TRN-706'] : [])
+    ];
     const expectedRequirements = [
       ...new Set(parents.flatMap((parent) => parent.mapping.requirementIds))
     ].sort();
@@ -457,7 +475,7 @@ for (const family of ledger.families ?? []) {
     if (
       JSON.stringify(candidate.mapping?.ownerLayers) !== JSON.stringify(expectedOwners) ||
       JSON.stringify(candidate.directWorkItems ?? []) !==
-        JSON.stringify(trn702ClauseIds.has(candidate.id) ? ['TRN-702'] : []) ||
+        JSON.stringify(expectedDirectWorkItems) ||
       JSON.stringify(candidate.mapping?.workItems) !== JSON.stringify(expectedWorkItems) ||
       JSON.stringify(candidate.mapping?.requirementIds) !== JSON.stringify(expectedRequirements) ||
       JSON.stringify(candidate.mapping?.parentImplementationSnapshot) !==

--- a/scripts/wap-context-pack.mjs
+++ b/scripts/wap-context-pack.mjs
@@ -10,7 +10,7 @@ import {
 const target = process.argv[2];
 if (!target) {
   console.error(
-    'Usage: node scripts/wap-context-pack.mjs TRN-7|TRN-702|TRN-703|WML-2|WML-201|WML-202|WML-203|WML-204|WML-205'
+    'Usage: node scripts/wap-context-pack.mjs TRN-7|TRN-702|TRN-703|TRN-706|WML-2|WML-201|WML-202|WML-203|WML-204|WML-205'
   );
   process.exit(1);
 }
@@ -19,6 +19,7 @@ const targetSprints = new Map([
   ['TRN-7', 'TRN-7'],
   ['TRN-702', 'TRN-7'],
   ['TRN-703', 'TRN-7'],
+  ['TRN-706', 'TRN-7'],
   ['WML-2', 'WML-2'],
   ['WML-201', 'WML-2'],
   ['WML-202', 'WML-2'],

--- a/spec-processing/scripts/generate-wap-knowledge-graph.mjs
+++ b/spec-processing/scripts/generate-wap-knowledge-graph.mjs
@@ -385,6 +385,7 @@ export function buildKnowledgeGraph(root = process.cwd(), targetId = 'WML-2') {
       status: workItem.status,
       ownerLayers: workItem.ownerLayers,
       sourceFamilies: workItem.sourceFamilies,
+      explicitUnmappedFamilies: workItem.explicitUnmappedFamilies,
       existingTickets: workItem.existingTickets,
       outputs: workItem.outputs,
       acceptance: workItem.acceptance,
@@ -515,7 +516,9 @@ export function buildKnowledgeGraph(root = process.cwd(), targetId = 'WML-2') {
         workItem.id,
         workItem.sourceFamilies
           .filter((family) => normativeFamilyIds.has(family))
+          .concat(workItem.explicitUnmappedFamilies ?? [])
           .filter((family) => !directClauseFamiliesByWorkItem[workItem.id].includes(family))
+          .filter((family, index, families) => families.indexOf(family) === index)
           .sort((left, right) => left.localeCompare(right))
       ])
       .filter(([, families]) => families.length > 0)

--- a/spec-processing/scripts/generate-wap-selected-normative-clauses.mjs
+++ b/spec-processing/scripts/generate-wap-selected-normative-clauses.mjs
@@ -34,6 +34,73 @@ const recordedOn = option('--recorded-on');
 const outputPath =
   option('--output') ??
   'spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json';
+const refreshDirectWorkItems = args.includes('--refresh-direct-work-items');
+const directWorkItemClauseIds = new Map([
+  [
+    'TRN-702',
+    new Set([
+      'WDP-CL-UNITDATA-CONTENT-TRANSPARENCY',
+      'WDP-CL-IP-MAPPING-FRAGMENTATION',
+      'WDP-CL-UDP-LENGTH-BOUNDS',
+      'WDP-CL-IPV4-TOTAL-LENGTH',
+      'WDP-CL-IPV4-BASELINE-RECEIVE-SIZE',
+      'WDP-CL-IPV4-LARGE-SEND-GUARD',
+      'WDP-CL-IPV4-FRAGMENTATION-LOCATION',
+      'WDP-CL-IPV4-FRAGMENT-REASSEMBLY-KEY',
+      'WDP-CL-IPV4-DONT-FRAGMENT'
+    ])
+  ],
+  [
+    'TRN-706',
+    new Set([
+      'WDP-CL-CDPD-UDP-IP-PROFILE',
+      'WDP-CL-UNITDATA-CONTENT-TRANSPARENCY',
+      'WDP-CL-IP-MAPPING-FRAGMENTATION',
+      'WDP-CL-UDP-HEADER-LAYOUT',
+      'WDP-CL-UDP-LENGTH-BOUNDS',
+      'WDP-CL-IPV4-HEADER-LAYOUT',
+      'WDP-CL-IPV4-BASELINE-RECEIVE-SIZE',
+      'WDP-CL-IPV4-FRAGMENTATION-LOCATION',
+      'WDP-CL-IPV4-FRAGMENT-REASSEMBLY-KEY',
+      'WDP-CL-IPV4-HEADER-CHECKSUM',
+      'WDP-CL-IPV4-SOURCE-DESTINATION-FIELDS'
+    ])
+  ]
+]);
+const configuredDirectWorkItemIds = new Set(directWorkItemClauseIds.keys());
+
+function directWorkItemsForClause(clauseId) {
+  return [...directWorkItemClauseIds]
+    .filter(([, clauseIds]) => clauseIds.has(clauseId))
+    .map(([workItem]) => workItem);
+}
+
+if (refreshDirectWorkItems) {
+  const manifest = JSON.parse(fs.readFileSync(outputPath, 'utf8'));
+  for (const candidate of manifest.families.flatMap((family) => family.clauses)) {
+    const directWorkItems = directWorkItemsForClause(candidate.id);
+    if (directWorkItems.length) {
+      candidate.directWorkItems = directWorkItems;
+    } else {
+      delete candidate.directWorkItems;
+    }
+    candidate.mapping.workItems = [
+      ...new Set([
+        ...candidate.mapping.workItems.filter(
+          (workItem) => !configuredDirectWorkItemIds.has(workItem)
+        ),
+        ...directWorkItems
+      ])
+    ].sort();
+  }
+  fs.writeFileSync(outputPath, `${JSON.stringify(manifest, null, 2)}\n`);
+  console.log(
+    `Refreshed direct work-item mappings in ${outputPath} for ${[
+      ...directWorkItemClauseIds.keys()
+    ].join(', ')}`
+  );
+  process.exit(0);
+}
 
 if (
   !wmlTextPath ||
@@ -76,7 +143,8 @@ if (
       '--rfc-2396-text /absolute/path/rfc2396.txt ' +
       '--rfc-2616-text /absolute/path/rfc2616.txt ' +
       '--rfc-2617-text /absolute/path/rfc2617.txt ' +
-      '--recorded-on YYYY-MM-DD [--output path]'
+      '--recorded-on YYYY-MM-DD [--output path], or ' +
+      '--refresh-direct-work-items [--output path]'
   );
   process.exit(2);
 }
@@ -892,9 +960,10 @@ function clause(
   normativeForce,
   fixtureKind,
   obligationSynopsis,
-  anchorFamily = family,
-  directWorkItems = []
+  anchorFamily = family
 ) {
+  const clauseId = `${family.toUpperCase()}-CL-${key.toUpperCase().replaceAll('_', '-')}`;
+  const directWorkItems = directWorkItemsForClause(clauseId);
   const directFixtureImplemented =
     family === 'wcmp' ||
     family === 'wdp' ||
@@ -929,7 +998,7 @@ function clause(
             'cargo test --manifest-path transport-rust/Cargo.toml --lib network::wcmp'
         };
   clauseRows.push({
-    id: `${family.toUpperCase()}-CL-${key.toUpperCase().replaceAll('_', '-')}`,
+    id: clauseId,
     family,
     parentRows,
     ...(directWorkItems.length ? { directWorkItems } : {}),
@@ -1384,10 +1453,10 @@ clause('wdp', 'destination_address_semantics', ['WDP-PF-C-001', 'WDP-PF-C-002', 
 clause('wdp', 'source_address_semantics', ['WDP-PF-C-001', 'WDP-PF-C-002', 'WDP-NA-C-000', 'WDP-NA-C-003'], '6.3.1.1', 'implicit-must', 'transport-boundary', 'Treat the source address as the unique network identity of the device issuing the transport request.');
 clause('wdp', 'destination_port_semantics', ['WDP-PF-C-001', 'WDP-PF-C-002', 'WDP-NA-C-006'], '6.3.1.1', 'implicit-must', 'transport-boundary', 'Bind the destination port to the destination application or upper-layer protocol for that communication instance.');
 clause('wdp', 'source_port_semantics', ['WDP-PF-C-001', 'WDP-PF-C-002', 'WDP-NA-C-007'], '6.3.1.1', 'implicit-must', 'transport-boundary', 'Bind the source port to the requesting application or upper-layer protocol for that communication instance.');
-clause('wdp', 'unitdata_content_transparency', ['WDP-CORE-C-001', 'WDP-PF-C-001', 'WDP-PF-C-002'], '6.3.1.1', 'implicit-must', 'transport-boundary', 'Transmit and deliver the complete service data unit without manipulating its content.', 'wdp', ['TRN-702']);
+clause('wdp', 'unitdata_content_transparency', ['WDP-CORE-C-001', 'WDP-PF-C-001', 'WDP-PF-C-002'], '6.3.1.1', 'implicit-must', 'transport-boundary', 'Transmit and deliver the complete service data unit without manipulating its content.');
 clause('wdp', 'protocol_required_port_fields', ['WDP-CORE-C-001', 'WDP-NA-C-006', 'WDP-NA-C-007'], '7.1', 'implicit-must', 'binary-decoder', 'Carry both destination and source port fields in the selected WDP protocol mapping.');
 clause('wdp', 'ip_mapping_is_udp', ['WDP-C-001', 'WDP-CT-C-002', 'WDP-NA-C-003'], '7.2', 'implicit-must', 'transport-boundary', 'Map WDP directly to UDP for every selected bearer on which IP routing is available.');
-clause('wdp', 'ip_mapping_fragmentation', ['WDP-C-001', 'WDP-CT-C-002', 'WDP-NA-C-003'], '7.2', 'implicit-must', 'transport-boundary', 'Rely on IPv4 fragmentation and reassembly below UDP rather than adding a second WDP segmentation header on the CDPD/IP path.', 'wdp', ['TRN-702']);
+clause('wdp', 'ip_mapping_fragmentation', ['WDP-C-001', 'WDP-CT-C-002', 'WDP-NA-C-003'], '7.2', 'implicit-must', 'transport-boundary', 'Rely on IPv4 fragmentation and reassembly below UDP rather than adding a second WDP segmentation header on the CDPD/IP path.');
 clause('wdp', 'wap_port_registry', ['WDP-NA-C-006', 'WDP-NA-C-007'], 'appendix-b', 'table', 'transport-boundary', 'Recognize the complete WAP port assignment table, including connectionless, session, secure, push, vCard, and vCalendar services.');
 clause('wdp', 'selected_wsp_port', ['WDP-C-001', 'WDP-NA-C-006'], 'appendix-b', 'table', 'transport-boundary', 'Use registered UDP/WDP port 9200 for the selected non-secure connectionless WSP session service.');
 clause('wdp', 'selected_bearer_assignment', ['WDP-CT-C-002', 'WDP-NA-C-003'], 'appendix-c', 'table', 'transport-boundary', 'Represent the AMPS/CDPD/IPv4 network-bearer-address combination with assigned bearer value 0x0D when that registry is carried.');
@@ -1396,7 +1465,7 @@ clause('wdp', 'udp_unreliable_datagrams', ['WDP-C-001', 'WDP-CORE-C-001'], 'intr
 clause('wdp', 'udp_header_layout', ['WDP-CORE-C-001', 'WDP-NA-C-006', 'WDP-NA-C-007'], 'format', 'grammar', 'binary-decoder', 'Encode and decode the UDP header as 16-bit source port, destination port, length, and checksum fields followed by data.', 'rfc-768');
 clause('wdp', 'udp_source_port_zero', ['WDP-NA-C-007'], 'fields', 'table', 'binary-decoder', 'Use source port zero when the sender does not supply a meaningful reply port, and otherwise preserve the selected source port.', 'rfc-768');
 clause('wdp', 'udp_destination_port_context', ['WDP-NA-C-006', 'WDP-NA-C-003'], 'fields', 'implicit-must', 'transport-boundary', 'Interpret a UDP destination port within the context of its destination IPv4 address.', 'rfc-768');
-clause('wdp', 'udp_length_bounds', ['WDP-CORE-C-001'], 'fields', 'implicit-must', 'binary-decoder', 'Interpret UDP length as header plus data octets and reject values smaller than the eight-octet header.', 'rfc-768', ['TRN-702']);
+clause('wdp', 'udp_length_bounds', ['WDP-CORE-C-001'], 'fields', 'implicit-must', 'binary-decoder', 'Interpret UDP length as header plus data octets and reject values smaller than the eight-octet header.', 'rfc-768');
 clause('wdp', 'udp_checksum_coverage', ['WDP-CORE-C-001', 'WDP-NA-C-003'], 'fields', 'implicit-must', 'binary-decoder', 'Compute the UDP checksum over the IPv4 pseudo-header, UDP header, and data using 16-bit ones-complement arithmetic.', 'rfc-768');
 clause('wdp', 'udp_checksum_padding', ['WDP-CORE-C-001'], 'fields', 'implicit-must', 'binary-decoder', 'Zero-pad an odd checksum input to a two-octet boundary without transmitting the padding octet.', 'rfc-768');
 clause('wdp', 'udp_checksum_zero_encoding', ['WDP-CORE-C-001'], 'fields', 'implicit-must', 'binary-decoder', 'Transmit an arithmetically computed zero UDP checksum as all one bits.', 'rfc-768');
@@ -1410,12 +1479,12 @@ clause('wdp', 'ipv4_independent_datagrams', ['WDP-C-001', 'WDP-CORE-C-001', 'WDP
 clause('wdp', 'ipv4_fixed_address_size', ['WDP-NA-C-000', 'WDP-NA-C-003'], '2.3', 'implicit-must', 'binary-decoder', 'Represent each selected IPv4 source or destination address as four octets.', 'rfc-791');
 clause('wdp', 'ipv4_header_layout', ['WDP-NA-C-003'], '3.1', 'grammar', 'binary-decoder', 'Decode the complete IPv4 header field order and widths before passing its UDP payload to WDP.', 'rfc-791');
 clause('wdp', 'ipv4_version_and_ihl', ['WDP-NA-C-003'], '3.1', 'table', 'binary-decoder', 'Require IPv4 version value 4 and use IHL in 32-bit words with a minimum valid value of five.', 'rfc-791');
-clause('wdp', 'ipv4_total_length', ['WDP-CORE-C-001', 'WDP-NA-C-003'], '3.1', 'implicit-must', 'binary-decoder', 'Interpret IPv4 total length as header plus payload octets with a maximum representable value of 65,535.', 'rfc-791', ['TRN-702']);
-clause('wdp', 'ipv4_baseline_receive_size', ['WDP-CORE-C-001', 'WDP-NA-C-003'], '3.1', 'explicit-must', 'transport-boundary', 'Accept IPv4 datagrams up to 576 octets whether received whole or reassembled from fragments.', 'rfc-791', ['TRN-702']);
-clause('wdp', 'ipv4_large_send_guard', ['WDP-CORE-C-001', 'WDP-NA-C-003'], '3.1', 'explicit-should', 'transport-boundary', 'Send an IPv4 datagram larger than 576 octets only with assurance that the destination can accept it.', 'rfc-791', ['TRN-702']);
-clause('wdp', 'ipv4_fragmentation_location', ['WDP-CORE-C-001', 'WDP-NA-C-003'], '3.2', 'implicit-must', 'transport-boundary', 'Allow IPv4 fragmentation at gateways and reassemble fragments at the destination IP module below WDP.', 'rfc-791', ['TRN-702']);
-clause('wdp', 'ipv4_fragment_reassembly_key', ['WDP-CORE-C-001', 'WDP-NA-C-003'], '3.2', 'implicit-must', 'binary-decoder', 'Group IPv4 fragments by identification, source, destination, and protocol, then place data using fragment offsets and the final-fragment marker.', 'rfc-791', ['TRN-702']);
-clause('wdp', 'ipv4_dont_fragment', ['WDP-CORE-C-001', 'WDP-NA-C-003'], '3.2', 'explicit-must', 'error-policy', 'Do not fragment a datagram whose DF bit is set; discard it when the route cannot carry it intact.', 'rfc-791', ['TRN-702']);
+clause('wdp', 'ipv4_total_length', ['WDP-CORE-C-001', 'WDP-NA-C-003'], '3.1', 'implicit-must', 'binary-decoder', 'Interpret IPv4 total length as header plus payload octets with a maximum representable value of 65,535.', 'rfc-791');
+clause('wdp', 'ipv4_baseline_receive_size', ['WDP-CORE-C-001', 'WDP-NA-C-003'], '3.1', 'explicit-must', 'transport-boundary', 'Accept IPv4 datagrams up to 576 octets whether received whole or reassembled from fragments.', 'rfc-791');
+clause('wdp', 'ipv4_large_send_guard', ['WDP-CORE-C-001', 'WDP-NA-C-003'], '3.1', 'explicit-should', 'transport-boundary', 'Send an IPv4 datagram larger than 576 octets only with assurance that the destination can accept it.', 'rfc-791');
+clause('wdp', 'ipv4_fragmentation_location', ['WDP-CORE-C-001', 'WDP-NA-C-003'], '3.2', 'implicit-must', 'transport-boundary', 'Allow IPv4 fragmentation at gateways and reassemble fragments at the destination IP module below WDP.', 'rfc-791');
+clause('wdp', 'ipv4_fragment_reassembly_key', ['WDP-CORE-C-001', 'WDP-NA-C-003'], '3.2', 'implicit-must', 'binary-decoder', 'Group IPv4 fragments by identification, source, destination, and protocol, then place data using fragment offsets and the final-fragment marker.', 'rfc-791');
+clause('wdp', 'ipv4_dont_fragment', ['WDP-CORE-C-001', 'WDP-NA-C-003'], '3.2', 'explicit-must', 'error-policy', 'Do not fragment a datagram whose DF bit is set; discard it when the route cannot carry it intact.', 'rfc-791');
 clause('wdp', 'ipv4_ttl_zero', ['WDP-NA-C-003'], '3.1', 'explicit-must', 'error-policy', 'Destroy an IPv4 datagram when its time-to-live value reaches zero.', 'rfc-791');
 clause('wdp', 'ipv4_header_checksum', ['WDP-NA-C-003'], '3.1', 'explicit-must', 'binary-decoder', 'Verify the ones-complement IPv4 header checksum and discard a datagram immediately when verification fails.', 'rfc-791');
 clause('wdp', 'ipv4_source_destination_fields', ['WDP-PF-C-001', 'WDP-PF-C-002', 'WDP-NA-C-003'], '3.1', 'table', 'binary-decoder', 'Preserve the 32-bit IPv4 source and destination header fields across the WDP request and indication boundary.', 'rfc-791');

--- a/spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json
+++ b/spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json
@@ -20414,7 +20414,8 @@
             ],
             "workItems": [
               "T0-19",
-              "TRN-701"
+              "TRN-701",
+              "TRN-706"
             ],
             "requirementIds": [
               "RQ-TRN-002",
@@ -20426,7 +20427,10 @@
             },
             "clauseImplementationStatus": "implemented",
             "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented."
-          }
+          },
+          "directWorkItems": [
+            "TRN-706"
+          ]
         },
         {
           "id": "WDP-CL-UNITDATA-REQUEST-ANYTIME",
@@ -20791,7 +20795,8 @@
             "WDP-PF-C-002"
           ],
           "directWorkItems": [
-            "TRN-702"
+            "TRN-702",
+            "TRN-706"
           ],
           "sourceAnchor": {
             "documentId": "WAP-200-WDP",
@@ -20820,7 +20825,8 @@
             "workItems": [
               "T0-19",
               "TRN-701",
-              "TRN-702"
+              "TRN-702",
+              "TRN-706"
             ],
             "requirementIds": [
               "RQ-TRN-001"
@@ -20942,7 +20948,8 @@
             "WDP-NA-C-003"
           ],
           "directWorkItems": [
-            "TRN-702"
+            "TRN-702",
+            "TRN-706"
           ],
           "sourceAnchor": {
             "documentId": "WAP-200-WDP",
@@ -20971,7 +20978,8 @@
             "workItems": [
               "T0-19",
               "TRN-701",
-              "TRN-702"
+              "TRN-702",
+              "TRN-706"
             ],
             "requirementIds": [
               "RQ-TRN-001",
@@ -21207,7 +21215,8 @@
             ],
             "workItems": [
               "T0-19",
-              "TRN-701"
+              "TRN-701",
+              "TRN-706"
             ],
             "requirementIds": [
               "RQ-TRN-001",
@@ -21220,7 +21229,10 @@
             },
             "clauseImplementationStatus": "implemented",
             "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented."
-          }
+          },
+          "directWorkItems": [
+            "TRN-706"
+          ]
         },
         {
           "id": "WDP-CL-UDP-SOURCE-PORT-ZERO",
@@ -21319,7 +21331,8 @@
             "WDP-CORE-C-001"
           ],
           "directWorkItems": [
-            "TRN-702"
+            "TRN-702",
+            "TRN-706"
           ],
           "sourceAnchor": {
             "documentId": "rfc-768",
@@ -21348,7 +21361,8 @@
             "workItems": [
               "T0-19",
               "TRN-701",
-              "TRN-702"
+              "TRN-702",
+              "TRN-706"
             ],
             "requirementIds": [
               "RQ-TRN-001"
@@ -21860,7 +21874,8 @@
             ],
             "workItems": [
               "T0-19",
-              "TRN-701"
+              "TRN-701",
+              "TRN-706"
             ],
             "requirementIds": [
               "RQ-TRN-003"
@@ -21870,7 +21885,10 @@
             },
             "clauseImplementationStatus": "implemented",
             "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented."
-          }
+          },
+          "directWorkItems": [
+            "TRN-706"
+          ]
         },
         {
           "id": "WDP-CL-IPV4-VERSION-AND-IHL",
@@ -21975,7 +21993,8 @@
             "WDP-NA-C-003"
           ],
           "directWorkItems": [
-            "TRN-702"
+            "TRN-702",
+            "TRN-706"
           ],
           "sourceAnchor": {
             "documentId": "rfc-791",
@@ -22004,7 +22023,8 @@
             "workItems": [
               "T0-19",
               "TRN-701",
-              "TRN-702"
+              "TRN-702",
+              "TRN-706"
             ],
             "requirementIds": [
               "RQ-TRN-001",
@@ -22077,7 +22097,8 @@
             "WDP-NA-C-003"
           ],
           "directWorkItems": [
-            "TRN-702"
+            "TRN-702",
+            "TRN-706"
           ],
           "sourceAnchor": {
             "documentId": "rfc-791",
@@ -22106,7 +22127,8 @@
             "workItems": [
               "T0-19",
               "TRN-701",
-              "TRN-702"
+              "TRN-702",
+              "TRN-706"
             ],
             "requirementIds": [
               "RQ-TRN-001",
@@ -22128,7 +22150,8 @@
             "WDP-NA-C-003"
           ],
           "directWorkItems": [
-            "TRN-702"
+            "TRN-702",
+            "TRN-706"
           ],
           "sourceAnchor": {
             "documentId": "rfc-791",
@@ -22157,7 +22180,8 @@
             "workItems": [
               "T0-19",
               "TRN-701",
-              "TRN-702"
+              "TRN-702",
+              "TRN-706"
             ],
             "requirementIds": [
               "RQ-TRN-001",
@@ -22298,7 +22322,8 @@
             ],
             "workItems": [
               "T0-19",
-              "TRN-701"
+              "TRN-701",
+              "TRN-706"
             ],
             "requirementIds": [
               "RQ-TRN-003"
@@ -22308,7 +22333,10 @@
             },
             "clauseImplementationStatus": "implemented",
             "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented."
-          }
+          },
+          "directWorkItems": [
+            "TRN-706"
+          ]
         },
         {
           "id": "WDP-CL-IPV4-SOURCE-DESTINATION-FIELDS",
@@ -22344,7 +22372,8 @@
             ],
             "workItems": [
               "T0-19",
-              "TRN-701"
+              "TRN-701",
+              "TRN-706"
             ],
             "requirementIds": [
               "RQ-TRN-001",
@@ -22357,7 +22386,10 @@
             },
             "clauseImplementationStatus": "implemented",
             "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented."
-          }
+          },
+          "directWorkItems": [
+            "TRN-706"
+          ]
         },
         {
           "id": "WDP-CL-IPV4-ROBUST-INTEROPERATION",

--- a/spec-processing/source-manifests/wap-1.2.1-trn-7-knowledge-graph.json
+++ b/spec-processing/source-manifests/wap-1.2.1-trn-7-knowledge-graph.json
@@ -13,7 +13,7 @@
     "generator": "spec-processing/scripts/generate-wap-knowledge-graph.mjs",
     "inputs": {
       "docs/waves/wap-1.2.1-compliance-program.json": {
-        "sha256": "6497a1802b8ea8661aff21b847cd754564b305d5245e41c653b7cb9df6cd9865"
+        "sha256": "92b8d3321d22f08832d37c7c43af7771c1f7ff9941b47800b8e9de3d15bc0f6d"
       },
       "spec-processing/source-manifests/wap-1.2.1-class-conformance.json": {
         "sha256": "b76605b2144b32965a857b848b2e9e522baada6fae9fe51012b9eaa664e85d86"
@@ -25,14 +25,14 @@
         "sha256": "654284270a068b427ab05166247cb8e0644a99cf6af511f9b9c477d18ea36faa"
       },
       "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json": {
-        "sha256": "3e51cf531c278871d4fd0948017950c3a3992f152960a8e0f43e39dadf8d8740"
+        "sha256": "903e469345d86c37a7b76d7a8f17085be518747d553ef85d54dffb14d91ae32b"
       }
     },
     "policy": "Canonical manifests remain authoritative; this graph and its Obsidian/context projections are generated views."
   },
   "summary": {
     "nodeCount": 214,
-    "edgeCount": 613,
+    "edgeCount": 624,
     "nodesByType": {
       "clause": 77,
       "fixture": 77,
@@ -56,7 +56,7 @@
       "effective-document": 12,
       "maps-to": 114,
       "owned-by": 15,
-      "planned-by": 100,
+      "planned-by": 111,
       "refines": 154,
       "relates-to": 8,
       "requires-family": 2,
@@ -71,7 +71,7 @@
       "TRN-703": 28,
       "TRN-704": 0,
       "TRN-705": 0,
-      "TRN-706": 0,
+      "TRN-706": 11,
       "TRN-707": 0
     },
     "directClauseFamiliesByWorkItem": {
@@ -86,12 +86,14 @@
       ],
       "TRN-704": [],
       "TRN-705": [],
-      "TRN-706": [],
+      "TRN-706": [
+        "wdp"
+      ],
       "TRN-707": []
     },
     "unmappedNormativeFamiliesByWorkItem": {
       "TRN-706": [
-        "wdp"
+        "wtp"
       ],
       "TRN-707": [
         "wcmp",
@@ -101,7 +103,6 @@
     "workItemsWithoutDirectClauses": [
       "TRN-704",
       "TRN-705",
-      "TRN-706",
       "TRN-707"
     ]
   },
@@ -1203,7 +1204,8 @@
         "obligationSynopsis": "Declare the selected CDPD bearer as an IP-capable profile whose WDP datagram service is UDP over IPv4.",
         "workItems": [
           "T0-19",
-          "TRN-701"
+          "TRN-701",
+          "TRN-706"
         ],
         "ownerLayers": [
           "transport-rust"
@@ -1389,7 +1391,8 @@
         "workItems": [
           "T0-19",
           "TRN-701",
-          "TRN-702"
+          "TRN-702",
+          "TRN-706"
         ],
         "ownerLayers": [
           "transport-rust"
@@ -1465,7 +1468,8 @@
         "workItems": [
           "T0-19",
           "TRN-701",
-          "TRN-702"
+          "TRN-702",
+          "TRN-706"
         ],
         "ownerLayers": [
           "transport-rust"
@@ -1574,7 +1578,8 @@
         "workItems": [
           "T0-19",
           "TRN-701",
-          "TRN-702"
+          "TRN-702",
+          "TRN-706"
         ],
         "ownerLayers": [
           "transport-rust"
@@ -1611,7 +1616,8 @@
         "workItems": [
           "T0-19",
           "TRN-701",
-          "TRN-702"
+          "TRN-702",
+          "TRN-706"
         ],
         "ownerLayers": [
           "transport-rust"
@@ -1646,7 +1652,8 @@
         "obligationSynopsis": "Verify the ones-complement IPv4 header checksum and discard a datagram immediately when verification fails.",
         "workItems": [
           "T0-19",
-          "TRN-701"
+          "TRN-701",
+          "TRN-706"
         ],
         "ownerLayers": [
           "transport-rust"
@@ -1680,7 +1687,8 @@
         "obligationSynopsis": "Decode the complete IPv4 header field order and widths before passing its UDP payload to WDP.",
         "workItems": [
           "T0-19",
-          "TRN-701"
+          "TRN-701",
+          "TRN-706"
         ],
         "ownerLayers": [
           "transport-rust"
@@ -1859,7 +1867,8 @@
         "obligationSynopsis": "Preserve the 32-bit IPv4 source and destination header fields across the WDP request and indication boundary.",
         "workItems": [
           "T0-19",
-          "TRN-701"
+          "TRN-701",
+          "TRN-706"
         ],
         "ownerLayers": [
           "transport-rust"
@@ -2396,7 +2405,8 @@
         "obligationSynopsis": "Encode and decode the UDP header as 16-bit source port, destination port, length, and checksum fields followed by data.",
         "workItems": [
           "T0-19",
-          "TRN-701"
+          "TRN-701",
+          "TRN-706"
         ],
         "ownerLayers": [
           "transport-rust"
@@ -2504,7 +2514,8 @@
         "workItems": [
           "T0-19",
           "TRN-701",
-          "TRN-702"
+          "TRN-702",
+          "TRN-706"
         ],
         "ownerLayers": [
           "transport-rust"
@@ -2685,7 +2696,8 @@
         "workItems": [
           "T0-19",
           "TRN-701",
-          "TRN-702"
+          "TRN-702",
+          "TRN-706"
         ],
         "ownerLayers": [
           "transport-rust"
@@ -4813,18 +4825,26 @@
           "wdp",
           "wtp"
         ],
+        "explicitUnmappedFamilies": [
+          "wtp"
+        ],
         "existingTickets": [
           "T0-22",
           "T0-24"
         ],
         "outputs": [
-          "WDP/WTP packet and replay golden corpus"
+          "WDP/WTP packet and replay golden corpus",
+          "transport-rust/tests/network/interop/wdp_cdpd_ipv4_seed.json"
         ],
         "acceptance": [
-          "Positive, boundary, malformed, duplicate, timeout, and abort traces replay identically and cite exact effective source features."
+          "The selected WDP-only tranche replays positive codec round trips, the 576-octet boundary, malformed IPv4/UDP rejection, idempotent duplicate fragments, and simulated incomplete-assembly expiry against directly mapped WAP-200, RFC 768, and RFC 791 clauses.",
+          "WTP duplicate, retransmission, timeout, and abort families remain conditional on a future connection-oriented WSP/WTP claim and do not close TRN-706 in the strict connectionless profile."
         ],
         "evidence": [
-          "cargo test --manifest-path transport-rust/Cargo.toml --test interop_replay"
+          "cargo test --manifest-path transport-rust/Cargo.toml --test interop_replay",
+          "node scripts/check-wap-selected-normative-clauses.mjs",
+          "node scripts/wap-context-pack.mjs TRN-706",
+          "node scripts/check-wap-knowledge-graph.mjs"
         ],
         "source": "docs/waves/wap-1.2.1-compliance-program.json"
       }
@@ -6473,6 +6493,15 @@
       ]
     },
     {
+      "id": "clause:WDP-CL-CDPD-UDP-IP-PROFILE|planned-by|work-item:TRN-706",
+      "from": "clause:WDP-CL-CDPD-UDP-IP-PROFILE",
+      "relation": "planned-by",
+      "to": "work-item:TRN-706",
+      "sourceRefs": [
+        "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
+      ]
+    },
+    {
       "id": "clause:WDP-CL-CDPD-UDP-IP-PROFILE|refines|scr-row:WDP-CT-C-002",
       "from": "clause:WDP-CL-CDPD-UDP-IP-PROFILE",
       "relation": "refines",
@@ -6842,6 +6871,15 @@
       ]
     },
     {
+      "id": "clause:WDP-CL-IP-MAPPING-FRAGMENTATION|planned-by|work-item:TRN-706",
+      "from": "clause:WDP-CL-IP-MAPPING-FRAGMENTATION",
+      "relation": "planned-by",
+      "to": "work-item:TRN-706",
+      "sourceRefs": [
+        "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
+      ]
+    },
+    {
       "id": "clause:WDP-CL-IP-MAPPING-FRAGMENTATION|refines|scr-row:WDP-C-001",
       "from": "clause:WDP-CL-IP-MAPPING-FRAGMENTATION",
       "relation": "refines",
@@ -6999,6 +7037,15 @@
       "from": "clause:WDP-CL-IPV4-BASELINE-RECEIVE-SIZE",
       "relation": "planned-by",
       "to": "work-item:TRN-702",
+      "sourceRefs": [
+        "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
+      ]
+    },
+    {
+      "id": "clause:WDP-CL-IPV4-BASELINE-RECEIVE-SIZE|planned-by|work-item:TRN-706",
+      "from": "clause:WDP-CL-IPV4-BASELINE-RECEIVE-SIZE",
+      "relation": "planned-by",
+      "to": "work-item:TRN-706",
       "sourceRefs": [
         "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
       ]
@@ -7202,6 +7249,15 @@
       ]
     },
     {
+      "id": "clause:WDP-CL-IPV4-FRAGMENT-REASSEMBLY-KEY|planned-by|work-item:TRN-706",
+      "from": "clause:WDP-CL-IPV4-FRAGMENT-REASSEMBLY-KEY",
+      "relation": "planned-by",
+      "to": "work-item:TRN-706",
+      "sourceRefs": [
+        "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
+      ]
+    },
+    {
       "id": "clause:WDP-CL-IPV4-FRAGMENT-REASSEMBLY-KEY|refines|scr-row:WDP-CORE-C-001",
       "from": "clause:WDP-CL-IPV4-FRAGMENT-REASSEMBLY-KEY",
       "relation": "refines",
@@ -7274,6 +7330,15 @@
       ]
     },
     {
+      "id": "clause:WDP-CL-IPV4-FRAGMENTATION-LOCATION|planned-by|work-item:TRN-706",
+      "from": "clause:WDP-CL-IPV4-FRAGMENTATION-LOCATION",
+      "relation": "planned-by",
+      "to": "work-item:TRN-706",
+      "sourceRefs": [
+        "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
+      ]
+    },
+    {
       "id": "clause:WDP-CL-IPV4-FRAGMENTATION-LOCATION|refines|scr-row:WDP-CORE-C-001",
       "from": "clause:WDP-CL-IPV4-FRAGMENTATION-LOCATION",
       "relation": "refines",
@@ -7328,6 +7393,15 @@
       ]
     },
     {
+      "id": "clause:WDP-CL-IPV4-HEADER-CHECKSUM|planned-by|work-item:TRN-706",
+      "from": "clause:WDP-CL-IPV4-HEADER-CHECKSUM",
+      "relation": "planned-by",
+      "to": "work-item:TRN-706",
+      "sourceRefs": [
+        "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
+      ]
+    },
+    {
       "id": "clause:WDP-CL-IPV4-HEADER-CHECKSUM|refines|scr-row:WDP-NA-C-003",
       "from": "clause:WDP-CL-IPV4-HEADER-CHECKSUM",
       "relation": "refines",
@@ -7368,6 +7442,15 @@
       "from": "clause:WDP-CL-IPV4-HEADER-LAYOUT",
       "relation": "planned-by",
       "to": "work-item:TRN-701",
+      "sourceRefs": [
+        "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
+      ]
+    },
+    {
+      "id": "clause:WDP-CL-IPV4-HEADER-LAYOUT|planned-by|work-item:TRN-706",
+      "from": "clause:WDP-CL-IPV4-HEADER-LAYOUT",
+      "relation": "planned-by",
+      "to": "work-item:TRN-706",
       "sourceRefs": [
         "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
       ]
@@ -7665,6 +7748,15 @@
       "from": "clause:WDP-CL-IPV4-SOURCE-DESTINATION-FIELDS",
       "relation": "planned-by",
       "to": "work-item:TRN-701",
+      "sourceRefs": [
+        "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
+      ]
+    },
+    {
+      "id": "clause:WDP-CL-IPV4-SOURCE-DESTINATION-FIELDS|planned-by|work-item:TRN-706",
+      "from": "clause:WDP-CL-IPV4-SOURCE-DESTINATION-FIELDS",
+      "relation": "planned-by",
+      "to": "work-item:TRN-706",
       "sourceRefs": [
         "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
       ]
@@ -8588,6 +8680,15 @@
       ]
     },
     {
+      "id": "clause:WDP-CL-UDP-HEADER-LAYOUT|planned-by|work-item:TRN-706",
+      "from": "clause:WDP-CL-UDP-HEADER-LAYOUT",
+      "relation": "planned-by",
+      "to": "work-item:TRN-706",
+      "sourceRefs": [
+        "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
+      ]
+    },
+    {
       "id": "clause:WDP-CL-UDP-HEADER-LAYOUT|refines|scr-row:WDP-CORE-C-001",
       "from": "clause:WDP-CL-UDP-HEADER-LAYOUT",
       "relation": "refines",
@@ -8781,6 +8882,15 @@
       "from": "clause:WDP-CL-UDP-LENGTH-BOUNDS",
       "relation": "planned-by",
       "to": "work-item:TRN-702",
+      "sourceRefs": [
+        "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
+      ]
+    },
+    {
+      "id": "clause:WDP-CL-UDP-LENGTH-BOUNDS|planned-by|work-item:TRN-706",
+      "from": "clause:WDP-CL-UDP-LENGTH-BOUNDS",
+      "relation": "planned-by",
+      "to": "work-item:TRN-706",
       "sourceRefs": [
         "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
       ]
@@ -9087,6 +9197,15 @@
       "from": "clause:WDP-CL-UNITDATA-CONTENT-TRANSPARENCY",
       "relation": "planned-by",
       "to": "work-item:TRN-702",
+      "sourceRefs": [
+        "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
+      ]
+    },
+    {
+      "id": "clause:WDP-CL-UNITDATA-CONTENT-TRANSPARENCY|planned-by|work-item:TRN-706",
+      "from": "clause:WDP-CL-UNITDATA-CONTENT-TRANSPARENCY",
+      "relation": "planned-by",
+      "to": "work-item:TRN-706",
       "sourceRefs": [
         "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
       ]

--- a/spec-processing/source-manifests/wap-1.2.1-wml-2-knowledge-graph.json
+++ b/spec-processing/source-manifests/wap-1.2.1-wml-2-knowledge-graph.json
@@ -13,7 +13,7 @@
     "generator": "spec-processing/scripts/generate-wap-knowledge-graph.mjs",
     "inputs": {
       "docs/waves/wap-1.2.1-compliance-program.json": {
-        "sha256": "6497a1802b8ea8661aff21b847cd754564b305d5245e41c653b7cb9df6cd9865"
+        "sha256": "92b8d3321d22f08832d37c7c43af7771c1f7ff9941b47800b8e9de3d15bc0f6d"
       },
       "spec-processing/source-manifests/wap-1.2.1-class-conformance.json": {
         "sha256": "b76605b2144b32965a857b848b2e9e522baada6fae9fe51012b9eaa664e85d86"
@@ -25,7 +25,7 @@
         "sha256": "654284270a068b427ab05166247cb8e0644a99cf6af511f9b9c477d18ea36faa"
       },
       "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json": {
-        "sha256": "3e51cf531c278871d4fd0948017950c3a3992f152960a8e0f43e39dadf8d8740"
+        "sha256": "903e469345d86c37a7b76d7a8f17085be518747d553ef85d54dffb14d91ae32b"
       }
     },
     "policy": "Canonical manifests remain authoritative; this graph and its Obsidian/context projections are generated views."

--- a/transport-rust/tests/interop_replay.rs
+++ b/transport-rust/tests/interop_replay.rs
@@ -1,4 +1,8 @@
-use lowband_transport_rust::network::wdp::{WdpAddress, WdpDatagram, WdpServicePort};
+use lowband_transport_rust::network::wdp::{
+    decode_cdpd_ipv4_udp, encode_cdpd_ipv4_udp, CdpdIpv4SendPolicy, Ipv4Reassembler,
+    Ipv4ReassemblyOutcome, Ipv4ReassemblyPolicy, UdpChecksumPolicy, WdpAddress, WdpDatagram,
+    WdpServicePort,
+};
 use lowband_transport_rust::network::wsp::{
     decode_wsp_session_event, WspEncodingVersion, WspHeaderBlockDecodePolicy, WspMethod,
     WspSessionEvent, WspSessionMode,
@@ -14,6 +18,10 @@ use serde::Deserialize;
 use std::fs;
 use std::net::IpAddr;
 use std::path::{Path, PathBuf};
+
+const CLAUSE_LEDGER_SOURCE: &str = include_str!(
+    "../../spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
+);
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -32,6 +40,15 @@ struct ReplayCorpus {
     provenance: String,
     legal_reuse: String,
     derived_from: String,
+    profile: Option<String>,
+    source_documents: Option<Vec<ReplaySourceDocument>>,
+    clause_ids: Option<Vec<String>>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ReplaySourceDocument {
+    id: String,
+    sections: Vec<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -42,6 +59,8 @@ struct ReplayCase {
     datagrams: Option<Vec<ReplayDatagram>>,
     retransmission_steps: Option<Vec<ReplayRetransmissionStep>>,
     duplicate_steps: Option<Vec<ReplayDuplicateStep>>,
+    wdp_steps: Option<Vec<ReplayWdpStep>>,
+    wdp_reassembly_policy: Option<ReplayWdpReassemblyPolicy>,
     expected_events: Vec<ExpectedReplayEvent>,
     expected_transaction_outcomes: Vec<ExpectedTransactionOutcome>,
 }
@@ -81,6 +100,71 @@ struct ReplayDuplicateStep {
     tid: u16,
     is_terminal_result: bool,
     policy: ReplayDuplicatePolicy,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ReplayWdpDatagram {
+    src_addr: String,
+    dst_addr: String,
+    src_port: u16,
+    dst_port: u16,
+    payload: ReplayPayload,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(tag = "kind", rename_all = "camelCase")]
+enum ReplayPayload {
+    Bytes { bytes: Vec<u8> },
+    Repeat { byte: u8, length: usize },
+}
+
+#[derive(Debug, Clone, Copy, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ReplayWdpSendPolicy {
+    identification: u16,
+    time_to_live: u8,
+    dont_fragment: bool,
+    path_mtu: Option<usize>,
+    destination_accepts_large_datagrams: bool,
+    udp_checksum: ReplayUdpChecksumPolicy,
+}
+
+#[derive(Debug, Clone, Copy, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+enum ReplayUdpChecksumPolicy {
+    Generate,
+    Omit,
+}
+
+#[derive(Debug, Clone, Copy, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ReplayWdpReassemblyPolicy {
+    max_datagram_bytes: usize,
+    max_pending_datagrams: usize,
+    max_buffered_payload_bytes: usize,
+    timeout_ticks: u64,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(tag = "kind", rename_all = "camelCase")]
+enum ReplayWdpStep {
+    RoundTrip {
+        datagram: ReplayWdpDatagram,
+        send_policy: ReplayWdpSendPolicy,
+        expected_packet: Option<Vec<u8>>,
+        expected_packet_len: usize,
+    },
+    Decode {
+        packet: Vec<u8>,
+    },
+    Fragment {
+        tick: u64,
+        packet: Vec<u8>,
+    },
+    Expire {
+        tick: u64,
+    },
 }
 
 #[derive(Debug, Clone, Copy, Deserialize, PartialEq, Eq)]
@@ -182,6 +266,31 @@ enum ExpectedReplayEvent {
         tid: u16,
         cache_size: usize,
     },
+    WdpAccepted {
+        src_addr: Vec<u8>,
+        dst_addr: Vec<u8>,
+        src_port: u16,
+        dst_port: u16,
+        packet_len: usize,
+        payload_len: usize,
+    },
+    WdpRejected {
+        error: String,
+    },
+    WdpFragmentPending {
+        duplicate: bool,
+        buffered_payload_bytes: usize,
+        expected_payload_bytes: Option<usize>,
+        expires_at_tick: u64,
+    },
+    WdpReassembled {
+        packet_len: usize,
+        payload_len: usize,
+    },
+    WdpIncompleteExpired {
+        count: usize,
+        buffered_payload_bytes: usize,
+    },
 }
 
 #[derive(Debug, Deserialize)]
@@ -211,6 +320,13 @@ enum ExpectedTransactionOutcome {
         replayed_terminal: usize,
         dropped_duplicates: usize,
         final_cache_size: usize,
+    },
+    WdpReplaySummary {
+        accepted_datagrams: usize,
+        rejected_packets: usize,
+        duplicate_fragments: usize,
+        completed_reassemblies: usize,
+        expired_assemblies: usize,
     },
 }
 
@@ -262,6 +378,31 @@ enum ReplayEvent {
         tid: u16,
         cache_size: usize,
     },
+    WdpAccepted {
+        src_addr: Vec<u8>,
+        dst_addr: Vec<u8>,
+        src_port: u16,
+        dst_port: u16,
+        packet_len: usize,
+        payload_len: usize,
+    },
+    WdpRejected {
+        error: String,
+    },
+    WdpFragmentPending {
+        duplicate: bool,
+        buffered_payload_bytes: usize,
+        expected_payload_bytes: Option<usize>,
+        expires_at_tick: u64,
+    },
+    WdpReassembled {
+        packet_len: usize,
+        payload_len: usize,
+    },
+    WdpIncompleteExpired {
+        count: usize,
+        buffered_payload_bytes: usize,
+    },
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -290,6 +431,13 @@ enum ReplayTransactionOutcome {
         replayed_terminal: usize,
         dropped_duplicates: usize,
         final_cache_size: usize,
+    },
+    WdpReplaySummary {
+        accepted_datagrams: usize,
+        rejected_packets: usize,
+        duplicate_fragments: usize,
+        completed_reassemblies: usize,
+        expired_assemblies: usize,
     },
 }
 
@@ -337,7 +485,7 @@ fn validate_fixture_metadata(path: &Path, fixture: &ReplayFixture) {
     assert!(
         matches!(
             fixture.corpus.source_class.as_str(),
-            "interop-reference" | "heuristic"
+            "normative" | "interop-reference" | "heuristic"
         ),
         "fixture '{}' uses invalid source class '{}'",
         path.display(),
@@ -352,6 +500,58 @@ fn validate_fixture_metadata(path: &Path, fixture: &ReplayFixture) {
         path.display(),
         fixture.corpus.legal_reuse
     );
+    if let Some(source_documents) = &fixture.corpus.source_documents {
+        assert!(
+            !source_documents.is_empty()
+                && source_documents
+                    .iter()
+                    .all(|source| !source.id.is_empty() && !source.sections.is_empty()),
+            "fixture '{}' must include anchored source documents",
+            path.display()
+        );
+    }
+    if let Some(clause_ids) = &fixture.corpus.clause_ids {
+        assert!(
+            !clause_ids.is_empty(),
+            "fixture '{}' must include at least one mapped clause",
+            path.display()
+        );
+        let ledger: serde_json::Value =
+            serde_json::from_str(CLAUSE_LEDGER_SOURCE).expect("clause ledger should parse");
+        let mapped = ledger["families"]
+            .as_array()
+            .expect("families should be an array")
+            .iter()
+            .find(|family| family["family"] == "wdp")
+            .expect("WDP family should exist")["clauses"]
+            .as_array()
+            .expect("WDP clauses should be an array")
+            .iter()
+            .filter(|clause| {
+                clause["mapping"]["workItems"]
+                    .as_array()
+                    .is_some_and(|items| items.iter().any(|item| item == "TRN-706"))
+            })
+            .map(|clause| {
+                clause["id"]
+                    .as_str()
+                    .expect("mapped clause should have an ID")
+                    .to_string()
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(
+            clause_ids.as_slice(),
+            mapped.as_slice(),
+            "fixture '{}' clause mapping must match canonical TRN-706 mappings",
+            path.display()
+        );
+        assert_eq!(
+            fixture.corpus.profile.as_deref(),
+            Some("wap-net-core-selected-wdp-only"),
+            "fixture '{}' must retain its selected WDP-only profile boundary",
+            path.display()
+        );
+    }
     for case in &fixture.cases {
         assert!(
             !case.capture.capture_id.is_empty()
@@ -364,7 +564,7 @@ fn validate_fixture_metadata(path: &Path, fixture: &ReplayFixture) {
         assert!(
             matches!(
                 case.capture.source_family.as_str(),
-                "synthetic-seed" | "kannel" | "wireshark"
+                "synthetic-seed" | "wap-1.2.1-selected-wdp" | "kannel" | "wireshark"
             ),
             "fixture '{}' case '{}' uses unsupported source family '{}'",
             path.display(),
@@ -397,6 +597,17 @@ fn validate_fixture_metadata(path: &Path, fixture: &ReplayFixture) {
             path.display(),
             case.name
         );
+        if let Some(steps) = &case.wdp_steps {
+            assert!(
+                !steps.is_empty()
+                    && case.datagrams.is_none()
+                    && case.retransmission_steps.is_none()
+                    && case.duplicate_steps.is_none(),
+                "fixture '{}' case '{}' must keep the WDP replay lane typed and separate",
+                path.display(),
+                case.name
+            );
+        }
     }
 }
 
@@ -417,6 +628,46 @@ fn to_datagram(input: &ReplayDatagram) -> WdpDatagram {
         src_port: input.src_port,
         dst_port: input.dst_port,
         payload: input.payload.clone(),
+    }
+}
+
+fn replay_payload(input: &ReplayPayload) -> Vec<u8> {
+    match input {
+        ReplayPayload::Bytes { bytes } => bytes.clone(),
+        ReplayPayload::Repeat { byte, length } => vec![*byte; *length],
+    }
+}
+
+fn to_wdp_datagram(input: &ReplayWdpDatagram) -> WdpDatagram {
+    WdpDatagram {
+        src_addr: parse_addr(&input.src_addr),
+        dst_addr: parse_addr(&input.dst_addr),
+        src_port: input.src_port,
+        dst_port: input.dst_port,
+        payload: replay_payload(&input.payload),
+    }
+}
+
+fn to_wdp_send_policy(input: ReplayWdpSendPolicy) -> CdpdIpv4SendPolicy {
+    CdpdIpv4SendPolicy {
+        identification: input.identification,
+        time_to_live: input.time_to_live,
+        dont_fragment: input.dont_fragment,
+        path_mtu: input.path_mtu,
+        destination_accepts_large_datagrams: input.destination_accepts_large_datagrams,
+        udp_checksum: match input.udp_checksum {
+            ReplayUdpChecksumPolicy::Generate => UdpChecksumPolicy::Generate,
+            ReplayUdpChecksumPolicy::Omit => UdpChecksumPolicy::Omit,
+        },
+    }
+}
+
+fn to_wdp_reassembly_policy(input: ReplayWdpReassemblyPolicy) -> Ipv4ReassemblyPolicy {
+    Ipv4ReassemblyPolicy {
+        max_datagram_bytes: input.max_datagram_bytes,
+        max_pending_datagrams: input.max_pending_datagrams,
+        max_buffered_payload_bytes: input.max_buffered_payload_bytes,
+        timeout_ticks: input.timeout_ticks,
     }
 }
 
@@ -591,6 +842,117 @@ fn replay_case(case: &ReplayCase) -> Vec<ReplayEvent> {
         }
     }
 
+    if let Some(steps) = &case.wdp_steps {
+        let mut reassembler = case
+            .wdp_reassembly_policy
+            .map(to_wdp_reassembly_policy)
+            .map(Ipv4Reassembler::new)
+            .transpose()
+            .unwrap_or_else(|error| panic!("case '{}' has invalid policy: {error}", case.name));
+
+        for step in steps {
+            match step {
+                ReplayWdpStep::RoundTrip {
+                    datagram,
+                    send_policy,
+                    expected_packet,
+                    expected_packet_len,
+                } => {
+                    let input = to_wdp_datagram(datagram);
+                    let packet = encode_cdpd_ipv4_udp(&input, to_wdp_send_policy(*send_policy))
+                        .unwrap_or_else(|error| {
+                            panic!("case '{}' WDP encode failed: {error}", case.name)
+                        });
+                    assert_eq!(
+                        packet.len(),
+                        *expected_packet_len,
+                        "case '{}' encoded packet length",
+                        case.name
+                    );
+                    if let Some(expected) = expected_packet {
+                        assert_eq!(
+                            packet.as_slice(),
+                            expected.as_slice(),
+                            "case '{}' encoded packet bytes",
+                            case.name
+                        );
+                    }
+                    let decoded = decode_cdpd_ipv4_udp(&packet).unwrap_or_else(|error| {
+                        panic!("case '{}' WDP decode failed: {error}", case.name)
+                    });
+                    assert_eq!(
+                        decoded, input,
+                        "case '{}' WDP round trip changed the datagram",
+                        case.name
+                    );
+                    out.push(ReplayEvent::WdpAccepted {
+                        src_addr: decoded.src_addr.value,
+                        dst_addr: decoded.dst_addr.value,
+                        src_port: decoded.src_port,
+                        dst_port: decoded.dst_port,
+                        packet_len: packet.len(),
+                        payload_len: decoded.payload.len(),
+                    });
+                }
+                ReplayWdpStep::Decode { packet } => {
+                    let error = decode_cdpd_ipv4_udp(packet)
+                        .expect_err("malformed WDP replay packet should be rejected");
+                    out.push(ReplayEvent::WdpRejected {
+                        error: error.to_string(),
+                    });
+                }
+                ReplayWdpStep::Fragment { tick, packet } => {
+                    let active = reassembler.as_mut().unwrap_or_else(|| {
+                        panic!(
+                            "case '{}' fragment step requires a reassembly policy",
+                            case.name
+                        )
+                    });
+                    match active.ingest(packet, *tick).unwrap_or_else(|error| {
+                        panic!("case '{}' fragment replay failed: {error}", case.name)
+                    }) {
+                        Ipv4ReassemblyOutcome::Pending(pending) => {
+                            out.push(ReplayEvent::WdpFragmentPending {
+                                duplicate: pending.duplicate,
+                                buffered_payload_bytes: pending.buffered_payload_bytes,
+                                expected_payload_bytes: pending.expected_payload_bytes,
+                                expires_at_tick: pending.expires_at_tick,
+                            });
+                        }
+                        Ipv4ReassemblyOutcome::Complete(packet) => {
+                            let decoded = decode_cdpd_ipv4_udp(&packet).unwrap_or_else(|error| {
+                                panic!(
+                                    "case '{}' reassembled WDP decode failed: {error}",
+                                    case.name
+                                )
+                            });
+                            out.push(ReplayEvent::WdpReassembled {
+                                packet_len: packet.len(),
+                                payload_len: decoded.payload.len(),
+                            });
+                        }
+                    }
+                }
+                ReplayWdpStep::Expire { tick } => {
+                    let active = reassembler.as_mut().unwrap_or_else(|| {
+                        panic!(
+                            "case '{}' expire step requires a reassembly policy",
+                            case.name
+                        )
+                    });
+                    let expired = active.expire(*tick);
+                    out.push(ReplayEvent::WdpIncompleteExpired {
+                        count: expired.len(),
+                        buffered_payload_bytes: expired
+                            .iter()
+                            .map(|assembly| assembly.buffered_payload_bytes)
+                            .sum(),
+                    });
+                }
+            }
+        }
+    }
+
     out
 }
 
@@ -698,6 +1060,49 @@ fn expected_events(case: &ReplayCase) -> Vec<ReplayEvent> {
                 decision: decision.clone(),
                 tid: *tid,
                 cache_size: *cache_size,
+            },
+            ExpectedReplayEvent::WdpAccepted {
+                src_addr,
+                dst_addr,
+                src_port,
+                dst_port,
+                packet_len,
+                payload_len,
+            } => ReplayEvent::WdpAccepted {
+                src_addr: src_addr.clone(),
+                dst_addr: dst_addr.clone(),
+                src_port: *src_port,
+                dst_port: *dst_port,
+                packet_len: *packet_len,
+                payload_len: *payload_len,
+            },
+            ExpectedReplayEvent::WdpRejected { error } => ReplayEvent::WdpRejected {
+                error: error.clone(),
+            },
+            ExpectedReplayEvent::WdpFragmentPending {
+                duplicate,
+                buffered_payload_bytes,
+                expected_payload_bytes,
+                expires_at_tick,
+            } => ReplayEvent::WdpFragmentPending {
+                duplicate: *duplicate,
+                buffered_payload_bytes: *buffered_payload_bytes,
+                expected_payload_bytes: *expected_payload_bytes,
+                expires_at_tick: *expires_at_tick,
+            },
+            ExpectedReplayEvent::WdpReassembled {
+                packet_len,
+                payload_len,
+            } => ReplayEvent::WdpReassembled {
+                packet_len: *packet_len,
+                payload_len: *payload_len,
+            },
+            ExpectedReplayEvent::WdpIncompleteExpired {
+                count,
+                buffered_payload_bytes,
+            } => ReplayEvent::WdpIncompleteExpired {
+                count: *count,
+                buffered_payload_bytes: *buffered_payload_bytes,
             },
         })
         .collect()
@@ -821,6 +1226,59 @@ fn derive_transaction_outcomes(events: &[ReplayEvent]) -> Vec<ReplayTransactionO
         });
     }
 
+    let accepted_datagrams = events
+        .iter()
+        .filter(|event| matches!(event, ReplayEvent::WdpAccepted { .. }))
+        .count();
+    let rejected_packets = events
+        .iter()
+        .filter(|event| matches!(event, ReplayEvent::WdpRejected { .. }))
+        .count();
+    let duplicate_fragments = events
+        .iter()
+        .filter(|event| {
+            matches!(
+                event,
+                ReplayEvent::WdpFragmentPending {
+                    duplicate: true,
+                    ..
+                }
+            )
+        })
+        .count();
+    let completed_reassemblies = events
+        .iter()
+        .filter(|event| matches!(event, ReplayEvent::WdpReassembled { .. }))
+        .count();
+    let expired_assemblies = events
+        .iter()
+        .filter_map(|event| match event {
+            ReplayEvent::WdpIncompleteExpired { count, .. } => Some(*count),
+            _ => None,
+        })
+        .sum();
+    if accepted_datagrams
+        + rejected_packets
+        + duplicate_fragments
+        + completed_reassemblies
+        + expired_assemblies
+        > 0
+        || events.iter().any(|event| {
+            matches!(
+                event,
+                ReplayEvent::WdpFragmentPending { .. } | ReplayEvent::WdpIncompleteExpired { .. }
+            )
+        })
+    {
+        out.push(ReplayTransactionOutcome::WdpReplaySummary {
+            accepted_datagrams,
+            rejected_packets,
+            duplicate_fragments,
+            completed_reassemblies,
+            expired_assemblies,
+        });
+    }
+
     out
 }
 
@@ -874,12 +1332,25 @@ fn expected_transaction_outcomes(case: &ReplayCase) -> Vec<ReplayTransactionOutc
                 dropped_duplicates: *dropped_duplicates,
                 final_cache_size: *final_cache_size,
             },
+            ExpectedTransactionOutcome::WdpReplaySummary {
+                accepted_datagrams,
+                rejected_packets,
+                duplicate_fragments,
+                completed_reassemblies,
+                expired_assemblies,
+            } => ReplayTransactionOutcome::WdpReplaySummary {
+                accepted_datagrams: *accepted_datagrams,
+                rejected_packets: *rejected_packets,
+                duplicate_fragments: *duplicate_fragments,
+                completed_reassemblies: *completed_reassemblies,
+                expired_assemblies: *expired_assemblies,
+            },
         })
         .collect()
 }
 
 #[test]
-fn interop_replay_fixture_get_reply_paths_are_deterministic() {
+fn interop_replay_fixture_paths_are_deterministic() {
     let root = interop_fixture_root();
     assert!(
         root.is_dir(),

--- a/transport-rust/tests/network/interop/README.md
+++ b/transport-rust/tests/network/interop/README.md
@@ -4,10 +4,25 @@ This directory is the canonical fixture lane for protocol-profile promotion chec
 
 Current seed corpus:
 
+- `wdp_cdpd_ipv4_seed.json`: selected-profile WDP-only replay for byte-exact
+  CDPD/UDP/IPv4 round trip, the 576-octet boundary, malformed IPv4/UDP
+  rejection, duplicate fragment idempotence, and simulated incomplete
+  reassembly expiry.
 - `connect_session_seed.json`: deterministic WSP session-setup replay for minimal `Connect` / `ConnectReply` over connection-oriented service ports.
 - `get_reply_seed.json`: deterministic WDP + WSP replay corpus for minimal `GET` / `REPLY` paths over known service ports.
 - `retransmission_seed.json`: deterministic WTP retransmission replay path for timer-expiry and ACK completion sequencing.
 - `duplicate_tid_seed.json`: deterministic duplicate-TID replay coverage for terminal replay and nonterminal duplicate drop behavior.
+
+Profile boundary:
+
+1. `wdp_cdpd_ipv4_seed.json` is the directly mapped `TRN-706` evidence for
+   the active `wap-net-core` selected WDP path.
+2. The connection-oriented WSP and WTP seeds remain conditional scaffolding.
+   They do not activate connection-oriented WSP/WTP and do not close the
+   declared `TRN-706` WTP-family gap.
+3. The simulated 30-tick incomplete-assembly expiry is a deterministic,
+   bounded implementation policy. It is not claimed as a source-defined WAP
+   timer value.
 
 Schema contract:
 
@@ -27,6 +42,10 @@ Schema contract:
 3. Each case must define:
    - deterministic `expectedEvents`
    - deterministic `expectedTransactionOutcomes`
+4. A directly mapped normative corpus additionally carries:
+   - `corpus.profile`
+   - source document section anchors
+   - exact canonical `clauseIds`
 
 Legal/reuse posture:
 

--- a/transport-rust/tests/network/interop/wdp_cdpd_ipv4_seed.json
+++ b/transport-rust/tests/network/interop/wdp_cdpd_ipv4_seed.json
@@ -1,0 +1,557 @@
+{
+  "schemaVersion": 1,
+  "corpus": {
+    "id": "wdp-cdpd-ipv4-selected-profile-seed",
+    "title": "Selected-profile WDP CDPD/UDP/IPv4 replay corpus",
+    "sourceClass": "normative",
+    "provenance": "Project-authored synthetic packets tied to selected WAP-200, RFC 768, and RFC 791 clauses.",
+    "legalReuse": "synthetic-derivative",
+    "derivedFrom": "transport-rust/src/network/wdp/ipv4_udp.rs + transport-rust/src/network/wdp/ipv4_reassembly.rs",
+    "profile": "wap-net-core-selected-wdp-only",
+    "sourceDocuments": [
+      {
+        "id": "WAP-200-WDP",
+        "sections": ["5.4.3", "6.3.1.1", "7.2"]
+      },
+      {
+        "id": "rfc-768",
+        "sections": ["format", "fields"]
+      },
+      {
+        "id": "rfc-791",
+        "sections": ["3.1", "3.2"]
+      }
+    ],
+    "clauseIds": [
+      "WDP-CL-CDPD-UDP-IP-PROFILE",
+      "WDP-CL-UNITDATA-CONTENT-TRANSPARENCY",
+      "WDP-CL-IP-MAPPING-FRAGMENTATION",
+      "WDP-CL-UDP-HEADER-LAYOUT",
+      "WDP-CL-UDP-LENGTH-BOUNDS",
+      "WDP-CL-IPV4-HEADER-LAYOUT",
+      "WDP-CL-IPV4-BASELINE-RECEIVE-SIZE",
+      "WDP-CL-IPV4-FRAGMENTATION-LOCATION",
+      "WDP-CL-IPV4-FRAGMENT-REASSEMBLY-KEY",
+      "WDP-CL-IPV4-HEADER-CHECKSUM",
+      "WDP-CL-IPV4-SOURCE-DESTINATION-FIELDS"
+    ]
+  },
+  "cases": [
+    {
+      "name": "selected_cdpd_udp_ipv4_positive_round_trip",
+      "capture": {
+        "captureId": "wdp-selected-positive-001",
+        "sourceFamily": "wap-1.2.1-selected-wdp",
+        "captureKind": "seed-trace",
+        "provenanceNote": "Byte-exact positive packet for the selected CDPD WDP-over-UDP/IPv4 path.",
+        "legalReuse": "synthetic-derivative"
+      },
+      "wdpSteps": [
+        {
+          "kind": "roundTrip",
+          "datagram": {
+            "srcAddr": "192.0.2.10",
+            "dstAddr": "192.0.2.7",
+            "srcPort": 49152,
+            "dstPort": 9200,
+            "payload": {
+              "kind": "bytes",
+              "bytes": [222, 173, 190, 239, 1]
+            }
+          },
+          "send_policy": {
+            "identification": 4660,
+            "timeToLive": 64,
+            "dontFragment": false,
+            "pathMtu": null,
+            "destinationAcceptsLargeDatagrams": false,
+            "udpChecksum": "generate"
+          },
+          "expected_packet": [
+            69,
+            0,
+            0,
+            33,
+            18,
+            52,
+            0,
+            0,
+            64,
+            17,
+            228,
+            134,
+            192,
+            0,
+            2,
+            10,
+            192,
+            0,
+            2,
+            7,
+            192,
+            0,
+            35,
+            240,
+            0,
+            13,
+            249,
+            51,
+            222,
+            173,
+            190,
+            239,
+            1
+          ],
+          "expected_packet_len": 33
+        }
+      ],
+      "expectedEvents": [
+        {
+          "kind": "wdpAccepted",
+          "src_addr": [192, 0, 2, 10],
+          "dst_addr": [192, 0, 2, 7],
+          "src_port": 49152,
+          "dst_port": 9200,
+          "packet_len": 33,
+          "payload_len": 5
+        }
+      ],
+      "expectedTransactionOutcomes": [
+        {
+          "kind": "wdpReplaySummary",
+          "accepted_datagrams": 1,
+          "rejected_packets": 0,
+          "duplicate_fragments": 0,
+          "completed_reassemblies": 0,
+          "expired_assemblies": 0
+        }
+      ]
+    },
+    {
+      "name": "selected_ipv4_576_octet_boundary_round_trip",
+      "capture": {
+        "captureId": "wdp-selected-boundary-001",
+        "sourceFamily": "wap-1.2.1-selected-wdp",
+        "captureKind": "seed-trace",
+        "provenanceNote": "Synthetic 548-octet UDP payload producing the exact 576-octet IPv4 receive baseline.",
+        "legalReuse": "synthetic-derivative"
+      },
+      "wdpSteps": [
+        {
+          "kind": "roundTrip",
+          "datagram": {
+            "srcAddr": "192.0.2.10",
+            "dstAddr": "192.0.2.7",
+            "srcPort": 49152,
+            "dstPort": 9200,
+            "payload": {
+              "kind": "repeat",
+              "byte": 165,
+              "length": 548
+            }
+          },
+          "send_policy": {
+            "identification": 22136,
+            "timeToLive": 64,
+            "dontFragment": false,
+            "pathMtu": null,
+            "destinationAcceptsLargeDatagrams": false,
+            "udpChecksum": "generate"
+          },
+          "expected_packet": null,
+          "expected_packet_len": 576
+        }
+      ],
+      "expectedEvents": [
+        {
+          "kind": "wdpAccepted",
+          "src_addr": [192, 0, 2, 10],
+          "dst_addr": [192, 0, 2, 7],
+          "src_port": 49152,
+          "dst_port": 9200,
+          "packet_len": 576,
+          "payload_len": 548
+        }
+      ],
+      "expectedTransactionOutcomes": [
+        {
+          "kind": "wdpReplaySummary",
+          "accepted_datagrams": 1,
+          "rejected_packets": 0,
+          "duplicate_fragments": 0,
+          "completed_reassemblies": 0,
+          "expired_assemblies": 0
+        }
+      ]
+    },
+    {
+      "name": "malformed_ipv4_header_checksum_is_rejected",
+      "capture": {
+        "captureId": "wdp-selected-malformed-ipv4-001",
+        "sourceFamily": "wap-1.2.1-selected-wdp",
+        "captureKind": "seed-trace",
+        "provenanceNote": "Positive packet with one checksum octet changed after encoding.",
+        "legalReuse": "synthetic-derivative"
+      },
+      "wdpSteps": [
+        {
+          "kind": "decode",
+          "packet": [
+            69,
+            0,
+            0,
+            33,
+            18,
+            52,
+            0,
+            0,
+            64,
+            17,
+            228,
+            135,
+            192,
+            0,
+            2,
+            10,
+            192,
+            0,
+            2,
+            7,
+            192,
+            0,
+            35,
+            240,
+            0,
+            13,
+            249,
+            51,
+            222,
+            173,
+            190,
+            239,
+            1
+          ]
+        }
+      ],
+      "expectedEvents": [
+        {
+          "kind": "wdpRejected",
+          "error": "invalid IPv4 header checksum"
+        }
+      ],
+      "expectedTransactionOutcomes": [
+        {
+          "kind": "wdpReplaySummary",
+          "accepted_datagrams": 0,
+          "rejected_packets": 1,
+          "duplicate_fragments": 0,
+          "completed_reassemblies": 0,
+          "expired_assemblies": 0
+        }
+      ]
+    },
+    {
+      "name": "malformed_udp_length_is_rejected",
+      "capture": {
+        "captureId": "wdp-selected-malformed-udp-001",
+        "sourceFamily": "wap-1.2.1-selected-wdp",
+        "captureKind": "seed-trace",
+        "provenanceNote": "Positive IPv4 packet with a UDP length below the eight-octet header.",
+        "legalReuse": "synthetic-derivative"
+      },
+      "wdpSteps": [
+        {
+          "kind": "decode",
+          "packet": [
+            69,
+            0,
+            0,
+            33,
+            18,
+            52,
+            0,
+            0,
+            64,
+            17,
+            228,
+            134,
+            192,
+            0,
+            2,
+            10,
+            192,
+            0,
+            2,
+            7,
+            192,
+            0,
+            35,
+            240,
+            0,
+            7,
+            249,
+            51,
+            222,
+            173,
+            190,
+            239,
+            1
+          ]
+        }
+      ],
+      "expectedEvents": [
+        {
+          "kind": "wdpRejected",
+          "error": "invalid UDP length 7; available UDP octets 13"
+        }
+      ],
+      "expectedTransactionOutcomes": [
+        {
+          "kind": "wdpReplaySummary",
+          "accepted_datagrams": 0,
+          "rejected_packets": 1,
+          "duplicate_fragments": 0,
+          "completed_reassemblies": 0,
+          "expired_assemblies": 0
+        }
+      ]
+    },
+    {
+      "name": "duplicate_ipv4_fragment_is_idempotent",
+      "capture": {
+        "captureId": "wdp-selected-duplicate-fragment-001",
+        "sourceFamily": "wap-1.2.1-selected-wdp",
+        "captureKind": "seed-trace",
+        "provenanceNote": "Synthetic first-fragment duplicate followed by the final fragment.",
+        "legalReuse": "synthetic-derivative"
+      },
+      "wdpReassemblyPolicy": {
+        "maxDatagramBytes": 576,
+        "maxPendingDatagrams": 8,
+        "maxBufferedPayloadBytes": 4608,
+        "timeoutTicks": 30
+      },
+      "wdpSteps": [
+        {
+          "kind": "fragment",
+          "tick": 2,
+          "packet": [
+            69,
+            0,
+            0,
+            28,
+            18,
+            52,
+            32,
+            0,
+            64,
+            17,
+            196,
+            139,
+            192,
+            0,
+            2,
+            10,
+            192,
+            0,
+            2,
+            7,
+            192,
+            0,
+            35,
+            240,
+            0,
+            13,
+            249,
+            51
+          ]
+        },
+        {
+          "kind": "fragment",
+          "tick": 3,
+          "packet": [
+            69,
+            0,
+            0,
+            28,
+            18,
+            52,
+            32,
+            0,
+            64,
+            17,
+            196,
+            139,
+            192,
+            0,
+            2,
+            10,
+            192,
+            0,
+            2,
+            7,
+            192,
+            0,
+            35,
+            240,
+            0,
+            13,
+            249,
+            51
+          ]
+        },
+        {
+          "kind": "fragment",
+          "tick": 4,
+          "packet": [
+            69,
+            0,
+            0,
+            25,
+            18,
+            52,
+            0,
+            1,
+            64,
+            17,
+            228,
+            141,
+            192,
+            0,
+            2,
+            10,
+            192,
+            0,
+            2,
+            7,
+            222,
+            173,
+            190,
+            239,
+            1
+          ]
+        }
+      ],
+      "expectedEvents": [
+        {
+          "kind": "wdpFragmentPending",
+          "duplicate": false,
+          "buffered_payload_bytes": 8,
+          "expected_payload_bytes": null,
+          "expires_at_tick": 32
+        },
+        {
+          "kind": "wdpFragmentPending",
+          "duplicate": true,
+          "buffered_payload_bytes": 8,
+          "expected_payload_bytes": null,
+          "expires_at_tick": 33
+        },
+        {
+          "kind": "wdpReassembled",
+          "packet_len": 33,
+          "payload_len": 5
+        }
+      ],
+      "expectedTransactionOutcomes": [
+        {
+          "kind": "wdpReplaySummary",
+          "accepted_datagrams": 0,
+          "rejected_packets": 0,
+          "duplicate_fragments": 1,
+          "completed_reassemblies": 1,
+          "expired_assemblies": 0
+        }
+      ]
+    },
+    {
+      "name": "incomplete_ipv4_assembly_expires_on_simulated_tick",
+      "capture": {
+        "captureId": "wdp-selected-timeout-001",
+        "sourceFamily": "wap-1.2.1-selected-wdp",
+        "captureKind": "seed-trace",
+        "provenanceNote": "Deterministic implementation-policy expiry; the 30-tick value is not claimed as a normative WAP timer.",
+        "legalReuse": "synthetic-derivative"
+      },
+      "wdpReassemblyPolicy": {
+        "maxDatagramBytes": 576,
+        "maxPendingDatagrams": 8,
+        "maxBufferedPayloadBytes": 4608,
+        "timeoutTicks": 30
+      },
+      "wdpSteps": [
+        {
+          "kind": "fragment",
+          "tick": 10,
+          "packet": [
+            69,
+            0,
+            0,
+            28,
+            18,
+            52,
+            32,
+            0,
+            64,
+            17,
+            196,
+            139,
+            192,
+            0,
+            2,
+            10,
+            192,
+            0,
+            2,
+            7,
+            192,
+            0,
+            35,
+            240,
+            0,
+            13,
+            249,
+            51
+          ]
+        },
+        {
+          "kind": "expire",
+          "tick": 39
+        },
+        {
+          "kind": "expire",
+          "tick": 40
+        }
+      ],
+      "expectedEvents": [
+        {
+          "kind": "wdpFragmentPending",
+          "duplicate": false,
+          "buffered_payload_bytes": 8,
+          "expected_payload_bytes": null,
+          "expires_at_tick": 40
+        },
+        {
+          "kind": "wdpIncompleteExpired",
+          "count": 0,
+          "buffered_payload_bytes": 0
+        },
+        {
+          "kind": "wdpIncompleteExpired",
+          "count": 1,
+          "buffered_payload_bytes": 8
+        }
+      ],
+      "expectedTransactionOutcomes": [
+        {
+          "kind": "wdpReplaySummary",
+          "accepted_datagrams": 0,
+          "rejected_packets": 0,
+          "duplicate_fragments": 0,
+          "completed_reassemblies": 0,
+          "expired_assemblies": 1
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- add canonical direct mappings and focused graph retrieval for TRN-706
- add a typed selected-profile WDP replay lane using the existing CDPD/UDP/IPv4 codec and IPv4 reassembler
- cover positive and 576-octet round trips, malformed rejection, duplicate fragments, and simulated incomplete-assembly expiry
- retain TRN-706 as in progress with an explicit conditional WTP-family gap

## Why

TRN-706 lacked canonical direct clause mappings and focused-target support, while the existing replay harness was centered on WSP/WTP fixtures. This adds bounded evidence for the active WDP profile without activating or claiming connection-oriented WSP/WTP.

## Validation

- `cargo test --manifest-path transport-rust/Cargo.toml --test interop_replay`
- `cargo test --manifest-path transport-rust/Cargo.toml --test wdp_constrained_replay`
- `make lint-rust-transport`
- `make test-rust-transport`
- `node scripts/check-wap-selected-normative-clauses.mjs`
- `node scripts/check-wap-compliance-program.mjs`
- `node scripts/check-wap-delta-register.mjs`
- `node scripts/check-wap-knowledge-graph.mjs`
- repository pre-commit and pre-push hooks

## Remaining gap

Connection-oriented WSP/WTP replay families remain conditional and unmapped. This change does not close TRN-706.
