### PR TITLE
fix(browser): make shell responsive and clarify gateway status

### DIFF
--- a/browser/frontend/src/app/browser-controller.ts
+++ b/browser/frontend/src/app/browser-controller.ts
@@ -447,8 +447,8 @@ export class BrowserController {
       return;
     }
 
-    this.presenter.setStatus(WAVES_COPY.status.networkModeEnabled);
     this.refs.fetchUrlInput.value = this.lastNetworkUrl || defaultStartUrl();
+    this.presenter.setStatus(WAVES_COPY.status.networkModeEnabled(this.refs.fetchUrlInput.value));
     this.startupProbe.start();
     this.updateBackButtonAvailability();
   }

--- a/browser/frontend/src/app/network.test.ts
+++ b/browser/frontend/src/app/network.test.ts
@@ -25,7 +25,7 @@ describe('app/network', () => {
     expect(
       isProbeReachable({
         ok: false,
-        status: 0,
+        status: 503,
         finalUrl: 'http://local.test/',
         contentType: '',
         error: {
@@ -37,7 +37,23 @@ describe('app/network', () => {
     ).toBe(false);
   });
 
-  it('treats other failures as reachable endpoint path', () => {
+  it('does not mistake a preflight policy rejection for gateway reachability', () => {
+    expect(
+      isProbeReachable({
+        ok: false,
+        status: 400,
+        finalUrl: 'wap://localhost/',
+        contentType: 'text/plain',
+        error: {
+          code: 'INVALID_REQUEST',
+          message: 'private destinations are blocked'
+        },
+        timingMs: { encode: 0, udpRtt: 0, decode: 0 }
+      })
+    ).toBe(false);
+  });
+
+  it('treats an upstream error response as evidence that an endpoint answered', () => {
     expect(
       isProbeReachable({
         ok: false,

--- a/browser/frontend/src/app/network.ts
+++ b/browser/frontend/src/app/network.ts
@@ -7,5 +7,14 @@ export const isProbeReachable = (response: FetchResponse): boolean => {
   if (response.ok) {
     return true;
   }
-  return !isNetworkUnavailableErrorCode(response.error?.code);
+  // A non-zero status proves that an upstream endpoint answered, even when
+  // the returned deck itself is unusable. Status-zero failures such as a
+  // destination-policy rejection happen before any network exchange and must
+  // not be presented as evidence that a WAP gateway is reachable.
+  const errorCode = response.error?.code;
+  return (
+    response.status > 0 &&
+    errorCode !== 'INVALID_REQUEST' &&
+    !isNetworkUnavailableErrorCode(errorCode)
+  );
 };

--- a/browser/frontend/src/app/startup-network-probe.test.ts
+++ b/browser/frontend/src/app/startup-network-probe.test.ts
@@ -26,17 +26,15 @@ const createDeps = (
   const showToast = vi.fn();
 
   const base: StartupNetworkProbeDependencies = {
-    fetchDeck: vi.fn(
-      async (): Promise<FetchResponse> => ({
-        ok: true,
-        status: 200,
-        finalUrl: 'wap://localhost/',
-        contentType: 'text/vnd.wap.wml',
-        timingMs: { encode: 0, udpRtt: 1, decode: 0 },
-        engineDeckInput: undefined,
-        wml: '<wml/>'
-      })
-    ),
+    fetchDeck: vi.fn(async (): Promise<FetchResponse> => ({
+      ok: true,
+      status: 200,
+      finalUrl: 'wap://localhost/',
+      contentType: 'text/vnd.wap.wml',
+      timingMs: { encode: 0, udpRtt: 1, decode: 0 },
+      engineDeckInput: undefined,
+      wml: '<wml/>'
+    })),
     getTargetUrl: vi.fn(() => 'wap://localhost/'),
     getRunMode: vi.fn((): RunMode => 'network'),
     setLastNetworkUrl: vi.fn(),
@@ -84,16 +82,14 @@ describe('StartupNetworkProbeController', () => {
 
   it('retries unreachable responses and reports that the gateway was not verified', async () => {
     const deps = createDeps({
-      fetchDeck: vi.fn(
-        async (): Promise<FetchResponse> => ({
-          ok: false,
-          status: 0,
-          finalUrl: 'wap://localhost/',
-          contentType: 'text/plain',
-          timingMs: { encode: 0, udpRtt: 0, decode: 0 },
-          error: { code: 'TRANSPORT_UNAVAILABLE', message: 'offline' }
-        })
-      )
+      fetchDeck: vi.fn(async (): Promise<FetchResponse> => ({
+        ok: false,
+        status: 0,
+        finalUrl: 'wap://localhost/',
+        contentType: 'text/plain',
+        timingMs: { encode: 0, udpRtt: 0, decode: 0 },
+        error: { code: 'TRANSPORT_UNAVAILABLE', message: 'offline' }
+      }))
     });
 
     const controller = new StartupNetworkProbeController(deps);

--- a/browser/frontend/src/app/startup-network-probe.test.ts
+++ b/browser/frontend/src/app/startup-network-probe.test.ts
@@ -26,15 +26,17 @@ const createDeps = (
   const showToast = vi.fn();
 
   const base: StartupNetworkProbeDependencies = {
-    fetchDeck: vi.fn(async (): Promise<FetchResponse> => ({
-      ok: true,
-      status: 200,
-      finalUrl: 'wap://localhost/',
-      contentType: 'text/vnd.wap.wml',
-      timingMs: { encode: 0, udpRtt: 1, decode: 0 },
-      engineDeckInput: undefined,
-      wml: '<wml/>'
-    })),
+    fetchDeck: vi.fn(
+      async (): Promise<FetchResponse> => ({
+        ok: true,
+        status: 200,
+        finalUrl: 'wap://localhost/',
+        contentType: 'text/vnd.wap.wml',
+        timingMs: { encode: 0, udpRtt: 1, decode: 0 },
+        engineDeckInput: undefined,
+        wml: '<wml/>'
+      })
+    ),
     getTargetUrl: vi.fn(() => 'wap://localhost/'),
     getRunMode: vi.fn((): RunMode => 'network'),
     setLastNetworkUrl: vi.fn(),
@@ -67,7 +69,7 @@ describe('StartupNetworkProbeController', () => {
     expect(deps.fetchDeck).not.toHaveBeenCalled();
   });
 
-  it('marks network ready when a reachable probe succeeds', async () => {
+  it('reports the checked gateway when a reachable probe succeeds', async () => {
     const deps = createDeps();
 
     const controller = new StartupNetworkProbeController(deps);
@@ -76,20 +78,22 @@ describe('StartupNetworkProbeController', () => {
 
     expect(deps.fetchDeck).toHaveBeenCalledTimes(1);
     expect(deps.setLastNetworkUrl).toHaveBeenCalledWith('wap://localhost/');
-    expect(deps.setStatus).toHaveBeenCalledWith(WAVES_COPY.status.readyNetwork);
+    expect(deps.setStatus).toHaveBeenCalledWith(WAVES_COPY.status.readyNetwork('wap://localhost/'));
     expect(deps.patchSessionState).not.toHaveBeenCalled();
   });
 
-  it('retries unreachable responses and reports network unavailable after exhausting attempts', async () => {
+  it('retries unreachable responses and reports that the gateway was not verified', async () => {
     const deps = createDeps({
-      fetchDeck: vi.fn(async (): Promise<FetchResponse> => ({
-        ok: false,
-        status: 503,
-        finalUrl: 'wap://localhost/',
-        contentType: 'text/plain',
-        timingMs: { encode: 0, udpRtt: 0, decode: 0 },
-        error: { code: 'TRANSPORT_UNAVAILABLE', message: 'offline' }
-      }))
+      fetchDeck: vi.fn(
+        async (): Promise<FetchResponse> => ({
+          ok: false,
+          status: 0,
+          finalUrl: 'wap://localhost/',
+          contentType: 'text/plain',
+          timingMs: { encode: 0, udpRtt: 0, decode: 0 },
+          error: { code: 'TRANSPORT_UNAVAILABLE', message: 'offline' }
+        })
+      )
     });
 
     const controller = new StartupNetworkProbeController(deps);
@@ -98,11 +102,13 @@ describe('StartupNetworkProbeController', () => {
 
     expect(deps.fetchDeck).toHaveBeenCalledTimes(3);
     expect(deps.wait).toHaveBeenCalledTimes(2);
+    const expectedMessage = WAVES_COPY.status.gatewayCheckFailed('wap://localhost/', 'offline');
     expect(deps.patchSessionState).toHaveBeenCalledWith({
       navigationStatus: 'error',
-      lastError: WAVES_COPY.status.networkUnavailable
+      lastError: expectedMessage
     });
-    expect(deps.showToast).toHaveBeenCalledWith(WAVES_COPY.status.networkUnavailable, 'error');
+    expect(deps.setStatus).toHaveBeenCalledWith(expectedMessage);
+    expect(deps.showToast).toHaveBeenCalledWith(expectedMessage, 'error');
   });
 
   it('ignores stale failures after cancellation', async () => {

--- a/browser/frontend/src/app/startup-network-probe.ts
+++ b/browser/frontend/src/app/startup-network-probe.ts
@@ -37,6 +37,7 @@ export class StartupNetworkProbeController {
       return;
     }
     this.deps.setLastNetworkUrl(targetUrl);
+    let lastFailure: string = WAVES_COPY.status.networkUnavailable;
 
     for (let attempt = 1; attempt <= WAVES_CONFIG.networkProbeMaxAttempts; attempt += 1) {
       if (!this.isCurrent(probeGeneration)) {
@@ -59,13 +60,15 @@ export class StartupNetworkProbeController {
           return;
         }
         if (isProbeReachable(probe)) {
-          this.deps.setStatus(WAVES_COPY.status.readyNetwork);
+          this.deps.setStatus(WAVES_COPY.status.readyNetwork(targetUrl));
           return;
         }
-      } catch {
+        lastFailure = probe.error?.message || WAVES_COPY.status.networkUnavailable;
+      } catch (error) {
         if (!this.isCurrent(probeGeneration)) {
           return;
         }
+        lastFailure = error instanceof Error ? error.message : WAVES_COPY.status.networkUnavailable;
       }
       if (attempt < WAVES_CONFIG.networkProbeMaxAttempts) {
         await this.deps.wait(WAVES_CONFIG.networkProbeDelayMs);
@@ -75,7 +78,7 @@ export class StartupNetworkProbeController {
     if (!this.isCurrent(probeGeneration)) {
       return;
     }
-    const message = WAVES_COPY.status.networkUnavailable;
+    const message = WAVES_COPY.status.gatewayCheckFailed(targetUrl, lastFailure);
     this.deps.patchSessionState({
       navigationStatus: 'error',
       lastError: message

--- a/browser/frontend/src/app/waves-copy.ts
+++ b/browser/frontend/src/app/waves-copy.ts
@@ -56,6 +56,7 @@ const locale = {
     fetchFailed: 'Fetch failed:',
     loading: 'Loading ',
     followingExternalIntent: 'Following external intent:',
+    checkingGateway: 'Checking WAP gateway',
     ready: 'Ready',
     fetchedAndLoaded: 'Fetched and loaded'
   },
@@ -70,12 +71,12 @@ const locale = {
   status: {
     starting: `Starting ${WAVES_CONFIG.appTagline}...`,
     ready: 'Ready.',
-    readyNetwork: 'Ready. Network available.',
+    readyNetwork: (url: string) => `Ready. WAP gateway responded at ${url}.`,
     bootShellReady: 'Shell ready.',
     bootEngineReady: 'Engine ready.',
     bootDeckReady: 'Deck ready.',
     localModeEnabled: 'Local mode enabled. Network fetches are disabled.',
-    networkModeEnabled: 'Network mode enabled.',
+    networkModeEnabled: (url: string) => `Checking WAP gateway at ${url}...`,
     loadedLocalDeck: (label: string) => `Loaded local example: ${label}`,
     localExternalIntentCaptured: (url: string) =>
       `Local mode captured external intent: ${url} (not fetched).`,
@@ -112,8 +113,12 @@ const locale = {
     scriptExecutionFailed: (categoryLabel: string, message: string) =>
       `Script error (${categoryLabel}): ${message}`,
     fetchedAndLoadedDeck: (url: string) => `Fetched and loaded deck from ${url}`,
-    networkUnavailableToast: 'No network available currently. WAP server/gateway is unreachable.',
-    networkUnavailable: 'No network available currently. Could not reach WAP server/gateway.',
+    networkUnavailableToast:
+      'Could not reach the WAP server or gateway. Check that Kannel is running and the address is reachable.',
+    networkUnavailable:
+      'Could not reach the WAP server or gateway. Network mode remains available.',
+    gatewayCheckFailed: (url: string, reason: string) =>
+      `Error: WAP gateway not verified at ${url}. ${reason}`,
     error: (message: string) => `Error: ${message}`,
     scriptDialogAlert: (message: string) => `Script alert("${message}") shown.`,
     scriptDialogConfirm: (message: string) =>

--- a/browser/frontend/src/styles.css
+++ b/browser/frontend/src/styles.css
@@ -37,6 +37,7 @@
 
 html,
 body {
+  width: 100%;
   min-height: 100%;
 }
 
@@ -48,9 +49,15 @@ body {
 }
 
 #app {
-  max-width: 1280px;
-  margin: 0 auto;
+  width: 100%;
+  min-height: 100vh;
   padding: 18px;
+}
+
+.browser-shell {
+  display: flex;
+  flex-direction: column;
+  min-height: calc(100vh - 36px);
 }
 
 /* win95.css has a global header hero style; reset for app chrome header */
@@ -138,10 +145,14 @@ button,
   display: grid;
   grid-template-columns: 1.25fr 0.75fr;
   gap: 12px;
+  flex: 1;
   padding: 12px;
 }
 
 .device-frame {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
   border: 2px inset #d5d5d5;
   box-shadow: -1px -1px 0 #828282;
   background: silver;
@@ -223,6 +234,7 @@ textarea.form-95 {
 }
 
 .viewport {
+  flex: 1;
   border: 2px inset #d5d5d5;
   box-shadow: -1px -1px 0 #828282;
   min-height: 520px;
@@ -408,6 +420,10 @@ pre {
 @media (max-width: 900px) {
   #app {
     padding: 10px;
+  }
+
+  .browser-shell {
+    min-height: calc(100vh - 20px);
   }
 
   .browser-main {

--- a/browser/frontend/src/ui-helpers.test.ts
+++ b/browser/frontend/src/ui-helpers.test.ts
@@ -10,6 +10,9 @@ describe('ui-helpers', () => {
     expect(inferStatusTone(`${WAVES_COPY.statusPrefix.followingExternalIntent} http://x`)).toBe(
       'loading'
     );
+    expect(inferStatusTone(WAVES_COPY.status.networkModeEnabled('wap://localhost/'))).toBe(
+      'loading'
+    );
     expect(inferStatusTone(WAVES_COPY.status.ready)).toBe('ok');
     expect(inferStatusTone(WAVES_COPY.status.fetchedAndLoadedDeck('http://x'))).toBe('ok');
     expect(inferStatusTone('Rendered current card.')).toBe('idle');

--- a/browser/frontend/src/ui-helpers.ts
+++ b/browser/frontend/src/ui-helpers.ts
@@ -30,7 +30,8 @@ export const inferStatusTone = (message: string): StatusTone => {
   }
   if (
     message.startsWith(WAVES_COPY.statusPrefix.loading) ||
-    message.startsWith(WAVES_COPY.statusPrefix.followingExternalIntent)
+    message.startsWith(WAVES_COPY.statusPrefix.followingExternalIntent) ||
+    message.startsWith(WAVES_COPY.statusPrefix.checkingGateway)
   ) {
     return 'loading';
   }


### PR DESCRIPTION
## Summary

- let the Waves shell, workspace, and deck viewport grow with the native window instead of capping the application canvas at 1280px
- show an explicit in-progress gateway check when entering network mode
- only report gateway readiness when the transport provides real upstream-response evidence
- surface the checked URL and failure reason when a startup probe cannot verify the gateway

## Validation

- `pnpm --dir browser/frontend test` (156 tests)
- `pnpm --dir browser/frontend typecheck`
- `pnpm --dir browser/frontend lint`
- `pnpm --dir browser/frontend build`
- Chrome visual checks at 1024x768 and 1968x1158

## Notes

- This is localized to the browser frontend; transport and engine contracts are unchanged.
- Preflight policy failures, explicit transport unavailability, and gateway timeouts no longer produce a green readiness state.
