### PR TITLE
build(browser): make contracts:codegen self-sufficient on a clean checkout

### DIFF
--- a/browser/package.json
+++ b/browser/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "dev": "pnpm --dir frontend dev",
     "build": "pnpm --dir frontend build",
-    "contracts:codegen": "cargo run --manifest-path src-tauri/Cargo.toml --bin generate_contracts && node ./scripts/generate-contract-wrappers.mjs",
+    "contracts:codegen": "mkdir -p frontend/dist && (test -f frontend/dist/index.html || echo '<!doctype html><title>contracts-codegen-placeholder</title>' > frontend/dist/index.html) && cargo run --manifest-path src-tauri/Cargo.toml --bin generate_contracts && node ./scripts/generate-contract-wrappers.mjs",
     "contracts:check": "pnpm run contracts:codegen && git diff --exit-code -- contracts/generated/engine-host.ts contracts/generated/transport-host.ts contracts/generated/tauri-host-client.ts contracts/engine.ts contracts/transport.ts",
     "tauri:icons": "cd src-tauri && cargo tauri icon icons/waves.svg --output icons",
     "tauri:dev": "cd src-tauri && cargo tauri dev",


### PR DESCRIPTION
## Summary

- `pnpm --dir browser run contracts:check` (and `contracts:codegen`) failed on a clean checkout with an opaque proc-macro panic: `generate_contracts` links `wavenav_host`'s lib target, which unconditionally declares `pub mod bootstrap;`, whose `tauri::generate_context!()` call reads `tauri.conf.json`'s `frontendDist` at compile time and panics if `browser/frontend/dist` doesn't exist yet — even though `generate_contracts` itself never touches the frontend build output.
- CI already worked around this with an inline placeholder-dist step in `.github/workflows/ci.yml`, but that workaround was undocumented for local contributors following `AGENTS.md`'s instruction to run `contracts:check` after a contract-affecting change.
- Fixes #311 by baking the same placeholder-dist step into `contracts:codegen` itself (`mkdir -p frontend/dist`, skip if a real `index.html` already exists) — the preferred fix from the issue (self-sufficient, no manual step) rather than just documenting the workaround.

## Test plan

- [x] Verified on a genuinely clean checkout (`rm -rf browser/frontend/dist`, fresh `pnpm install`): `pnpm --dir browser run contracts:check` now succeeds with zero drift, no manual step required.
- [x] `pre-push` hooks passed (engine/transport/browser-tauri fmt+clippy+test, host-sample build).
- [x] Does not touch `.github/workflows/ci.yml`'s existing placeholder step — that step is still needed independently for the job's earlier fmt-check/coverage steps, which also require the crate to compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)