### PR TITLE
feat(browser): reference-handset visual scaffold (WBP-02)

### DIFF
--- a/browser/frontend/src/app/browser-shell-template.test.ts
+++ b/browser/frontend/src/app/browser-shell-template.test.ts
@@ -52,4 +52,28 @@ describe('mountBrowserShell', () => {
     const railPanel = document.querySelector<HTMLDetailsElement>('#utility-rail-panel');
     expect(railPanel?.open).toBe(true);
   });
+
+  it('wraps the device frame in a handset housing and wires the display-scale control', () => {
+    document.body.innerHTML = '<div id="app"></div>';
+    document.documentElement.style.removeProperty('--handset-scale');
+    mountBrowserShell('http://example.test/start.wml', 'local');
+
+    const housing = document.querySelector('.handset-housing');
+    expect(housing?.querySelector('.device-frame')).not.toBeNull();
+
+    const scaleSelect = document.querySelector<HTMLSelectElement>('#handset-scale-select');
+    expect(scaleSelect).not.toBeNull();
+    expect(scaleSelect?.value).toBe('1');
+
+    if (scaleSelect) {
+      scaleSelect.value = '2';
+      scaleSelect.dispatchEvent(new Event('change'));
+    }
+    expect(document.documentElement.style.getPropertyValue('--handset-scale')).toBe('2');
+
+    // Display scale must not touch the independent viewport-cols engine config.
+    expect((document.querySelector('#viewport-cols') as HTMLInputElement).value).toBe(
+      String(WAVES_CONFIG.defaultViewportCols)
+    );
+  });
 });

--- a/browser/frontend/src/app/browser-shell-template.ts
+++ b/browser/frontend/src/app/browser-shell-template.ts
@@ -1,4 +1,5 @@
 import type { WvStatusPanel } from '../components/status-panel';
+import { bindHandsetScaleControl } from './handset-scale-control';
 import { WAVES_CONFIG } from './waves-config';
 import { WAVES_COPY } from './waves-copy';
 import { developerDrawerTemplate } from './shell/developer-drawer-template';
@@ -142,6 +143,11 @@ export const mountBrowserShell = (
   const utilityRailPanelEl = document.querySelector<HTMLDetailsElement>('#utility-rail-panel');
   if (utilityRailPanelEl && utilityRailPrefersNarrow()) {
     utilityRailPanelEl.open = false;
+  }
+
+  const handsetScaleSelectEl = document.querySelector<HTMLSelectElement>('#handset-scale-select');
+  if (handsetScaleSelectEl) {
+    bindHandsetScaleControl(handsetScaleSelectEl, document.documentElement);
   }
 
   return {

--- a/browser/frontend/src/app/handset-scale-control.test.ts
+++ b/browser/frontend/src/app/handset-scale-control.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest';
+import {
+  DEFAULT_HANDSET_SCALE,
+  bindHandsetScaleControl,
+  isHandsetScaleStep,
+  setHandsetScale
+} from './handset-scale-control';
+
+describe('isHandsetScaleStep', () => {
+  it('accepts only the documented integer steps', () => {
+    expect(isHandsetScaleStep(1)).toBe(true);
+    expect(isHandsetScaleStep(2)).toBe(true);
+    expect(isHandsetScaleStep(3)).toBe(true);
+    expect(isHandsetScaleStep(0)).toBe(false);
+    expect(isHandsetScaleStep(1.5)).toBe(false);
+    expect(isHandsetScaleStep(4)).toBe(false);
+    expect(isHandsetScaleStep(Number.NaN)).toBe(false);
+  });
+});
+
+describe('setHandsetScale', () => {
+  it('writes the --handset-scale custom property on the given root', () => {
+    const root = document.createElement('div');
+    setHandsetScale(root, 2);
+    expect(root.style.getPropertyValue('--handset-scale')).toBe('2');
+  });
+});
+
+describe('bindHandsetScaleControl', () => {
+  it('applies the selected step to root on change', () => {
+    const root = document.createElement('div');
+    const select = document.createElement('select');
+    for (const step of [1, 2, 3]) {
+      const option = document.createElement('option');
+      option.value = String(step);
+      select.appendChild(option);
+    }
+    select.value = String(DEFAULT_HANDSET_SCALE);
+
+    bindHandsetScaleControl(select, root);
+
+    select.value = '3';
+    select.dispatchEvent(new Event('change'));
+
+    expect(root.style.getPropertyValue('--handset-scale')).toBe('3');
+  });
+
+  it('stops reacting once unbound', () => {
+    const root = document.createElement('div');
+    const select = document.createElement('select');
+    const option = document.createElement('option');
+    option.value = '2';
+    select.appendChild(option);
+    select.value = '2';
+
+    const unbind = bindHandsetScaleControl(select, root);
+    unbind();
+    select.dispatchEvent(new Event('change'));
+
+    expect(root.style.getPropertyValue('--handset-scale')).toBe('');
+  });
+
+  it('ignores out-of-range select values without throwing', () => {
+    const root = document.createElement('div');
+    const select = document.createElement('select');
+    const option = document.createElement('option');
+    option.value = '9';
+    select.appendChild(option);
+    select.value = '9';
+
+    bindHandsetScaleControl(select, root);
+    select.dispatchEvent(new Event('change'));
+
+    expect(root.style.getPropertyValue('--handset-scale')).toBe('');
+  });
+});

--- a/browser/frontend/src/app/handset-scale-control.ts
+++ b/browser/frontend/src/app/handset-scale-control.ts
@@ -1,0 +1,31 @@
+export const HANDSET_SCALE_STEPS = [1, 2, 3] as const;
+
+export type HandsetScaleStep = (typeof HANDSET_SCALE_STEPS)[number];
+
+export const DEFAULT_HANDSET_SCALE: HandsetScaleStep = 1;
+
+export const isHandsetScaleStep = (value: number): value is HandsetScaleStep =>
+  (HANDSET_SCALE_STEPS as readonly number[]).includes(value);
+
+export const setHandsetScale = (root: HTMLElement, scale: HandsetScaleStep): void => {
+  root.style.setProperty('--handset-scale', String(scale));
+};
+
+// Wires the display-scale <select> to the `--handset-scale` custom property
+// consumed by `.handset-stage`'s `zoom`. This only changes rendered pixel
+// size: the engine computes row/column wrapping from the configured viewport
+// column count, independent of this value, so scale steps never touch
+// engine state (see WBP-02 accept criteria).
+export const bindHandsetScaleControl = (
+  selectEl: HTMLSelectElement,
+  root: HTMLElement
+): (() => void) => {
+  const handler = (): void => {
+    const parsed = Number(selectEl.value);
+    if (isHandsetScaleStep(parsed)) {
+      setHandsetScale(root, parsed);
+    }
+  };
+  selectEl.addEventListener('change', handler);
+  return () => selectEl.removeEventListener('change', handler);
+};

--- a/browser/frontend/src/app/shell/handset-stage-template.ts
+++ b/browser/frontend/src/app/shell/handset-stage-template.ts
@@ -2,30 +2,32 @@ import { WAVES_COPY } from '../waves-copy';
 
 export const handsetStageTemplate = () => `
   <section class="handset-stage" aria-label="Handset display">
-    <div class="device-frame">
-      <div class="device-header">
-        <span>${WAVES_COPY.shell.deckView}</span>
-        <span id="active-url-label" class="muted-url">${WAVES_COPY.shell.idle}</span>
-      </div>
-      <div
-        id="viewport"
-        class="viewport viewport-skeleton"
-        aria-busy="true"
-        tabindex="0"
-      >
-        <div class="skeleton-line"></div>
-        <div class="skeleton-line skeleton-line-wide"></div>
-        <div class="skeleton-line"></div>
-        <div class="skeleton-line skeleton-line-short"></div>
-        <div class="skeleton-line"></div>
-        <div class="skeleton-line skeleton-line-wide"></div>
-        <div class="skeleton-line"></div>
-        <div class="skeleton-hint">${WAVES_COPY.shell.firstRenderPending}</div>
-      </div>
-      <div class="softkey-row" role="group" aria-label="Softkey navigation">
-        <button id="btn-up" class="btn">${WAVES_COPY.shell.up}</button>
-        <button id="btn-enter" class="btn">${WAVES_COPY.shell.select}</button>
-        <button id="btn-down" class="btn">${WAVES_COPY.shell.down}</button>
+    <div class="handset-housing">
+      <div class="device-frame">
+        <div class="device-header">
+          <span>${WAVES_COPY.shell.deckView}</span>
+          <span id="active-url-label" class="muted-url">${WAVES_COPY.shell.idle}</span>
+        </div>
+        <div
+          id="viewport"
+          class="viewport viewport-skeleton"
+          aria-busy="true"
+          tabindex="0"
+        >
+          <div class="skeleton-line"></div>
+          <div class="skeleton-line skeleton-line-wide"></div>
+          <div class="skeleton-line"></div>
+          <div class="skeleton-line skeleton-line-short"></div>
+          <div class="skeleton-line"></div>
+          <div class="skeleton-line skeleton-line-wide"></div>
+          <div class="skeleton-line"></div>
+          <div class="skeleton-hint">${WAVES_COPY.shell.firstRenderPending}</div>
+        </div>
+        <div class="softkey-row" role="group" aria-label="Softkey navigation">
+          <button id="btn-up" class="btn">${WAVES_COPY.shell.up}</button>
+          <button id="btn-enter" class="btn">${WAVES_COPY.shell.select}</button>
+          <button id="btn-down" class="btn">${WAVES_COPY.shell.down}</button>
+        </div>
       </div>
     </div>
   </section>

--- a/browser/frontend/src/app/shell/utility-rail-template.ts
+++ b/browser/frontend/src/app/shell/utility-rail-template.ts
@@ -18,6 +18,14 @@ export const utilityRailTemplate = () => `
             min="1"
           />
         </label>
+        <label class="compact-field">
+          ${WAVES_COPY.shell.displayScale}
+          <select id="handset-scale-select" class="form-95">
+            <option value="1">1x</option>
+            <option value="2">2x</option>
+            <option value="3">3x</option>
+          </select>
+        </label>
         <wv-surface-panel heading="${WAVES_COPY.shell.status}">
           <wv-status-panel id="status"></wv-status-panel>
         </wv-surface-panel>

--- a/browser/frontend/src/app/waves-copy.ts
+++ b/browser/frontend/src/app/waves-copy.ts
@@ -16,6 +16,7 @@ const locale = {
     select: 'Select',
     down: 'Down',
     viewportCols: 'Viewport Cols',
+    displayScale: 'Display Scale',
     utilityRail: 'Utility Rail',
     status: 'Status',
     developerTools: 'Developer Tools',

--- a/browser/frontend/src/styles.css
+++ b/browser/frontend/src/styles.css
@@ -29,6 +29,21 @@
   /* Toast semantic tones */
   --toast-ok-bg: #d8f8d8;
   --toast-error-bg: #ffd6d6;
+
+  /* Handset housing + LCD semantic tones (reference-handset scaffold, WBP-02).
+     Housing is a restrained warm-silver/graphite chassis; the LCD uses a
+     low-saturation monochrome-green tint rather than a plain white page. */
+  --handset-housing-bg: #c7c2b4;
+  --handset-housing-highlight: #efece0;
+  --handset-housing-shadow: #6f6a5c;
+  --lcd-bg: #d7e4d2;
+  --lcd-fg: #1c2b1c;
+  --lcd-focus-bg: #1c2b1c;
+  --lcd-focus-fg: #d7e4d2;
+
+  /* Deterministic integer display-scale step; never changes engine-computed
+     rows/columns/wrapping, only the rendered pixel size of the handset frame. */
+  --handset-scale: 1;
 }
 
 * {
@@ -153,9 +168,30 @@ button,
   display: flex;
   flex-direction: column;
   min-width: 0;
+  /* Integer step only; falls back to no-op (1x) on WebKit builds predating
+     `zoom` support (Safari < 17), which is an acceptable static degradation. */
+  zoom: var(--handset-scale);
 }
 
-.handset-stage .device-frame {
+.handset-housing {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  min-width: 0;
+  padding: 10px;
+  border-radius: 6px;
+  background: linear-gradient(
+    145deg,
+    var(--handset-housing-highlight),
+    var(--handset-housing-bg) 55%,
+    var(--handset-housing-shadow)
+  );
+  box-shadow:
+    inset 0 1px 0 var(--handset-housing-highlight),
+    0 1px 2px rgba(0, 0, 0, 0.35);
+}
+
+.handset-housing .device-frame {
   flex: 1;
 }
 
@@ -275,8 +311,8 @@ textarea.form-95 {
   box-shadow: -1px -1px 0 #828282;
   min-height: 520px;
   padding: 8px;
-  background: #fff;
-  color: #111;
+  background: var(--lcd-bg);
+  color: var(--lcd-fg);
   font-family: 'Courier New', Courier, monospace;
   line-height: 1.4;
 }
@@ -321,8 +357,8 @@ textarea.form-95 {
 }
 
 .wml-segment-link.is-focused {
-  color: #fff;
-  background: #08216b;
+  color: var(--lcd-focus-fg);
+  background: var(--lcd-focus-bg);
   text-decoration: none;
 }
 
@@ -454,6 +490,17 @@ pre {
 
   to {
     background-position: -100% 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .skeleton-line {
+    animation: none;
+    background: #eee;
+  }
+
+  .wv-shell-window {
+    transition: none;
   }
 }
 


### PR DESCRIPTION
## Summary

- Implements `WBP-02` from `docs/waves/WAVES_BROWSER_PRODUCT_IMPLEMENTATION_PLAN.md`, building on `WBP-01`'s (#343) handset-stage seam.
- Adds semantic tokens for handset housing (warm-silver/graphite bezel) and LCD (low-saturation monochrome-green) instead of hardcoded colors, per `WAVES_DESKTOP_PRODUCT_DESIGN.md`'s Visual Language section.
- Wraps `.device-frame` in a new `.handset-housing` chassis inside `handset-stage-template.ts`, giving the stage a restrained handset-housing boundary around the existing viewport adapter (no engine/render changes).
- Adds a deterministic integer display-scale control (1x/2x/3x) in the utility rail, wired through a small standalone `handset-scale-control.ts` module (`--handset-scale` custom property + `zoom` on `.handset-stage`). Chosen over `transform: scale()` because `zoom` reflows layout correctly at each step without a manual size-compensation wrapper.
- Disables the skeleton shimmer animation and shell-fade transition under `prefers-reduced-motion: reduce`.
- Inverse-video link focus (`.wml-segment-link.is-focused`) now uses the same LCD focus tokens instead of hardcoded navy/white.

## Test plan

- [x] `pnpm --dir browser/frontend run typecheck`
- [x] `pnpm --dir browser/frontend run lint`
- [x] `pnpm --dir browser/frontend run format:check`
- [x] `pnpm --dir browser/frontend run test` (165 passed, incl. 4 new tests for the housing wrapper, scale control unit behavior, and scale-select wiring)
- [x] `pnpm --dir browser/frontend run build`
- [x] Manually verified in-browser via `vite dev`: housing bezel + green-tinted LCD render correctly; switching the display-scale select to 2x zooms the whole handset stage (housing, text, softkeys) uniformly with no clipping, while `#viewport-cols` (engine wrap config) stays unchanged, confirming scale is purely cosmetic.
- [x] pre-commit/pre-push hooks passed (lint-staged, frontend typecheck, rust fmt/clippy across engine/transport/browser-tauri, host-sample build sanity)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
