### PR TITLE
test(transport): make private redirect policy test deterministic on Linux

### DIFF
--- a/transport-rust/src/fetch_runtime/execution.rs
+++ b/transport-rust/src/fetch_runtime/execution.rs
@@ -285,9 +285,31 @@ fn destination_policy_error(error: &reqwest::Error) -> Option<FetchDestinationEr
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::io::Write;
+    use crate::fetch_policy::DestinationHostClass;
+    use std::io::{Read, Write};
     use std::net::TcpListener;
     use std::thread;
+
+    fn read_http_request_headers(stream: &mut impl Read) {
+        const MAX_TEST_REQUEST_HEADER_BYTES: usize = 8 * 1024;
+
+        let mut request = [0_u8; MAX_TEST_REQUEST_HEADER_BYTES];
+        let mut request_len = 0;
+        while !request[..request_len]
+            .windows(4)
+            .any(|window| window == b"\r\n\r\n")
+        {
+            assert!(
+                request_len < request.len(),
+                "redirect test request headers must stay bounded"
+            );
+            let read = stream
+                .read(&mut request[request_len..])
+                .expect("read redirect request");
+            assert!(read > 0, "redirect request must contain complete headers");
+            request_len += read;
+        }
+    }
 
     #[test]
     fn http_client_rejects_private_dns_answer() {
@@ -317,6 +339,10 @@ mod tests {
         let listener_address = listener.local_addr().expect("read redirect server address");
         let server = thread::spawn(move || {
             let (mut stream, _) = listener.accept().expect("accept redirect request");
+            // Linux may reset a TCP connection closed with unread request bytes, racing the
+            // response and masking the intended reqwest redirect-policy error with an I/O error.
+            // Consume the complete GET request before writing and closing the fixture response.
+            read_http_request_headers(&mut stream);
             stream
                 .write_all(
                     b"HTTP/1.1 302 Found\r\nLocation: http://127.0.0.1:9/private\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
@@ -340,6 +366,11 @@ mod tests {
         assert!(
             policy_error.is_policy_blocked(),
             "classification must come from the error type, not its message text"
+        );
+        assert_eq!(
+            policy_error,
+            FetchDestinationError::blocked_host(DestinationHostClass::Loopback),
+            "the redirect target must retain its typed loopback policy classification"
         );
         let message = policy_error.to_string();
         assert!(message.contains("public-only"));


### PR DESCRIPTION
## Summary

- make the private-redirect policy regression deterministic on Linux
- preserve typed `PublicOnly` loopback classification through reqwest redirects
- eliminate a fixture-level TCP reset race without weakening destination validation

## Root Cause

The fixture server wrote its 302 response and closed the connection without first consuming the
client request. On Linux, closing a socket with unread request bytes can produce a TCP reset, so
reqwest could return an I/O error before processing the redirect and exposing the typed
destination-policy error.

## What Changed

- consume the complete HTTP request headers with an 8 KiB bound before writing the fixture response
- document the Linux TCP-reset behavior in the regression test
- assert the typed loopback policy classification in addition to the stable public message

## Validation

- exact failing test with `RUST_BACKTRACE=1`, `--exact`, and `--nocapture`
- exact test repeated 10 consecutive times
- `make lint-rust-transport`
- `make test-rust-transport`
- `cargo test --tests --manifest-path transport-rust/Cargo.toml --target-dir transport-rust/target/llvm-cov-target --all-features -- --test-threads=1`
- repository pre-commit and pre-push hooks

## Scope Notes

- production fetch and redirect behavior is unchanged
- `PublicOnly` validation remains enforced for original URLs, resolved addresses, and every redirect destination
