### PR TITLE
feat(transport): denote waps:// as unprotected pending WTLS-00

### DIFF
--- a/docs/architecture/wtls-modernization-research.md
+++ b/docs/architecture/wtls-modernization-research.md
@@ -459,6 +459,17 @@ research produces the following ordered backlog.
 Do not start `WTLS-06` by choosing algorithms first. `WTLS-01` through `WTLS-05` determine the
 actual wire, trust, and interoperability requirements the provider must satisfy.
 
+`WTLS-00` partial status (2026-07-25): the `waps://` native fetch path now emits a
+`transport.fetch.native.security` transport event (`protected: false, reason:
+"wtls-not-implemented", reference: "WTLS-00"`) on every request, and the code path is documented
+inline referencing this decision (`transport-rust/src/native_fetch.rs`,
+`warn_if_unprotected_waps_scheme`). This satisfies the "denote the current state" half of
+`WTLS-00`'s exit condition. It does **not** yet satisfy the rest: there is no unavoidable
+host/user-visible warning surfaced through the typed `FetchDeckResponse` contract, no
+credential/sensitive-submission blocking, and no release-profile fail-closed behavior. Those
+remain open and should be picked up together with `WTLS-08` (`SecurityOutcome` contract) rather
+than bolted onto the transport-event-log mechanism used here.
+
 ## Verification strategy
 
 Historical conformance evidence should include:

--- a/transport-rust/src/native_fetch.rs
+++ b/transport-rust/src/native_fetch.rs
@@ -155,6 +155,8 @@ pub(crate) fn execute_native_wap_request_with_transport(
         }
     };
 
+    warn_if_unprotected_waps_scheme(&parsed, plan.request_id.as_deref(), &plan.request_url);
+
     let transaction_id = CONNECTIONLESS_INITIAL_TRANSACTION_ID;
     let encoded_request = match encode_native_wap_request(
         transaction_id,
@@ -311,6 +313,41 @@ fn default_service_port(scheme: &str) -> u16 {
     }
 }
 
+/// `waps://` selects the WTLS-secured port (9202) by URL convention, but this crate does not
+/// yet invoke `network::wtls` from any live send path -- `encode_native_wap_request` produces
+/// the identical unprotected connectionless-WSP payload for `wap://` and `waps://` alike. This
+/// is the explicitly decided, temporary state from
+/// `docs/architecture/decisions/0002-separate-modern-security-from-wtls-compatibility.md`
+/// (development/interoperability `waps://` may stay available while WTLS is deferred, but "it
+/// reports no established security, emits an unavoidable warning"), tracked as `WTLS-00` in
+/// `docs/architecture/wtls-modernization-research.md`. Do not remove this warning by treating a
+/// `waps://` request as secure until `WTLS-08` ("Integrate live secure routes") actually routes
+/// it through a conformance-tested WTLS codec and returns a real `SecurityOutcome`.
+fn warn_if_unprotected_waps_scheme(parsed: &Url, request_id: Option<&str>, request_url: &str) {
+    if let Some(payload) = unprotected_waps_warning_payload(parsed.scheme()) {
+        log_transport_event(
+            "transport.fetch.native.security",
+            request_id,
+            request_url,
+            payload,
+        );
+    }
+}
+
+/// Pure decision half of [`warn_if_unprotected_waps_scheme`], split out so the warning payload
+/// is unit-testable without capturing stdout.
+fn unprotected_waps_warning_payload(scheme: &str) -> Option<serde_json::Value> {
+    if scheme != "waps" {
+        return None;
+    }
+    Some(serde_json::json!({
+        "scheme": "waps",
+        "protected": false,
+        "reason": "wtls-not-implemented",
+        "reference": "WTLS-00"
+    }))
+}
+
 fn request_uri(parsed: &Url) -> String {
     let path = if parsed.path().is_empty() {
         "/"
@@ -434,6 +471,20 @@ mod tests {
     use crate::network::wdp::transport_trait::WdpResult;
     use crate::network::wsp::connectionless::{decode_uintvar, encode_uintvar};
     use std::sync::{Mutex, OnceLock};
+
+    #[test]
+    fn unprotected_waps_warning_payload_flags_waps_scheme() {
+        let payload = unprotected_waps_warning_payload("waps").expect("waps must warn");
+        assert_eq!(payload["scheme"], "waps");
+        assert_eq!(payload["protected"], false);
+        assert_eq!(payload["reason"], "wtls-not-implemented");
+        assert_eq!(payload["reference"], "WTLS-00");
+    }
+
+    #[test]
+    fn unprotected_waps_warning_payload_is_silent_for_wap_scheme() {
+        assert_eq!(unprotected_waps_warning_payload("wap"), None);
+    }
 
     struct FakeDatagramTransport {
         sent: Vec<WdpDatagram>,


### PR DESCRIPTION
## Summary

- `waps://` selects the WTLS-secured port (9202) by URL convention, but the native fetch path currently sends the exact same unprotected connectionless-WSP payload as `wap://` -- `network::wtls` is not invoked from any live send path yet. This was verified during the WTLS research memo (#316) and is the explicitly decided, temporary state described in `docs/architecture/decisions/0002-separate-modern-security-from-wtls-compatibility.md`, tracked as `WTLS-00` in `docs/architecture/wtls-modernization-research.md`.
- Denotes this concretely in code, not only in docs: `transport-rust/src/native_fetch.rs` now emits a `transport.fetch.native.security` transport event (`protected: false, reason: "wtls-not-implemented", reference: "WTLS-00"`) for every `waps://` native request, plus an inline doc comment at `warn_if_unprotected_waps_scheme` pointing back at ADR 0002 / WTLS-00 and warning against removing it before `WTLS-08` lands.
- Updates `wtls-modernization-research.md` with an explicit note that this satisfies only the "denote the current state" half of WTLS-00's exit condition -- not the full one (no typed `SecurityOutcome` contract field, no credential blocking, no release-profile fail-closed behavior). Those remain WTLS-08-adjacent follow-up work, intentionally not attempted here.

## Test plan

- [x] `cargo test unprotected_waps` -- both new tests pass (`unprotected_waps_warning_payload_flags_waps_scheme`, `unprotected_waps_warning_payload_is_silent_for_wap_scheme`).
- [x] Full `transport-rust` suite still green (221 tests, 0 failed).
- [x] `cargo fmt --check` and `cargo clippy --all-targets --all-features -- -D warnings` clean.
- [x] `pre-push` hooks passed (engine/transport/browser-tauri fmt+clippy+test, host-sample build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)