### PR TITLE
feat(browser): shell component foundation (WBP-01)

### DIFF
--- a/browser/frontend/src/app/browser-shell-template.test.ts
+++ b/browser/frontend/src/app/browser-shell-template.test.ts
@@ -19,4 +19,37 @@ describe('mountBrowserShell', () => {
     expect(softkeyRow?.getAttribute('role')).toBe('group');
     expect(softkeyRow?.getAttribute('aria-label')).toBeTruthy();
   });
+
+  it('decomposes the shell into landmark-labelled sections', () => {
+    document.body.innerHTML = '<div id="app"></div>';
+    mountBrowserShell('http://example.test/start.wml', 'local');
+
+    const nav = document.querySelector('nav.nav-toolbar');
+    const handsetStage = document.querySelector('section.handset-stage');
+    const utilityRail = document.querySelector('aside.utility-rail');
+    const devDrawerSection = document.querySelector('section.developer-drawer-section');
+
+    expect(nav?.getAttribute('aria-label')).toBeTruthy();
+    expect(handsetStage?.getAttribute('aria-label')).toBeTruthy();
+    expect(utilityRail?.getAttribute('aria-label')).toBeTruthy();
+    expect(devDrawerSection?.getAttribute('aria-label')).toBeTruthy();
+
+    // Handset stage still owns the engine viewport adapter directly.
+    expect(handsetStage?.querySelector('#viewport')).not.toBeNull();
+    // Developer drawer moved out from under the utility rail to its own
+    // top-level sibling section, per the desktop product IA.
+    expect(utilityRail?.querySelector('#dev-drawer')).toBeNull();
+    expect(devDrawerSection?.querySelector('#dev-drawer')).not.toBeNull();
+
+    const phaseBarSlot = document.querySelector('.phase-bar-slot');
+    expect(phaseBarSlot?.hasAttribute('hidden')).toBe(true);
+  });
+
+  it('opens the utility rail by default at normal window widths', () => {
+    document.body.innerHTML = '<div id="app"></div>';
+    mountBrowserShell('http://example.test/start.wml', 'local');
+
+    const railPanel = document.querySelector<HTMLDetailsElement>('#utility-rail-panel');
+    expect(railPanel?.open).toBe(true);
+  });
 });

--- a/browser/frontend/src/app/browser-shell-template.ts
+++ b/browser/frontend/src/app/browser-shell-template.ts
@@ -1,6 +1,13 @@
 import type { WvStatusPanel } from '../components/status-panel';
 import { WAVES_CONFIG } from './waves-config';
 import { WAVES_COPY } from './waves-copy';
+import { developerDrawerTemplate } from './shell/developer-drawer-template';
+import { handsetStageTemplate } from './shell/handset-stage-template';
+import { navigationToolbarTemplate } from './shell/navigation-toolbar-template';
+import {
+  UTILITY_RAIL_NARROW_MEDIA_QUERY,
+  utilityRailTemplate
+} from './shell/utility-rail-template';
 
 const browserShellTemplate = () => `
   <div class="browser-shell card square wv-shell-window">
@@ -9,118 +16,17 @@ const browserShellTemplate = () => `
         <div class="brand">${WAVES_COPY.app.brand}</div>
         <div class="caption">${WAVES_COPY.app.tagline}</div>
       </div>
-      <div class="nav-row">
-        <button id="btn-back" class="btn chrome-btn">${WAVES_COPY.shell.back}</button>
-        <button id="btn-reload" class="btn chrome-btn">${WAVES_COPY.shell.reload}</button>
-        <input id="fetch-url" class="form-95" type="text" value="" aria-label="Address" />
-        <button id="btn-fetch-url" class="btn chrome-btn primary">${WAVES_COPY.shell.go}</button>
-      </div>
-      <div class="mode-row">
-        <label class="mode-field">
-          <span>${WAVES_COPY.shell.mode}</span>
-          <select id="run-mode" class="form-95">
-            <option value="local">${WAVES_COPY.shell.localMode}</option>
-            <option value="network">${WAVES_COPY.shell.networkMode}</option>
-          </select>
-        </label>
-        <label id="local-example-wrap" class="mode-field">
-          <span>${WAVES_COPY.shell.localExample}</span>
-          <select id="local-example" class="form-95"></select>
-        </label>
-        <button id="btn-load-local" class="btn chrome-btn">${WAVES_COPY.shell.loadLocal}</button>
-      </div>
+      ${navigationToolbarTemplate()}
     </header>
 
     <main class="browser-main">
-      <section class="device-frame">
-        <div class="device-header">
-          <span>${WAVES_COPY.shell.deckView}</span>
-          <span id="active-url-label" class="muted-url">${WAVES_COPY.shell.idle}</span>
-        </div>
-        <div
-          id="viewport"
-          class="viewport viewport-skeleton"
-          aria-busy="true"
-          tabindex="0"
-        >
-          <div class="skeleton-line"></div>
-          <div class="skeleton-line skeleton-line-wide"></div>
-          <div class="skeleton-line"></div>
-          <div class="skeleton-line skeleton-line-short"></div>
-          <div class="skeleton-line"></div>
-          <div class="skeleton-line skeleton-line-wide"></div>
-          <div class="skeleton-line"></div>
-          <div class="skeleton-hint">${WAVES_COPY.shell.firstRenderPending}</div>
-        </div>
-        <div class="softkey-row" role="group" aria-label="Softkey navigation">
-          <button id="btn-up" class="btn">${WAVES_COPY.shell.up}</button>
-          <button id="btn-enter" class="btn">${WAVES_COPY.shell.select}</button>
-          <button id="btn-down" class="btn">${WAVES_COPY.shell.down}</button>
-        </div>
-      </section>
-
-      <aside class="side-panel">
-        <label class="compact-field">
-          ${WAVES_COPY.shell.viewportCols}
-          <input
-            id="viewport-cols"
-            class="form-95"
-            type="number"
-            value="${WAVES_CONFIG.defaultViewportCols}"
-            min="1"
-          />
-        </label>
-        <wv-surface-panel heading="${WAVES_COPY.shell.status}">
-          <wv-status-panel id="status"></wv-status-panel>
-        </wv-surface-panel>
-        <details id="local-example-notes" class="local-example-notes" aria-live="polite">
-          <summary>${WAVES_COPY.shell.localExampleNotes}</summary>
-          <div class="local-example-notes-body">
-            <p id="local-example-coverage" class="local-example-notes-coverage"></p>
-            <p id="local-example-description"></p>
-            <p id="local-example-goal"></p>
-            <h3>${WAVES_COPY.shell.localExampleTestingAc}</h3>
-            <ul id="local-example-testing-ac"></ul>
-          </div>
-        </details>
-        <div id="toast" class="toast toast-hidden" role="alert" aria-live="polite"></div>
-
-        <details id="dev-drawer" class="dev-drawer">
-          <summary>${WAVES_COPY.shell.developerTools}</summary>
-          <div class="panel-body">
-            <div class="actions">
-              <button id="btn-health" class="btn wv95-btn">${WAVES_COPY.shell.health}</button>
-              <button id="btn-render" class="btn wv95-btn">${WAVES_COPY.shell.render}</button>
-              <button id="btn-snapshot" class="btn wv95-btn">${WAVES_COPY.shell.snapshot}</button>
-              <button id="btn-clear-intent" class="btn wv95-btn">${WAVES_COPY.shell.clearExternalIntent}</button>
-              <button id="btn-export-timeline" class="btn wv95-btn">${WAVES_COPY.shell.exportTimeline}</button>
-              <button id="btn-clear-timeline" class="btn wv95-btn">${WAVES_COPY.shell.clearTimeline}</button>
-            </div>
-            <details id="debug-raw-mode" class="debug-raw-mode">
-              <summary>${WAVES_COPY.shell.rawWmlPaste}</summary>
-              <div class="debug-raw-mode-content">
-                <label class="compact-field">
-                  ${WAVES_COPY.shell.baseUrl}
-                  <input id="base-url" class="form-95" type="text" value="" />
-                </label>
-                <textarea id="wml-input" class="form-95"></textarea>
-                <div class="actions">
-                  <button id="btn-load-context" class="btn wv95-btn">${WAVES_COPY.shell.loadRawWml}</button>
-                </div>
-              </div>
-            </details>
-            <h3>${WAVES_COPY.shell.sessionState}</h3>
-            <pre id="session-state"></pre>
-            <h3>${WAVES_COPY.shell.transportResponse}</h3>
-            <pre id="transport-response"></pre>
-            <h3>${WAVES_COPY.shell.runtimeSnapshot}</h3>
-            <pre id="snapshot"></pre>
-            <h3>${WAVES_COPY.shell.eventTimeline}</h3>
-            <pre id="timeline"></pre>
-          </div>
-        </details>
-      </aside>
+      ${handsetStageTemplate()}
+      ${utilityRailTemplate()}
     </main>
+
+    <div class="phase-bar-slot" hidden aria-hidden="true"></div>
+
+    ${developerDrawerTemplate()}
   </div>
 `;
 
@@ -148,6 +54,20 @@ export interface BrowserShellRefs {
   localExampleGoalEl: HTMLParagraphElement;
   localExampleTestingAcEl: HTMLUListElement;
 }
+
+// Narrow windows start with the utility rail collapsed so the handset stage
+// gets the available width; the native <details> disclosure still lets the
+// user reopen it manually. Guarded because jsdom's matchMedia support is
+// inconsistent across environments running this same mount path in tests.
+const utilityRailPrefersNarrow = (): boolean => {
+  try {
+    return typeof window.matchMedia === 'function'
+      ? window.matchMedia(UTILITY_RAIL_NARROW_MEDIA_QUERY).matches
+      : false;
+  } catch {
+    return false;
+  }
+};
 
 export const mountBrowserShell = (
   defaultUrl: string,
@@ -218,6 +138,11 @@ export const mountBrowserShell = (
   fetchUrlInput.value = defaultUrl;
   runModeSelectEl.value = defaultRunMode;
   baseUrlInput.value = WAVES_CONFIG.defaultDebugBaseUrl;
+
+  const utilityRailPanelEl = document.querySelector<HTMLDetailsElement>('#utility-rail-panel');
+  if (utilityRailPanelEl && utilityRailPrefersNarrow()) {
+    utilityRailPanelEl.open = false;
+  }
 
   return {
     wmlInput,

--- a/browser/frontend/src/app/shell/developer-drawer-template.ts
+++ b/browser/frontend/src/app/shell/developer-drawer-template.ts
@@ -1,0 +1,40 @@
+import { WAVES_COPY } from '../waves-copy';
+
+export const developerDrawerTemplate = () => `
+  <section class="developer-drawer-section" aria-label="Developer tools">
+    <details id="dev-drawer" class="dev-drawer">
+      <summary>${WAVES_COPY.shell.developerTools}</summary>
+      <div class="panel-body">
+        <div class="actions">
+          <button id="btn-health" class="btn wv95-btn">${WAVES_COPY.shell.health}</button>
+          <button id="btn-render" class="btn wv95-btn">${WAVES_COPY.shell.render}</button>
+          <button id="btn-snapshot" class="btn wv95-btn">${WAVES_COPY.shell.snapshot}</button>
+          <button id="btn-clear-intent" class="btn wv95-btn">${WAVES_COPY.shell.clearExternalIntent}</button>
+          <button id="btn-export-timeline" class="btn wv95-btn">${WAVES_COPY.shell.exportTimeline}</button>
+          <button id="btn-clear-timeline" class="btn wv95-btn">${WAVES_COPY.shell.clearTimeline}</button>
+        </div>
+        <details id="debug-raw-mode" class="debug-raw-mode">
+          <summary>${WAVES_COPY.shell.rawWmlPaste}</summary>
+          <div class="debug-raw-mode-content">
+            <label class="compact-field">
+              ${WAVES_COPY.shell.baseUrl}
+              <input id="base-url" class="form-95" type="text" value="" />
+            </label>
+            <textarea id="wml-input" class="form-95"></textarea>
+            <div class="actions">
+              <button id="btn-load-context" class="btn wv95-btn">${WAVES_COPY.shell.loadRawWml}</button>
+            </div>
+          </div>
+        </details>
+        <h3>${WAVES_COPY.shell.sessionState}</h3>
+        <pre id="session-state"></pre>
+        <h3>${WAVES_COPY.shell.transportResponse}</h3>
+        <pre id="transport-response"></pre>
+        <h3>${WAVES_COPY.shell.runtimeSnapshot}</h3>
+        <pre id="snapshot"></pre>
+        <h3>${WAVES_COPY.shell.eventTimeline}</h3>
+        <pre id="timeline"></pre>
+      </div>
+    </details>
+  </section>
+`;

--- a/browser/frontend/src/app/shell/handset-stage-template.ts
+++ b/browser/frontend/src/app/shell/handset-stage-template.ts
@@ -1,0 +1,32 @@
+import { WAVES_COPY } from '../waves-copy';
+
+export const handsetStageTemplate = () => `
+  <section class="handset-stage" aria-label="Handset display">
+    <div class="device-frame">
+      <div class="device-header">
+        <span>${WAVES_COPY.shell.deckView}</span>
+        <span id="active-url-label" class="muted-url">${WAVES_COPY.shell.idle}</span>
+      </div>
+      <div
+        id="viewport"
+        class="viewport viewport-skeleton"
+        aria-busy="true"
+        tabindex="0"
+      >
+        <div class="skeleton-line"></div>
+        <div class="skeleton-line skeleton-line-wide"></div>
+        <div class="skeleton-line"></div>
+        <div class="skeleton-line skeleton-line-short"></div>
+        <div class="skeleton-line"></div>
+        <div class="skeleton-line skeleton-line-wide"></div>
+        <div class="skeleton-line"></div>
+        <div class="skeleton-hint">${WAVES_COPY.shell.firstRenderPending}</div>
+      </div>
+      <div class="softkey-row" role="group" aria-label="Softkey navigation">
+        <button id="btn-up" class="btn">${WAVES_COPY.shell.up}</button>
+        <button id="btn-enter" class="btn">${WAVES_COPY.shell.select}</button>
+        <button id="btn-down" class="btn">${WAVES_COPY.shell.down}</button>
+      </div>
+    </div>
+  </section>
+`;

--- a/browser/frontend/src/app/shell/navigation-toolbar-template.ts
+++ b/browser/frontend/src/app/shell/navigation-toolbar-template.ts
@@ -1,0 +1,26 @@
+import { WAVES_COPY } from '../waves-copy';
+
+export const navigationToolbarTemplate = () => `
+  <nav class="nav-toolbar" aria-label="Browser navigation">
+    <div class="nav-row">
+      <button id="btn-back" class="btn chrome-btn">${WAVES_COPY.shell.back}</button>
+      <button id="btn-reload" class="btn chrome-btn">${WAVES_COPY.shell.reload}</button>
+      <input id="fetch-url" class="form-95" type="text" value="" aria-label="Address" />
+      <button id="btn-fetch-url" class="btn chrome-btn primary">${WAVES_COPY.shell.go}</button>
+    </div>
+    <div class="mode-row">
+      <label class="mode-field">
+        <span>${WAVES_COPY.shell.mode}</span>
+        <select id="run-mode" class="form-95">
+          <option value="local">${WAVES_COPY.shell.localMode}</option>
+          <option value="network">${WAVES_COPY.shell.networkMode}</option>
+        </select>
+      </label>
+      <label id="local-example-wrap" class="mode-field">
+        <span>${WAVES_COPY.shell.localExample}</span>
+        <select id="local-example" class="form-95"></select>
+      </label>
+      <button id="btn-load-local" class="btn chrome-btn">${WAVES_COPY.shell.loadLocal}</button>
+    </div>
+  </nav>
+`;

--- a/browser/frontend/src/app/shell/utility-rail-template.ts
+++ b/browser/frontend/src/app/shell/utility-rail-template.ts
@@ -1,0 +1,38 @@
+import { WAVES_CONFIG } from '../waves-config';
+import { WAVES_COPY } from '../waves-copy';
+
+export const UTILITY_RAIL_NARROW_MEDIA_QUERY = '(max-width: 900px)';
+
+export const utilityRailTemplate = () => `
+  <aside class="utility-rail" aria-label="Utility rail">
+    <details id="utility-rail-panel" class="utility-rail-panel" open>
+      <summary>${WAVES_COPY.shell.utilityRail}</summary>
+      <div class="utility-rail-body">
+        <label class="compact-field">
+          ${WAVES_COPY.shell.viewportCols}
+          <input
+            id="viewport-cols"
+            class="form-95"
+            type="number"
+            value="${WAVES_CONFIG.defaultViewportCols}"
+            min="1"
+          />
+        </label>
+        <wv-surface-panel heading="${WAVES_COPY.shell.status}">
+          <wv-status-panel id="status"></wv-status-panel>
+        </wv-surface-panel>
+        <details id="local-example-notes" class="local-example-notes" aria-live="polite">
+          <summary>${WAVES_COPY.shell.localExampleNotes}</summary>
+          <div class="local-example-notes-body">
+            <p id="local-example-coverage" class="local-example-notes-coverage"></p>
+            <p id="local-example-description"></p>
+            <p id="local-example-goal"></p>
+            <h3>${WAVES_COPY.shell.localExampleTestingAc}</h3>
+            <ul id="local-example-testing-ac"></ul>
+          </div>
+        </details>
+      </div>
+    </details>
+    <div id="toast" class="toast toast-hidden" role="alert" aria-live="polite"></div>
+  </aside>
+`;

--- a/browser/frontend/src/app/waves-copy.ts
+++ b/browser/frontend/src/app/waves-copy.ts
@@ -16,6 +16,7 @@ const locale = {
     select: 'Select',
     down: 'Down',
     viewportCols: 'Viewport Cols',
+    utilityRail: 'Utility Rail',
     status: 'Status',
     developerTools: 'Developer Tools',
     health: 'Health',

--- a/browser/frontend/src/styles.css
+++ b/browser/frontend/src/styles.css
@@ -149,6 +149,16 @@ button,
   padding: 12px;
 }
 
+.handset-stage {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
+.handset-stage .device-frame {
+  flex: 1;
+}
+
 .device-frame {
   display: flex;
   min-width: 0;
@@ -175,10 +185,36 @@ button,
   white-space: nowrap;
 }
 
-.side-panel {
+.utility-rail {
   display: flex;
   flex-direction: column;
   gap: 8px;
+}
+
+.utility-rail-panel {
+  border: 2px solid;
+  border-bottom-color: #424242;
+  border-right-color: #424242;
+  border-left-color: #fff;
+  border-top-color: #fff;
+  background: silver;
+  color: #212529;
+}
+
+.utility-rail-panel > summary {
+  cursor: pointer;
+  padding: 4px 6px;
+  color: #fff;
+  font-weight: 700;
+  background: linear-gradient(90deg, #08216b, #a5cef7);
+}
+
+.utility-rail-body {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  border-top: 1px solid #7f7f7f;
+  padding: 8px;
 }
 
 .compact-field {
@@ -345,6 +381,10 @@ textarea.form-95 {
 
 .local-example-notes-body li {
   margin-bottom: 4px;
+}
+
+.developer-drawer-section {
+  padding: 0 12px 12px;
 }
 
 .dev-drawer {


### PR DESCRIPTION
## Summary

- Implements `WBP-01` from `docs/waves/WAVES_BROWSER_PRODUCT_IMPLEMENTATION_PLAN.md`: decomposes the monolithic `browser-shell-template.ts` into four focused templates (`shell/navigation-toolbar-template.ts`, `shell/handset-stage-template.ts`, `shell/utility-rail-template.ts`, `shell/developer-drawer-template.ts`).
- Developer Tools drawer moves from nested-inside-utility-rail to its own top-level sibling `<section aria-label="Developer tools">`, matching the desktop product IA doc.
- Utility rail becomes a native collapsible `<details>`, defaulting closed under 900px width; reopens via the built-in disclosure widget (no new toggle JS).
- Adds a hidden, inert `.phase-bar-slot` placeholder reserving the IA's future phase-bar spot for `WBP-11` (no logic, no semantics).
- Adds `nav`/`section`/`aside` ARIA landmarks (`Browser navigation`, `Handset display`, `Utility rail`, `Developer tools`) as stable test/a11y anchors ahead of `WBP-05`.
- All existing element ids preserved unchanged; `shell-event-bindings.ts` and `browser-controller.ts` required no edits since they bind by id/selector, not DOM position.

## Test plan

- [x] `pnpm --dir browser/frontend run typecheck`
- [x] `pnpm --dir browser/frontend run lint`
- [x] `pnpm --dir browser/frontend run format:check`
- [x] `pnpm --dir browser/frontend run test` (159 passed, incl. 2 new landmark/rail-collapse tests)
- [x] `pnpm --dir browser/frontend run build`
- [x] Manually verified in-browser via `vite dev`: accessibility tree shows `region "Handset display"`, `complementary "Utility rail"`, `navigation "Browser navigation"`, `region "Developer tools"` correctly nested/sibling; rail collapses at narrow width and reopens on click.
- [x] pre-commit/pre-push hooks passed (lint-staged, frontend typecheck, rust fmt/clippy, host-sample build sanity)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
