### PR TITLE
fix(browser): close production build release gate

### DIFF
--- a/browser/frontend/src/vendor/win95/win95.css
+++ b/browser/frontend/src/vendor/win95/win95.css
@@ -119,7 +119,7 @@ Scrollbar (only chrome & safari)
 ::-webkit-scrollbar-corner:vertical {
   background-color: #000;
 }
-:-webkit-scrollbar-button:start:decrement,
+::-webkit-scrollbar-button:start:decrement,
 ::-webkit-scrollbar-button:end:increment {
   display: block;
 }

--- a/browser/frontend/vite.config.ts
+++ b/browser/frontend/vite.config.ts
@@ -5,11 +5,6 @@ import { defineConfig } from 'vite';
 const dirname = path.dirname(fileURLToPath(import.meta.url));
 
 export default defineConfig({
-  build: {
-    // The vendored Win95 stylesheet contains legacy WebKit scrollbar selectors
-    // that Lightning CSS rejects even though browsers safely ignore them.
-    cssMinify: 'esbuild'
-  },
   server: {
     fs: {
       // Local examples and the browser-test WASM package live outside frontend/.

--- a/docs/waves/WAP_1_2_1_COMPLIANCE_PROGRAM.md
+++ b/docs/waves/WAP_1_2_1_COMPLIANCE_PROGRAM.md
@@ -246,9 +246,11 @@ and Wayback procedure are in
 6. a compatibility statement that identifies `CCR-CLASSC-C-001`, discloses
    optional and conditional profiles, and does not imply formal certification.
 
-The currently known frontend CSS-minification defect is an explicit release
-work item (`REL-1004`), so a green unit-test count cannot conceal a red
-production build.
+The frontend CSS-minification defect tracked by `REL-1004` is closed: the
+vendored WebKit scrollbar selector is valid, and clean frontend and Tauri
+production builds pass under the declared Node and pnpm toolchain. Production
+builds remain explicit release evidence, so a green unit-test count cannot
+conceal a red build.
 
 ## Planning relationship
 

--- a/docs/waves/WAP_1_2_1_PLANNING_BASELINE.md
+++ b/docs/waves/WAP_1_2_1_PLANNING_BASELINE.md
@@ -31,7 +31,7 @@ explicit capability/mode.
 | Fixtures | All 780 clause fixtures have target locations; 149 clauses now have direct conformance assessment and 631 remain unassessed |
 | Successor delta | All 201 selected rows are classified; 17 have successor-derived foundations, with 2 compatible and 15 requiring strict correction |
 | External dependencies | 43 authority-locked dependencies have 48 private artifacts; 60 residual labels are explicitly non-blocking for Class C and profile-activated |
-| Execution program | 13 dependency-ordered sprints contain 78 unique work items with machine-checked rollups |
+| Execution program | 13 dependency-ordered sprints contain 79 unique work items with machine-checked rollups |
 
 `SRC-006` is the only blocked source item. It prevents public promotion of
 recovered source binaries/derivatives, not internal evidence use,
@@ -61,12 +61,12 @@ gap.
 
 ## Work-program state
 
-The 78 work items currently roll up to:
+The 79 work items currently roll up to:
 
-- 15 done (source/profile/governance planning plus the first direct WDP/WCMP slices);
+- 16 done (source/profile/governance planning, the first direct WDP/WCMP slices, and the frontend production-build defect closure);
 - 1 blocked (`SRC-006`, external redistribution permission);
-- 11 in progress (WML evidence plus existing runtime, WAE, transport, and WSP foundations);
-- 51 todo.
+- 12 in progress (WML evidence plus existing runtime, WAE, transport, and WSP foundations);
+- 50 todo.
 
 New completion claims should follow the machine dependency graph:
 

--- a/docs/waves/wap-1.2.1-compliance-program.json
+++ b/docs/waves/wap-1.2.1-compliance-program.json
@@ -1429,7 +1429,7 @@
         },
         {
           "id": "REL-1004",
-          "status": "todo",
+          "status": "done",
           "ownerLayers": ["browser", "qa"],
           "sourceFamilies": ["conformance-governance"],
           "existingTickets": [],
@@ -1440,7 +1440,8 @@
             "The malformed WebKit scrollbar selector no longer blocks CSS minification and a clean worktree production build succeeds under the declared Node/pnpm runtime."
           ],
           "evidence": [
-            "pnpm --dir browser run build"
+            "pnpm --dir browser run build",
+            "pnpm --dir browser run tauri:build"
           ]
         },
         {

--- a/scripts/check-requirement-status-drift.mjs
+++ b/scripts/check-requirement-status-drift.mjs
@@ -158,7 +158,7 @@ for (const sprint of program.sprints ?? []) {
 }
 if (
   JSON.stringify(programStatusCounts) !==
-  JSON.stringify({ done: 15, blocked: 1, 'in-progress': 12, todo: 51 })
+  JSON.stringify({ done: 16, blocked: 1, 'in-progress': 12, todo: 50 })
 ) {
   failures.push('compliance-program work-item status rollup drift');
 }

--- a/spec-processing/source-manifests/wap-1.2.1-trn-7-knowledge-graph.json
+++ b/spec-processing/source-manifests/wap-1.2.1-trn-7-knowledge-graph.json
@@ -13,7 +13,7 @@
     "generator": "spec-processing/scripts/generate-wap-knowledge-graph.mjs",
     "inputs": {
       "docs/waves/wap-1.2.1-compliance-program.json": {
-        "sha256": "ecc532a8e6974a0ac19d0f6307f742be037c63b2e6905ce1e6d1451f89fc2d45"
+        "sha256": "412ce8db546268e168b82819b2d249b6a9d1f8c77d47faf33c5843fe7e91fffc"
       },
       "spec-processing/source-manifests/wap-1.2.1-class-conformance.json": {
         "sha256": "b76605b2144b32965a857b848b2e9e522baada6fae9fe51012b9eaa664e85d86"

--- a/spec-processing/source-manifests/wap-1.2.1-wml-2-knowledge-graph.json
+++ b/spec-processing/source-manifests/wap-1.2.1-wml-2-knowledge-graph.json
@@ -13,7 +13,7 @@
     "generator": "spec-processing/scripts/generate-wap-knowledge-graph.mjs",
     "inputs": {
       "docs/waves/wap-1.2.1-compliance-program.json": {
-        "sha256": "ecc532a8e6974a0ac19d0f6307f742be037c63b2e6905ce1e6d1451f89fc2d45"
+        "sha256": "412ce8db546268e168b82819b2d249b6a9d1f8c77d47faf33c5843fe7e91fffc"
       },
       "spec-processing/source-manifests/wap-1.2.1-class-conformance.json": {
         "sha256": "b76605b2144b32965a857b848b2e9e522baada6fae9fe51012b9eaa664e85d86"


### PR DESCRIPTION
## Summary

- correct the malformed vendored Win95 WebKit scrollbar selector
- remove the Vite esbuild CSS-minification workaround that masked the source defect
- mark REL-1004 done and synchronize the active compliance/planning rollups
- refresh the WML-2 and TRN-7 knowledge-graph provenance hashes derived from the compliance program

## Root cause

The vendored selector used a single-colon `:-webkit-scrollbar-button` pseudo-class form. Lightning CSS rejects it because WebKit scrollbar selectors require the double-colon pseudo-element form. The existing Vite configuration forced esbuild CSS minification, so the documented production command passed while the malformed source remained path-dependent.

Updating REL-1004 also changed the compliance-program source hash consumed by the generated WML-2 and TRN-7 knowledge graphs. Regenerating those manifests keeps their committed provenance metadata synchronized.

## Impact

The intended scrollbar rule is preserved with valid syntax. Both the frontend production bundle and Tauri production path now build without the masking override under the declared Node/pnpm toolchain. The compliance knowledge-graph drift gate also passes with current generated inputs.

## Validation

- `pnpm install --frozen-lockfile --ignore-scripts`
- `pnpm --dir browser run build`
- forced Lightning CSS Vite production build
- `pnpm --dir browser run tauri:build`
- `wasm-pack build --target web --out-dir ../pkg`
- `pnpm --dir browser/frontend run typecheck`
- `pnpm --dir browser/frontend run lint`
- `pnpm --dir browser/frontend run test` — 155 passed
- `cargo test --manifest-path browser/src-tauri/Cargo.toml` — 56 passed; external Kannel smoke tests ignored
- `pnpm --dir browser run contracts:check`
- `pnpm wap-graph:generate`
- `pnpm wap-graph:check`
- `node scripts/check-wap-compliance-program.mjs`
- `node scripts/check-requirement-status-drift.mjs`
- `git diff --check`
- repository pre-push hook matrix

## Residual validation

REL-1003 remains todo. Once the generated WASM story-host module exists, the frontend coverage command runs all 155 tests successfully but misses its configured global thresholds because that story-only module is counted as uncovered. Live GitHub CI remains the platform-specific verification for this PR.
