### PR TITLE
fix(ci): use supported GitHub Actions cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,10 +8,9 @@ updates:
       day: monday
       time: '06:00'
       timezone: Etc/UTC
+    # GitHub Actions supports a default cooldown, but not SemVer-specific cooldown keys.
     cooldown:
-      semver-major-days: 14
-      semver-minor-days: 7
-      semver-patch-days: 3
+      default-days: 7
     open-pull-requests-limit: 3
     groups:
       github-actions-non-major:

--- a/docs/ci/CI_SETUP.md
+++ b/docs/ci/CI_SETUP.md
@@ -261,7 +261,9 @@ Grouping and cadence:
   review.
 - Checks run weekly at deterministic UTC times: GitHub Actions on Monday, Node ecosystems on
   Tuesday, and Rust ecosystems on Wednesday.
-- Routine releases use a three-day patch, seven-day minor, and fourteen-day major cooldown.
+- Node and Cargo releases use a three-day patch, seven-day minor, and fourteen-day major
+  cooldown. GitHub Actions uses a seven-day default cooldown because that ecosystem does not
+  support SemVer-specific cooldown keys.
   Cooldowns do not delay security updates.
 - Open-PR limits are set per ecosystem/directory to prevent an update burst from flooding the
   review queue.


### PR DESCRIPTION
## Summary

- replace unsupported GitHub Actions SemVer cooldown fields with `cooldown.default-days: 7`
- retain the existing patch/minor/major cooldown policy for npm and Cargo ecosystems
- document the GitHub Actions cooldown exception in the active CI setup guide

## Root cause

GitHub Actions supports Dependabot's default cooldown, but it does not support
`semver-major-days`, `semver-minor-days`, or `semver-patch-days`. GitHub therefore rejected the
entire `dependabot.yml` configuration after #313 merged.

## Impact

This restores a valid Dependabot configuration while preserving the conservative update policy.
GitHub Actions updates retain a seven-day cooling period, patch/minor grouping stays unchanged,
and major updates remain isolated for manual review.

## Validation

- parsed `.github/dependabot.yml` successfully as YAML
- repository `check-yaml` hook passed
- targeted policy assertion passed across all eight update blocks
- Prettier and `git diff --check` passed
- repository pre-commit and full pre-push hooks passed
- engine tests: 261 passed
- engine, browser Tauri, and transport Rust format/Clippy checks passed

GitHub does not expose an official local or API validator for the full Dependabot configuration;
final runtime validation occurs when this configuration reaches the default branch.
