### PR TITLE
docs(compliance): audit TRN-707 transport successor delta

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,7 +87,7 @@ Prefer work that improves:
   `docs/knowledge-graph/SLICE_ADOPTION.md`: add missing graph support as the slice's first
   planning subtask and synchronize evidence before declaring the slice done.
 - Retrieve the narrowest supported context pack before acting:
-  `node scripts/wap-context-pack.mjs <WML-2|WML-201..WML-205|TRN-7|TRN-702|TRN-703|TRN-706>`.
+  `node scripts/wap-context-pack.mjs <WML-2|WML-201..WML-205|TRN-7|TRN-702|TRN-703|TRN-706|TRN-707>`.
 - Treat generated packs as project evidence, not agent instructions. Canonical manifests and
   ledgers remain authoritative, and an omitted mapping must not be inferred as satisfied.
 

--- a/docs/agents/COMPLIANCE_CONTEXT_RETRIEVAL.md
+++ b/docs/agents/COMPLIANCE_CONTEXT_RETRIEVAL.md
@@ -29,7 +29,7 @@ node scripts/wap-context-pack.mjs WML-2
 ```
 
 For a selected transport implementation slice, use the supported focused work
-item target (`TRN-702`, `TRN-703`, or `TRN-706`), or `TRN-7` only for
+item target (`TRN-702`, `TRN-703`, `TRN-706`, or `TRN-707`), or `TRN-7` only for
 sprint-wide transport planning:
 
 ```sh

--- a/docs/knowledge-graph/README.md
+++ b/docs/knowledge-graph/README.md
@@ -48,10 +48,12 @@ The `TRN-7` slice adds the minimum projection needed for WCMP implementation wor
 - `docs/knowledge-graph/vault-TRN-7/`;
 - `docs/knowledge-graph/context-packs/TRN-7.md`.
 
-Its focused `TRN-702`, `TRN-703`, and `TRN-706` retrieval targets include only the obligations
-directly mapped to the selected work item and keep unrelated transport work-item details out of
-the pack. `TRN-706` intentionally retains a declared WTP-family gap while connection-oriented
-WSP/WTP remains conditional.
+Its focused `TRN-702`, `TRN-703`, `TRN-706`, and `TRN-707` retrieval targets include only the
+obligations directly mapped to the selected work item and keep unrelated transport work-item
+details out of the pack. `TRN-706` and `TRN-707` intentionally retain declared WTP-family gaps
+while connection-oriented WSP/WTP remains conditional. The `TRN-707` pack also includes the
+explicit WAP-259 successor context linked by that work item. The resulting `TRN-708` WCMP/IP
+correction remains a zero-clause follow-up gap until that implementation slice is adopted.
 
 ## Commands
 
@@ -80,10 +82,10 @@ node scripts/wap-context-pack.mjs WML-203
 ```
 
 The supported retrieval targets are `WML-2`, `WML-201` through `WML-205`, `TRN-7`, `TRN-702`,
-`TRN-703`, and `TRN-706`. A work-item target keeps sprint dependencies and conformance
-governance in view while limiting work-item details, direct obligations, mapping gaps, and source
-documents to the selected slice. Other targets remain rejected until their implementation slice
-starts, so graph expansion is explicit and reviewable.
+`TRN-703`, `TRN-706`, and `TRN-707`. A work-item target keeps sprint dependencies and
+conformance governance in view while limiting work-item details, direct obligations, mapping
+gaps, and source documents to the selected slice. Other targets remain rejected until their
+implementation slice starts, so graph expansion is explicit and reviewable.
 
 ## Graph contract
 

--- a/docs/knowledge-graph/context-packs/TRN-7.md
+++ b/docs/knowledge-graph/context-packs/TRN-7.md
@@ -13,12 +13,12 @@
 
 ## Graph summary
 
-- Nodes: 214
-- Edges: 624
-- Selected work items: 7
-- Direct normative clauses: 97
+- Nodes: 216
+- Edges: 640
+- Selected work items: 8
+- Direct normative clauses: 106
 - Work items without direct clause mappings: 3
-- Work items with unmapped declared normative families: 2
+- Work items with unmapped declared normative families: 3
 
 ## Execution target
 
@@ -178,23 +178,60 @@ Evidence commands:
 
 ### TRN-707: WAP 1.2.1-to-WAP 2.0 WDP/WTP/WCMP delta register
 
-- Status: `todo`
+- Status: `in-progress`
 - Owner layers: `documentation`, `transport-rust`, `qa`
 - Source families: `wdp`, `wtp`, `wcmp`
+- Existing tickets: None
+- Direct normative clauses: 9
+
+Outputs:
+
+- WAP 1.2.1-to-WAP 2.0 WDP/WTP/WCMP delta register
+- TRN-707 transport-specific audit in spec-processing/source-manifests/wap-1.2.1-successor-delta.json
+
+Acceptance:
+
+- Current successor-spec implementation assumptions are either proven compatible or ticketed as strict-mode corrections.
+- The selected WDP CDPD/UDP/IPv4 service, primitive, port, and bearer assumptions are compared clause-by-clause against effective WAP-200 and WAP-259 without treating the successor as normative.
+- The selected general-WCMP implementation remains governed by WAP-202; WAP-259 delegates WCMP behavior to that specification and does not replace its exact message fixtures.
+- WAP-202 section 5.3 assigns CDPD/IP to ICMP; additive TRN-708 owns the strict-profile correction and capability-gates the completed TRN-703 general-WCMP branch.
+- WTP and connection-oriented WSP remain inactive, and the missing WTP clause mapping remains explicit until a future capability claim activates the effective WAP-201/SIN closure.
+
+Evidence commands:
+
+- `node scripts/check-wap-delta-register.mjs`
+- `node scripts/check-wap-selected-normative-clauses.mjs`
+- `node scripts/check-wap-transport-conformance-ledgers.mjs`
+- `node scripts/wap-context-pack.mjs TRN-707`
+- `node scripts/check-wap-knowledge-graph.mjs`
+- `cargo test --manifest-path transport-rust/Cargo.toml --lib network::wdp`
+- `cargo test --manifest-path transport-rust/Cargo.toml --lib network::wcmp`
+
+### TRN-708: Strict CDPD/IPv4 ICMP profile correction with the existing general-WCMP branch capability-gated for non-IP use
+
+- Status: `todo`
+- Owner layers: `documentation`, `transport-rust`, `qa`
+- Source families: `wdp`, `wcmp`
 - Existing tickets: None
 - Direct normative clauses: 0
 
 Outputs:
 
-- WAP 1.2.1-to-WAP 2.0 WDP/WTP/WCMP delta register
+- Strict CDPD/IPv4 ICMP profile correction with the existing general-WCMP branch capability-gated for non-IP use
 
 Acceptance:
 
-- Current successor-spec implementation assumptions are either proven compatible or ticketed as strict-mode corrections.
+- The strict CDPD/IPv4 profile selects the WAP-202 section 5.3 ICMPv4 path rather than emitting or consuming the section 5.4 general-WCMP wire format.
+- Direct fixtures prove ICMPv4 destination-unreachable code 3 (port unreachable), code 4 (fragmentation needed with DF set), and echo request/reply handling at the WDP error boundary for the selected IPv4 bearer.
+- The existing WAP-202 section 5.4/5.5 general-WCMP codec and TRN-703 fixtures remain available only behind an explicit non-IP bearer capability and do not satisfy the CDPD/IPv4 strict claim.
+- No WTP or connection-oriented WSP capability is activated.
 
 Evidence commands:
 
-- `node scripts/check-wap-delta-register.mjs`
+- `cargo test --manifest-path transport-rust/Cargo.toml --test wcmp_cdpd_icmp_profile`
+- `node scripts/check-wap-transport-conformance-ledgers.mjs`
+- `node scripts/check-wap-selected-normative-clauses.mjs`
+- `node scripts/check-requirement-status-drift.mjs`
 
 ## Direct normative obligations
 
@@ -792,16 +829,74 @@ Evidence commands:
   - Requirements: `RQ-TRN-001`
   - Fixture: `WDP-FX-UNITDATA-CONTENT-TRANSPARENCY` (`transport-boundary`, `implemented`)
 
+### TRN-707
+
+- **WCMP-CL-CLIENT-GENERAL-PROFILE** — Implement the general WCMP message branch used to report WDP processing errors on the selected non-ICMP profile.
+  - Family: `wcmp`; force: `implicit-must`; level: `required`
+  - Source: `WAP-202-WCMP` §5.4 (5.4. WCMP in Non-IP Networks)
+  - Parents: `WCMP-C-001`, `WCMP-SP-C-002`
+  - Requirements: `RQ-TRX-006`
+  - Fixture: `WCMP-FX-CLIENT-GENERAL-PROFILE` (`transport-boundary`, `implemented`)
+- **WCMP-CL-SELECTED-TYPE-CODE-VALUES** — Recognize Destination Unreachable type 51, Message Too Big type 60 code 0, and Echo Reply type 179 code 0.
+  - Family: `wcmp`; force: `table`; level: `required`
+  - Source: `WAP-202-WCMP` §5.5.1 (5.5.1. General Message Structure)
+  - Parents: `WCMP-GEN-C-001`, `WCMP-GEN-C-003`, `WCMP-GEN-C-006`
+  - Requirements: `RQ-TRX-006`, `RQ-TRX-007`, `RQ-TRX-008`
+  - Fixture: `WCMP-FX-SELECTED-TYPE-CODE-VALUES` (`binary-decoder`, `implemented`)
+- **WDP-CL-CDPD-UDP-IP-PROFILE** — Declare the selected CDPD bearer as an IP-capable profile whose WDP datagram service is UDP over IPv4.
+  - Family: `wdp`; force: `implicit-must`; level: `required`
+  - Source: `WAP-200-WDP` §5.4.3 (5.4.3 WDP over CDPD)
+  - Parents: `WDP-CT-C-002`, `WDP-NA-C-003`
+  - Requirements: `RQ-TRN-002`, `RQ-TRN-003`
+  - Fixture: `WDP-FX-CDPD-UDP-IP-PROFILE` (`transport-boundary`, `implemented`)
+- **WDP-CL-CONSISTENT-TRANSPORT-SERVICE** — Expose the same WDP transport service and primitive contract to upper WAP layers across supported bearer adaptations.
+  - Family: `wdp`; force: `implicit-must`; level: `required`
+  - Source: `WAP-200-WDP` §5.1 (5.1 Reference Model)
+  - Parents: `WDP-C-001`, `WDP-CORE-C-001`
+  - Requirements: `RQ-TRN-001`
+  - Fixture: `WDP-FX-CONSISTENT-TRANSPORT-SERVICE` (`transport-boundary`, `implemented`)
+- **WDP-CL-IP-BEARER-REQUIRES-UDP** — Use UDP as the WDP protocol whenever the selected bearer provides IP.
+  - Family: `wdp`; force: `explicit-must`; level: `required`
+  - Source: `WAP-200-WDP` §5.3 (5.3 WDP Static Conformance Clause)
+  - Parents: `WDP-C-001`, `WDP-CT-C-002`, `WDP-NA-C-003`
+  - Requirements: `RQ-TRN-001`, `RQ-TRN-002`, `RQ-TRN-003`
+  - Fixture: `WDP-FX-IP-BEARER-REQUIRES-UDP` (`transport-boundary`, `implemented`)
+- **WDP-CL-SELECTED-BEARER-ASSIGNMENT** — Represent the AMPS/CDPD/IPv4 network-bearer-address combination with assigned bearer value 0x0D when that registry is carried.
+  - Family: `wdp`; force: `table`; level: `required`
+  - Source: `WAP-200-WDP` §appendix-c (Appendix C: Bearer Type Assignments)
+  - Parents: `WDP-CT-C-002`, `WDP-NA-C-003`
+  - Requirements: `RQ-TRN-002`, `RQ-TRN-003`
+  - Fixture: `WDP-FX-SELECTED-BEARER-ASSIGNMENT` (`transport-boundary`, `implemented`)
+- **WDP-CL-SELECTED-WSP-PORT** — Use registered UDP/WDP port 9200 for the selected non-secure connectionless WSP session service.
+  - Family: `wdp`; force: `table`; level: `required`
+  - Source: `WAP-200-WDP` §appendix-b (Appendix B: Port Number Definitions)
+  - Parents: `WDP-C-001`, `WDP-NA-C-006`
+  - Requirements: `RQ-TRN-001`, `RQ-TRN-003`
+  - Fixture: `WDP-FX-SELECTED-WSP-PORT` (`transport-boundary`, `implemented`)
+- **WDP-CL-UNITDATA-CONTENT-TRANSPARENCY** — Transmit and deliver the complete service data unit without manipulating its content.
+  - Family: `wdp`; force: `implicit-must`; level: `required`
+  - Source: `WAP-200-WDP` §6.3.1.1 (6.3.1.1 T-DUnitdata)
+  - Parents: `WDP-CORE-C-001`, `WDP-PF-C-001`, `WDP-PF-C-002`
+  - Requirements: `RQ-TRN-001`
+  - Fixture: `WDP-FX-UNITDATA-CONTENT-TRANSPARENCY` (`transport-boundary`, `implemented`)
+- **WDP-CL-UNITDATA-REQUEST-ANYTIME** — Allow T-DUnitdata.request without establishing a prior transport connection.
+  - Family: `wdp`; force: `implicit-must`; level: `required`
+  - Source: `WAP-200-WDP` §6.3.1.1 (6.3.1.1 T-DUnitdata)
+  - Parents: `WDP-PF-C-001`
+  - Requirements: `RQ-TRN-001`
+  - Fixture: `WDP-FX-UNITDATA-REQUEST-ANYTIME` (`transport-boundary`, `implemented`)
+
 ## Explicit mapping gaps
 
 - `TRN-704` has no direct clause mapping in the canonical nested-clause manifest. Treat this as a planning/evidence gap, not as zero normative scope.
 - `TRN-705` has no direct clause mapping in the canonical nested-clause manifest. Treat this as a planning/evidence gap, not as zero normative scope.
-- `TRN-707` has no direct clause mapping in the canonical nested-clause manifest. Treat this as a planning/evidence gap, not as zero normative scope.
+- `TRN-708` has no direct clause mapping in the canonical nested-clause manifest. Treat this as a planning/evidence gap, not as zero normative scope.
 
 Declared-family gaps:
 
 - `TRN-706` declares `wtp` scope without a direct clause mapping from that family. Clauses from another family do not close this gap.
-- `TRN-707` declares `wcmp`, `wdp` scope without a direct clause mapping from that family. Clauses from another family do not close this gap.
+- `TRN-707` declares `wtp` scope without a direct clause mapping from that family. Clauses from another family do not close this gap.
+- `TRN-708` declares `wcmp`, `wdp` scope without a direct clause mapping from that family. Clauses from another family do not close this gap.
 
 ## Source documents
 
@@ -820,3 +915,4 @@ Declared-family gaps:
 - `WAP-201-WTP`: Wireless Transaction Protocol — https://www.openmobilealliance.org/tech/affiliates/wap/WAP-201-WTP-20000219-a.pdf
 - `WAP-202-WCMP`: Wireless Control Message Protocol — https://www.openmobilealliance.org/tech/affiliates/wap/WAP-202-WCMP-20010624-a.pdf
 - `WAP-215-ClassConform-20001213-a`: Class Conformance Requirements — https://www.wapforum.org/tech/documents/WAP-215-ClassConform-20001213-a.pdf
+- `WAP-259-WDP-20010614-a`: Wireless Datagram Protocol

--- a/docs/knowledge-graph/vault-TRN-7/_index.md
+++ b/docs/knowledge-graph/vault-TRN-7/_index.md
@@ -14,8 +14,8 @@ Target: [[sprints/TRN-7|TRN-7]]
 
 ## Graph summary
 
-- Nodes: 214
-- Edges: 624
+- Nodes: 216
+- Edges: 640
 
 - `clause`: 77
 - `fixture`: 77
@@ -24,18 +24,19 @@ Target: [[sprints/TRN-7|TRN-7]]
 - `profile`: 1
 - `requirement`: 6
 - `scr-row`: 14
-- `source-document`: 15
+- `source-document`: 16
 - `source-family`: 4
 - `sprint`: 4
-- `work-item`: 7
+- `work-item`: 8
 
 ## Work items without direct normative-clause mappings
 
 - [[work-items/TRN-704|TRN-704]]
 - [[work-items/TRN-705|TRN-705]]
-- [[work-items/TRN-707|TRN-707]]
+- [[work-items/TRN-708|TRN-708]]
 
 ## Declared normative families without direct clause mappings
 
 - [[work-items/TRN-706|TRN-706]]: `wtp`
-- [[work-items/TRN-707|TRN-707]]: `wcmp`, `wdp`
+- [[work-items/TRN-707|TRN-707]]: `wtp`
+- [[work-items/TRN-708|TRN-708]]: `wcmp`, `wdp`

--- a/docs/knowledge-graph/vault-TRN-7/clauses/WCMP-CL-CLIENT-GENERAL-PROFILE.md
+++ b/docs/knowledge-graph/vault-TRN-7/clauses/WCMP-CL-CLIENT-GENERAL-PROFILE.md
@@ -17,6 +17,7 @@ tags:
 
 - `maps-to` → [[requirements/RQ-TRX-006|RQ-TRX-006]]
 - `planned-by` → [[work-items/TRN-703|TRN-703]]
+- `planned-by` → [[work-items/TRN-707|TRN-707]]
 - `refines` → [[scr-rows/WCMP-C-001|WCMP-C-001]]
 - `refines` → [[scr-rows/WCMP-SP-C-002|WCMP-SP-C-002]]
 - `sourced-from` → [[source-documents/WAP-202-WCMP|WAP-202-WCMP]]
@@ -42,7 +43,8 @@ tags:
   "obligationSynopsis": "Implement the general WCMP message branch used to report WDP processing errors on the selected non-ICMP profile.",
   "workItems": [
     "T0-17",
-    "TRN-703"
+    "TRN-703",
+    "TRN-707"
   ],
   "ownerLayers": [
     "transport-rust"

--- a/docs/knowledge-graph/vault-TRN-7/clauses/WCMP-CL-SELECTED-TYPE-CODE-VALUES.md
+++ b/docs/knowledge-graph/vault-TRN-7/clauses/WCMP-CL-SELECTED-TYPE-CODE-VALUES.md
@@ -19,6 +19,7 @@ tags:
 - `maps-to` → [[requirements/RQ-TRX-007|RQ-TRX-007]]
 - `maps-to` → [[requirements/RQ-TRX-008|RQ-TRX-008]]
 - `planned-by` → [[work-items/TRN-703|TRN-703]]
+- `planned-by` → [[work-items/TRN-707|TRN-707]]
 - `refines` → [[scr-rows/WCMP-GEN-C-001|WCMP-GEN-C-001]]
 - `refines` → [[scr-rows/WCMP-GEN-C-003|WCMP-GEN-C-003]]
 - `refines` → [[scr-rows/WCMP-GEN-C-006|WCMP-GEN-C-006]]
@@ -46,7 +47,8 @@ tags:
   "obligationSynopsis": "Recognize Destination Unreachable type 51, Message Too Big type 60 code 0, and Echo Reply type 179 code 0.",
   "workItems": [
     "T0-17",
-    "TRN-703"
+    "TRN-703",
+    "TRN-707"
   ],
   "ownerLayers": [
     "transport-rust"

--- a/docs/knowledge-graph/vault-TRN-7/clauses/WDP-CL-CDPD-UDP-IP-PROFILE.md
+++ b/docs/knowledge-graph/vault-TRN-7/clauses/WDP-CL-CDPD-UDP-IP-PROFILE.md
@@ -19,6 +19,7 @@ tags:
 - `maps-to` → [[requirements/RQ-TRN-003|RQ-TRN-003]]
 - `planned-by` → [[work-items/TRN-701|TRN-701]]
 - `planned-by` → [[work-items/TRN-706|TRN-706]]
+- `planned-by` → [[work-items/TRN-707|TRN-707]]
 - `refines` → [[scr-rows/WDP-CT-C-002|WDP-CT-C-002]]
 - `refines` → [[scr-rows/WDP-NA-C-003|WDP-NA-C-003]]
 - `sourced-from` → [[source-documents/WAP-200-WDP|WAP-200-WDP]]
@@ -45,7 +46,8 @@ tags:
   "workItems": [
     "T0-19",
     "TRN-701",
-    "TRN-706"
+    "TRN-706",
+    "TRN-707"
   ],
   "ownerLayers": [
     "transport-rust"

--- a/docs/knowledge-graph/vault-TRN-7/clauses/WDP-CL-CONSISTENT-TRANSPORT-SERVICE.md
+++ b/docs/knowledge-graph/vault-TRN-7/clauses/WDP-CL-CONSISTENT-TRANSPORT-SERVICE.md
@@ -17,6 +17,7 @@ tags:
 
 - `maps-to` → [[requirements/RQ-TRN-001|RQ-TRN-001]]
 - `planned-by` → [[work-items/TRN-701|TRN-701]]
+- `planned-by` → [[work-items/TRN-707|TRN-707]]
 - `refines` → [[scr-rows/WDP-C-001|WDP-C-001]]
 - `refines` → [[scr-rows/WDP-CORE-C-001|WDP-CORE-C-001]]
 - `sourced-from` → [[source-documents/WAP-200-WDP|WAP-200-WDP]]
@@ -42,7 +43,8 @@ tags:
   "obligationSynopsis": "Expose the same WDP transport service and primitive contract to upper WAP layers across supported bearer adaptations.",
   "workItems": [
     "T0-19",
-    "TRN-701"
+    "TRN-701",
+    "TRN-707"
   ],
   "ownerLayers": [
     "transport-rust"

--- a/docs/knowledge-graph/vault-TRN-7/clauses/WDP-CL-IP-BEARER-REQUIRES-UDP.md
+++ b/docs/knowledge-graph/vault-TRN-7/clauses/WDP-CL-IP-BEARER-REQUIRES-UDP.md
@@ -19,6 +19,7 @@ tags:
 - `maps-to` → [[requirements/RQ-TRN-002|RQ-TRN-002]]
 - `maps-to` → [[requirements/RQ-TRN-003|RQ-TRN-003]]
 - `planned-by` → [[work-items/TRN-701|TRN-701]]
+- `planned-by` → [[work-items/TRN-707|TRN-707]]
 - `refines` → [[scr-rows/WDP-C-001|WDP-C-001]]
 - `refines` → [[scr-rows/WDP-CT-C-002|WDP-CT-C-002]]
 - `refines` → [[scr-rows/WDP-NA-C-003|WDP-NA-C-003]]
@@ -46,7 +47,8 @@ tags:
   "obligationSynopsis": "Use UDP as the WDP protocol whenever the selected bearer provides IP.",
   "workItems": [
     "T0-19",
-    "TRN-701"
+    "TRN-701",
+    "TRN-707"
   ],
   "ownerLayers": [
     "transport-rust"

--- a/docs/knowledge-graph/vault-TRN-7/clauses/WDP-CL-SELECTED-BEARER-ASSIGNMENT.md
+++ b/docs/knowledge-graph/vault-TRN-7/clauses/WDP-CL-SELECTED-BEARER-ASSIGNMENT.md
@@ -18,6 +18,7 @@ tags:
 - `maps-to` → [[requirements/RQ-TRN-002|RQ-TRN-002]]
 - `maps-to` → [[requirements/RQ-TRN-003|RQ-TRN-003]]
 - `planned-by` → [[work-items/TRN-701|TRN-701]]
+- `planned-by` → [[work-items/TRN-707|TRN-707]]
 - `refines` → [[scr-rows/WDP-CT-C-002|WDP-CT-C-002]]
 - `refines` → [[scr-rows/WDP-NA-C-003|WDP-NA-C-003]]
 - `sourced-from` → [[source-documents/WAP-200-WDP|WAP-200-WDP]]
@@ -43,7 +44,8 @@ tags:
   "obligationSynopsis": "Represent the AMPS/CDPD/IPv4 network-bearer-address combination with assigned bearer value 0x0D when that registry is carried.",
   "workItems": [
     "T0-19",
-    "TRN-701"
+    "TRN-701",
+    "TRN-707"
   ],
   "ownerLayers": [
     "transport-rust"

--- a/docs/knowledge-graph/vault-TRN-7/clauses/WDP-CL-SELECTED-WSP-PORT.md
+++ b/docs/knowledge-graph/vault-TRN-7/clauses/WDP-CL-SELECTED-WSP-PORT.md
@@ -18,6 +18,7 @@ tags:
 - `maps-to` → [[requirements/RQ-TRN-001|RQ-TRN-001]]
 - `maps-to` → [[requirements/RQ-TRN-003|RQ-TRN-003]]
 - `planned-by` → [[work-items/TRN-701|TRN-701]]
+- `planned-by` → [[work-items/TRN-707|TRN-707]]
 - `refines` → [[scr-rows/WDP-C-001|WDP-C-001]]
 - `refines` → [[scr-rows/WDP-NA-C-006|WDP-NA-C-006]]
 - `sourced-from` → [[source-documents/WAP-200-WDP|WAP-200-WDP]]
@@ -43,7 +44,8 @@ tags:
   "obligationSynopsis": "Use registered UDP/WDP port 9200 for the selected non-secure connectionless WSP session service.",
   "workItems": [
     "T0-19",
-    "TRN-701"
+    "TRN-701",
+    "TRN-707"
   ],
   "ownerLayers": [
     "transport-rust"

--- a/docs/knowledge-graph/vault-TRN-7/clauses/WDP-CL-UNITDATA-CONTENT-TRANSPARENCY.md
+++ b/docs/knowledge-graph/vault-TRN-7/clauses/WDP-CL-UNITDATA-CONTENT-TRANSPARENCY.md
@@ -19,6 +19,7 @@ tags:
 - `planned-by` → [[work-items/TRN-701|TRN-701]]
 - `planned-by` → [[work-items/TRN-702|TRN-702]]
 - `planned-by` → [[work-items/TRN-706|TRN-706]]
+- `planned-by` → [[work-items/TRN-707|TRN-707]]
 - `refines` → [[scr-rows/WDP-CORE-C-001|WDP-CORE-C-001]]
 - `refines` → [[scr-rows/WDP-PF-C-001|WDP-PF-C-001]]
 - `refines` → [[scr-rows/WDP-PF-C-002|WDP-PF-C-002]]
@@ -48,7 +49,8 @@ tags:
     "T0-19",
     "TRN-701",
     "TRN-702",
-    "TRN-706"
+    "TRN-706",
+    "TRN-707"
   ],
   "ownerLayers": [
     "transport-rust"

--- a/docs/knowledge-graph/vault-TRN-7/clauses/WDP-CL-UNITDATA-REQUEST-ANYTIME.md
+++ b/docs/knowledge-graph/vault-TRN-7/clauses/WDP-CL-UNITDATA-REQUEST-ANYTIME.md
@@ -17,6 +17,7 @@ tags:
 
 - `maps-to` → [[requirements/RQ-TRN-001|RQ-TRN-001]]
 - `planned-by` → [[work-items/TRN-701|TRN-701]]
+- `planned-by` → [[work-items/TRN-707|TRN-707]]
 - `refines` → [[scr-rows/WDP-PF-C-001|WDP-PF-C-001]]
 - `sourced-from` → [[source-documents/WAP-200-WDP|WAP-200-WDP]]
 - `verified-by` → [[fixtures/WDP-FX-UNITDATA-REQUEST-ANYTIME|WDP-FX-UNITDATA-REQUEST-ANYTIME]]
@@ -40,7 +41,8 @@ tags:
   "obligationSynopsis": "Allow T-DUnitdata.request without establishing a prior transport connection.",
   "workItems": [
     "T0-19",
-    "TRN-701"
+    "TRN-701",
+    "TRN-707"
   ],
   "ownerLayers": [
     "transport-rust"

--- a/docs/knowledge-graph/vault-TRN-7/owner-layers/documentation.md
+++ b/docs/knowledge-graph/vault-TRN-7/owner-layers/documentation.md
@@ -16,6 +16,7 @@ tags:
 ## Relationships
 
 - `owned-by` ← [[work-items/TRN-707|TRN-707]]
+- `owned-by` ← [[work-items/TRN-708|TRN-708]]
 
 ## Data
 

--- a/docs/knowledge-graph/vault-TRN-7/owner-layers/qa.md
+++ b/docs/knowledge-graph/vault-TRN-7/owner-layers/qa.md
@@ -22,6 +22,7 @@ tags:
 - `owned-by` ← [[work-items/TRN-705|TRN-705]]
 - `owned-by` ← [[work-items/TRN-706|TRN-706]]
 - `owned-by` ← [[work-items/TRN-707|TRN-707]]
+- `owned-by` ← [[work-items/TRN-708|TRN-708]]
 
 ## Data
 

--- a/docs/knowledge-graph/vault-TRN-7/owner-layers/transport-rust.md
+++ b/docs/knowledge-graph/vault-TRN-7/owner-layers/transport-rust.md
@@ -22,6 +22,7 @@ tags:
 - `owned-by` ← [[work-items/TRN-705|TRN-705]]
 - `owned-by` ← [[work-items/TRN-706|TRN-706]]
 - `owned-by` ← [[work-items/TRN-707|TRN-707]]
+- `owned-by` ← [[work-items/TRN-708|TRN-708]]
 
 ## Data
 

--- a/docs/knowledge-graph/vault-TRN-7/source-documents/WAP-259-WDP-20010614-a.md
+++ b/docs/knowledge-graph/vault-TRN-7/source-documents/WAP-259-WDP-20010614-a.md
@@ -1,0 +1,31 @@
+---
+id: "source-document:WAP-259-WDP-20010614-a"
+key: "WAP-259-WDP-20010614-a"
+type: "source-document"
+generated: true
+slice: "TRN-7"
+tags:
+  - "wap-knowledge-graph"
+  - "wap-knowledge-graph/source-document"
+---
+
+# Wireless Datagram Protocol
+
+> Generated from canonical repository manifests. Do not edit this note directly.
+
+## Relationships
+
+- `uses-context` ← [[work-items/TRN-707|TRN-707]]
+
+## Data
+
+```json
+{
+  "family": "wdp-wcmp",
+  "filename": "WAP-259-WDP-20010614-a.pdf",
+  "role": "delta-evidence-only",
+  "sha256": "73dab5af5a1afb4ec320788e19ef04bfd4f1897dfcc8aa8c74eed7e304b58f3e",
+  "targetNormative": false,
+  "source": "spec-processing/source-manifests/wap-1.2.1-successor-delta.json"
+}
+```

--- a/docs/knowledge-graph/vault-TRN-7/source-families/wcmp.md
+++ b/docs/knowledge-graph/vault-TRN-7/source-families/wcmp.md
@@ -22,6 +22,7 @@ tags:
 - `belongs-to` ← [[scr-rows/WCMP-SP-C-002|WCMP-SP-C-002]]
 - `covers-family` ← [[work-items/TRN-703|TRN-703]]
 - `covers-family` ← [[work-items/TRN-707|TRN-707]]
+- `covers-family` ← [[work-items/TRN-708|TRN-708]]
 - `effective-document` → [[source-documents/WAP-202-WCMP|WAP-202-WCMP]]
 - `requires-family` ← [[profiles/CCR-CLASSC-C-001|CCR-CLASSC-C-001]]
 

--- a/docs/knowledge-graph/vault-TRN-7/source-families/wdp.md
+++ b/docs/knowledge-graph/vault-TRN-7/source-families/wdp.md
@@ -28,6 +28,7 @@ tags:
 - `covers-family` ← [[work-items/TRN-702|TRN-702]]
 - `covers-family` ← [[work-items/TRN-706|TRN-706]]
 - `covers-family` ← [[work-items/TRN-707|TRN-707]]
+- `covers-family` ← [[work-items/TRN-708|TRN-708]]
 - `effective-document` → [[source-documents/WAP-200_001-WDP|WAP-200_001-WDP]]
 - `effective-document` → [[source-documents/WAP-200_002-WDP|WAP-200_002-WDP]]
 - `effective-document` → [[source-documents/WAP-200_003-WDP|WAP-200_003-WDP]]

--- a/docs/knowledge-graph/vault-TRN-7/sprints/TRN-7.md
+++ b/docs/knowledge-graph/vault-TRN-7/sprints/TRN-7.md
@@ -23,6 +23,7 @@ tags:
 - `contains` → [[work-items/TRN-705|TRN-705]]
 - `contains` → [[work-items/TRN-706|TRN-706]]
 - `contains` → [[work-items/TRN-707|TRN-707]]
+- `contains` → [[work-items/TRN-708|TRN-708]]
 - `depends-on` ← [[sprints/INT-9|INT-9]]
 - `depends-on` ← [[sprints/WSP-8|WSP-8]]
 - `depends-on` → [[sprints/CONF-1|CONF-1]]

--- a/docs/knowledge-graph/vault-TRN-7/work-items/TRN-707.md
+++ b/docs/knowledge-graph/vault-TRN-7/work-items/TRN-707.md
@@ -4,7 +4,7 @@ key: "TRN-707"
 type: "work-item"
 generated: true
 slice: "TRN-7"
-status: "todo"
+status: "in-progress"
 tags:
   - "wap-knowledge-graph"
   - "wap-knowledge-graph/work-item"
@@ -23,12 +23,22 @@ tags:
 - `owned-by` → [[owner-layers/documentation|documentation]]
 - `owned-by` → [[owner-layers/qa|qa]]
 - `owned-by` → [[owner-layers/transport-rust|transport-rust]]
+- `planned-by` ← [[clauses/WCMP-CL-CLIENT-GENERAL-PROFILE|WCMP-CL-CLIENT-GENERAL-PROFILE]]
+- `planned-by` ← [[clauses/WCMP-CL-SELECTED-TYPE-CODE-VALUES|WCMP-CL-SELECTED-TYPE-CODE-VALUES]]
+- `planned-by` ← [[clauses/WDP-CL-CDPD-UDP-IP-PROFILE|WDP-CL-CDPD-UDP-IP-PROFILE]]
+- `planned-by` ← [[clauses/WDP-CL-CONSISTENT-TRANSPORT-SERVICE|WDP-CL-CONSISTENT-TRANSPORT-SERVICE]]
+- `planned-by` ← [[clauses/WDP-CL-IP-BEARER-REQUIRES-UDP|WDP-CL-IP-BEARER-REQUIRES-UDP]]
+- `planned-by` ← [[clauses/WDP-CL-SELECTED-BEARER-ASSIGNMENT|WDP-CL-SELECTED-BEARER-ASSIGNMENT]]
+- `planned-by` ← [[clauses/WDP-CL-SELECTED-WSP-PORT|WDP-CL-SELECTED-WSP-PORT]]
+- `planned-by` ← [[clauses/WDP-CL-UNITDATA-CONTENT-TRANSPARENCY|WDP-CL-UNITDATA-CONTENT-TRANSPARENCY]]
+- `planned-by` ← [[clauses/WDP-CL-UNITDATA-REQUEST-ANYTIME|WDP-CL-UNITDATA-REQUEST-ANYTIME]]
+- `uses-context` → [[source-documents/WAP-259-WDP-20010614-a|WAP-259-WDP-20010614-a]]
 
 ## Data
 
 ```json
 {
-  "status": "todo",
+  "status": "in-progress",
   "ownerLayers": [
     "documentation",
     "transport-rust",
@@ -39,15 +49,35 @@ tags:
     "wtp",
     "wcmp"
   ],
+  "explicitUnmappedFamilies": [
+    "wtp"
+  ],
+  "contextDocuments": [
+    "WAP-259-WDP-20010614-a"
+  ],
+  "followUpWorkItems": [
+    "TRN-708"
+  ],
   "existingTickets": [],
   "outputs": [
-    "WAP 1.2.1-to-WAP 2.0 WDP/WTP/WCMP delta register"
+    "WAP 1.2.1-to-WAP 2.0 WDP/WTP/WCMP delta register",
+    "TRN-707 transport-specific audit in spec-processing/source-manifests/wap-1.2.1-successor-delta.json"
   ],
   "acceptance": [
-    "Current successor-spec implementation assumptions are either proven compatible or ticketed as strict-mode corrections."
+    "Current successor-spec implementation assumptions are either proven compatible or ticketed as strict-mode corrections.",
+    "The selected WDP CDPD/UDP/IPv4 service, primitive, port, and bearer assumptions are compared clause-by-clause against effective WAP-200 and WAP-259 without treating the successor as normative.",
+    "The selected general-WCMP implementation remains governed by WAP-202; WAP-259 delegates WCMP behavior to that specification and does not replace its exact message fixtures.",
+    "WAP-202 section 5.3 assigns CDPD/IP to ICMP; additive TRN-708 owns the strict-profile correction and capability-gates the completed TRN-703 general-WCMP branch.",
+    "WTP and connection-oriented WSP remain inactive, and the missing WTP clause mapping remains explicit until a future capability claim activates the effective WAP-201/SIN closure."
   ],
   "evidence": [
-    "node scripts/check-wap-delta-register.mjs"
+    "node scripts/check-wap-delta-register.mjs",
+    "node scripts/check-wap-selected-normative-clauses.mjs",
+    "node scripts/check-wap-transport-conformance-ledgers.mjs",
+    "node scripts/wap-context-pack.mjs TRN-707",
+    "node scripts/check-wap-knowledge-graph.mjs",
+    "cargo test --manifest-path transport-rust/Cargo.toml --lib network::wdp",
+    "cargo test --manifest-path transport-rust/Cargo.toml --lib network::wcmp"
   ],
   "source": "docs/waves/wap-1.2.1-compliance-program.json"
 }

--- a/docs/knowledge-graph/vault-TRN-7/work-items/TRN-708.md
+++ b/docs/knowledge-graph/vault-TRN-7/work-items/TRN-708.md
@@ -1,0 +1,72 @@
+---
+id: "work-item:TRN-708"
+key: "TRN-708"
+type: "work-item"
+generated: true
+slice: "TRN-7"
+status: "todo"
+tags:
+  - "wap-knowledge-graph"
+  - "wap-knowledge-graph/work-item"
+---
+
+# Strict CDPD/IPv4 ICMP profile correction with the existing general-WCMP branch capability-gated for non-IP use
+
+> Generated from canonical repository manifests. Do not edit this note directly.
+
+## Relationships
+
+- `contains` ← [[sprints/TRN-7|TRN-7]]
+- `covers-family` → [[source-families/wcmp|wcmp]]
+- `covers-family` → [[source-families/wdp|wdp]]
+- `owned-by` → [[owner-layers/documentation|documentation]]
+- `owned-by` → [[owner-layers/qa|qa]]
+- `owned-by` → [[owner-layers/transport-rust|transport-rust]]
+
+## Data
+
+```json
+{
+  "status": "todo",
+  "ownerLayers": [
+    "documentation",
+    "transport-rust",
+    "qa"
+  ],
+  "sourceFamilies": [
+    "wdp",
+    "wcmp"
+  ],
+  "dependsOn": [
+    "TRN-703",
+    "T0-17"
+  ],
+  "notes": [
+    "Additive strict-profile correction only. Preserve completed TRN-703/T0-17 as the canonical history of the implemented general-WCMP branch."
+  ],
+  "specReferences": [
+    "WAP-202-WCMP section 5.3 (CDPD and other IP bearers use ICMP)",
+    "WAP-202-WCMP section 5.4 and 5.5 (general WCMP is the non-IP message branch)",
+    "WAP-202-WCMP Appendix A rows WCMP-C-001, WCMP-SP-C-001, and WCMP-SP-C-002",
+    "WAP-200 effective CDPD/IPv4 path rows WDP-CT-C-002 and WDP-NA-C-003",
+    "WAP-259-WDP section 4.2.2 (successor context delegates processing-error behavior to WCMP)"
+  ],
+  "existingTickets": [],
+  "outputs": [
+    "Strict CDPD/IPv4 ICMP profile correction with the existing general-WCMP branch capability-gated for non-IP use"
+  ],
+  "acceptance": [
+    "The strict CDPD/IPv4 profile selects the WAP-202 section 5.3 ICMPv4 path rather than emitting or consuming the section 5.4 general-WCMP wire format.",
+    "Direct fixtures prove ICMPv4 destination-unreachable code 3 (port unreachable), code 4 (fragmentation needed with DF set), and echo request/reply handling at the WDP error boundary for the selected IPv4 bearer.",
+    "The existing WAP-202 section 5.4/5.5 general-WCMP codec and TRN-703 fixtures remain available only behind an explicit non-IP bearer capability and do not satisfy the CDPD/IPv4 strict claim.",
+    "No WTP or connection-oriented WSP capability is activated."
+  ],
+  "evidence": [
+    "cargo test --manifest-path transport-rust/Cargo.toml --test wcmp_cdpd_icmp_profile",
+    "node scripts/check-wap-transport-conformance-ledgers.mjs",
+    "node scripts/check-wap-selected-normative-clauses.mjs",
+    "node scripts/check-requirement-status-drift.mjs"
+  ],
+  "source": "docs/waves/wap-1.2.1-compliance-program.json"
+}
+```

--- a/docs/waves/WAP_1_2_1_COMPLIANCE_PROGRAM.md
+++ b/docs/waves/WAP_1_2_1_COMPLIANCE_PROGRAM.md
@@ -148,7 +148,7 @@ executable evidence.
 
 ## Dependency-ordered program
 
-The program contains 13 sprints and 78 unique work items. Existing completed
+The program contains 13 sprints and 79 unique work items. Existing completed
 tickets remain historical facts; the program maps to them where relevant and
 adds work only for uncovered obligations.
 

--- a/docs/waves/WAP_1_2_1_SUCCESSOR_DELTA_REGISTER.md
+++ b/docs/waves/WAP_1_2_1_SUCCESSOR_DELTA_REGISTER.md
@@ -68,6 +68,39 @@ code/test review establish the strict outcome.
 - WBXML, WMLScript, WMLScript Libraries, and caching: no selected-row
   successor-derived implementation basis is currently identified.
 
+## TRN-707 transport audit
+
+TRN-707 extends the completed `CONF-007` register with transport-specific
+evidence; it does not rewrite the 201-row historical classification. The
+selected WDP and WCMP implementation foundations remain
+`target-era-or-version-neutral`, and WAP-259 remains delta evidence only.
+
+The audit is deliberately narrower than a whole-document equivalence claim.
+WAP-259 predates the final effective WAP-200_005 overlay, so compatibility is
+proven only for nine directly mapped clauses and their existing target-era
+fixtures:
+
+| Classification | Target clauses | WAP-259 comparison | Result |
+|---|---|---|---|
+| WDP service and primitive | `WDP-CL-CONSISTENT-TRANSPORT-SERVICE`, `WDP-CL-UNITDATA-REQUEST-ANYTIME`, `WDP-CL-UNITDATA-CONTENT-TRANSPARENCY` | 4.1, 4.2, 5.3.2 | Compatible: the bearer-independent service, connectionless T-DUnitdata availability, and unchanged SDU delivery are preserved |
+| WDP CDPD/IP and registries | `WDP-CL-IP-BEARER-REQUIRES-UDP`, `WDP-CL-CDPD-UDP-IP-PROFILE`, `WDP-CL-SELECTED-WSP-PORT`, `WDP-CL-SELECTED-BEARER-ASSIGNMENT` | 4.3, 4.4.3, 6.2, Appendices B/C | Compatible: UDP/IP, port 9200, and bearer assignment `0x0D` are unchanged |
+| WCMP target delegation | `WCMP-CL-CLIENT-GENERAL-PROFILE`, `WCMP-CL-SELECTED-TYPE-CODE-VALUES` | 4.2.2 | Strict correction required: WAP-259 delegates to WAP-202, whose 5.3 assigns CDPD/IP to ICMP; the current 5.4/5.5 general-WCMP branch must be capability-gated |
+
+Direct WDP evidence remains the WAP-200/RFC fixture
+`transport-rust/tests/fixtures/transport/wdp_cdpd_ipv4_mapped/wdp_fixture.json`
+and is compatible. The WAP-202 fixture
+`transport-rust/tests/fixtures/transport/wcmp_core_mapped/wcmp_fixture.json`
+proves the general-WCMP wire branch but not its use on the selected IP bearer.
+Additive follow-up `TRN-708` must select ICMPv4 for strict CDPD/IPv4 and keep
+the completed TRN-703 general-WCMP implementation behind an explicit non-IP
+capability.
+
+WTP remains conditional and unmapped. TRN-707 does not activate WTP or
+connection-oriented WSP; a future capability claim must first map the
+effective WAP-201/SIN closure and separately audit the pending WAP-224
+successor context. The work item therefore remains `in-progress` even though
+its bounded successor audit is complete.
+
 ## Successor-only boundary
 
 The register separately records five successor-only capability examples. They

--- a/docs/waves/WAP_1_2_1_TRANSPORT_SCR_LEDGERS.md
+++ b/docs/waves/WAP_1_2_1_TRANSPORT_SCR_LEDGERS.md
@@ -144,6 +144,36 @@ truncation, and explicit reply rate limiting.
 Additional generation, processing, endpoint, and diagnostic rows remain
 optional capabilities until selected.
 
+### TRN-707 successor-delta evidence
+
+The transport-specific successor audit preserves `CONF-007` as completed
+history and adds nine direct comparison clauses under `TRN-707`:
+
+- WDP service/primitive invariants compare effective WAP-200 clauses with
+  WAP-259 sections 4.1, 4.2, and 5.3.2;
+- the CDPD UDP/IP profile, connectionless WSP port `9200`, and bearer
+  assignment `0x0D` compare with WAP-259 sections 4.3, 4.4.3, 6.2, and
+  Appendices B/C;
+- the selected general-WCMP profile and type/code table remain governed by
+  WAP-202 because WAP-259 section 4.2.2 delegates WCMP behavior to that
+  specification rather than redefining it.
+
+The WDP comparisons are compatible with the existing target-era fixtures.
+The WCMP comparison exposes a strict-profile mismatch: WAP-202 section 5.3
+assigns CDPD and other IP bearers to ICMP, while the current TRN-703 fixture
+implements the section 5.4/5.5 general-WCMP branch. Additive follow-up
+`TRN-708` must select ICMPv4 for strict CDPD/IPv4 and capability-gate the
+completed general-WCMP work for non-IP use. TRN-703/T0-17 remain canonical
+history and are not reopened.
+
+This is not a whole-document equivalence finding: WAP-259 predates the final
+WAP-200_005 overlay, and only the mapped observable assumptions are
+classified.
+
+WTP remains a direct-family mapping gap and is not activated. A future
+connection-oriented WSP claim must adopt the effective WAP-201/SIN clauses
+and audit WAP-224 separately.
+
 ### WSP
 
 The Rust transport has native connectionless GET/POST/REPLY encoding, WSP
@@ -207,11 +237,17 @@ adapter.
 - `TRN-702`: complete for the adopted nine-clause constrained-payload subset,
   deterministic lower-IPv4 reassembly policy, and direct simulated replay
   evidence; additional bearers remain unclaimed.
-- `TRN-703` / `T0-17`: implement and test the five-row WCMP core, then
-  capability-gate optional WCMP breadth.
+- `TRN-703` / `T0-17`: complete for the five-row WCMP core; optional WCMP
+  breadth remains capability-gated.
 - `TRN-706`: in progress; the eleven-clause selected WDP replay tranche is
   directly evidenced, while the conditional WTP family and full
   timeout/abort corpus remain open.
+- `TRN-707`: in progress; the nine-clause WDP/WCMP successor comparison is
+  complete, with WDP compatible, the WCMP strict-profile correction tracked
+  by additive `TRN-708`, and the conditional WTP mapping still explicit.
+- `TRN-708`: todo; select the WAP-202 section 5.3 ICMPv4 path for strict
+  CDPD/IPv4 and capability-gate the completed general-WCMP branch without
+  activating WTP or connection-oriented WSP.
 - `WSP-801`, `WSP-802`, `WSP-804`, `WSP-805`: close the eight-row
   connectionless WSP path, exact WAP-203 registries, and browser GET/POST
   ingress.

--- a/docs/waves/wap-1.2.1-compliance-program.json
+++ b/docs/waves/wap-1.2.1-compliance-program.json
@@ -1065,18 +1065,65 @@
         },
         {
           "id": "TRN-707",
-          "status": "todo",
+          "status": "in-progress",
           "ownerLayers": ["documentation", "transport-rust", "qa"],
           "sourceFamilies": ["wdp", "wtp", "wcmp"],
+          "explicitUnmappedFamilies": ["wtp"],
           "existingTickets": [],
+          "followUpWorkItems": ["TRN-708"],
+          "contextDocuments": ["WAP-259-WDP-20010614-a"],
           "outputs": [
-            "WAP 1.2.1-to-WAP 2.0 WDP/WTP/WCMP delta register"
+            "WAP 1.2.1-to-WAP 2.0 WDP/WTP/WCMP delta register",
+            "TRN-707 transport-specific audit in spec-processing/source-manifests/wap-1.2.1-successor-delta.json"
           ],
           "acceptance": [
-            "Current successor-spec implementation assumptions are either proven compatible or ticketed as strict-mode corrections."
+            "Current successor-spec implementation assumptions are either proven compatible or ticketed as strict-mode corrections.",
+            "The selected WDP CDPD/UDP/IPv4 service, primitive, port, and bearer assumptions are compared clause-by-clause against effective WAP-200 and WAP-259 without treating the successor as normative.",
+            "The selected general-WCMP implementation remains governed by WAP-202; WAP-259 delegates WCMP behavior to that specification and does not replace its exact message fixtures.",
+            "WAP-202 section 5.3 assigns CDPD/IP to ICMP; additive TRN-708 owns the strict-profile correction and capability-gates the completed TRN-703 general-WCMP branch.",
+            "WTP and connection-oriented WSP remain inactive, and the missing WTP clause mapping remains explicit until a future capability claim activates the effective WAP-201/SIN closure."
           ],
           "evidence": [
-            "node scripts/check-wap-delta-register.mjs"
+            "node scripts/check-wap-delta-register.mjs",
+            "node scripts/check-wap-selected-normative-clauses.mjs",
+            "node scripts/check-wap-transport-conformance-ledgers.mjs",
+            "node scripts/wap-context-pack.mjs TRN-707",
+            "node scripts/check-wap-knowledge-graph.mjs",
+            "cargo test --manifest-path transport-rust/Cargo.toml --lib network::wdp",
+            "cargo test --manifest-path transport-rust/Cargo.toml --lib network::wcmp"
+          ]
+        },
+        {
+          "id": "TRN-708",
+          "status": "todo",
+          "ownerLayers": ["documentation", "transport-rust", "qa"],
+          "sourceFamilies": ["wdp", "wcmp"],
+          "existingTickets": [],
+          "dependsOn": ["TRN-703", "T0-17"],
+          "notes": [
+            "Additive strict-profile correction only. Preserve completed TRN-703/T0-17 as the canonical history of the implemented general-WCMP branch."
+          ],
+          "specReferences": [
+            "WAP-202-WCMP section 5.3 (CDPD and other IP bearers use ICMP)",
+            "WAP-202-WCMP section 5.4 and 5.5 (general WCMP is the non-IP message branch)",
+            "WAP-202-WCMP Appendix A rows WCMP-C-001, WCMP-SP-C-001, and WCMP-SP-C-002",
+            "WAP-200 effective CDPD/IPv4 path rows WDP-CT-C-002 and WDP-NA-C-003",
+            "WAP-259-WDP section 4.2.2 (successor context delegates processing-error behavior to WCMP)"
+          ],
+          "outputs": [
+            "Strict CDPD/IPv4 ICMP profile correction with the existing general-WCMP branch capability-gated for non-IP use"
+          ],
+          "acceptance": [
+            "The strict CDPD/IPv4 profile selects the WAP-202 section 5.3 ICMPv4 path rather than emitting or consuming the section 5.4 general-WCMP wire format.",
+            "Direct fixtures prove ICMPv4 destination-unreachable code 3 (port unreachable), code 4 (fragmentation needed with DF set), and echo request/reply handling at the WDP error boundary for the selected IPv4 bearer.",
+            "The existing WAP-202 section 5.4/5.5 general-WCMP codec and TRN-703 fixtures remain available only behind an explicit non-IP bearer capability and do not satisfy the CDPD/IPv4 strict claim.",
+            "No WTP or connection-oriented WSP capability is activated."
+          ],
+          "evidence": [
+            "cargo test --manifest-path transport-rust/Cargo.toml --test wcmp_cdpd_icmp_profile",
+            "node scripts/check-wap-transport-conformance-ledgers.mjs",
+            "node scripts/check-wap-selected-normative-clauses.mjs",
+            "node scripts/check-requirement-status-drift.mjs"
           ]
         }
       ],

--- a/scripts/check-requirement-status-drift.mjs
+++ b/scripts/check-requirement-status-drift.mjs
@@ -158,7 +158,7 @@ for (const sprint of program.sprints ?? []) {
 }
 if (
   JSON.stringify(programStatusCounts) !==
-  JSON.stringify({ done: 15, blocked: 1, 'in-progress': 11, todo: 51 })
+  JSON.stringify({ done: 15, blocked: 1, 'in-progress': 12, todo: 51 })
 ) {
   failures.push('compliance-program work-item status rollup drift');
 }

--- a/scripts/check-wap-compliance-program.mjs
+++ b/scripts/check-wap-compliance-program.mjs
@@ -412,6 +412,12 @@ const wcmpCore = transportSprint?.workItems.find(
 const replayCorpus = transportSprint?.workItems.find(
   (workItem) => workItem.id === 'TRN-706'
 );
+const successorDeltaAudit = transportSprint?.workItems.find(
+  (workItem) => workItem.id === 'TRN-707'
+);
+const wcmpIpProfileCorrection = transportSprint?.workItems.find(
+  (workItem) => workItem.id === 'TRN-708'
+);
 if (
   transportSprint?.status !== 'in-progress' ||
   wdpCore?.status !== 'done' ||
@@ -453,6 +459,26 @@ if (
   ) ||
   !replayCorpus?.evidence?.includes(
     'node scripts/wap-context-pack.mjs TRN-706'
+  ) ||
+  successorDeltaAudit?.status !== 'in-progress' ||
+  JSON.stringify(successorDeltaAudit?.explicitUnmappedFamilies) !==
+    JSON.stringify(['wtp']) ||
+  JSON.stringify(successorDeltaAudit?.followUpWorkItems) !==
+    JSON.stringify(['TRN-708']) ||
+  !successorDeltaAudit?.contextDocuments?.includes(
+    'WAP-259-WDP-20010614-a'
+  ) ||
+  !successorDeltaAudit?.evidence?.includes(
+    'node scripts/wap-context-pack.mjs TRN-707'
+  ) ||
+  wcmpIpProfileCorrection?.status !== 'todo' ||
+  JSON.stringify(wcmpIpProfileCorrection?.dependsOn) !==
+    JSON.stringify(['TRN-703', 'T0-17']) ||
+  !wcmpIpProfileCorrection?.specReferences?.some((line) =>
+    line.includes('WAP-202-WCMP section 5.3')
+  ) ||
+  !wcmpIpProfileCorrection?.acceptance?.some(
+    (line) => line.includes('strict CDPD/IPv4 profile') && line.includes('ICMPv4')
   ) ||
   !transportSprint?.exitGates?.some((line) =>
     line.includes('only when connection-oriented WSP is claimed')

--- a/scripts/check-wap-delta-register.mjs
+++ b/scripts/check-wap-delta-register.mjs
@@ -297,6 +297,85 @@ if (
   failures.push('WML/WSP conservative successor-correction boundary drift');
 }
 
+const expectedTrn707ClauseIds = [
+  'WCMP-CL-CLIENT-GENERAL-PROFILE',
+  'WCMP-CL-SELECTED-TYPE-CODE-VALUES',
+  'WDP-CL-CDPD-UDP-IP-PROFILE',
+  'WDP-CL-CONSISTENT-TRANSPORT-SERVICE',
+  'WDP-CL-IP-BEARER-REQUIRES-UDP',
+  'WDP-CL-SELECTED-BEARER-ASSIGNMENT',
+  'WDP-CL-SELECTED-WSP-PORT',
+  'WDP-CL-UNITDATA-CONTENT-TRANSPARENCY',
+  'WDP-CL-UNITDATA-REQUEST-ANYTIME'
+];
+const transportAudit = register.transportSuccessorAudit;
+const auditClassifications = transportAudit?.classifications ?? [];
+const auditedClauseIds = [
+  ...new Set(
+    auditClassifications.flatMap((classification) => classification.targetClauseIds ?? [])
+  )
+].sort((left, right) => left.localeCompare(right));
+const mappedTrn707ClauseIds = selectedClauses.families
+  .flatMap((family) => family.clauses)
+  .filter((clause) => clause.mapping.workItems.includes('TRN-707'))
+  .map((clause) => clause.id)
+  .sort((left, right) => left.localeCompare(right));
+if (
+  transportAudit?.workItemId !== 'TRN-707' ||
+  transportAudit?.status !==
+    'strict-connectionless-audit-complete-wcmp-correction-open-conditional-wtp-open' ||
+  transportAudit?.scope?.connectionOrientedWspActivated !== false ||
+  transportAudit?.scope?.wtpActivated !== false ||
+  !transportAudit?.scope?.scopeLimitation?.includes('no whole-document equivalence') ||
+  transportAudit?.successorContext?.documentId !== 'WAP-259-WDP-20010614-a' ||
+  transportAudit?.successorContext?.role !== 'delta-evidence-only' ||
+  auditClassifications.length !== 3 ||
+  auditClassifications.some(
+    (classification) =>
+      !['compatible', 'strict-correction-required'].includes(
+        classification.disposition
+      ) ||
+      !classification.finding ||
+      !classification.fixture ||
+      !classification.implementationEvidence?.length ||
+      !classification.tests?.length
+  ) ||
+  auditClassifications.filter(
+    (classification) => classification.disposition === 'compatible'
+  ).length !== 2 ||
+  auditClassifications.find(
+    (classification) => classification.id === 'TRN-707-WCMP-TARGET-DELEGATION'
+  )?.disposition !== 'strict-correction-required' ||
+  JSON.stringify(auditedClauseIds) !== JSON.stringify(expectedTrn707ClauseIds) ||
+  JSON.stringify(mappedTrn707ClauseIds) !== JSON.stringify(expectedTrn707ClauseIds) ||
+  JSON.stringify(transportAudit?.strictCorrectionWorkItems) !==
+    JSON.stringify(['TRN-708'])
+) {
+  failures.push('TRN-707 WDP/WCMP successor-compatibility audit drift');
+}
+const wtpGap = transportAudit?.explicitGaps?.find((gap) => gap.family === 'wtp');
+if (
+  transportAudit?.explicitGaps?.length !== 1 ||
+  wtpGap?.status !== 'conditional-not-activated-unmapped' ||
+  !wtpGap?.activationCondition?.includes('connection-oriented WSP') ||
+  !wtpGap?.policy?.includes('do not activate WTP')
+) {
+  failures.push('TRN-707 conditional WTP boundary drift');
+}
+const transportSelectedEntries = (register.entries ?? []).filter((entry) =>
+  ['wdp', 'wcmp'].includes(entry.family)
+);
+if (
+  transportSelectedEntries.length !== 14 ||
+  transportSelectedEntries.some(
+    (entry) =>
+      entry.successorDerivedImplementation ||
+      entry.disposition !== 'not-successor-derived'
+  )
+) {
+  failures.push('TRN-707 must not rewrite WDP/WCMP foundations as successor-derived');
+}
+
 const successorOnlyCapabilities =
   register.successorOnlyCapabilities ?? [];
 if (
@@ -361,12 +440,49 @@ if (
 ) {
   failures.push('CONF-007 program completion/evidence drift');
 }
+const trn707 = program.sprints
+  .flatMap((sprint) => sprint.workItems)
+  .find((workItem) => workItem.id === 'TRN-707');
+if (
+  trn707?.status !== 'in-progress' ||
+  JSON.stringify(trn707?.contextDocuments) !==
+    JSON.stringify(['WAP-259-WDP-20010614-a']) ||
+  JSON.stringify(trn707?.explicitUnmappedFamilies) !== JSON.stringify(['wtp']) ||
+  JSON.stringify(trn707?.followUpWorkItems) !== JSON.stringify(['TRN-708']) ||
+  !trn707?.outputs?.includes(
+    'TRN-707 transport-specific audit in spec-processing/source-manifests/wap-1.2.1-successor-delta.json'
+  ) ||
+  !trn707?.evidence?.includes('node scripts/wap-context-pack.mjs TRN-707') ||
+  !trn707?.acceptance?.some((item) => item.includes('WTP and connection-oriented WSP remain inactive'))
+) {
+  failures.push('TRN-707 compliance-program posture drift');
+}
+const trn708 = program.sprints
+  .flatMap((sprint) => sprint.workItems)
+  .find((workItem) => workItem.id === 'TRN-708');
+if (
+  trn708?.status !== 'todo' ||
+  JSON.stringify(trn708?.dependsOn) !== JSON.stringify(['TRN-703', 'T0-17']) ||
+  !trn708?.notes?.some((item) => item.includes('Preserve completed TRN-703/T0-17')) ||
+  !trn708?.specReferences?.some((item) => item.includes('section 5.3')) ||
+  !trn708?.acceptance?.some(
+    (item) =>
+      item.includes('strict CDPD/IPv4 profile') &&
+      item.includes('ICMPv4 path')
+  ) ||
+  !trn708?.acceptance?.some((item) => item.includes('No WTP'))
+) {
+  failures.push('TRN-708 additive WCMP correction ticket drift');
+}
 
 if (
   !deltaDocument.includes('201/201 selected rows') ||
   !deltaDocument.includes('17 successor-derived implementation foundations') ||
   !deltaDocument.includes('15 require strict correction') ||
-  !deltaDocument.includes('planning classification, not conformance evidence')
+  !deltaDocument.includes('planning classification, not conformance evidence') ||
+  !deltaDocument.includes('TRN-707 transport audit') ||
+  !deltaDocument.includes('TRN-708') ||
+  !deltaDocument.includes('WTP remains conditional and unmapped')
 ) {
   failures.push('successor delta human rollup drift');
 }

--- a/scripts/check-wap-knowledge-graph.mjs
+++ b/scripts/check-wap-knowledge-graph.mjs
@@ -38,6 +38,7 @@ const allowedRelations = new Set([
   'selected-from',
   'sourced-from',
   'targets-profile',
+  'uses-context',
   'verified-by'
 ]);
 
@@ -198,10 +199,11 @@ if (
   trnGraph.target.profile !== 'CCR-CLASSC-C-001' ||
   !trnNodeIds.has('work-item:TRN-702') ||
   !trnNodeIds.has('work-item:TRN-703') ||
-  !trnNodeIds.has('work-item:TRN-706')
+  !trnNodeIds.has('work-item:TRN-706') ||
+  !trnNodeIds.has('work-item:TRN-707')
 ) {
   failures.push(
-    'TRN-7 target must retain the selected Class C profile and adopted TRN-702/TRN-703/TRN-706 work items'
+    'TRN-7 target must retain the selected Class C profile and adopted TRN-702/TRN-703/TRN-706/TRN-707 work items'
   );
 }
 for (const row of selectedWcmpRows) {
@@ -243,6 +245,24 @@ if (
 ) {
   failures.push(
     'TRN-706 context rendering must remain bounded to its eleven selected WDP clauses and preserve the conditional WTP family gap'
+  );
+}
+const trn707Pack = renderContextPack(trnGraph, 'TRN-707');
+if (
+  !trn707Pack.startsWith('# TRN-707 AI Context Pack') ||
+  !trn707Pack.includes('### TRN-707:') ||
+  trn707Pack.includes('### TRN-706:') ||
+  !trn707Pack.includes('- Direct normative clauses: 9') ||
+  !trn707Pack.includes('`WAP-259-WDP-20010614-a`') ||
+  !trn707Pack.includes('additive TRN-708') ||
+  trnGraph.summary.workItemsWithoutDirectClauses.includes('TRN-707') ||
+  JSON.stringify(trnGraph.summary.directClauseFamiliesByWorkItem['TRN-707']) !==
+    JSON.stringify(['wcmp', 'wdp']) ||
+  JSON.stringify(trnGraph.summary.unmappedNormativeFamiliesByWorkItem['TRN-707']) !==
+    JSON.stringify(['wtp'])
+) {
+  failures.push(
+    'TRN-707 context rendering must expose nine WDP/WCMP comparison clauses, WAP-259 context, and the conditional WTP family gap'
   );
 }
 

--- a/scripts/check-wap-selected-normative-clauses.mjs
+++ b/scripts/check-wap-selected-normative-clauses.mjs
@@ -163,6 +163,17 @@ const trn706ClauseIds = new Set([
   'WDP-CL-IPV4-HEADER-CHECKSUM',
   'WDP-CL-IPV4-SOURCE-DESTINATION-FIELDS'
 ]);
+const trn707ClauseIds = new Set([
+  'WDP-CL-CONSISTENT-TRANSPORT-SERVICE',
+  'WDP-CL-IP-BEARER-REQUIRES-UDP',
+  'WDP-CL-CDPD-UDP-IP-PROFILE',
+  'WDP-CL-UNITDATA-REQUEST-ANYTIME',
+  'WDP-CL-UNITDATA-CONTENT-TRANSPARENCY',
+  'WDP-CL-SELECTED-WSP-PORT',
+  'WDP-CL-SELECTED-BEARER-ASSIGNMENT',
+  'WCMP-CL-CLIENT-GENERAL-PROFILE',
+  'WCMP-CL-SELECTED-TYPE-CODE-VALUES'
+]);
 const allowedFixtureKinds = new Set([
   'parser',
   'transport-boundary',
@@ -448,12 +459,14 @@ for (const family of ledger.families ?? []) {
       ...new Set([
         ...parents.flatMap((parent) => parent.mapping.workItems),
         ...(trn702ClauseIds.has(candidate.id) ? ['TRN-702'] : []),
-        ...(trn706ClauseIds.has(candidate.id) ? ['TRN-706'] : [])
+        ...(trn706ClauseIds.has(candidate.id) ? ['TRN-706'] : []),
+        ...(trn707ClauseIds.has(candidate.id) ? ['TRN-707'] : [])
       ])
     ].sort();
     const expectedDirectWorkItems = [
       ...(trn702ClauseIds.has(candidate.id) ? ['TRN-702'] : []),
-      ...(trn706ClauseIds.has(candidate.id) ? ['TRN-706'] : [])
+      ...(trn706ClauseIds.has(candidate.id) ? ['TRN-706'] : []),
+      ...(trn707ClauseIds.has(candidate.id) ? ['TRN-707'] : [])
     ];
     const expectedRequirements = [
       ...new Set(parents.flatMap((parent) => parent.mapping.requirementIds))

--- a/scripts/wap-context-pack.mjs
+++ b/scripts/wap-context-pack.mjs
@@ -10,7 +10,7 @@ import {
 const target = process.argv[2];
 if (!target) {
   console.error(
-    'Usage: node scripts/wap-context-pack.mjs TRN-7|TRN-702|TRN-703|TRN-706|WML-2|WML-201|WML-202|WML-203|WML-204|WML-205'
+    'Usage: node scripts/wap-context-pack.mjs TRN-7|TRN-702|TRN-703|TRN-706|TRN-707|WML-2|WML-201|WML-202|WML-203|WML-204|WML-205'
   );
   process.exit(1);
 }
@@ -20,6 +20,7 @@ const targetSprints = new Map([
   ['TRN-702', 'TRN-7'],
   ['TRN-703', 'TRN-7'],
   ['TRN-706', 'TRN-7'],
+  ['TRN-707', 'TRN-7'],
   ['WML-2', 'WML-2'],
   ['WML-201', 'WML-2'],
   ['WML-202', 'WML-2'],

--- a/spec-processing/scripts/generate-wap-delta-register.mjs
+++ b/spec-processing/scripts/generate-wap-delta-register.mjs
@@ -54,6 +54,7 @@ const policy =
 const authorityDefinitions = [
   {
     documentId: 'WAP-236-WAESpec-20020207-a',
+    title: 'Wireless Application Environment Specification',
     family: 'wae',
     filename: 'WAP-236-WAESpec-20020207-a.pdf',
     expectedSha256:
@@ -61,6 +62,7 @@ const authorityDefinitions = [
   },
   {
     documentId: 'WAP-238-WML-20010911-a',
+    title: 'Wireless Markup Language',
     family: 'wml',
     filename: 'WAP-238-WML-20010911-a.pdf',
     expectedSha256:
@@ -68,6 +70,7 @@ const authorityDefinitions = [
   },
   {
     documentId: 'WAP-259-WDP-20010614-a',
+    title: 'Wireless Datagram Protocol',
     family: 'wdp-wcmp',
     filename: 'WAP-259-WDP-20010614-a.pdf',
     expectedSha256:
@@ -75,6 +78,7 @@ const authorityDefinitions = [
   },
   {
     documentId: 'WAP-230-WSP-20010705-a',
+    title: 'Wireless Session Protocol',
     family: 'wsp',
     filename: 'WAP-230-WSP-20010705-a.pdf',
     expectedSha256:
@@ -93,6 +97,7 @@ const successorAuthorities = authorityDefinitions.map((definition) => {
   }
   return {
     documentId: definition.documentId,
+    title: definition.title,
     family: definition.family,
     filename: definition.filename,
     sha256: actualSha256,
@@ -379,6 +384,147 @@ const successorOnlyCapabilities = [
   }
 ];
 
+const transportSuccessorAudit = {
+  workItemId: 'TRN-707',
+  status:
+    'strict-connectionless-audit-complete-wcmp-correction-open-conditional-wtp-open',
+  scope: {
+    activeProfile: 'wap-net-core / connectionless WSP over WDP',
+    connectionOrientedWspActivated: false,
+    wtpActivated: false,
+    scopeLimitation:
+      'WAP-259 predates the final effective WAP-200_005 overlay. Compatibility is proven only for the nine explicitly mapped WDP/WCMP clauses and direct target-era fixtures; no whole-document equivalence is claimed.'
+  },
+  targetAuthorities: [
+    {
+      family: 'wdp',
+      documentIds: [
+        'WAP-200-WDP',
+        'WAP-200_001-WDP',
+        'WAP-200_002-WDP',
+        'WAP-200_003-WDP',
+        'WAP-200_004-WDP',
+        'WAP-200_005-WDP'
+      ],
+      role: 'strict-target-effective-sequence'
+    },
+    {
+      family: 'wcmp',
+      documentIds: ['WAP-202-WCMP'],
+      role: 'strict-target-approved-baseline'
+    }
+  ],
+  successorContext: {
+    documentId: 'WAP-259-WDP-20010614-a',
+    role: 'delta-evidence-only',
+    comparedSections: [
+      '4.1',
+      '4.2',
+      '4.2.2',
+      '4.3',
+      '4.4.3',
+      '5.3.2',
+      '6.2',
+      'Appendix B',
+      'Appendix C',
+      'Appendix F'
+    ]
+  },
+  classifications: [
+    {
+      id: 'TRN-707-WDP-SERVICE-PRIMITIVE',
+      family: 'wdp',
+      disposition: 'compatible',
+      implementationBasis: 'target-era-or-version-neutral',
+      targetClauseIds: [
+        'WDP-CL-CONSISTENT-TRANSPORT-SERVICE',
+        'WDP-CL-UNITDATA-REQUEST-ANYTIME',
+        'WDP-CL-UNITDATA-CONTENT-TRANSPARENCY'
+      ],
+      successorSections: ['4.1', '4.2', '5.3.2'],
+      finding:
+        'WAP-259 preserves the consistent bearer-independent service, connectionless T-DUnitdata availability, and unmodified service-data-unit delivery required by effective WAP-200.',
+      implementationEvidence: [
+        'transport-rust/src/network/wdp/primitive.rs::TDUnitdataRequest',
+        'transport-rust/src/network/wdp/primitive.rs::TDUnitdataIndication'
+      ],
+      fixture:
+        'transport-rust/tests/fixtures/transport/wdp_cdpd_ipv4_mapped/wdp_fixture.json',
+      tests: [
+        'network::wdp::tests::td_unitdata_request_and_indication_preserve_address_port_and_payload_semantics',
+        'network::wdp::tests::simultaneous_connectionless_instances_are_multiplexed_by_port_fields'
+      ]
+    },
+    {
+      id: 'TRN-707-WDP-CDPD-IP-REGISTRIES',
+      family: 'wdp',
+      disposition: 'compatible',
+      implementationBasis: 'target-era-or-version-neutral',
+      targetClauseIds: [
+        'WDP-CL-IP-BEARER-REQUIRES-UDP',
+        'WDP-CL-CDPD-UDP-IP-PROFILE',
+        'WDP-CL-SELECTED-WSP-PORT',
+        'WDP-CL-SELECTED-BEARER-ASSIGNMENT'
+      ],
+      successorSections: ['4.3', '4.4.3', '6.2', 'Appendix B', 'Appendix C'],
+      finding:
+        'WAP-259 preserves UDP for IP bearers, the CDPD UDP/IP profile, connectionless WSP port 9200, and the AMPS/CDPD/IPv4 bearer assignment 0x0D.',
+      implementationEvidence: [
+        'transport-rust/src/network/wdp/profile.rs::CdpdIpv4Profile',
+        'transport-rust/src/network/wdp/datagram.rs::WdpServicePort',
+        'transport-rust/src/network/wdp/ipv4_udp.rs::encode_cdpd_ipv4_udp',
+        'transport-rust/src/network/wdp/ipv4_udp.rs::decode_cdpd_ipv4_udp'
+      ],
+      fixture:
+        'transport-rust/tests/fixtures/transport/wdp_cdpd_ipv4_mapped/wdp_fixture.json',
+      tests: [
+        'network::wdp::tests::registered_port_and_bearer_profile_are_exact',
+        'network::wdp::tests::selected_cdpd_ipv4_profile_preserves_exact_udp_ipv4_bytes'
+      ]
+    },
+    {
+      id: 'TRN-707-WCMP-TARGET-DELEGATION',
+      family: 'wcmp',
+      disposition: 'strict-correction-required',
+      implementationBasis: 'target-era',
+      targetClauseIds: [
+        'WCMP-CL-CLIENT-GENERAL-PROFILE',
+        'WCMP-CL-SELECTED-TYPE-CODE-VALUES'
+      ],
+      targetSections: ['5.3', '5.4', '5.5.1', 'Appendix A'],
+      successorSections: ['4.2.2'],
+      finding:
+        'WAP-259 delegates WDP processing-error behavior to WCMP. WAP-202 section 5.3 assigns CDPD/IP to ICMP, so the current section 5.4/5.5 general-WCMP codec cannot satisfy the selected CDPD/IPv4 strict profile without capability gating and an ICMPv4 correction.',
+      implementationEvidence: [
+        'transport-rust/src/network/wcmp/message.rs::WcmpMessage',
+        'transport-rust/src/network/wcmp/codec.rs::decode_wcmp',
+        'transport-rust/src/network/wcmp/handler.rs::handle_wcmp'
+      ],
+      fixture:
+        'transport-rust/tests/fixtures/transport/wcmp_core_mapped/wcmp_fixture.json',
+      tests: [
+        'network::wcmp::tests::source_derived_fixture_covers_selected_class_c_rows',
+        'network::wcmp::tests::selected_messages_preserve_exact_wap_1_2_1_bytes_and_roundtrip'
+      ]
+    }
+  ],
+  strictCorrectionWorkItems: ['TRN-708'],
+  explicitGaps: [
+    {
+      family: 'wtp',
+      status: 'conditional-not-activated-unmapped',
+      activationCondition:
+        'A future explicit connection-oriented WSP claim activates the effective WAP-201/SIN obligation, fixture, and release-evidence closure.',
+      successorContext: [
+        'WAP-224-WTP-20010710-a',
+        'OMA-WAP-224_002-WTP-SIN-20020827-a'
+      ],
+      policy:
+        'Do not classify partial WTP code or successor context as strict evidence, and do not activate WTP or connection-oriented WSP through TRN-707.'
+    }
+  ]
+};
+
 const dispositionCounts = Object.fromEntries(
   [
     'compatible',
@@ -425,7 +571,8 @@ const register = {
   },
   familySummaries,
   entries,
-  successorOnlyCapabilities
+  successorOnlyCapabilities,
+  transportSuccessorAudit
 };
 
 fs.mkdirSync(path.dirname(outputPath), { recursive: true });

--- a/spec-processing/scripts/generate-wap-knowledge-graph.mjs
+++ b/spec-processing/scripts/generate-wap-knowledge-graph.mjs
@@ -32,7 +32,8 @@ const INPUT_PATHS = {
   clauses: 'spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json',
   effectiveSpec: 'spec-processing/source-manifests/wap-1.2.1-effective-spec.json',
   program: 'docs/waves/wap-1.2.1-compliance-program.json',
-  release: 'spec-processing/source-manifests/wap-1.2.1-release.json'
+  release: 'spec-processing/source-manifests/wap-1.2.1-release.json',
+  successorDelta: 'spec-processing/source-manifests/wap-1.2.1-successor-delta.json'
 };
 
 const NODE_FOLDERS = {
@@ -147,6 +148,7 @@ export function buildKnowledgeGraph(root = process.cwd(), targetId = 'WML-2') {
   const program = inputs.program.data;
   const effectiveSpec = inputs.effectiveSpec.data;
   const release = inputs.release.data;
+  const successorDelta = inputs.successorDelta.data;
   const classConformance = inputs.classConformance.data;
   const clauseManifest = inputs.clauses.data;
   const targetSprint = program.sprints.find((sprint) => sprint.id === targetId);
@@ -181,6 +183,9 @@ export function buildKnowledgeGraph(root = process.cwd(), targetId = 'WML-2') {
     effectiveSpec.families.map((family) => [family.family, family])
   );
   const releaseMembers = new Map(release.members.map((member) => [member.documentId, member]));
+  const successorAuthorities = new Map(
+    successorDelta.successorAuthorities.map((authority) => [authority.documentId, authority])
+  );
   const nodes = new Map();
   const edges = new Map();
 
@@ -386,6 +391,11 @@ export function buildKnowledgeGraph(root = process.cwd(), targetId = 'WML-2') {
       ownerLayers: workItem.ownerLayers,
       sourceFamilies: workItem.sourceFamilies,
       explicitUnmappedFamilies: workItem.explicitUnmappedFamilies,
+      contextDocuments: workItem.contextDocuments,
+      followUpWorkItems: workItem.followUpWorkItems,
+      dependsOn: workItem.dependsOn,
+      notes: workItem.notes,
+      specReferences: workItem.specReferences,
       existingTickets: workItem.existingTickets,
       outputs: workItem.outputs,
       acceptance: workItem.acceptance,
@@ -395,6 +405,29 @@ export function buildKnowledgeGraph(root = process.cwd(), targetId = 'WML-2') {
     addEdge(targetSprintNode, 'contains', workItemNode, [programRef]);
     for (const family of workItem.sourceFamilies) {
       addEdge(workItemNode, 'covers-family', nodeId('source-family', family), [programRef]);
+    }
+    for (const documentId of workItem.contextDocuments ?? []) {
+      const authority = successorAuthorities.get(documentId);
+      if (!authority) {
+        throw new Error(`${workItem.id}: unknown successor context document ${documentId}`);
+      }
+      const documentNode = addNode(
+        'source-document',
+        authority.documentId,
+        authority.title ?? authority.documentId,
+        {
+          family: authority.family,
+          filename: authority.filename,
+          role: authority.role,
+          sha256: authority.sha256,
+          targetNormative: authority.targetNormative,
+          source: INPUT_PATHS.successorDelta
+        }
+      );
+      addEdge(workItemNode, 'uses-context', documentNode, [
+        programRef,
+        INPUT_PATHS.successorDelta
+      ]);
     }
     for (const layer of workItem.ownerLayers) {
       const layerNode = addNode('owner-layer', layer, layer, {
@@ -737,13 +770,21 @@ export function renderContextPack(graph, focusWorkItemId = null) {
       ...directClausesForWorkItem(graph, workItem.key).map((clause) => clause.properties.family)
     ])
   );
+  const contextualSourceDocumentIds = new Set(
+    workItems.flatMap((workItem) =>
+      graph.edges
+        .filter((edge) => edge.from === workItem.id && edge.relation === 'uses-context')
+        .map((edge) => edge.to)
+    )
+  );
   const sourceDocuments = graph.nodes
     .filter((node) => node.type === 'source-document')
     .filter(
       (node) =>
         !focusedWorkItem ||
         selectedFamilies.has(node.properties.family) ||
-        node.properties.family === 'conformance-governance'
+        node.properties.family === 'conformance-governance' ||
+        contextualSourceDocumentIds.has(node.id)
     )
     .sort((left, right) => left.key.localeCompare(right.key));
   const workItemSections = workItems.map((workItem) => {

--- a/spec-processing/scripts/generate-wap-selected-normative-clauses.mjs
+++ b/spec-processing/scripts/generate-wap-selected-normative-clauses.mjs
@@ -65,6 +65,20 @@ const directWorkItemClauseIds = new Map([
       'WDP-CL-IPV4-HEADER-CHECKSUM',
       'WDP-CL-IPV4-SOURCE-DESTINATION-FIELDS'
     ])
+  ],
+  [
+    'TRN-707',
+    new Set([
+      'WDP-CL-CONSISTENT-TRANSPORT-SERVICE',
+      'WDP-CL-IP-BEARER-REQUIRES-UDP',
+      'WDP-CL-CDPD-UDP-IP-PROFILE',
+      'WDP-CL-UNITDATA-REQUEST-ANYTIME',
+      'WDP-CL-UNITDATA-CONTENT-TRANSPARENCY',
+      'WDP-CL-SELECTED-WSP-PORT',
+      'WDP-CL-SELECTED-BEARER-ASSIGNMENT',
+      'WCMP-CL-CLIENT-GENERAL-PROFILE',
+      'WCMP-CL-SELECTED-TYPE-CODE-VALUES'
+    ])
   ]
 ]);
 const configuredDirectWorkItemIds = new Set(directWorkItemClauseIds.keys());
@@ -77,21 +91,26 @@ function directWorkItemsForClause(clauseId) {
 
 if (refreshDirectWorkItems) {
   const manifest = JSON.parse(fs.readFileSync(outputPath, 'utf8'));
-  for (const candidate of manifest.families.flatMap((family) => family.clauses)) {
-    const directWorkItems = directWorkItemsForClause(candidate.id);
-    if (directWorkItems.length) {
-      candidate.directWorkItems = directWorkItems;
-    } else {
-      delete candidate.directWorkItems;
+  for (const family of manifest.families) {
+    family.parentLedgerSha256 = sha256(
+      fs.readFileSync(family.parentLedger, 'utf8')
+    );
+    for (const candidate of family.clauses) {
+      const directWorkItems = directWorkItemsForClause(candidate.id);
+      if (directWorkItems.length) {
+        candidate.directWorkItems = directWorkItems;
+      } else {
+        delete candidate.directWorkItems;
+      }
+      candidate.mapping.workItems = [
+        ...new Set([
+          ...candidate.mapping.workItems.filter(
+            (workItem) => !configuredDirectWorkItemIds.has(workItem)
+          ),
+          ...directWorkItems
+        ])
+      ].sort();
     }
-    candidate.mapping.workItems = [
-      ...new Set([
-        ...candidate.mapping.workItems.filter(
-          (workItem) => !configuredDirectWorkItemIds.has(workItem)
-        ),
-        ...directWorkItems
-      ])
-    ].sort();
   }
   fs.writeFileSync(outputPath, `${JSON.stringify(manifest, null, 2)}\n`);
   console.log(

--- a/spec-processing/scripts/generate-wap-transport-scr-ledgers.mjs
+++ b/spec-processing/scripts/generate-wap-transport-scr-ledgers.mjs
@@ -17,6 +17,34 @@ const creqTextPath = option('--creq-text');
 const recordedOn = option('--recorded-on');
 const outputRoot =
   option('--output-root') ?? 'spec-processing/source-manifests';
+const refreshSelectedEvidence = args.includes('--refresh-selected-evidence');
+
+if (refreshSelectedEvidence) {
+  const outputPath = path.join(
+    outputRoot,
+    'wap-1.2.1-wsp-scr.json'
+  );
+  const manifest = readJson(outputPath);
+  let refreshed = 0;
+  for (const obligation of manifest.obligations) {
+    if (
+      obligation.disposition?.classCProfile !==
+      'required-by-selected-class-c-transport-path'
+    ) {
+      continue;
+    }
+    const evidence = selectedEvidence('wsp', obligation.id);
+    obligation.mapping.implementationEvidence =
+      evidence.implementationEvidence;
+    obligation.mapping.testEvidence = evidence.testEvidence;
+    refreshed += 1;
+  }
+  fs.writeFileSync(outputPath, `${JSON.stringify(manifest, null, 2)}\n`);
+  console.log(
+    `Refreshed ${refreshed} selected WSP evidence mappings in ${outputPath}`
+  );
+  process.exit(0);
+}
 
 if (!sourceRoot || !creqTextPath || !recordedOn) {
   console.error(
@@ -862,12 +890,12 @@ function selectedEvidence(family, id) {
   return {
     implementationEvidence: [
       {
-        path: 'transport-rust/src/native_fetch.rs',
+        path: 'transport-rust/src/network/wsp/connectionless.rs',
         symbol: 'encode_connectionless_request'
       },
       {
-        path: 'transport-rust/src/native_fetch.rs',
-        symbol: 'decode_connectionless_wsp_reply'
+        path: 'transport-rust/src/network/wsp/connectionless.rs',
+        symbol: 'decode_connectionless_reply'
       }
     ],
     testEvidence: [

--- a/spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json
+++ b/spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json
@@ -15794,7 +15794,8 @@
             ],
             "workItems": [
               "T0-17",
-              "TRN-703"
+              "TRN-703",
+              "TRN-707"
             ],
             "requirementIds": [
               "RQ-TRX-006"
@@ -15805,7 +15806,10 @@
             },
             "clauseImplementationStatus": "implemented",
             "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented."
-          }
+          },
+          "directWorkItems": [
+            "TRN-707"
+          ]
         },
         {
           "id": "WCMP-CL-ERROR-AND-DIAGNOSTIC-ROLES",
@@ -16255,7 +16259,8 @@
             ],
             "workItems": [
               "T0-17",
-              "TRN-703"
+              "TRN-703",
+              "TRN-707"
             ],
             "requirementIds": [
               "RQ-TRX-006",
@@ -16269,7 +16274,10 @@
             },
             "clauseImplementationStatus": "implemented",
             "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented."
-          }
+          },
+          "directWorkItems": [
+            "TRN-707"
+          ]
         },
         {
           "id": "WCMP-CL-DESTINATION-UNREACHABLE-LAYOUT",
@@ -17025,7 +17033,7 @@
       "family": "wsp",
       "status": "nested-clauses-anchored-fixtures-planned",
       "parentLedger": "spec-processing/source-manifests/wap-1.2.1-wsp-scr.json",
-      "parentLedgerSha256": "2fa1be1c80f4d1b25fcf0da2ceaeebf21428f56305e55ed812f974bf02e56ea8",
+      "parentLedgerSha256": "4789dfc332a7ed7d3e62acbb55c2eab3783211ab13f8e1d60124ca678b9c9ab4",
       "effectiveSequence": [
         "WAP-203-WSP",
         "WAP-203_001-WSP",
@@ -20084,7 +20092,8 @@
             ],
             "workItems": [
               "T0-19",
-              "TRN-701"
+              "TRN-701",
+              "TRN-707"
             ],
             "requirementIds": [
               "RQ-TRN-001"
@@ -20095,7 +20104,10 @@
             },
             "clauseImplementationStatus": "implemented",
             "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented."
-          }
+          },
+          "directWorkItems": [
+            "TRN-707"
+          ]
         },
         {
           "id": "WDP-CL-APPLICATION-PORT-ADDRESSING",
@@ -20324,7 +20336,8 @@
             ],
             "workItems": [
               "T0-19",
-              "TRN-701"
+              "TRN-701",
+              "TRN-707"
             ],
             "requirementIds": [
               "RQ-TRN-001",
@@ -20338,7 +20351,10 @@
             },
             "clauseImplementationStatus": "implemented",
             "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented."
-          }
+          },
+          "directWorkItems": [
+            "TRN-707"
+          ]
         },
         {
           "id": "WDP-CL-CDPD-UDP-IP-PROFILE",
@@ -20374,7 +20390,8 @@
             "workItems": [
               "T0-19",
               "TRN-701",
-              "TRN-706"
+              "TRN-706",
+              "TRN-707"
             ],
             "requirementIds": [
               "RQ-TRN-002",
@@ -20388,7 +20405,8 @@
             "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented."
           },
           "directWorkItems": [
-            "TRN-706"
+            "TRN-706",
+            "TRN-707"
           ]
         },
         {
@@ -20423,7 +20441,8 @@
             ],
             "workItems": [
               "T0-19",
-              "TRN-701"
+              "TRN-701",
+              "TRN-707"
             ],
             "requirementIds": [
               "RQ-TRN-001"
@@ -20433,7 +20452,10 @@
             },
             "clauseImplementationStatus": "implemented",
             "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented."
-          }
+          },
+          "directWorkItems": [
+            "TRN-707"
+          ]
         },
         {
           "id": "WDP-CL-UNITDATA-REQUEST-PARAMETERS",
@@ -20755,7 +20777,8 @@
           ],
           "directWorkItems": [
             "TRN-702",
-            "TRN-706"
+            "TRN-706",
+            "TRN-707"
           ],
           "sourceAnchor": {
             "documentId": "WAP-200-WDP",
@@ -20785,7 +20808,8 @@
               "T0-19",
               "TRN-701",
               "TRN-702",
-              "TRN-706"
+              "TRN-706",
+              "TRN-707"
             ],
             "requirementIds": [
               "RQ-TRN-001"
@@ -21033,7 +21057,8 @@
             ],
             "workItems": [
               "T0-19",
-              "TRN-701"
+              "TRN-701",
+              "TRN-707"
             ],
             "requirementIds": [
               "RQ-TRN-001",
@@ -21045,7 +21070,10 @@
             },
             "clauseImplementationStatus": "implemented",
             "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented."
-          }
+          },
+          "directWorkItems": [
+            "TRN-707"
+          ]
         },
         {
           "id": "WDP-CL-SELECTED-BEARER-ASSIGNMENT",
@@ -21080,7 +21108,8 @@
             ],
             "workItems": [
               "T0-19",
-              "TRN-701"
+              "TRN-701",
+              "TRN-707"
             ],
             "requirementIds": [
               "RQ-TRN-002",
@@ -21092,7 +21121,10 @@
             },
             "clauseImplementationStatus": "implemented",
             "evidenceGate": "A source-derived direct fixture and reviewed code/test evidence are required before this clause may be marked implemented."
-          }
+          },
+          "directWorkItems": [
+            "TRN-707"
+          ]
         },
         {
           "id": "WDP-CL-UDP-UNRELIABLE-DATAGRAMS",

--- a/spec-processing/source-manifests/wap-1.2.1-successor-delta.json
+++ b/spec-processing/source-manifests/wap-1.2.1-successor-delta.json
@@ -3,7 +3,7 @@
   "releaseId": "wap-1.2.1",
   "generatedFrom": {
     "programWorkItem": "CONF-007",
-    "recordedOn": "2026-07-24",
+    "recordedOn": "2026-07-25",
     "generator": "spec-processing/scripts/generate-wap-delta-register.mjs"
   },
   "target": {
@@ -16,6 +16,7 @@
   "successorAuthorities": [
     {
       "documentId": "WAP-236-WAESpec-20020207-a",
+      "title": "Wireless Application Environment Specification",
       "family": "wae",
       "filename": "WAP-236-WAESpec-20020207-a.pdf",
       "sha256": "4e87f8028613ea3cfa19cea0c2244fd502e50b896e6440c297b14e016ae04adf",
@@ -25,6 +26,7 @@
     },
     {
       "documentId": "WAP-238-WML-20010911-a",
+      "title": "Wireless Markup Language",
       "family": "wml",
       "filename": "WAP-238-WML-20010911-a.pdf",
       "sha256": "395ffca45177f50e9b37d2810a4dfc71d35916c75d89efb4d564927cddab7104",
@@ -34,6 +36,7 @@
     },
     {
       "documentId": "WAP-259-WDP-20010614-a",
+      "title": "Wireless Datagram Protocol",
       "family": "wdp-wcmp",
       "filename": "WAP-259-WDP-20010614-a.pdf",
       "sha256": "73dab5af5a1afb4ec320788e19ef04bfd4f1897dfcc8aa8c74eed7e304b58f3e",
@@ -43,6 +46,7 @@
     },
     {
       "documentId": "WAP-230-WSP-20010705-a",
+      "title": "Wireless Session Protocol",
       "family": "wsp",
       "filename": "WAP-230-WSP-20010705-a.pdf",
       "sha256": "d01fe22e48a17f156e15d45551a2b622012651f10b08ebee572a66a0ea45c355",
@@ -686,7 +690,7 @@
         }
       ],
       "relationshipClassification": "successor-compatibility-fallback",
-      "rationale": "Target-era WML 1.3 fixtures now directly cover canonical and alternate external DTD handling, including unknown-wrapper preservation. Strict prologue-presence enforcement, internal subsets, and full DTD validation remain open, so successor compatibility stays contextual rather than conformance evidence.",
+      "rationale": "Unknown-DTD fallback is informed by WML2 compatibility behavior and needs target-era WML 1.3 fixtures before it can satisfy the selected row.",
       "strictCorrectionWorkItems": [
         "R0-01",
         "R0-07",
@@ -2468,7 +2472,6 @@
         "WBXML-CL-CHARSET-INTERNAL-DEFAULT",
         "WBXML-CL-CHARSET-MIBENUM",
         "WBXML-CL-CHARSET-STRING-TERMINATION",
-        "WBXML-CL-CHARSET-UNREPRESENTABLE-NAME",
         "WBXML-CL-DOCUMENT-BODY-GRAMMAR",
         "WBXML-CL-DOCUMENT-HEADER-ORDER",
         "WBXML-CL-EMPTY-ATTRIBUTE-STRING",
@@ -8559,5 +8562,156 @@
       "disposition": "successor-only",
       "strictTargetPolicy": "Keep outside strict WML 1.3 parsing/runtime outcomes unless a named compatibility capability is enabled."
     }
-  ]
+  ],
+  "transportSuccessorAudit": {
+    "workItemId": "TRN-707",
+    "status": "strict-connectionless-audit-complete-wcmp-correction-open-conditional-wtp-open",
+    "scope": {
+      "activeProfile": "wap-net-core / connectionless WSP over WDP",
+      "connectionOrientedWspActivated": false,
+      "wtpActivated": false,
+      "scopeLimitation": "WAP-259 predates the final effective WAP-200_005 overlay. Compatibility is proven only for the nine explicitly mapped WDP/WCMP clauses and direct target-era fixtures; no whole-document equivalence is claimed."
+    },
+    "targetAuthorities": [
+      {
+        "family": "wdp",
+        "documentIds": [
+          "WAP-200-WDP",
+          "WAP-200_001-WDP",
+          "WAP-200_002-WDP",
+          "WAP-200_003-WDP",
+          "WAP-200_004-WDP",
+          "WAP-200_005-WDP"
+        ],
+        "role": "strict-target-effective-sequence"
+      },
+      {
+        "family": "wcmp",
+        "documentIds": [
+          "WAP-202-WCMP"
+        ],
+        "role": "strict-target-approved-baseline"
+      }
+    ],
+    "successorContext": {
+      "documentId": "WAP-259-WDP-20010614-a",
+      "role": "delta-evidence-only",
+      "comparedSections": [
+        "4.1",
+        "4.2",
+        "4.2.2",
+        "4.3",
+        "4.4.3",
+        "5.3.2",
+        "6.2",
+        "Appendix B",
+        "Appendix C",
+        "Appendix F"
+      ]
+    },
+    "classifications": [
+      {
+        "id": "TRN-707-WDP-SERVICE-PRIMITIVE",
+        "family": "wdp",
+        "disposition": "compatible",
+        "implementationBasis": "target-era-or-version-neutral",
+        "targetClauseIds": [
+          "WDP-CL-CONSISTENT-TRANSPORT-SERVICE",
+          "WDP-CL-UNITDATA-REQUEST-ANYTIME",
+          "WDP-CL-UNITDATA-CONTENT-TRANSPARENCY"
+        ],
+        "successorSections": [
+          "4.1",
+          "4.2",
+          "5.3.2"
+        ],
+        "finding": "WAP-259 preserves the consistent bearer-independent service, connectionless T-DUnitdata availability, and unmodified service-data-unit delivery required by effective WAP-200.",
+        "implementationEvidence": [
+          "transport-rust/src/network/wdp/primitive.rs::TDUnitdataRequest",
+          "transport-rust/src/network/wdp/primitive.rs::TDUnitdataIndication"
+        ],
+        "fixture": "transport-rust/tests/fixtures/transport/wdp_cdpd_ipv4_mapped/wdp_fixture.json",
+        "tests": [
+          "network::wdp::tests::td_unitdata_request_and_indication_preserve_address_port_and_payload_semantics",
+          "network::wdp::tests::simultaneous_connectionless_instances_are_multiplexed_by_port_fields"
+        ]
+      },
+      {
+        "id": "TRN-707-WDP-CDPD-IP-REGISTRIES",
+        "family": "wdp",
+        "disposition": "compatible",
+        "implementationBasis": "target-era-or-version-neutral",
+        "targetClauseIds": [
+          "WDP-CL-IP-BEARER-REQUIRES-UDP",
+          "WDP-CL-CDPD-UDP-IP-PROFILE",
+          "WDP-CL-SELECTED-WSP-PORT",
+          "WDP-CL-SELECTED-BEARER-ASSIGNMENT"
+        ],
+        "successorSections": [
+          "4.3",
+          "4.4.3",
+          "6.2",
+          "Appendix B",
+          "Appendix C"
+        ],
+        "finding": "WAP-259 preserves UDP for IP bearers, the CDPD UDP/IP profile, connectionless WSP port 9200, and the AMPS/CDPD/IPv4 bearer assignment 0x0D.",
+        "implementationEvidence": [
+          "transport-rust/src/network/wdp/profile.rs::CdpdIpv4Profile",
+          "transport-rust/src/network/wdp/datagram.rs::WdpServicePort",
+          "transport-rust/src/network/wdp/ipv4_udp.rs::encode_cdpd_ipv4_udp",
+          "transport-rust/src/network/wdp/ipv4_udp.rs::decode_cdpd_ipv4_udp"
+        ],
+        "fixture": "transport-rust/tests/fixtures/transport/wdp_cdpd_ipv4_mapped/wdp_fixture.json",
+        "tests": [
+          "network::wdp::tests::registered_port_and_bearer_profile_are_exact",
+          "network::wdp::tests::selected_cdpd_ipv4_profile_preserves_exact_udp_ipv4_bytes"
+        ]
+      },
+      {
+        "id": "TRN-707-WCMP-TARGET-DELEGATION",
+        "family": "wcmp",
+        "disposition": "strict-correction-required",
+        "implementationBasis": "target-era",
+        "targetClauseIds": [
+          "WCMP-CL-CLIENT-GENERAL-PROFILE",
+          "WCMP-CL-SELECTED-TYPE-CODE-VALUES"
+        ],
+        "targetSections": [
+          "5.3",
+          "5.4",
+          "5.5.1",
+          "Appendix A"
+        ],
+        "successorSections": [
+          "4.2.2"
+        ],
+        "finding": "WAP-259 delegates WDP processing-error behavior to WCMP. WAP-202 section 5.3 assigns CDPD/IP to ICMP, so the current section 5.4/5.5 general-WCMP codec cannot satisfy the selected CDPD/IPv4 strict profile without capability gating and an ICMPv4 correction.",
+        "implementationEvidence": [
+          "transport-rust/src/network/wcmp/message.rs::WcmpMessage",
+          "transport-rust/src/network/wcmp/codec.rs::decode_wcmp",
+          "transport-rust/src/network/wcmp/handler.rs::handle_wcmp"
+        ],
+        "fixture": "transport-rust/tests/fixtures/transport/wcmp_core_mapped/wcmp_fixture.json",
+        "tests": [
+          "network::wcmp::tests::source_derived_fixture_covers_selected_class_c_rows",
+          "network::wcmp::tests::selected_messages_preserve_exact_wap_1_2_1_bytes_and_roundtrip"
+        ]
+      }
+    ],
+    "strictCorrectionWorkItems": [
+      "TRN-708"
+    ],
+    "explicitGaps": [
+      {
+        "family": "wtp",
+        "status": "conditional-not-activated-unmapped",
+        "activationCondition": "A future explicit connection-oriented WSP claim activates the effective WAP-201/SIN obligation, fixture, and release-evidence closure.",
+        "successorContext": [
+          "WAP-224-WTP-20010710-a",
+          "OMA-WAP-224_002-WTP-SIN-20020827-a"
+        ],
+        "policy": "Do not classify partial WTP code or successor context as strict evidence, and do not activate WTP or connection-oriented WSP through TRN-707."
+      }
+    ]
+  }
 }

--- a/spec-processing/source-manifests/wap-1.2.1-trn-7-knowledge-graph.json
+++ b/spec-processing/source-manifests/wap-1.2.1-trn-7-knowledge-graph.json
@@ -13,7 +13,7 @@
     "generator": "spec-processing/scripts/generate-wap-knowledge-graph.mjs",
     "inputs": {
       "docs/waves/wap-1.2.1-compliance-program.json": {
-        "sha256": "92b8d3321d22f08832d37c7c43af7771c1f7ff9941b47800b8e9de3d15bc0f6d"
+        "sha256": "ecc532a8e6974a0ac19d0f6307f742be037c63b2e6905ce1e6d1451f89fc2d45"
       },
       "spec-processing/source-manifests/wap-1.2.1-class-conformance.json": {
         "sha256": "b76605b2144b32965a857b848b2e9e522baada6fae9fe51012b9eaa664e85d86"
@@ -25,14 +25,17 @@
         "sha256": "654284270a068b427ab05166247cb8e0644a99cf6af511f9b9c477d18ea36faa"
       },
       "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json": {
-        "sha256": "f297867c62012a7a93b164c9586fca2a0e614f83186908f3696253176412e40a"
+        "sha256": "fd7ce0464bb0585ad40b9bc6f41317ef5f13661dd94a4c54139ee2f8a1738e8a"
+      },
+      "spec-processing/source-manifests/wap-1.2.1-successor-delta.json": {
+        "sha256": "7c3525ab173855498217de0ea9332241002628da31d497fa1f86e5c0aea9414c"
       }
     },
     "policy": "Canonical manifests remain authoritative; this graph and its Obsidian/context projections are generated views."
   },
   "summary": {
-    "nodeCount": 214,
-    "edgeCount": 624,
+    "nodeCount": 216,
+    "edgeCount": 640,
     "nodesByType": {
       "clause": 77,
       "fixture": 77,
@@ -41,28 +44,29 @@
       "profile": 1,
       "requirement": 6,
       "scr-row": 14,
-      "source-document": 15,
+      "source-document": 16,
       "source-family": 4,
       "sprint": 4,
-      "work-item": 7
+      "work-item": 8
     },
     "edgesByRelation": {
       "amended-by": 8,
       "applied-before": 8,
       "belongs-to": 14,
-      "contains": 7,
-      "covers-family": 12,
+      "contains": 8,
+      "covers-family": 14,
       "depends-on": 3,
       "effective-document": 12,
       "maps-to": 114,
-      "owned-by": 15,
-      "planned-by": 111,
+      "owned-by": 18,
+      "planned-by": 120,
       "refines": 154,
       "relates-to": 8,
       "requires-family": 2,
       "selected-from": 1,
       "sourced-from": 77,
       "targets-profile": 1,
+      "uses-context": 1,
       "verified-by": 77
     },
     "directClauseCountsByWorkItem": {
@@ -72,7 +76,8 @@
       "TRN-704": 0,
       "TRN-705": 0,
       "TRN-706": 11,
-      "TRN-707": 0
+      "TRN-707": 9,
+      "TRN-708": 0
     },
     "directClauseFamiliesByWorkItem": {
       "TRN-701": [
@@ -89,13 +94,20 @@
       "TRN-706": [
         "wdp"
       ],
-      "TRN-707": []
+      "TRN-707": [
+        "wcmp",
+        "wdp"
+      ],
+      "TRN-708": []
     },
     "unmappedNormativeFamiliesByWorkItem": {
       "TRN-706": [
         "wtp"
       ],
       "TRN-707": [
+        "wtp"
+      ],
+      "TRN-708": [
         "wcmp",
         "wdp"
       ]
@@ -103,7 +115,7 @@
     "workItemsWithoutDirectClauses": [
       "TRN-704",
       "TRN-705",
-      "TRN-707"
+      "TRN-708"
     ]
   },
   "nodes": [
@@ -129,7 +141,8 @@
         "obligationSynopsis": "Implement the general WCMP message branch used to report WDP processing errors on the selected non-ICMP profile.",
         "workItems": [
           "T0-17",
-          "TRN-703"
+          "TRN-703",
+          "TRN-707"
         ],
         "ownerLayers": [
           "transport-rust"
@@ -1024,7 +1037,8 @@
         "obligationSynopsis": "Recognize Destination Unreachable type 51, Message Too Big type 60 code 0, and Echo Reply type 179 code 0.",
         "workItems": [
           "T0-17",
-          "TRN-703"
+          "TRN-703",
+          "TRN-707"
         ],
         "ownerLayers": [
           "transport-rust"
@@ -1205,7 +1219,8 @@
         "workItems": [
           "T0-19",
           "TRN-701",
-          "TRN-706"
+          "TRN-706",
+          "TRN-707"
         ],
         "ownerLayers": [
           "transport-rust"
@@ -1241,7 +1256,8 @@
         "obligationSynopsis": "Expose the same WDP transport service and primitive contract to upper WAP layers across supported bearer adaptations.",
         "workItems": [
           "T0-19",
-          "TRN-701"
+          "TRN-701",
+          "TRN-707"
         ],
         "ownerLayers": [
           "transport-rust"
@@ -1352,7 +1368,8 @@
         "obligationSynopsis": "Use UDP as the WDP protocol whenever the selected bearer provides IP.",
         "workItems": [
           "T0-19",
-          "TRN-701"
+          "TRN-701",
+          "TRN-707"
         ],
         "ownerLayers": [
           "transport-rust"
@@ -2046,7 +2063,8 @@
         "obligationSynopsis": "Represent the AMPS/CDPD/IPv4 network-bearer-address combination with assigned bearer value 0x0D when that registry is carried.",
         "workItems": [
           "T0-19",
-          "TRN-701"
+          "TRN-701",
+          "TRN-707"
         ],
         "ownerLayers": [
           "transport-rust"
@@ -2082,7 +2100,8 @@
         "obligationSynopsis": "Use registered UDP/WDP port 9200 for the selected non-secure connectionless WSP session service.",
         "workItems": [
           "T0-19",
-          "TRN-701"
+          "TRN-701",
+          "TRN-707"
         ],
         "ownerLayers": [
           "transport-rust"
@@ -2697,7 +2716,8 @@
           "T0-19",
           "TRN-701",
           "TRN-702",
-          "TRN-706"
+          "TRN-706",
+          "TRN-707"
         ],
         "ownerLayers": [
           "transport-rust"
@@ -2771,7 +2791,8 @@
         "obligationSynopsis": "Allow T-DUnitdata.request without establishing a prior transport connection.",
         "workItems": [
           "T0-19",
-          "TRN-701"
+          "TRN-701",
+          "TRN-707"
         ],
         "ownerLayers": [
           "transport-rust"
@@ -4517,6 +4538,20 @@
       }
     },
     {
+      "id": "source-document:WAP-259-WDP-20010614-a",
+      "key": "WAP-259-WDP-20010614-a",
+      "type": "source-document",
+      "title": "Wireless Datagram Protocol",
+      "properties": {
+        "family": "wdp-wcmp",
+        "filename": "WAP-259-WDP-20010614-a.pdf",
+        "role": "delta-evidence-only",
+        "sha256": "73dab5af5a1afb4ec320788e19ef04bfd4f1897dfcc8aa8c74eed7e304b58f3e",
+        "targetNormative": false,
+        "source": "spec-processing/source-manifests/wap-1.2.1-successor-delta.json"
+      }
+    },
+    {
       "id": "source-family:wcmp",
       "key": "wcmp",
       "type": "source-family",
@@ -4855,7 +4890,7 @@
       "type": "work-item",
       "title": "WAP 1.2.1-to-WAP 2.0 WDP/WTP/WCMP delta register",
       "properties": {
-        "status": "todo",
+        "status": "in-progress",
         "ownerLayers": [
           "documentation",
           "transport-rust",
@@ -4866,15 +4901,84 @@
           "wtp",
           "wcmp"
         ],
+        "explicitUnmappedFamilies": [
+          "wtp"
+        ],
+        "contextDocuments": [
+          "WAP-259-WDP-20010614-a"
+        ],
+        "followUpWorkItems": [
+          "TRN-708"
+        ],
         "existingTickets": [],
         "outputs": [
-          "WAP 1.2.1-to-WAP 2.0 WDP/WTP/WCMP delta register"
+          "WAP 1.2.1-to-WAP 2.0 WDP/WTP/WCMP delta register",
+          "TRN-707 transport-specific audit in spec-processing/source-manifests/wap-1.2.1-successor-delta.json"
         ],
         "acceptance": [
-          "Current successor-spec implementation assumptions are either proven compatible or ticketed as strict-mode corrections."
+          "Current successor-spec implementation assumptions are either proven compatible or ticketed as strict-mode corrections.",
+          "The selected WDP CDPD/UDP/IPv4 service, primitive, port, and bearer assumptions are compared clause-by-clause against effective WAP-200 and WAP-259 without treating the successor as normative.",
+          "The selected general-WCMP implementation remains governed by WAP-202; WAP-259 delegates WCMP behavior to that specification and does not replace its exact message fixtures.",
+          "WAP-202 section 5.3 assigns CDPD/IP to ICMP; additive TRN-708 owns the strict-profile correction and capability-gates the completed TRN-703 general-WCMP branch.",
+          "WTP and connection-oriented WSP remain inactive, and the missing WTP clause mapping remains explicit until a future capability claim activates the effective WAP-201/SIN closure."
         ],
         "evidence": [
-          "node scripts/check-wap-delta-register.mjs"
+          "node scripts/check-wap-delta-register.mjs",
+          "node scripts/check-wap-selected-normative-clauses.mjs",
+          "node scripts/check-wap-transport-conformance-ledgers.mjs",
+          "node scripts/wap-context-pack.mjs TRN-707",
+          "node scripts/check-wap-knowledge-graph.mjs",
+          "cargo test --manifest-path transport-rust/Cargo.toml --lib network::wdp",
+          "cargo test --manifest-path transport-rust/Cargo.toml --lib network::wcmp"
+        ],
+        "source": "docs/waves/wap-1.2.1-compliance-program.json"
+      }
+    },
+    {
+      "id": "work-item:TRN-708",
+      "key": "TRN-708",
+      "type": "work-item",
+      "title": "Strict CDPD/IPv4 ICMP profile correction with the existing general-WCMP branch capability-gated for non-IP use",
+      "properties": {
+        "status": "todo",
+        "ownerLayers": [
+          "documentation",
+          "transport-rust",
+          "qa"
+        ],
+        "sourceFamilies": [
+          "wdp",
+          "wcmp"
+        ],
+        "dependsOn": [
+          "TRN-703",
+          "T0-17"
+        ],
+        "notes": [
+          "Additive strict-profile correction only. Preserve completed TRN-703/T0-17 as the canonical history of the implemented general-WCMP branch."
+        ],
+        "specReferences": [
+          "WAP-202-WCMP section 5.3 (CDPD and other IP bearers use ICMP)",
+          "WAP-202-WCMP section 5.4 and 5.5 (general WCMP is the non-IP message branch)",
+          "WAP-202-WCMP Appendix A rows WCMP-C-001, WCMP-SP-C-001, and WCMP-SP-C-002",
+          "WAP-200 effective CDPD/IPv4 path rows WDP-CT-C-002 and WDP-NA-C-003",
+          "WAP-259-WDP section 4.2.2 (successor context delegates processing-error behavior to WCMP)"
+        ],
+        "existingTickets": [],
+        "outputs": [
+          "Strict CDPD/IPv4 ICMP profile correction with the existing general-WCMP branch capability-gated for non-IP use"
+        ],
+        "acceptance": [
+          "The strict CDPD/IPv4 profile selects the WAP-202 section 5.3 ICMPv4 path rather than emitting or consuming the section 5.4 general-WCMP wire format.",
+          "Direct fixtures prove ICMPv4 destination-unreachable code 3 (port unreachable), code 4 (fragmentation needed with DF set), and echo request/reply handling at the WDP error boundary for the selected IPv4 bearer.",
+          "The existing WAP-202 section 5.4/5.5 general-WCMP codec and TRN-703 fixtures remain available only behind an explicit non-IP bearer capability and do not satisfy the CDPD/IPv4 strict claim.",
+          "No WTP or connection-oriented WSP capability is activated."
+        ],
+        "evidence": [
+          "cargo test --manifest-path transport-rust/Cargo.toml --test wcmp_cdpd_icmp_profile",
+          "node scripts/check-wap-transport-conformance-ledgers.mjs",
+          "node scripts/check-wap-selected-normative-clauses.mjs",
+          "node scripts/check-requirement-status-drift.mjs"
         ],
         "source": "docs/waves/wap-1.2.1-compliance-program.json"
       }
@@ -4895,6 +4999,15 @@
       "from": "clause:WCMP-CL-CLIENT-GENERAL-PROFILE",
       "relation": "planned-by",
       "to": "work-item:TRN-703",
+      "sourceRefs": [
+        "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
+      ]
+    },
+    {
+      "id": "clause:WCMP-CL-CLIENT-GENERAL-PROFILE|planned-by|work-item:TRN-707",
+      "from": "clause:WCMP-CL-CLIENT-GENERAL-PROFILE",
+      "relation": "planned-by",
+      "to": "work-item:TRN-707",
       "sourceRefs": [
         "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
       ]
@@ -6178,6 +6291,15 @@
       ]
     },
     {
+      "id": "clause:WCMP-CL-SELECTED-TYPE-CODE-VALUES|planned-by|work-item:TRN-707",
+      "from": "clause:WCMP-CL-SELECTED-TYPE-CODE-VALUES",
+      "relation": "planned-by",
+      "to": "work-item:TRN-707",
+      "sourceRefs": [
+        "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
+      ]
+    },
+    {
       "id": "clause:WCMP-CL-SELECTED-TYPE-CODE-VALUES|refines|scr-row:WCMP-GEN-C-001",
       "from": "clause:WCMP-CL-SELECTED-TYPE-CODE-VALUES",
       "relation": "refines",
@@ -6502,6 +6624,15 @@
       ]
     },
     {
+      "id": "clause:WDP-CL-CDPD-UDP-IP-PROFILE|planned-by|work-item:TRN-707",
+      "from": "clause:WDP-CL-CDPD-UDP-IP-PROFILE",
+      "relation": "planned-by",
+      "to": "work-item:TRN-707",
+      "sourceRefs": [
+        "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
+      ]
+    },
+    {
       "id": "clause:WDP-CL-CDPD-UDP-IP-PROFILE|refines|scr-row:WDP-CT-C-002",
       "from": "clause:WDP-CL-CDPD-UDP-IP-PROFILE",
       "relation": "refines",
@@ -6551,6 +6682,15 @@
       "from": "clause:WDP-CL-CONSISTENT-TRANSPORT-SERVICE",
       "relation": "planned-by",
       "to": "work-item:TRN-701",
+      "sourceRefs": [
+        "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
+      ]
+    },
+    {
+      "id": "clause:WDP-CL-CONSISTENT-TRANSPORT-SERVICE|planned-by|work-item:TRN-707",
+      "from": "clause:WDP-CL-CONSISTENT-TRANSPORT-SERVICE",
+      "relation": "planned-by",
+      "to": "work-item:TRN-707",
       "sourceRefs": [
         "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
       ]
@@ -6776,6 +6916,15 @@
       "from": "clause:WDP-CL-IP-BEARER-REQUIRES-UDP",
       "relation": "planned-by",
       "to": "work-item:TRN-701",
+      "sourceRefs": [
+        "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
+      ]
+    },
+    {
+      "id": "clause:WDP-CL-IP-BEARER-REQUIRES-UDP|planned-by|work-item:TRN-707",
+      "from": "clause:WDP-CL-IP-BEARER-REQUIRES-UDP",
+      "relation": "planned-by",
+      "to": "work-item:TRN-707",
       "sourceRefs": [
         "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
       ]
@@ -8068,6 +8217,15 @@
       ]
     },
     {
+      "id": "clause:WDP-CL-SELECTED-BEARER-ASSIGNMENT|planned-by|work-item:TRN-707",
+      "from": "clause:WDP-CL-SELECTED-BEARER-ASSIGNMENT",
+      "relation": "planned-by",
+      "to": "work-item:TRN-707",
+      "sourceRefs": [
+        "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
+      ]
+    },
+    {
       "id": "clause:WDP-CL-SELECTED-BEARER-ASSIGNMENT|refines|scr-row:WDP-CT-C-002",
       "from": "clause:WDP-CL-SELECTED-BEARER-ASSIGNMENT",
       "relation": "refines",
@@ -8126,6 +8284,15 @@
       "from": "clause:WDP-CL-SELECTED-WSP-PORT",
       "relation": "planned-by",
       "to": "work-item:TRN-701",
+      "sourceRefs": [
+        "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
+      ]
+    },
+    {
+      "id": "clause:WDP-CL-SELECTED-WSP-PORT|planned-by|work-item:TRN-707",
+      "from": "clause:WDP-CL-SELECTED-WSP-PORT",
+      "relation": "planned-by",
+      "to": "work-item:TRN-707",
       "sourceRefs": [
         "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
       ]
@@ -9211,6 +9378,15 @@
       ]
     },
     {
+      "id": "clause:WDP-CL-UNITDATA-CONTENT-TRANSPARENCY|planned-by|work-item:TRN-707",
+      "from": "clause:WDP-CL-UNITDATA-CONTENT-TRANSPARENCY",
+      "relation": "planned-by",
+      "to": "work-item:TRN-707",
+      "sourceRefs": [
+        "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
+      ]
+    },
+    {
       "id": "clause:WDP-CL-UNITDATA-CONTENT-TRANSPARENCY|refines|scr-row:WDP-CORE-C-001",
       "from": "clause:WDP-CL-UNITDATA-CONTENT-TRANSPARENCY",
       "relation": "refines",
@@ -9368,6 +9544,15 @@
       "from": "clause:WDP-CL-UNITDATA-REQUEST-ANYTIME",
       "relation": "planned-by",
       "to": "work-item:TRN-701",
+      "sourceRefs": [
+        "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
+      ]
+    },
+    {
+      "id": "clause:WDP-CL-UNITDATA-REQUEST-ANYTIME|planned-by|work-item:TRN-707",
+      "from": "clause:WDP-CL-UNITDATA-REQUEST-ANYTIME",
+      "relation": "planned-by",
+      "to": "work-item:TRN-707",
       "sourceRefs": [
         "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json"
       ]
@@ -10156,6 +10341,15 @@
       ]
     },
     {
+      "id": "sprint:TRN-7|contains|work-item:TRN-708",
+      "from": "sprint:TRN-7",
+      "relation": "contains",
+      "to": "work-item:TRN-708",
+      "sourceRefs": [
+        "docs/waves/wap-1.2.1-compliance-program.json"
+      ]
+    },
+    {
       "id": "sprint:TRN-7|depends-on|sprint:CONF-1",
       "from": "sprint:TRN-7",
       "relation": "depends-on",
@@ -10492,6 +10686,61 @@
     {
       "id": "work-item:TRN-707|owned-by|owner-layer:transport-rust",
       "from": "work-item:TRN-707",
+      "relation": "owned-by",
+      "to": "owner-layer:transport-rust",
+      "sourceRefs": [
+        "docs/waves/wap-1.2.1-compliance-program.json"
+      ]
+    },
+    {
+      "id": "work-item:TRN-707|uses-context|source-document:WAP-259-WDP-20010614-a",
+      "from": "work-item:TRN-707",
+      "relation": "uses-context",
+      "to": "source-document:WAP-259-WDP-20010614-a",
+      "sourceRefs": [
+        "docs/waves/wap-1.2.1-compliance-program.json",
+        "spec-processing/source-manifests/wap-1.2.1-successor-delta.json"
+      ]
+    },
+    {
+      "id": "work-item:TRN-708|covers-family|source-family:wcmp",
+      "from": "work-item:TRN-708",
+      "relation": "covers-family",
+      "to": "source-family:wcmp",
+      "sourceRefs": [
+        "docs/waves/wap-1.2.1-compliance-program.json"
+      ]
+    },
+    {
+      "id": "work-item:TRN-708|covers-family|source-family:wdp",
+      "from": "work-item:TRN-708",
+      "relation": "covers-family",
+      "to": "source-family:wdp",
+      "sourceRefs": [
+        "docs/waves/wap-1.2.1-compliance-program.json"
+      ]
+    },
+    {
+      "id": "work-item:TRN-708|owned-by|owner-layer:documentation",
+      "from": "work-item:TRN-708",
+      "relation": "owned-by",
+      "to": "owner-layer:documentation",
+      "sourceRefs": [
+        "docs/waves/wap-1.2.1-compliance-program.json"
+      ]
+    },
+    {
+      "id": "work-item:TRN-708|owned-by|owner-layer:qa",
+      "from": "work-item:TRN-708",
+      "relation": "owned-by",
+      "to": "owner-layer:qa",
+      "sourceRefs": [
+        "docs/waves/wap-1.2.1-compliance-program.json"
+      ]
+    },
+    {
+      "id": "work-item:TRN-708|owned-by|owner-layer:transport-rust",
+      "from": "work-item:TRN-708",
       "relation": "owned-by",
       "to": "owner-layer:transport-rust",
       "sourceRefs": [

--- a/spec-processing/source-manifests/wap-1.2.1-wml-2-knowledge-graph.json
+++ b/spec-processing/source-manifests/wap-1.2.1-wml-2-knowledge-graph.json
@@ -13,7 +13,7 @@
     "generator": "spec-processing/scripts/generate-wap-knowledge-graph.mjs",
     "inputs": {
       "docs/waves/wap-1.2.1-compliance-program.json": {
-        "sha256": "92b8d3321d22f08832d37c7c43af7771c1f7ff9941b47800b8e9de3d15bc0f6d"
+        "sha256": "ecc532a8e6974a0ac19d0f6307f742be037c63b2e6905ce1e6d1451f89fc2d45"
       },
       "spec-processing/source-manifests/wap-1.2.1-class-conformance.json": {
         "sha256": "b76605b2144b32965a857b848b2e9e522baada6fae9fe51012b9eaa664e85d86"
@@ -25,7 +25,10 @@
         "sha256": "654284270a068b427ab05166247cb8e0644a99cf6af511f9b9c477d18ea36faa"
       },
       "spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json": {
-        "sha256": "f297867c62012a7a93b164c9586fca2a0e614f83186908f3696253176412e40a"
+        "sha256": "fd7ce0464bb0585ad40b9bc6f41317ef5f13661dd94a4c54139ee2f8a1738e8a"
+      },
+      "spec-processing/source-manifests/wap-1.2.1-successor-delta.json": {
+        "sha256": "7c3525ab173855498217de0ea9332241002628da31d497fa1f86e5c0aea9414c"
       }
     },
     "policy": "Canonical manifests remain authoritative; this graph and its Obsidian/context projections are generated views."

--- a/spec-processing/source-manifests/wap-1.2.1-wsp-scr.json
+++ b/spec-processing/source-manifests/wap-1.2.1-wsp-scr.json
@@ -1843,12 +1843,12 @@
         "assessmentNote": "Native connectionless GET/POST/REPLY encoding exists with synthetic tests, but exact WAP-203 PDU, primitive, status, and assigned-number coverage is incomplete.",
         "implementationEvidence": [
           {
-            "path": "transport-rust/src/native_fetch.rs",
+            "path": "transport-rust/src/network/wsp/connectionless.rs",
             "symbol": "encode_connectionless_request"
           },
           {
-            "path": "transport-rust/src/native_fetch.rs",
-            "symbol": "decode_connectionless_wsp_reply"
+            "path": "transport-rust/src/network/wsp/connectionless.rs",
+            "symbol": "decode_connectionless_reply"
           }
         ],
         "testEvidence": [
@@ -1899,12 +1899,12 @@
         "assessmentNote": "Native connectionless GET/POST/REPLY encoding exists with synthetic tests, but exact WAP-203 PDU, primitive, status, and assigned-number coverage is incomplete.",
         "implementationEvidence": [
           {
-            "path": "transport-rust/src/native_fetch.rs",
+            "path": "transport-rust/src/network/wsp/connectionless.rs",
             "symbol": "encode_connectionless_request"
           },
           {
-            "path": "transport-rust/src/native_fetch.rs",
-            "symbol": "decode_connectionless_wsp_reply"
+            "path": "transport-rust/src/network/wsp/connectionless.rs",
+            "symbol": "decode_connectionless_reply"
           }
         ],
         "testEvidence": [
@@ -1955,12 +1955,12 @@
         "assessmentNote": "Native connectionless GET/POST/REPLY encoding exists with synthetic tests, but exact WAP-203 PDU, primitive, status, and assigned-number coverage is incomplete.",
         "implementationEvidence": [
           {
-            "path": "transport-rust/src/native_fetch.rs",
+            "path": "transport-rust/src/network/wsp/connectionless.rs",
             "symbol": "encode_connectionless_request"
           },
           {
-            "path": "transport-rust/src/native_fetch.rs",
-            "symbol": "decode_connectionless_wsp_reply"
+            "path": "transport-rust/src/network/wsp/connectionless.rs",
+            "symbol": "decode_connectionless_reply"
           }
         ],
         "testEvidence": [
@@ -2011,12 +2011,12 @@
         "assessmentNote": "Native connectionless GET/POST/REPLY encoding exists with synthetic tests, but exact WAP-203 PDU, primitive, status, and assigned-number coverage is incomplete.",
         "implementationEvidence": [
           {
-            "path": "transport-rust/src/native_fetch.rs",
+            "path": "transport-rust/src/network/wsp/connectionless.rs",
             "symbol": "encode_connectionless_request"
           },
           {
-            "path": "transport-rust/src/native_fetch.rs",
-            "symbol": "decode_connectionless_wsp_reply"
+            "path": "transport-rust/src/network/wsp/connectionless.rs",
+            "symbol": "decode_connectionless_reply"
           }
         ],
         "testEvidence": [

--- a/transport-rust/tests/fixtures/transport/wcmp_core_mapped/meta.toml
+++ b/transport-rust/tests/fixtures/transport/wcmp_core_mapped/meta.toml
@@ -1,7 +1,7 @@
 name = "wcmp-core-mapped"
 description = "Source-derived WAP-202 general-WCMP byte vectors, bounded generation, handling, and deterministic error outcomes."
 mode = "mapped"
-work_items = ["TRN-703", "T0-17"]
+work_items = ["TRN-703", "TRN-707", "T0-17"]
 spec_items = [
   "WCMP-C-001",
   "WCMP-SP-C-002",
@@ -19,4 +19,5 @@ testing_ac = [
   "Suppresses error-to-error, repeated fragmented-datagram, and congestion responses.",
   "Rejects oversized messages and truncates only Echo Reply data to the return-path fragment limit.",
   "Rejects malformed, truncated, invalid-code, and unsupported/reserved messages deterministically.",
+  "Proves the WAP-202 general-WCMP branch audited by TRN-707; TRN-708 must capability-gate it from the strict CDPD/IPv4 ICMP profile.",
 ]

--- a/transport-rust/tests/fixtures/transport/wdp_cdpd_ipv4_mapped/meta.toml
+++ b/transport-rust/tests/fixtures/transport/wdp_cdpd_ipv4_mapped/meta.toml
@@ -1,7 +1,7 @@
 name = "wdp-cdpd-ipv4-mapped"
 description = "Source-derived WAP-200, RFC 768, and RFC 791 evidence for the selected Class C CDPD/IPv4 WDP path."
 mode = "mapped"
-work_items = ["TRN-701", "T0-19"]
+work_items = ["TRN-701", "TRN-707", "T0-19"]
 spec_items = [
   "WDP-C-001",
   "WDP-CORE-C-001",
@@ -25,4 +25,5 @@ testing_ac = [
   "Rejects invalid IPv4 version, IHL, total length, TTL, protocol, checksum, and unreassembled fragments deterministically.",
   "Keeps IPv4 fragmentation/reassembly below WDP and does not claim WDP segmentation/reassembly closure.",
   "Enforces the 576-octet IPv4 baseline send assurance and DF/path-MTU discard policies deterministically.",
+  "Provides target-era proof for the narrowly mapped TRN-707 WAP-259 compatibility comparison without treating the successor source as normative.",
 ]


### PR DESCRIPTION
## Summary

- add nine direct TRN-707 WDP/WCMP clause mappings and focused retrieval support
- prove the bounded WDP successor assumptions compatible with the WAP 1.2.1 target
- record the WAP-202 CDPD/IP WCMP mismatch and add corrective follow-up TRN-708
- preserve CONF-007 canonical history while extending its transport-specific evidence
- keep WTP conditional and connection-oriented WSP inactive
- regenerate the canonical graph, context-pack, vault, and successor-delta projections

## Why

TRN-707 had no direct clause mapping and the TRN-7 context pack declared WDP/WCMP family gaps. This change establishes the minimum canonical mapping needed to audit the current successor-spec assumptions against WAP-200, WAP-202, and the WAP-259 successor delta without reopening completed TRN-701/TRN-703 work.

## Classification and impact

- WDP service primitives and CDPD/UDP/IPv4 registry groups are classified as compatible within the audited scope.
- WCMP needs a narrowly scoped strict-mode correction: WAP-202 section 5.3 assigns CDPD/IP handling to ICMP, while the existing TRN-703 fixture implements the section 5.4/5.5 general-WCMP branch.
- TRN-708 captures that correction with clause-specific acceptance tests.
- TRN-707 remains conservatively in progress; missing WTP mappings remain explicit.
- No WTP or connection-oriented WSP behavior is activated.

## Validation

- `node scripts/check-wap-delta-register.mjs`
- `node scripts/check-wap-selected-normative-clauses.mjs`
- `node scripts/check-wap-transport-conformance-ledgers.mjs`
- `node scripts/check-requirement-status-drift.mjs`
- `node scripts/check-wap-compliance-program.mjs`
- `node scripts/check-wap-knowledge-graph.mjs`
- `node spec-processing/scripts/generate-wap-knowledge-graph.mjs --check`
- `cargo test --manifest-path transport-rust/Cargo.toml --lib network::wdp` (25 passed)
- `cargo test --manifest-path transport-rust/Cargo.toml --lib network::wcmp` (11 passed)
- `cargo test --manifest-path transport-rust/Cargo.toml --test fixture_harness` (1 passed)
- repository pre-push checks, including engine/browser/transport formatting and Clippy plus 261 engine tests
