### PR TITLE
docs: resync merged workstreams and refresh Project Atlas

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,13 +37,13 @@ Secondary docs:
 Status source: `docs/waves/wap-1.2.1-compliance-program.json`,
 `docs/waves/WORK_ITEMS.md`, `docs/waves/MAINTENANCE_WORK_ITEMS.md`,
 `docs/wml-engine/work-items.md`, and `.github/workflows/engine-fuzz.yml`
-(updated 2026-07-24).
+(updated 2026-07-25).
 
 | Track | Implemented | Roadmap / In Progress |
 |---|---|---|
-| Waves desktop app (`browser/`) | Desktop shell is usable end-to-end: network/local mode, runtime deck navigation, focused text/select editing, browser back/reload flow, debug/timeline surfaces, and an ordinary-browser story adapter backed by the real WASM engine | Broaden spec-driven Waves stories as stable runtime behavior lands; keep timer/dialog and debug-connector work dependency-gated |
+| Waves desktop app (`browser/`) | Desktop shell is usable end-to-end: network/local mode, runtime deck navigation, focused text/select editing, browser back/reload flow, debug/timeline surfaces, and an ordinary-browser story adapter backed by the real WASM engine | Preserve the completed W0-05 timer/dialog baseline while broadening spec-driven stories; keep downstream Dialogs/WMLS-5 and debug-connector work dependency-gated |
 | WaveNav runtime (`engine-wasm/`) | Runtime covers deck/card parsing, navigation, focus, input/select semantics, deterministic render output, native/WASM parity checks, and 23/23 mapped WML-204 clause fixtures | Finish the remaining WML-2 parser/DTD/error gaps before advancing WML-3 runtime breadth |
-| Lowband transport (`transport-rust/`) | The selected WDP path is 9/9 rows implemented, WCMP is 5/5, TRN-702 constrained-payload/reassembly behavior is direct-fixture-backed, and the pinned WBXML decoder has all 47 selected client clauses implemented | Close broader WBXML feature-row limitations and selected connectionless WSP evidence; activate WTP only with connection-oriented WSP |
+| Lowband transport (`transport-rust/`) | The selected WDP path is 9/9 rows implemented, WCMP is 5/5, TRN-702 constraints and the TRN-706 WDP replay tranche are direct-fixture-backed, TRN-707 records the successor delta, and the pinned WBXML decoder has all 47 selected client clauses implemented | Close the TRN-708 strict CDPD/IP correction, broader WBXML feature-row limitations, and selected connectionless WSP evidence; activate WTP only with connection-oriented WSP |
 | WAP evidence program | 22/201 selected parent rows are implemented and 149/780 clauses are directly assessed; Atlas renders the canonical program and active documents | 78 partial and 101 missing parents remain, so the project stays explicitly pre-conformance |
 | Frame-based render/input migration | Additive frame-oriented host commands are already in place for the hot browser paths | Finish the deliberate `M1-09` migration only after the current runtime/debug boundary work settles |
 | Fuzz hardening (`engine-wasm/engine/fuzz`) | Cargo-fuzz scaffold with `engine_wml_fuzzer`, starter corpus seeds, and scheduled weekly CI run | Add target coverage for transport/protocol surfaces, grow dictionaries/corpus, and tune campaign budgets |
@@ -101,6 +101,7 @@ make lint-rust-transport
 make test-rust-transport
 pnpm test:story all
 pnpm wap-graph:check
+pnpm --dir docs-portal run check
 pnpm --dir docs-portal run build
 cd engine-wasm/engine && cargo +nightly fuzz run engine_wml_fuzzer -- -runs=200
 ```

--- a/browser/README.md
+++ b/browser/README.md
@@ -82,6 +82,11 @@ Regenerate host contract types from Rust:
 pnpm --dir browser run contracts:codegen
 ```
 
+The command is self-sufficient on a clean checkout: it creates the minimal
+`frontend/dist/index.html` required by Tauri's compile-time configuration when
+no real frontend build exists. Use `pnpm --dir browser run contracts:check` to
+regenerate the contracts and fail on committed drift.
+
 Regenerate Tauri app icons from canonical SVG source:
 
 ```bash

--- a/docs-portal/README.md
+++ b/docs-portal/README.md
@@ -16,7 +16,8 @@ pnpm dev
 ## Validate
 
 ```sh
-pnpm build
+pnpm --dir docs-portal run check
+pnpm --dir docs-portal run build
 ```
 
 The static production build is emitted under `dist/` with the configured `/wap-labs/atlas` base.

--- a/docs-portal/src/lib/repository.ts
+++ b/docs-portal/src/lib/repository.ts
@@ -216,7 +216,7 @@ export function isActiveDoc(id: string): boolean {
   return (
     !id.split('/').includes('archive') &&
     !/[-_]archive(?:\.md)?$/i.test(basename) &&
-    !/\b20\d{2}[-_]\d{2}[-_]\d{2}\b/.test(id)
+    !/(?:^|[^0-9])20\d{2}[-_]\d{2}[-_]\d{2}(?:[^0-9]|$)/.test(id)
   );
 }
 

--- a/docs/ci/CI_SETUP.md
+++ b/docs/ci/CI_SETUP.md
@@ -66,6 +66,7 @@ Jobs:
   - builds the marketing site when selected by path filtering or full CI
 - `Project Atlas Build`
   - validates the WAP knowledge graph
+  - validates transport conformance evidence references against current source and tests
   - builds the Project Atlas documentation portal
 - `Browser Shell Skeleton Checks`
   - installs Linux Tauri system packages
@@ -201,14 +202,19 @@ Triggers:
 
 - `push` to `main` when paths change:
   - `marketing-site/**`
+  - `docs-portal/**`
+  - `docs/**`
+  - `spec-processing/source-manifests/**`
   - `engine-wasm/host-sample/**`
+  - `pnpm-lock.yaml`
+  - `pnpm-workspace.yaml`
   - `.github/workflows/pages.yml`
 - `workflow_dispatch`
 
 Behavior:
 
-- builds marketing site and host-sample
-- assembles combined `_site` artifact
+- builds the marketing site, WaveNav simulator, and Project Atlas
+- assembles the three applications under `/`, `/simulator/`, and `/atlas/`
 - deploys to `gh-pages` branch with `peaceiris/actions-gh-pages`
 
 ### 7) Transport WAP Smoke (`.github/workflows/transport-wap-smoke.yml`)
@@ -318,7 +324,9 @@ Do not require:
 - Tauri/GTK pkg-config errors (`gio-2.0`, `glib-2.0`, `gobject-2.0`)
   - Ensure Linux dependencies are installed in the workflow before Rust build/check steps.
 - Tauri frontend dist missing during Rust compile
-  - Ensure `browser/frontend/dist/index.html` placeholder exists for CI/build-time config.
+  - `pnpm --dir browser run contracts:codegen` and `contracts:check` create the minimal
+    `browser/frontend/dist/index.html` automatically. Direct Tauri compile/coverage commands still
+    need a real frontend build or an explicit placeholder for the compile-time config.
 - Lockfile/cache mismatches
   - Confirm the correct lockfile path is used for `actions/setup-node` cache keys.
 - Branch protection check name mismatch

--- a/docs/waves/NATIVE_WSP_POST_RESEARCH_NOTES.md
+++ b/docs/waves/NATIVE_WSP_POST_RESEARCH_NOTES.md
@@ -18,7 +18,7 @@ The native desktop `GET` lane is already working against Kannel. The next featur
 
 Canonical source:
 
-- [OMA-WAP-TS-WSP-V1_0-20020920-C.cleaned.md](/Users/dsteele/repos/wap-labs/spec-processing/source-material/parsed-markdown/docling-cleaned/OMA-WAP-TS-WSP-V1_0-20020920-C.cleaned.md)
+- [OMA-WAP-TS-WSP-V1_0-20020920-C.cleaned.md](../../spec-processing/source-material/parsed-markdown/docling-cleaned/OMA-WAP-TS-WSP-V1_0-20020920-C.cleaned.md)
 
 The key connectionless `Post` layout is:
 
@@ -41,7 +41,7 @@ Why this matters:
 
 Canonical source:
 
-- [OMA-WAP-TS-WSP-V1_0-20020920-C.cleaned.md](/Users/dsteele/repos/wap-labs/spec-processing/source-material/parsed-markdown/docling-cleaned/OMA-WAP-TS-WSP-V1_0-20020920-C.cleaned.md)
+- [OMA-WAP-TS-WSP-V1_0-20020920-C.cleaned.md](../../spec-processing/source-material/parsed-markdown/docling-cleaned/OMA-WAP-TS-WSP-V1_0-20020920-C.cleaned.md)
 
 The `Get` layout is:
 
@@ -53,8 +53,8 @@ This is already proven live in the native desktop path and should remain the com
 
 Canonical sources:
 
-- [WAP-191_105-WML-20020212-a.cleaned.md](/Users/dsteele/repos/wap-labs/spec-processing/source-material/parsed-markdown/docling-cleaned/WAP-191_105-WML-20020212-a.cleaned.md)
-- [WAP-238-WML-20010911-a.cleaned.md](/Users/dsteele/repos/wap-labs/spec-processing/source-material/parsed-markdown/docling-cleaned/WAP-238-WML-20010911-a.cleaned.md)
+- [WAP-191_105-WML-20020212-a.cleaned.md](../../spec-processing/source-material/parsed-markdown/docling-cleaned/WAP-191_105-WML-20020212-a.cleaned.md)
+- [WAP-238-WML-20010911-a.cleaned.md](../../spec-processing/source-material/parsed-markdown/docling-cleaned/WAP-238-WML-20010911-a.cleaned.md)
 
 Relevant rules:
 
@@ -77,8 +77,8 @@ For this MVP slice, the most important rules are:
 
 Relevant source set:
 
-- [WAP-193-WMLScript-20001025-a.cleaned.md](/Users/dsteele/repos/wap-labs/spec-processing/source-material/parsed-markdown/docling-cleaned/WAP-193-WMLScript-20001025-a.cleaned.md)
-- [WAP-193_101-WMLScript-20010928-a.cleaned.md](/Users/dsteele/repos/wap-labs/spec-processing/source-material/parsed-markdown/docling-cleaned/WAP-193_101-WMLScript-20010928-a.cleaned.md)
+- [WAP-193-WMLScript-20001025-a.cleaned.md](../../spec-processing/source-material/parsed-markdown/docling-cleaned/WAP-193-WMLScript-20001025-a.cleaned.md)
+- [WAP-193_101-WMLScript-20010928-a.cleaned.md](../../spec-processing/source-material/parsed-markdown/docling-cleaned/WAP-193_101-WMLScript-20010928-a.cleaned.md)
 
 Conclusion:
 
@@ -92,7 +92,7 @@ Conclusion:
 
 Relevant path:
 
-- [navigation.rs](/Users/dsteele/repos/wap-labs/engine-wasm/engine/src/engine_runtime_internal/navigation.rs)
+- [navigation.rs](../../engine-wasm/engine/src/engine_runtime_internal/navigation.rs)
 
 Current state:
 
@@ -108,8 +108,8 @@ Gap still to keep in mind:
 
 Relevant paths:
 
-- [fetch_runtime.rs](/Users/dsteele/repos/wap-labs/transport-rust/src/fetch_runtime.rs)
-- [native_fetch.rs](/Users/dsteele/repos/wap-labs/transport-rust/src/native_fetch.rs)
+- [fetch_runtime.rs](../../transport-rust/src/fetch_runtime.rs)
+- [native_fetch.rs](../../transport-rust/src/native_fetch.rs)
 
 Current state:
 
@@ -121,7 +121,7 @@ Current state:
 
 Relevant path:
 
-- [kannel.conf](/Users/dsteele/repos/wap-labs/docker/kannel/kannel.conf)
+- [kannel.conf](../../docker/kannel/kannel.conf)
 
 Current lab mapping:
 

--- a/docs/waves/NETWORKING_EXTERNAL_SOURCE_INDEX.md
+++ b/docs/waves/NETWORKING_EXTERNAL_SOURCE_INDEX.md
@@ -10,19 +10,19 @@ Catalog external and supplemental networking references that may inform fixture 
 
 Canonical machine-readable source:
 
-- [spec-processing/external-source-index.json](/Users/dsteele/repos/wap-labs/spec-processing/external-source-index.json)
+- [spec-processing/external-source-index.json](../../spec-processing/external-source-index.json)
 
 Source authority policy:
 
-- [docs/waves/SOURCE_AUTHORITY_POLICY.md](/Users/dsteele/repos/wap-labs/docs/waves/SOURCE_AUTHORITY_POLICY.md)
+- [docs/waves/SOURCE_AUTHORITY_POLICY.md](../../docs/waves/SOURCE_AUTHORITY_POLICY.md)
 
 ## Current indexed entries
 
 | ID | Family | Status | Source Class | Path | Mapped `RQ-*` IDs | Notes |
 | --- | --- | --- | --- | --- | --- | --- |
-| `supplemental-wap-slide-deck` | `supplemental-context` | `present` | `heuristic` | [spec-processing/source-material/WAP.pdf](/Users/dsteele/repos/wap-labs/spec-processing/source-material/WAP.pdf) | `RQ-TRN-010`, `RQ-TRN-012`, `RQ-TRN-014` | Slide-deck context only; useful for terminology reinforcement. |
-| `supplemental-wiley-tech-brief` | `supplemental-context` | `present` | `heuristic` | [spec-processing/source-material/vdoc.pub_the-wireless-application-protocol-wap-a-wiley-tech-brief.pdf](/Users/dsteele/repos/wap-labs/spec-processing/source-material/vdoc.pub_the-wireless-application-protocol-wap-a-wiley-tech-brief.pdf) | `RQ-TRN-001`, `RQ-TRN-006`, `RQ-TRN-010` | Historical context only; cannot redefine transport requirements. |
-| `supplemental-emulator-notes` | `supplemental-context` | `present` | `heuristic` | [spec-processing/external-parsed/wap_emulator_spec_notes.md](/Users/dsteele/repos/wap-labs/spec-processing/external-parsed/wap_emulator_spec_notes.md) | `RQ-TRN-007`, `RQ-TRN-012`, `RQ-TRN-014` | Candidate-fixture and triage aid only. |
+| `supplemental-wap-slide-deck` | `supplemental-context` | `present` | `heuristic` | [spec-processing/source-material/WAP.pdf](../../spec-processing/source-material/WAP.pdf) | `RQ-TRN-010`, `RQ-TRN-012`, `RQ-TRN-014` | Slide-deck context only; useful for terminology reinforcement. |
+| `supplemental-wiley-tech-brief` | `supplemental-context` | `present` | `heuristic` | [spec-processing/source-material/vdoc.pub_the-wireless-application-protocol-wap-a-wiley-tech-brief.pdf](../../spec-processing/source-material/vdoc.pub_the-wireless-application-protocol-wap-a-wiley-tech-brief.pdf) | `RQ-TRN-001`, `RQ-TRN-006`, `RQ-TRN-010` | Historical context only; cannot redefine transport requirements. |
+| `supplemental-emulator-notes` | `supplemental-context` | `present` | `heuristic` | [spec-processing/external-parsed/wap_emulator_spec_notes.md](../../spec-processing/external-parsed/wap_emulator_spec_notes.md) | `RQ-TRN-007`, `RQ-TRN-012`, `RQ-TRN-014` | Candidate-fixture and triage aid only. |
 | `interop-kannel-networking-sources` | `kannel` | `planned` | `interop-reference` | not yet ingested | `RQ-TRN-005`, `RQ-TRN-007`, `RQ-TRN-010`, `RQ-TRN-012` | Target family for future external ingestion. |
 | `interop-wireshark-dissectors` | `wireshark` | `planned` | `interop-reference` | not yet ingested | `RQ-TRN-001`, `RQ-TRN-007`, `RQ-TRN-012`, `RQ-TRN-014`, `RQ-SEC-004` | Target family for future external ingestion. |
 
@@ -47,7 +47,7 @@ This keeps the index useful for replay and fixture planning without letting exte
 
 Future Kannel and Wireshark drops should land under:
 
-- [spec-processing/new-source-material/external-networking/README.md](/Users/dsteele/repos/wap-labs/spec-processing/new-source-material/external-networking/README.md)
+- [spec-processing/new-source-material/external-networking/README.md](../../spec-processing/new-source-material/external-networking/README.md)
 
 ## Current conclusion
 

--- a/docs/waves/NETWORKING_VECTOR_ADOPTION_SWEEP.md
+++ b/docs/waves/NETWORKING_VECTOR_ADOPTION_SWEEP.md
@@ -10,7 +10,7 @@ Rank publicly available WAP interoperability and conformance-vector candidates t
 
 Machine-readable register:
 
-- [docs/waves/networking-vector-adoption.json](/Users/dsteele/repos/wap-labs/docs/waves/networking-vector-adoption.json)
+- [docs/waves/networking-vector-adoption.json](../../docs/waves/networking-vector-adoption.json)
 
 Validation command:
 

--- a/docs/waves/NETWORK_PROFILE_DECISION_RECORD.md
+++ b/docs/waves/NETWORK_PROFILE_DECISION_RECORD.md
@@ -91,7 +91,7 @@ Rollback action:
 
 ## Operational tracking
 
-Use [docs/waves/TRANSPORT_E2E_READINESS_SCORECARD.md](/Users/dsteele/repos/wap-labs/docs/waves/TRANSPORT_E2E_READINESS_SCORECARD.md) to track how close Waves is to:
+Use [docs/waves/TRANSPORT_E2E_READINESS_SCORECARD.md](../../docs/waves/TRANSPORT_E2E_READINESS_SCORECARD.md) to track how close Waves is to:
 
 1. `transport-rust` -> local Kannel -> local WML server E2E smoke
 2. browser/host -> transport -> local Kannel -> local WML server E2E smoke

--- a/docs/waves/RUNTIME_MARKUP_SPEC_TRACEABILITY.md
+++ b/docs/waves/RUNTIME_MARKUP_SPEC_TRACEABILITY.md
@@ -1,7 +1,7 @@
 # Waves Runtime Markup Spec Traceability
 
 Version: v0.3
-Status: WML/WBXML feature and nested-clause ledgers complete; direct evidence in progress (WML-204 23/23 mapped clauses, WML-203 44/50)
+Status: WML/WBXML feature and nested-clause ledgers complete; direct evidence in progress (WML-204 23/23 mapped clauses, WML-203 49/49)
 
 ## Purpose
 

--- a/docs/waves/SPRINT_PLAN_2026-03_MASTER_PRIORITIZED.md
+++ b/docs/waves/SPRINT_PLAN_2026-03_MASTER_PRIORITIZED.md
@@ -203,7 +203,7 @@ Completed foundation:
 
 Implementation reference:
 
-- [NATIVE_WSP_POST_RESEARCH_NOTES.md](/Users/dsteele/repos/wap-labs/docs/waves/NATIVE_WSP_POST_RESEARCH_NOTES.md)
+- [NATIVE_WSP_POST_RESEARCH_NOTES.md](../../docs/waves/NATIVE_WSP_POST_RESEARCH_NOTES.md)
 
 ### Exit Gates
 
@@ -237,7 +237,7 @@ Completed this sprint:
 4. transport/engine payload-size guardrails for active boundaries
 5. story-driven host-sample and Waves-browser acceptance harnesses
 6. WML-204 input/select direct evidence (23/23 mapped clauses)
-7. WML-203 WBXML evidence tranche (44/50 mapped clauses)
+7. WML-203 WML/WBXML evidence tranche (49/49 mapped clauses)
 8. TRN-701 WDP, TRN-702 constrained payload, and TRN-703 WCMP direct evidence
 
 ## Capacity and WIP Rules

--- a/docs/waves/TRANSPORT_E2E_READINESS_SCORECARD.md
+++ b/docs/waves/TRANSPORT_E2E_READINESS_SCORECARD.md
@@ -48,14 +48,14 @@ Score: `8.0 / 8.0` (`100%`)
 
 | Gate | Description | Transport-to-Kannel | Browser-to-Kannel | Evidence |
 | --- | --- | --- | --- | --- |
-| `G1` | Local Kannel + WML stack boots reliably with one command | `1.0` | `1.0` | `make up`, `make status`, [docs/wap-test-environment/README.md](/Users/dsteele/repos/wap-labs/docs/wap-test-environment/README.md) |
-| `G2` | Real transport request can fetch through local Kannel | `1.0` | `1.0` | [transport-rust/tests/kannel_smoke.rs](/Users/dsteele/repos/wap-labs/transport-rust/tests/kannel_smoke.rs), [browser/src-tauri/src/tests/fetch_commands.rs](/Users/dsteele/repos/wap-labs/browser/src-tauri/src/tests/fetch_commands.rs), `make smoke-transport-wap`; native-mode smoke now forces `wap-net-core` rather than relying on ambient bridge defaults |
+| `G1` | Local Kannel + WML stack boots reliably with one command | `1.0` | `1.0` | `make up`, `make status`, [docs/wap-test-environment/README.md](../../docs/wap-test-environment/README.md) |
+| `G2` | Real transport request can fetch through local Kannel | `1.0` | `1.0` | [transport-rust/tests/kannel_smoke.rs](../../transport-rust/tests/kannel_smoke.rs), [browser/src-tauri/src/tests/fetch_commands.rs](../../browser/src-tauri/src/tests/fetch_commands.rs), `make smoke-transport-wap`; native-mode smoke now forces `wap-net-core` rather than relying on ambient bridge defaults |
 | `G3` | Assertions validate deck identity and normalized engine input, not just HTTP success | `1.0` | `1.0` | transport smoke asserts deck/card markers for root + login decks; browser host smokes assert engine load, card identity, render markers, and navigation outcome |
 | `G4` | At least one multi-step real gateway scenario exists (redirect/login/session/navigation) | `1.0` | `1.0` | native Kannel smoke now covers register -> login success flow at transport, host, and browser-engine levels |
 | `G5` | One-command runnable smoke exists for local and CI-like use | `1.0` | `1.0` | `make smoke-transport-wap` now runs native-only transport, host, and browser-render smoke checks |
-| `G6` | Failure diagnostics are preserved automatically (gateway/server/test logs) | `1.0` | `1.0` | [scripts/transport-wap-smoke.sh](/Users/dsteele/repos/wap-labs/scripts/transport-wap-smoke.sh) now writes status/log artifacts into a temp directory and prints the path on success/failure |
-| `G7` | Browser path runs against real Kannel via host transport rather than mocks | `n/a` | `1.0` | ignored host-native smoke in [browser/src-tauri/src/tests/fetch_commands.rs](/Users/dsteele/repos/wap-labs/browser/src-tauri/src/tests/fetch_commands.rs) forces `wap-net-core` and disabled fallback |
-| `G8` | Browser/render assertions validate visible WML outcome from real gateway-served deck | `n/a` | `1.0` | browser host smokes validate real Kannel-backed render output for the root deck and the navigated menu card via native fetch in [browser/src-tauri/tests/kannel_smoke.rs](/Users/dsteele/repos/wap-labs/browser/src-tauri/tests/kannel_smoke.rs) |
+| `G6` | Failure diagnostics are preserved automatically (gateway/server/test logs) | `1.0` | `1.0` | [scripts/transport-wap-smoke.sh](../../scripts/transport-wap-smoke.sh) now writes status/log artifacts into a temp directory and prints the path on success/failure |
+| `G7` | Browser path runs against real Kannel via host transport rather than mocks | `n/a` | `1.0` | ignored host-native smoke in [browser/src-tauri/src/tests/fetch_commands.rs](../../browser/src-tauri/src/tests/fetch_commands.rs) forces `wap-net-core` and disabled fallback |
+| `G8` | Browser/render assertions validate visible WML outcome from real gateway-served deck | `n/a` | `1.0` | browser host smokes validate real Kannel-backed render output for the root deck and the navigated menu card via native fetch in [browser/src-tauri/tests/kannel_smoke.rs](../../browser/src-tauri/tests/kannel_smoke.rs) |
 
 ## Interpretation
 
@@ -76,13 +76,13 @@ Score: `8.0 / 8.0` (`100%`)
 
 ### Existing strengths
 
-1. active profile is explicitly `wap-net-core`, with `gateway-bridged` retained as rollback posture, in [docs/waves/NETWORK_PROFILE_DECISION_RECORD.md](/Users/dsteele/repos/wap-labs/docs/waves/NETWORK_PROFILE_DECISION_RECORD.md)
-2. local Kannel + WML stack is documented and runnable in [docs/wap-test-environment/README.md](/Users/dsteele/repos/wap-labs/docs/wap-test-environment/README.md)
+1. active profile is explicitly `wap-net-core`, with `gateway-bridged` retained as rollback posture, in [docs/waves/NETWORK_PROFILE_DECISION_RECORD.md](../../docs/waves/NETWORK_PROFILE_DECISION_RECORD.md)
+2. local Kannel + WML stack is documented and runnable in [docs/wap-test-environment/README.md](../../docs/wap-test-environment/README.md)
 3. transport-specific native smoke path exists:
-   - [transport-rust/tests/kannel_smoke.rs](/Users/dsteele/repos/wap-labs/transport-rust/tests/kannel_smoke.rs)
+   - [transport-rust/tests/kannel_smoke.rs](../../transport-rust/tests/kannel_smoke.rs)
    - `make smoke-transport-wap`
-4. on-demand CI smoke workflow exists in [docs/ci/CI_SETUP.md](/Users/dsteele/repos/wap-labs/docs/ci/CI_SETUP.md)
-5. protocol-native replay harness exists in [transport-rust/tests/interop_replay.rs](/Users/dsteele/repos/wap-labs/transport-rust/tests/interop_replay.rs)
+4. on-demand CI smoke workflow exists in [docs/ci/CI_SETUP.md](../../docs/ci/CI_SETUP.md)
+5. protocol-native replay harness exists in [transport-rust/tests/interop_replay.rs](../../transport-rust/tests/interop_replay.rs)
 
 ### Main gaps
 
@@ -124,5 +124,5 @@ Suggested scope:
 When transport/gateway/browser integration changes materially, update:
 
 1. this scorecard
-2. [docs/waves/NETWORK_PROFILE_DECISION_RECORD.md](/Users/dsteele/repos/wap-labs/docs/waves/NETWORK_PROFILE_DECISION_RECORD.md)
-3. [docs/waves/networking-implementation-checklist.md](/Users/dsteele/repos/wap-labs/docs/waves/networking-implementation-checklist.md) if promotion gates or execution posture change
+2. [docs/waves/NETWORK_PROFILE_DECISION_RECORD.md](../../docs/waves/NETWORK_PROFILE_DECISION_RECORD.md)
+3. [docs/waves/networking-implementation-checklist.md](../../docs/waves/networking-implementation-checklist.md) if promotion gates or execution posture change

--- a/docs/waves/WAP_1_2_1_WML_SCR_LEDGER.md
+++ b/docs/waves/WAP_1_2_1_WML_SCR_LEDGER.md
@@ -25,6 +25,17 @@ node scripts/check-wap-conformance-ledger.mjs
 node scripts/check-wap-selected-normative-clauses.mjs
 ```
 
+Known evidence-reference gap (2026-07-25): the generated WML SCR still cites
+the retired parser test names
+`helper_parse_inline_nodes_parses_text_links_break_and_unknown_wrappers` for
+`WML-C-17` and `helper_parse_card_nodes_parses_mixed_content_paths` for
+`WML-C-24`. Their replacement production-parser tests are
+`parses_mixed_inline_text_links_break_and_unknown_wrappers` and
+`parses_mixed_card_level_content_paths`. Regenerate the hash-locked WML SCR
+from its private extraction inputs after correcting the existing generator;
+do not hand-edit the generated ledger or infer a row-status change from the
+rename.
+
 ## Effective source chain
 
 The ledger applies the locked WML family precedence:

--- a/docs/waves/WORK_ITEMS.md
+++ b/docs/waves/WORK_ITEMS.md
@@ -1095,11 +1095,11 @@ Completed `B0` through `B3` tickets are archived in:
 - `RQ-TRN-001..015`, `RQ-TRX-010`
 10. `Notes`:
 - Keep scope constrained to WML form submission first; do not widen into full connection-oriented WSP session work unless required to land baseline login/register flows.
-- Research note: [NATIVE_WSP_POST_RESEARCH_NOTES.md](/Users/dsteele/repos/wap-labs/docs/waves/NATIVE_WSP_POST_RESEARCH_NOTES.md)
+- Research note: [NATIVE_WSP_POST_RESEARCH_NOTES.md](../../docs/waves/NATIVE_WSP_POST_RESEARCH_NOTES.md)
 - Landed evidence:
-  - transport native `POST` login/register smoke in [transport-rust/tests/kannel_smoke.rs](/Users/dsteele/repos/wap-labs/transport-rust/tests/kannel_smoke.rs)
-  - Tauri host native `POST` smoke in [browser/src-tauri/src/tests/fetch_commands.rs](/Users/dsteele/repos/wap-labs/browser/src-tauri/src/tests/fetch_commands.rs)
-  - browser-engine native `POST` smoke in [browser/src-tauri/tests/kannel_smoke.rs](/Users/dsteele/repos/wap-labs/browser/src-tauri/tests/kannel_smoke.rs)
+  - transport native `POST` login/register smoke in [transport-rust/tests/kannel_smoke.rs](../../transport-rust/tests/kannel_smoke.rs)
+  - Tauri host native `POST` smoke in [browser/src-tauri/src/tests/fetch_commands.rs](../../browser/src-tauri/src/tests/fetch_commands.rs)
+  - browser-engine native `POST` smoke in [browser/src-tauri/tests/kannel_smoke.rs](../../browser/src-tauri/tests/kannel_smoke.rs)
 
 ### A5-04 Minimal WML text-input interaction baseline
 

--- a/docs/waves/networking-external-response-triage.md
+++ b/docs/waves/networking-external-response-triage.md
@@ -25,7 +25,7 @@ Scope: Normalize external assistant responses into actionable, spec-safe inputs 
 5. Interop requires capture/replay fixtures for `CONNECT`/`GET`/`REPLY` and retransmit flows.
 
 These align with:
-- [NETWORKING_GAP_MASTER.md](/Users/dsteele/repos/wap-labs/docs/waves/NETWORKING_GAP_MASTER.md)
+- [NETWORKING_GAP_MASTER.md](../../docs/waves/NETWORKING_GAP_MASTER.md)
 
 ## Needs Verification Before Adoption (medium confidence)
 
@@ -87,9 +87,9 @@ Implementation must continue to anchor on the repo’s canonical spec set and ti
 
 Current external/supplemental source indexing lives in:
 
-- [docs/waves/NETWORKING_EXTERNAL_SOURCE_INDEX.md](/Users/dsteele/repos/wap-labs/docs/waves/NETWORKING_EXTERNAL_SOURCE_INDEX.md)
-- [spec-processing/external-source-index.json](/Users/dsteele/repos/wap-labs/spec-processing/external-source-index.json)
-- [spec-processing/new-source-material/external-networking/README.md](/Users/dsteele/repos/wap-labs/spec-processing/new-source-material/external-networking/README.md)
+- [docs/waves/NETWORKING_EXTERNAL_SOURCE_INDEX.md](../../docs/waves/NETWORKING_EXTERNAL_SOURCE_INDEX.md)
+- [spec-processing/external-source-index.json](../../spec-processing/external-source-index.json)
+- [spec-processing/new-source-material/external-networking/README.md](../../spec-processing/new-source-material/external-networking/README.md)
 
 Validation command:
 


### PR DESCRIPTION
## Summary

- resync active documentation with merged W0-05, WML-203, TRN-706, TRN-707, M1-23, transport CI, contract-codegen, and Dependabot policy evidence
- correct WML-203 coverage to 49/49 while preserving its broader in-progress status and explicit residual gaps
- replace developer-machine absolute documentation links with repository-relative links
- fix Project Atlas active-document filtering so underscore-delimited date-stamped snapshots are excluded
- document the known generated WML SCR references to two retired parser test names without hand-editing generated compliance projections

## Canonical and generated boundaries

No canonical compliance manifests changed. The selected-clause, transport SCR, successor-delta, knowledge-graph, context-pack, and vault generators were run and produced no committed drift. Manual active documentation and the Atlas source filter are the only changed sources.

## Validation

Passed:

- `node spec-processing/scripts/generate-wap-selected-normative-clauses.mjs --refresh-direct-work-items`
- `node spec-processing/scripts/generate-wap-transport-scr-ledgers.mjs --refresh-selected-evidence`
- `node spec-processing/scripts/generate-wap-delta-register.mjs --recorded-on 2026-07-25`
- `pnpm wap-graph:generate`
- `pnpm wap-graph:check`
- `pnpm --dir docs-portal run check`
- `pnpm --dir docs-portal run build` (731 pages)
- `pnpm --dir browser run contracts:check`
- `pnpm test:story W0-05`
- focused WDP, WCMP, WBXML, TRN-706 replay, redirect, and frontend test suites
- repository pre-push hooks, including 261 engine tests and Rust fmt/clippy checks
- active Markdown link audit and `git diff --check`

Known residual gap: `node scripts/check-wap-conformance-ledger.mjs` still detects two generated WML SCR references to parser tests renamed before this audit. Correct regeneration requires unavailable hash-locked private extraction inputs, so this PR documents the gap and does not infer a status change.
