### PR TITLE
test(ci): wire transport conformance ledger check into CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -355,7 +355,7 @@ jobs:
   docs-portal:
     name: Project Atlas Build
     needs: [changes]
-    if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.ci == 'true' || needs.changes.outputs.docs_portal == 'true' }}
+    if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.ci == 'true' || needs.changes.outputs.docs_portal == 'true' || needs.changes.outputs.rust_transport == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -376,6 +376,9 @@ jobs:
 
       - name: Validate knowledge graph
         run: pnpm wap-graph:check
+
+      - name: Validate transport conformance evidence
+        run: node scripts/check-wap-transport-conformance-ledgers.mjs
 
       - name: Build project Atlas
         run: pnpm --dir docs-portal run build


### PR DESCRIPTION
## Summary

- `scripts/check-wap-transport-conformance-ledgers.mjs` validates that compliance manifest `implementationEvidence`/`testEvidence` references (path + symbol) still point at real code, but was never invoked by any GitHub Actions workflow.
- Adds it as a step in the existing `docs-portal` job (alongside the knowledge-graph check it's a natural sibling of), and widens that job's trigger to also fire on `transport-rust/**` changes — a code-side symbol rename is the actual failure mode this check exists to catch, and that wouldn't have run the job under its previous `docs_portal`/`ci`-only trigger.
- Fixes #310.

Related: #309 was the concrete instance of the drift this gate would have caught — closed separately as already fixed by unrelated work, but the process gap this issue addresses is independent of that specific instance.

## Test plan

- [x] `node scripts/check-wap-transport-conformance-ledgers.mjs` passes locally (exit 0).
- [x] `pnpm run wap-graph:check` still passes (sibling check unaffected).
- [x] `pre-push` hooks passed (engine/transport/browser-tauri fmt+clippy+test, host-sample build).
- [ ] CI run on this PR (will confirm the new step executes and passes in the actual workflow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)