### PR TITLE
ci: harden Dependabot workflow boundaries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ jobs:
   changes:
     name: Detect Changed Areas
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     outputs:
       full_ci: ${{ steps.scope.outputs.full_ci }}
       ci: ${{ steps.filter.outputs.ci }}
@@ -39,11 +40,13 @@ jobs:
       - name: Determine CI scope
         id: scope
         env:
-          FULL_CI: ${{ github.event_name != 'pull_request' || github.event.pull_request.user.login == 'dependabot[bot]' }}
+          FULL_CI: ${{ github.event_name != 'pull_request' || (github.event.pull_request.user.login == 'dependabot[bot]' && github.event.pull_request.head.repo.full_name == github.repository) }}
         run: echo "full_ci=${FULL_CI}" >> "${GITHUB_OUTPUT}"
 
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Detect changes
         id: filter
@@ -99,9 +102,12 @@ jobs:
   repo-hygiene:
     name: Repo Hygiene
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Setup pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
@@ -172,9 +178,12 @@ jobs:
     needs: [changes]
     if: ${{ needs.changes.outputs.full_ci == 'true' || needs.changes.outputs.ci == 'true' || needs.changes.outputs.rust_engine == 'true' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
@@ -218,9 +227,12 @@ jobs:
     needs: [changes]
     if: ${{ needs.changes.outputs.full_ci == 'true' || needs.changes.outputs.ci == 'true' || needs.changes.outputs.rust_transport == 'true' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
@@ -258,9 +270,12 @@ jobs:
     needs: [changes]
     if: ${{ needs.changes.outputs.full_ci == 'true' || needs.changes.outputs.ci == 'true' || needs.changes.outputs.host_sample == 'true' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
@@ -351,9 +366,12 @@ jobs:
     needs: [changes]
     if: ${{ needs.changes.outputs.full_ci == 'true' || needs.changes.outputs.ci == 'true' || needs.changes.outputs.marketing_site == 'true' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Setup pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
@@ -366,7 +384,7 @@ jobs:
           cache-dependency-path: marketing-site/pnpm-lock.yaml
 
       - name: Install marketing-site deps
-        run: pnpm --dir marketing-site --ignore-workspace install --frozen-lockfile
+        run: pnpm --dir marketing-site --ignore-workspace install --frozen-lockfile --ignore-scripts
 
       - name: Build marketing-site
         run: pnpm --dir marketing-site --ignore-workspace run build
@@ -376,9 +394,12 @@ jobs:
     needs: [changes]
     if: ${{ needs.changes.outputs.full_ci == 'true' || needs.changes.outputs.ci == 'true' || needs.changes.outputs.docs_portal == 'true' || needs.changes.outputs.rust_transport == 'true' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Setup pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
@@ -407,9 +428,12 @@ jobs:
     needs: [changes]
     if: ${{ needs.changes.outputs.full_ci == 'true' || needs.changes.outputs.ci == 'true' || needs.changes.outputs.browser_shell == 'true' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Install Linux system deps for Tauri
         run: |
@@ -475,9 +499,12 @@ jobs:
     needs: [changes]
     if: ${{ needs.changes.outputs.full_ci == 'true' || needs.changes.outputs.ci == 'true' || needs.changes.outputs.wml_server == 'true' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Setup Node
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
@@ -487,7 +514,7 @@ jobs:
           cache-dependency-path: wml-server/package-lock.json
 
       - name: Install wml-server deps
-        run: npm --prefix wml-server ci
+        run: npm --prefix wml-server ci --ignore-scripts
 
       - name: Node syntax check
         run: node --check wml-server/server.js
@@ -497,9 +524,12 @@ jobs:
     needs: [changes]
     if: ${{ needs.changes.outputs.full_ci == 'true' || needs.changes.outputs.ci == 'true' || needs.changes.outputs.browser_frontend == 'true' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Setup pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
@@ -520,6 +550,8 @@ jobs:
   ci-gate:
     name: CI Required Gate
     if: ${{ always() }}
+    permissions: {}
+    timeout-minutes: 5
     needs:
       - changes
       - repo-hygiene

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -18,6 +18,7 @@ jobs:
   analyze:
     name: Analyze (${{ matrix.language }})
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix:
@@ -29,6 +30,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -4,20 +4,25 @@ on:
   pull_request:
     types: [opened, reopened, synchronize, ready_for_review]
 
-permissions:
-  contents: write
-  pull-requests: write
+permissions: {}
 
 jobs:
-  enable-automerge:
-    name: Enable Auto-merge for Dependabot PRs
+  evaluate-policy:
+    name: Evaluate Dependabot Auto-merge Policy
     if: >-
       ${{
         github.event.pull_request.user.login == 'dependabot[bot]' &&
+        github.event.pull_request.head.repo.full_name == github.repository &&
         github.event.pull_request.base.ref == github.event.repository.default_branch &&
         github.event.pull_request.draft == false
       }}
     runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      update-type: ${{ steps.dependabot-metadata.outputs.update-type }}
     steps:
       - name: Read Dependabot metadata
         id: dependabot-metadata
@@ -25,12 +30,21 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
+  enable-automerge:
+    name: Enable Auto-merge for Dependabot PRs
+    needs: [evaluate-policy]
+    if: >-
+      ${{
+        needs.evaluate-policy.outputs.update-type == 'version-update:semver-patch' ||
+        needs.evaluate-policy.outputs.update-type == 'version-update:semver-minor'
+      }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
       - name: Enable GitHub auto-merge for patch and minor updates
-        if: >-
-          ${{
-            steps.dependabot-metadata.outputs.update-type == 'version-update:semver-patch' ||
-            steps.dependabot-metadata.outputs.update-type == 'version-update:semver-minor'
-          }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_URL: ${{ github.event.pull_request.html_url }}

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -5,7 +5,7 @@ on:
   push:
     branches: [main]
   schedule:
-    - cron: "27 6 * * 1"
+    - cron: '27 6 * * 1'
   workflow_dispatch:
 
 permissions:
@@ -16,12 +16,12 @@ jobs:
     name: Dependency Review
     if: ${{ github.event_name == 'pull_request' }}
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: write
+    timeout-minutes: 15
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Dependency review
         uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5
@@ -29,9 +29,12 @@ jobs:
   rust-audit:
     name: Rust Advisory Audit
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
@@ -63,9 +66,12 @@ jobs:
   node-audit:
     name: Node Dependency Audit
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Setup pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
@@ -73,8 +79,8 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
-          node-version: "22"
-          cache: "pnpm"
+          node-version: '22'
+          cache: 'pnpm'
           cache-dependency-path: pnpm-lock.yaml
 
       - name: Install pnpm workspace deps
@@ -86,8 +92,8 @@ jobs:
       - name: Setup Node cache for wml-server npm audit
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
-          node-version: "22"
-          cache: "npm"
+          node-version: '22'
+          cache: 'npm'
           cache-dependency-path: wml-server/package-lock.json
 
       - name: Audit npm-only wml-server dependencies (high+)

--- a/docs/ci/CI_SETUP.md
+++ b/docs/ci/CI_SETUP.md
@@ -35,8 +35,14 @@ Core behavior:
 - Derives `full_ci` from the event and pull-request author.
 - Forces the complete validation matrix for Dependabot-authored PRs, pushes to `main`, and manual
   runs while preserving path filtering for ordinary PRs.
+- Requires a Dependabot-authored PR to use a repository-owned head branch before granting it
+  full-matrix treatment.
 - Runs repository-wide hygiene checks and layer-specific Rust/Node checks.
 - Reports the stable aggregate check `CI Required Gate`.
+- Keeps PR validation read-only, does not persist checkout credentials for later build steps, and
+  does not expose a write token or repository secrets to checked-out PR code.
+- Sets explicit job timeouts so a hung build or dependency cannot consume the default six-hour
+  GitHub-hosted runner window.
 
 Jobs:
 
@@ -63,6 +69,7 @@ Jobs:
   - uploads screenshots, traces, and structured evidence when a story fails
   - host-sample typecheck/lint/format checks
 - `Marketing Site Build`
+  - installs with lifecycle scripts disabled
   - builds the marketing site when selected by path filtering or full CI
 - `Project Atlas Build`
   - validates the WAP knowledge graph
@@ -76,7 +83,7 @@ Jobs:
 - `Browser Frontend Unit Tests`
   - runs the browser frontend unit suite and coverage gate
 - `WML Server Sanity`
-  - installs `wml-server` deps and runs Node syntax check
+  - installs `wml-server` deps with lifecycle scripts disabled and runs Node syntax check
 - `CI Required Gate`
   - runs with `always()` after all validation jobs
   - fails on failed/cancelled prerequisites
@@ -106,6 +113,7 @@ Jobs:
 
 - `Dependency Review`
   - PR-only
+  - read-only; it does not post PR comments
   - runs `actions/dependency-review-action`
 - `Rust Advisory Audit`
   - runs `cargo audit` in:
@@ -280,6 +288,8 @@ Grouping and cadence:
 Auto-merge behavior:
 
 - The workflow runs on `pull_request`, not `pull_request_target`.
+- The workflow defaults to no token permissions and first evaluates repository-owned Dependabot
+  PR metadata in a read-only job.
 - `dependabot/fetch-metadata` is pinned to a full commit SHA and verifies that the PR and commits
   are Dependabot-owned.
 - Only patch and minor updates have auto-merge enabled. The metadata action reports the highest
@@ -291,6 +301,9 @@ Auto-merge behavior:
 - The workflow uses `gh pr merge --auto --squash`, so GitHub queues the merge and waits for every
   required ruleset check. It does not merge around CI, security, CodeQL, review, or signature
   requirements.
+- Only the final, policy-approved job receives `contents: write` and `pull-requests: write`. That
+  job does not check out or execute PR code, and the write token is not passed to the metadata
+  action.
 - On Dependabot rebases/synchronizations, the workflow re-runs and re-enables auto-merge for the updated head.
 
 Lockfile ownership:
@@ -301,6 +314,9 @@ Lockfile ownership:
   changes.
 - pnpm frozen installs, `npm ci`, and `cargo metadata --locked` verify that Dependabot supplied a
   usable lockfile without mutating the PR.
+- Node package installation uses `--ignore-scripts` in PR CI. Later build and test commands still
+  execute the checked-in project scripts and dependency binaries required for validation, but
+  only with read-only job permissions and without persisted checkout credentials.
 
 Repository setting prerequisites are documented in `docs/ci/REQUIRED_CHECKS.md`.
 

--- a/docs/ci/REQUIRED_CHECKS.md
+++ b/docs/ci/REQUIRED_CHECKS.md
@@ -71,8 +71,14 @@ In **Settings > General > Pull Requests**:
 
 In **Settings > Actions > General > Workflow permissions**:
 
-- Keep the default `GITHUB_TOKEN` permission read-only. The auto-merge workflow requests only
-  `contents: write` and `pull-requests: write` for its gated Dependabot job.
+- Keep the default `GITHUB_TOKEN` permission read-only.
+- Do not enable **Send write tokens to workflows from pull requests**.
+- PR validation workflows explicitly use read-only permissions and disable persisted checkout
+  credentials. Dependency Review does not receive PR write permission because comment summaries
+  are not enabled.
+- The auto-merge workflow defaults to no permissions, reads Dependabot metadata in a read-only
+  job, and requests `contents: write` plus `pull-requests: write` only in the final gated job.
+  That final job does not check out or execute pull-request code.
 - The setting that lets Actions create and approve pull requests is not required; this workflow
   neither creates nor approves pull requests.
 


### PR DESCRIPTION
## Summary

- keep Dependabot's full CI matrix while removing persisted checkout credentials from PR validation jobs
- split Dependabot auto-merge into a read-only metadata policy job and a write-scoped final job that never checks out or executes PR code
- make Dependency Review read-only, disable Node install lifecycle scripts where builds do not require them, and bound validation jobs with explicit timeouts
- document the workflow trust boundaries and required repository settings

## Why

Dependabot updates intentionally execute newly selected compiler, build, and test dependencies. The validation workflows should therefore retain complete coverage while minimizing token exposure, install-time execution, and runaway job duration. The previous auto-merge job also gave its metadata action the same write token used to enable auto-merge even though metadata evaluation only needs read access.

## Impact

Required check names and the full Dependabot build matrix are unchanged. Patch and minor updates remain eligible for GitHub auto-merge only after branch protection, CI, security, and CodeQL requirements pass. Major updates still require manual review.

## Validation

- actionlint v1.7.12 (excluding the pre-existing intentionally disabled `if: false` Clippy step)
- parsed all modified workflow YAML
- verified every action reference remains pinned to a full 40-character SHA
- Prettier and repository pre-commit checks
- marketing-site frozen install with `--ignore-scripts` and production build
- wml-server `npm ci --ignore-scripts` and Node syntax check
- repository pre-push checks, including Rust formatting, Clippy, and 261 engine tests

## Security review

No concrete exploitable HIGH or MEDIUM GitHub Actions findings were identified. These changes are defense-in-depth reductions in credential, permission, install-hook, and resource exposure.
