### PR TITLE
feat(browser): minimum Welcome/Help surface and first tutorial deck (WBP-04)

### DIFF
--- a/browser/frontend/src/app/browser-shell-template.test.ts
+++ b/browser/frontend/src/app/browser-shell-template.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { mountBrowserShell } from './browser-shell-template';
 import { WAVES_CONFIG } from './waves-config';
 
@@ -101,5 +101,28 @@ describe('mountBrowserShell', () => {
       runModeSelectEl.dispatchEvent(new Event('change'));
     }
     expect(routeLabelEl?.textContent).toBe('Network — localhost');
+  });
+
+  it('wires the Welcome/Help panel into the ordinary mode/local-example controls', () => {
+    document.body.innerHTML = '<div id="app"></div>';
+    mountBrowserShell('wap://localhost/start.wml', 'network');
+
+    const welcomePanel = document.querySelector('#welcome-help-panel');
+    expect(welcomePanel).not.toBeNull();
+
+    const runModeSelectEl = document.querySelector<HTMLSelectElement>('#run-mode');
+    const loadLocalBtnEl = document.querySelector<HTMLButtonElement>('#btn-load-local');
+    const loadClickSpy = vi.fn();
+    loadLocalBtnEl?.addEventListener('click', loadClickSpy);
+
+    document.querySelector<HTMLButtonElement>('#btn-start-tour')?.click();
+
+    expect(runModeSelectEl?.value).toBe('local');
+    expect(loadClickSpy).toHaveBeenCalledTimes(1);
+
+    // Mode is already "local" from the tour click above; confirm "Connect to
+    // a WAP Server" switches it to network.
+    document.querySelector<HTMLButtonElement>('#btn-connect-network')?.click();
+    expect(runModeSelectEl?.value).toBe('network');
   });
 });

--- a/browser/frontend/src/app/browser-shell-template.ts
+++ b/browser/frontend/src/app/browser-shell-template.ts
@@ -1,6 +1,7 @@
 import type { WvStatusPanel } from '../components/status-panel';
 import { bindHandsetScaleControl } from './handset-scale-control';
 import { bindRouteIndicator } from './route-indicator';
+import { bindWelcomeHelpControls } from './welcome-help-control';
 import { WAVES_CONFIG } from './waves-config';
 import { WAVES_COPY } from './waves-copy';
 import { developerDrawerTemplate } from './shell/developer-drawer-template';
@@ -154,6 +155,21 @@ export const mountBrowserShell = (
   const routeLabelEl = document.querySelector<HTMLSpanElement>('#route-label');
   if (routeLabelEl) {
     bindRouteIndicator(routeLabelEl, runModeSelectEl, fetchUrlInput);
+  }
+
+  const startTourBtn = document.querySelector<HTMLButtonElement>('#btn-start-tour');
+  const tryLocalBtn = document.querySelector<HTMLButtonElement>('#btn-try-local-examples');
+  const connectNetworkBtn = document.querySelector<HTMLButtonElement>('#btn-connect-network');
+  if (startTourBtn && tryLocalBtn && connectNetworkBtn) {
+    bindWelcomeHelpControls({
+      startTourBtn,
+      tryLocalBtn,
+      connectNetworkBtn,
+      runModeSelectEl,
+      localExampleSelectEl,
+      loadLocalBtnEl,
+      fetchUrlInputEl: fetchUrlInput
+    });
   }
 
   return {

--- a/browser/frontend/src/app/shell/developer-drawer-template.ts
+++ b/browser/frontend/src/app/shell/developer-drawer-template.ts
@@ -2,7 +2,7 @@ import { WAVES_COPY } from '../waves-copy';
 
 export const developerDrawerTemplate = () => `
   <section class="developer-drawer-section" aria-label="Developer tools">
-    <details id="dev-drawer" class="dev-drawer">
+    <details id="dev-drawer" class="dev-drawer chrome-disclosure">
       <summary>${WAVES_COPY.shell.developerTools}</summary>
       <div class="panel-body">
         <div class="actions">

--- a/browser/frontend/src/app/shell/utility-rail-template.ts
+++ b/browser/frontend/src/app/shell/utility-rail-template.ts
@@ -1,13 +1,15 @@
 import { WAVES_CONFIG } from '../waves-config';
 import { WAVES_COPY } from '../waves-copy';
+import { welcomeHelpTemplate } from './welcome-help-template';
 
 export const UTILITY_RAIL_NARROW_MEDIA_QUERY = '(max-width: 900px)';
 
 export const utilityRailTemplate = () => `
   <aside class="utility-rail" aria-label="Utility rail">
-    <details id="utility-rail-panel" class="utility-rail-panel" open>
+    <details id="utility-rail-panel" class="utility-rail-panel chrome-disclosure" open>
       <summary>${WAVES_COPY.shell.utilityRail}</summary>
       <div class="utility-rail-body">
+        ${welcomeHelpTemplate()}
         <label class="compact-field">
           ${WAVES_COPY.shell.viewportCols}
           <input
@@ -29,7 +31,11 @@ export const utilityRailTemplate = () => `
         <wv-surface-panel heading="${WAVES_COPY.shell.status}">
           <wv-status-panel id="status"></wv-status-panel>
         </wv-surface-panel>
-        <details id="local-example-notes" class="local-example-notes" aria-live="polite">
+        <details
+          id="local-example-notes"
+          class="local-example-notes chrome-disclosure"
+          aria-live="polite"
+        >
           <summary>${WAVES_COPY.shell.localExampleNotes}</summary>
           <div class="local-example-notes-body">
             <p id="local-example-coverage" class="local-example-notes-coverage"></p>

--- a/browser/frontend/src/app/shell/welcome-help-template.ts
+++ b/browser/frontend/src/app/shell/welcome-help-template.ts
@@ -1,0 +1,24 @@
+import { WAVES_COPY } from '../waves-copy';
+
+export const welcomeHelpTemplate = () => `
+  <details id="welcome-help-panel" class="welcome-help-panel chrome-disclosure" open>
+    <summary>${WAVES_COPY.shell.welcomeHelpTitle}</summary>
+    <div class="welcome-help-body">
+      <p>${WAVES_COPY.shell.welcomeIntro}</p>
+      <p>${WAVES_COPY.shell.welcomeModes}</p>
+      <div class="actions">
+        <button id="btn-start-tour" class="btn wv95-btn">${WAVES_COPY.shell.takeTheTour}</button>
+        <button id="btn-try-local-examples" class="btn wv95-btn">
+          ${WAVES_COPY.shell.tryLocalExamples}
+        </button>
+        <button id="btn-connect-network" class="btn wv95-btn">
+          ${WAVES_COPY.shell.connectToServer}
+        </button>
+      </div>
+      <h3>${WAVES_COPY.shell.controlsReferenceTitle}</h3>
+      <p>${WAVES_COPY.shell.controlsReferenceBody}</p>
+      <h3>${WAVES_COPY.shell.troubleshootingTitle}</h3>
+      <p>${WAVES_COPY.shell.troubleshootingBody}</p>
+    </div>
+  </details>
+`;

--- a/browser/frontend/src/app/waves-copy.ts
+++ b/browser/frontend/src/app/waves-copy.ts
@@ -49,7 +49,21 @@ const locale = {
     localExampleCoverage: 'Coverage:',
     localExampleDescription: 'Description:',
     localExampleGoal: 'Goal:',
-    localExampleTestingAc: 'Testing AC'
+    localExampleTestingAc: 'Testing AC',
+    welcomeHelpTitle: 'Welcome / Help',
+    welcomeIntro:
+      'Waves emulates a WAP 1.2.1 / WML 1.3 handset — decks and cards, not modern web pages.',
+    welcomeModes:
+      'Local mode browses bundled example decks with no network required. Network mode fetches real WML through a WAP gateway.',
+    takeTheTour: 'Take the Tour',
+    tryLocalExamples: 'Try Local Examples',
+    connectToServer: 'Connect to a WAP Server',
+    controlsReferenceTitle: 'Controls',
+    controlsReferenceBody:
+      'Up and Down move focus between links. Select activates the focused link. Back returns through card history.',
+    troubleshootingTitle: 'Troubleshooting',
+    troubleshootingBody:
+      'No network available? Switch Mode to Local to keep browsing bundled examples without a WAP gateway.'
   },
   sampleDeck: {
     intro: WAVES_CONFIG.appTagline,

--- a/browser/frontend/src/app/welcome-help-control.test.ts
+++ b/browser/frontend/src/app/welcome-help-control.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it, vi } from 'vitest';
+import { TUTORIAL_EXAMPLE_KEY, bindWelcomeHelpControls } from './welcome-help-control';
+
+const setup = () => {
+  const startTourBtn = document.createElement('button');
+  const tryLocalBtn = document.createElement('button');
+  const connectNetworkBtn = document.createElement('button');
+
+  const runModeSelectEl = document.createElement('select');
+  for (const value of ['local', 'network']) {
+    const option = document.createElement('option');
+    option.value = value;
+    runModeSelectEl.appendChild(option);
+  }
+  runModeSelectEl.value = 'network';
+
+  const localExampleSelectEl = document.createElement('select');
+  for (const value of ['someOtherExample', TUTORIAL_EXAMPLE_KEY]) {
+    const option = document.createElement('option');
+    option.value = value;
+    localExampleSelectEl.appendChild(option);
+  }
+  localExampleSelectEl.value = 'someOtherExample';
+
+  const loadLocalBtnEl = document.createElement('button');
+  const fetchUrlInputEl = document.createElement('input');
+
+  document.body.append(
+    startTourBtn,
+    tryLocalBtn,
+    connectNetworkBtn,
+    runModeSelectEl,
+    localExampleSelectEl,
+    loadLocalBtnEl,
+    fetchUrlInputEl
+  );
+
+  return {
+    startTourBtn,
+    tryLocalBtn,
+    connectNetworkBtn,
+    runModeSelectEl,
+    localExampleSelectEl,
+    loadLocalBtnEl,
+    fetchUrlInputEl
+  };
+};
+
+describe('bindWelcomeHelpControls', () => {
+  it('Take the Tour switches to local mode, selects the tutorial deck, and clicks load', () => {
+    const refs = setup();
+    const modeChangeSpy = vi.fn();
+    refs.runModeSelectEl.addEventListener('change', modeChangeSpy);
+    const loadClickSpy = vi.fn();
+    refs.loadLocalBtnEl.addEventListener('click', loadClickSpy);
+
+    bindWelcomeHelpControls(refs);
+    refs.startTourBtn.click();
+
+    expect(refs.runModeSelectEl.value).toBe('local');
+    expect(modeChangeSpy).toHaveBeenCalledTimes(1);
+    expect(refs.localExampleSelectEl.value).toBe(TUTORIAL_EXAMPLE_KEY);
+    expect(loadClickSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('Try Local Examples switches to local mode and focuses the example picker without loading anything', () => {
+    const refs = setup();
+    const loadClickSpy = vi.fn();
+    refs.loadLocalBtnEl.addEventListener('click', loadClickSpy);
+
+    bindWelcomeHelpControls(refs);
+    refs.tryLocalBtn.click();
+
+    expect(refs.runModeSelectEl.value).toBe('local');
+    expect(document.activeElement).toBe(refs.localExampleSelectEl);
+    expect(loadClickSpy).not.toHaveBeenCalled();
+  });
+
+  it('Connect to a WAP Server switches to network mode and focuses the address field', () => {
+    const refs = setup();
+    refs.runModeSelectEl.value = 'local';
+
+    bindWelcomeHelpControls(refs);
+    refs.connectNetworkBtn.click();
+
+    expect(refs.runModeSelectEl.value).toBe('network');
+    expect(document.activeElement).toBe(refs.fetchUrlInputEl);
+  });
+
+  it('does not dispatch a redundant change event when already in the target mode', () => {
+    const refs = setup();
+    refs.runModeSelectEl.value = 'local';
+    const modeChangeSpy = vi.fn();
+    refs.runModeSelectEl.addEventListener('change', modeChangeSpy);
+
+    bindWelcomeHelpControls(refs);
+    refs.tryLocalBtn.click();
+
+    expect(modeChangeSpy).not.toHaveBeenCalled();
+  });
+
+  it('stops reacting once unbound', () => {
+    const refs = setup();
+    refs.runModeSelectEl.value = 'local';
+    const unbind = bindWelcomeHelpControls(refs);
+    unbind();
+
+    refs.connectNetworkBtn.click();
+
+    // Handler no longer runs: mode is unchanged and the address field never focuses.
+    expect(refs.runModeSelectEl.value).toBe('local');
+    expect(document.activeElement).not.toBe(refs.fetchUrlInputEl);
+  });
+});

--- a/browser/frontend/src/app/welcome-help-control.ts
+++ b/browser/frontend/src/app/welcome-help-control.ts
@@ -1,0 +1,54 @@
+// Key of the bundled onboarding tutorial deck, `your-first-deck.wml`
+// (see engine-wasm/examples/source/your-first-deck.wml), loaded through the
+// ordinary local-example path rather than a bespoke tutorial loader.
+export const TUTORIAL_EXAMPLE_KEY = 'yourFirstDeck';
+
+export interface WelcomeHelpControlRefs {
+  startTourBtn: HTMLButtonElement;
+  tryLocalBtn: HTMLButtonElement;
+  connectNetworkBtn: HTMLButtonElement;
+  runModeSelectEl: HTMLSelectElement;
+  localExampleSelectEl: HTMLSelectElement;
+  loadLocalBtnEl: HTMLButtonElement;
+  fetchUrlInputEl: HTMLInputElement;
+}
+
+const setRunMode = (runModeSelectEl: HTMLSelectElement, mode: 'local' | 'network'): void => {
+  if (runModeSelectEl.value === mode) {
+    return;
+  }
+  runModeSelectEl.value = mode;
+  runModeSelectEl.dispatchEvent(new Event('change'));
+};
+
+// Wires the Welcome/Help panel's three entry points to the existing
+// mode-select, local-example-select, and load-local controls -- the same
+// ones a user would click directly -- so onboarding never bypasses the
+// ordinary engine load path (see WBP-04 accept criteria in
+// WAVES_BROWSER_PRODUCT_IMPLEMENTATION_PLAN.md).
+export const bindWelcomeHelpControls = (refs: WelcomeHelpControlRefs): (() => void) => {
+  const handleStartTour = (): void => {
+    setRunMode(refs.runModeSelectEl, 'local');
+    refs.localExampleSelectEl.value = TUTORIAL_EXAMPLE_KEY;
+    refs.localExampleSelectEl.dispatchEvent(new Event('change'));
+    refs.loadLocalBtnEl.click();
+  };
+  const handleTryLocal = (): void => {
+    setRunMode(refs.runModeSelectEl, 'local');
+    refs.localExampleSelectEl.focus();
+  };
+  const handleConnectNetwork = (): void => {
+    setRunMode(refs.runModeSelectEl, 'network');
+    refs.fetchUrlInputEl.focus();
+  };
+
+  refs.startTourBtn.addEventListener('click', handleStartTour);
+  refs.tryLocalBtn.addEventListener('click', handleTryLocal);
+  refs.connectNetworkBtn.addEventListener('click', handleConnectNetwork);
+
+  return () => {
+    refs.startTourBtn.removeEventListener('click', handleStartTour);
+    refs.tryLocalBtn.removeEventListener('click', handleTryLocal);
+    refs.connectNetworkBtn.removeEventListener('click', handleConnectNetwork);
+  };
+};

--- a/browser/frontend/src/styles.css
+++ b/browser/frontend/src/styles.css
@@ -242,7 +242,10 @@ button,
   gap: 8px;
 }
 
-.utility-rail-panel {
+/* Shared silver-bezel disclosure-widget chrome reused by the utility rail,
+   welcome/help, local-example-notes, and developer-drawer panels instead of
+   repeating the same border/summary declarations per widget. */
+.chrome-disclosure {
   border: 2px solid;
   border-bottom-color: #424242;
   border-right-color: #424242;
@@ -252,7 +255,7 @@ button,
   color: #212529;
 }
 
-.utility-rail-panel > summary {
+.chrome-disclosure > summary {
   cursor: pointer;
   padding: 4px 6px;
   color: #fff;
@@ -388,24 +391,6 @@ textarea.form-95 {
   font-weight: 700;
 }
 
-.local-example-notes {
-  border: 2px solid;
-  border-bottom-color: #424242;
-  border-right-color: #424242;
-  border-left-color: #fff;
-  border-top-color: #fff;
-  background: silver;
-  color: #212529;
-}
-
-.local-example-notes > summary {
-  cursor: pointer;
-  padding: 4px 6px;
-  color: #fff;
-  font-weight: 700;
-  background: linear-gradient(90deg, #08216b, #a5cef7);
-}
-
 .local-example-notes-body {
   border-top: 1px solid #7f7f7f;
   padding: 8px;
@@ -434,25 +419,23 @@ textarea.form-95 {
   margin-bottom: 4px;
 }
 
+.welcome-help-body {
+  border-top: 1px solid #7f7f7f;
+  padding: 8px;
+  font-size: 12px;
+}
+
+.welcome-help-body p {
+  margin: 0 0 6px;
+}
+
+.welcome-help-body h3 {
+  margin: 8px 0 4px;
+  font-size: 12px;
+}
+
 .developer-drawer-section {
   padding: 0 12px 12px;
-}
-
-.dev-drawer {
-  border: 2px solid;
-  border-bottom-color: #424242;
-  border-right-color: #424242;
-  border-left-color: #fff;
-  border-top-color: #fff;
-  background: silver;
-}
-
-.dev-drawer > summary {
-  cursor: pointer;
-  padding: 4px 6px;
-  color: #fff;
-  font-weight: 700;
-  background: linear-gradient(90deg, #08216b, #a5cef7);
 }
 
 .panel-body {

--- a/engine-wasm/examples/generated/examples.ts
+++ b/engine-wasm/examples/generated/examples.ts
@@ -3101,5 +3101,291 @@ export const EXAMPLES: HostExample[] = [
       "Press Enter on \"Back\" and confirm return to home."
     ],
     "wml": "<wml>\n  <card id=\"home\">\n    <p>supercalifragilisticpseudopneumonoultramicroscopicsilicovolcanoconiosis</p>\n    <a href=\"#next\">Continue</a>\n  </card>\n  <card id=\"next\">\n    <p>Wrap test complete.</p>\n    <a href=\"#home\">Back</a>\n  </card>\n</wml>\n"
+  },
+  {
+    "key": "yourFirstDeck",
+    "label": "Your First Deck",
+    "description": "Guided first-run tutorial deck teaching the Up/Down/Select/Back softkey controls.",
+    "goal": "Verify a newcomer can move focus, select a link, and use Back to return through engine card history using only the four softkey controls.",
+    "workItems": [
+      "WBP-04"
+    ],
+    "specItems": [
+      "WBP-04"
+    ],
+    "testingAc": [
+      "Press Select on \"Select this link to continue\"; activeCardId should become next.",
+      "Press Down then Up; focus should move to the second link then back to the first.",
+      "Press Down then Select; activeCardId should become detail-two.",
+      "Press Back; activeCardId should return to next.",
+      "Press Select on \"First option\"; activeCardId should become detail-one."
+    ],
+    "flows": [
+      {
+        "id": "keypad-softkey-tour",
+        "title": "Up/Down/Select/Back softkeys move focus, navigate, and pop history",
+        "target": "host-sample",
+        "workItems": [
+          "WBP-04"
+        ],
+        "specItems": [
+          "WBP-04"
+        ],
+        "initial": {
+          "state": {
+            "activeCardId": "start",
+            "focusedLinkIndex": 0
+          }
+        },
+        "steps": [
+          {
+            "action": {
+              "type": "key",
+              "key": "enter"
+            },
+            "expect": {
+              "state": {
+                "activeCardId": "next",
+                "focusedLinkIndex": 0
+              },
+              "traceKinds": [
+                "KEY",
+                "ACTION_FRAGMENT"
+              ]
+            }
+          },
+          {
+            "action": {
+              "type": "key",
+              "key": "down"
+            },
+            "expect": {
+              "state": {
+                "activeCardId": "next",
+                "focusedLinkIndex": 1
+              }
+            }
+          },
+          {
+            "action": {
+              "type": "key",
+              "key": "up"
+            },
+            "expect": {
+              "state": {
+                "activeCardId": "next",
+                "focusedLinkIndex": 0
+              }
+            }
+          },
+          {
+            "action": {
+              "type": "key",
+              "key": "down"
+            },
+            "expect": {
+              "state": {
+                "activeCardId": "next",
+                "focusedLinkIndex": 1
+              }
+            }
+          },
+          {
+            "action": {
+              "type": "key",
+              "key": "enter"
+            },
+            "expect": {
+              "state": {
+                "activeCardId": "detail-two",
+                "focusedLinkIndex": 0
+              },
+              "traceKinds": [
+                "KEY",
+                "ACTION_FRAGMENT"
+              ]
+            }
+          },
+          {
+            "action": {
+              "type": "back"
+            },
+            "expect": {
+              "state": {
+                "activeCardId": "next",
+                "focusedLinkIndex": 0
+              },
+              "traceKinds": [
+                "ACTION_BACK"
+              ]
+            }
+          },
+          {
+            "action": {
+              "type": "key",
+              "key": "enter"
+            },
+            "expect": {
+              "state": {
+                "activeCardId": "detail-one",
+                "focusedLinkIndex": 0
+              },
+              "traceKinds": [
+                "KEY",
+                "ACTION_FRAGMENT"
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "id": "waves-keypad-softkey-tour",
+        "title": "Waves UI drives the softkey tour through the ordinary engine path",
+        "target": "waves-browser",
+        "setup": {
+          "runMode": "local"
+        },
+        "workItems": [
+          "WBP-04"
+        ],
+        "specItems": [
+          "WBP-04"
+        ],
+        "initial": {
+          "state": {
+            "activeCardId": "start",
+            "focusedLinkIndex": 0
+          },
+          "session": {
+            "runMode": "local",
+            "navigationStatus": "loaded"
+          },
+          "render": {
+            "textIncludes": [
+              "Welcome to Waves.",
+              "Select this link to continue"
+            ]
+          }
+        },
+        "steps": [
+          {
+            "action": {
+              "type": "key",
+              "key": "enter"
+            },
+            "expect": {
+              "state": {
+                "activeCardId": "next",
+                "focusedLinkIndex": 0
+              },
+              "traceKinds": [
+                "KEY",
+                "ACTION_FRAGMENT"
+              ],
+              "render": {
+                "textIncludes": [
+                  "Nice work. You selected a link.",
+                  "First option",
+                  "Second option"
+                ]
+              }
+            }
+          },
+          {
+            "action": {
+              "type": "key",
+              "key": "down"
+            },
+            "expect": {
+              "state": {
+                "activeCardId": "next",
+                "focusedLinkIndex": 1
+              }
+            }
+          },
+          {
+            "action": {
+              "type": "key",
+              "key": "up"
+            },
+            "expect": {
+              "state": {
+                "activeCardId": "next",
+                "focusedLinkIndex": 0
+              }
+            }
+          },
+          {
+            "action": {
+              "type": "key",
+              "key": "down"
+            },
+            "expect": {
+              "state": {
+                "activeCardId": "next",
+                "focusedLinkIndex": 1
+              }
+            }
+          },
+          {
+            "action": {
+              "type": "key",
+              "key": "enter"
+            },
+            "expect": {
+              "state": {
+                "activeCardId": "detail-two",
+                "focusedLinkIndex": 0
+              },
+              "traceKinds": [
+                "KEY",
+                "ACTION_FRAGMENT"
+              ],
+              "render": {
+                "textIncludes": [
+                  "Now try Back to return through history."
+                ]
+              }
+            }
+          },
+          {
+            "action": {
+              "type": "back"
+            },
+            "expect": {
+              "state": {
+                "activeCardId": "next",
+                "focusedLinkIndex": 0
+              },
+              "traceKinds": [
+                "ACTION_BACK"
+              ]
+            }
+          },
+          {
+            "action": {
+              "type": "key",
+              "key": "enter"
+            },
+            "expect": {
+              "state": {
+                "activeCardId": "detail-one",
+                "focusedLinkIndex": 0
+              },
+              "traceKinds": [
+                "KEY",
+                "ACTION_FRAGMENT"
+              ],
+              "render": {
+                "textIncludes": [
+                  "You selected the first option."
+                ]
+              }
+            }
+          }
+        ]
+      }
+    ],
+    "wml": "<wml>\n  <card id=\"start\">\n    <p>Welcome to Waves.</p>\n    <p>Up and Down move focus between links. Select activates the focused link.</p>\n    <a href=\"#next\">Select this link to continue</a>\n  </card>\n  <card id=\"next\">\n    <p>Nice work. You selected a link.</p>\n    <p>Try Down, then Select, to open the second option.</p>\n    <a href=\"#detail-one\">First option</a>\n    <a href=\"#detail-two\">Second option</a>\n  </card>\n  <card id=\"detail-one\">\n    <p>You selected the first option.</p>\n    <a href=\"#next\">Back to options</a>\n  </card>\n  <card id=\"detail-two\">\n    <p>You moved focus with Down, then selected the second option.</p>\n    <p>Now try Back to return through history.</p>\n    <a href=\"#next\">Back to options</a>\n  </card>\n</wml>\n"
   }
 ];

--- a/engine-wasm/examples/source/your-first-deck.flow.json
+++ b/engine-wasm/examples/source/your-first-deck.flow.json
@@ -1,0 +1,186 @@
+{
+  "version": 1,
+  "example": "yourFirstDeck",
+  "flows": [
+    {
+      "id": "keypad-softkey-tour",
+      "title": "Up/Down/Select/Back softkeys move focus, navigate, and pop history",
+      "workItems": ["WBP-04"],
+      "specItems": ["WBP-04"],
+      "initial": {
+        "state": {
+          "activeCardId": "start",
+          "focusedLinkIndex": 0
+        }
+      },
+      "steps": [
+        {
+          "action": { "type": "key", "key": "enter" },
+          "expect": {
+            "state": {
+              "activeCardId": "next",
+              "focusedLinkIndex": 0
+            },
+            "traceKinds": ["KEY", "ACTION_FRAGMENT"]
+          }
+        },
+        {
+          "action": { "type": "key", "key": "down" },
+          "expect": {
+            "state": {
+              "activeCardId": "next",
+              "focusedLinkIndex": 1
+            }
+          }
+        },
+        {
+          "action": { "type": "key", "key": "up" },
+          "expect": {
+            "state": {
+              "activeCardId": "next",
+              "focusedLinkIndex": 0
+            }
+          }
+        },
+        {
+          "action": { "type": "key", "key": "down" },
+          "expect": {
+            "state": {
+              "activeCardId": "next",
+              "focusedLinkIndex": 1
+            }
+          }
+        },
+        {
+          "action": { "type": "key", "key": "enter" },
+          "expect": {
+            "state": {
+              "activeCardId": "detail-two",
+              "focusedLinkIndex": 0
+            },
+            "traceKinds": ["KEY", "ACTION_FRAGMENT"]
+          }
+        },
+        {
+          "action": { "type": "back" },
+          "expect": {
+            "state": {
+              "activeCardId": "next",
+              "focusedLinkIndex": 0
+            },
+            "traceKinds": ["ACTION_BACK"]
+          }
+        },
+        {
+          "action": { "type": "key", "key": "enter" },
+          "expect": {
+            "state": {
+              "activeCardId": "detail-one",
+              "focusedLinkIndex": 0
+            },
+            "traceKinds": ["KEY", "ACTION_FRAGMENT"]
+          }
+        }
+      ]
+    },
+    {
+      "id": "waves-keypad-softkey-tour",
+      "title": "Waves UI drives the softkey tour through the ordinary engine path",
+      "target": "waves-browser",
+      "setup": { "runMode": "local" },
+      "workItems": ["WBP-04"],
+      "specItems": ["WBP-04"],
+      "initial": {
+        "state": {
+          "activeCardId": "start",
+          "focusedLinkIndex": 0
+        },
+        "session": {
+          "runMode": "local",
+          "navigationStatus": "loaded"
+        },
+        "render": {
+          "textIncludes": ["Welcome to Waves.", "Select this link to continue"]
+        }
+      },
+      "steps": [
+        {
+          "action": { "type": "key", "key": "enter" },
+          "expect": {
+            "state": {
+              "activeCardId": "next",
+              "focusedLinkIndex": 0
+            },
+            "render": {
+              "textIncludes": ["Nice work. You selected a link.", "First option", "Second option"]
+            },
+            "traceKinds": ["KEY", "ACTION_FRAGMENT"]
+          }
+        },
+        {
+          "action": { "type": "key", "key": "down" },
+          "expect": {
+            "state": {
+              "activeCardId": "next",
+              "focusedLinkIndex": 1
+            }
+          }
+        },
+        {
+          "action": { "type": "key", "key": "up" },
+          "expect": {
+            "state": {
+              "activeCardId": "next",
+              "focusedLinkIndex": 0
+            }
+          }
+        },
+        {
+          "action": { "type": "key", "key": "down" },
+          "expect": {
+            "state": {
+              "activeCardId": "next",
+              "focusedLinkIndex": 1
+            }
+          }
+        },
+        {
+          "action": { "type": "key", "key": "enter" },
+          "expect": {
+            "state": {
+              "activeCardId": "detail-two",
+              "focusedLinkIndex": 0
+            },
+            "render": {
+              "textIncludes": ["Now try Back to return through history."]
+            },
+            "traceKinds": ["KEY", "ACTION_FRAGMENT"]
+          }
+        },
+        {
+          "action": { "type": "back" },
+          "expect": {
+            "state": {
+              "activeCardId": "next",
+              "focusedLinkIndex": 0
+            },
+            "traceKinds": ["ACTION_BACK"]
+          }
+        },
+        {
+          "action": { "type": "key", "key": "enter" },
+          "expect": {
+            "state": {
+              "activeCardId": "detail-one",
+              "focusedLinkIndex": 0
+            },
+            "render": {
+              "textIncludes": ["You selected the first option."]
+            },
+            "traceKinds": ["KEY", "ACTION_FRAGMENT"]
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/engine-wasm/examples/source/your-first-deck.wml
+++ b/engine-wasm/examples/source/your-first-deck.wml
@@ -1,0 +1,35 @@
+<!--
+label: Your First Deck
+description: Guided first-run tutorial deck teaching the Up/Down/Select/Back softkey controls.
+goal: Verify a newcomer can move focus, select a link, and use Back to return through engine card history using only the four softkey controls.
+work-items: WBP-04
+spec-items: WBP-04
+testing-ac:
+- Press Select on "Select this link to continue"; activeCardId should become next.
+- Press Down then Up; focus should move to the second link then back to the first.
+- Press Down then Select; activeCardId should become detail-two.
+- Press Back; activeCardId should return to next.
+- Press Select on "First option"; activeCardId should become detail-one.
+-->
+<wml>
+  <card id="start">
+    <p>Welcome to Waves.</p>
+    <p>Up and Down move focus between links. Select activates the focused link.</p>
+    <a href="#next">Select this link to continue</a>
+  </card>
+  <card id="next">
+    <p>Nice work. You selected a link.</p>
+    <p>Try Down, then Select, to open the second option.</p>
+    <a href="#detail-one">First option</a>
+    <a href="#detail-two">Second option</a>
+  </card>
+  <card id="detail-one">
+    <p>You selected the first option.</p>
+    <a href="#next">Back to options</a>
+  </card>
+  <card id="detail-two">
+    <p>You moved focus with Down, then selected the second option.</p>
+    <p>Now try Back to return through history.</p>
+    <a href="#next">Back to options</a>
+  </card>
+</wml>


### PR DESCRIPTION
## Summary

- Implements `WBP-04` from `docs/waves/WAVES_BROWSER_PRODUCT_IMPLEMENTATION_PLAN.md`, the minimum Welcome/Help + first tutorial slice, aligned with `docs/waves/USER_ONBOARDING_EXPERIENCE_PLAN.md`'s Phase U0-01/U0-04 (Welcome Home + one tutorial deck), scoped down to what doesn't require the persistence layer (`WBP-12`, not yet built).
- Adds a **Welcome/Help panel** (`browser/frontend/src/app/shell/welcome-help-template.ts`) as the first item in the utility rail: short "what is Waves" + Local-vs-Network copy, a Controls reference (Up/Down/Select/Back), a Troubleshooting note, and three entry points:
  - **Take the Tour** — switches to Local mode, selects the new tutorial deck, and clicks Load Local.
  - **Try Local Examples** — switches to Local mode and focuses the example picker.
  - **Connect to a WAP Server** — switches to Network mode and focuses the address field.
  - All three (`welcome-help-control.ts`) drive the *existing* mode-select / local-example-select / load-local button rather than adding a parallel loader, so onboarding never bypasses the ordinary engine path.
- Open by default, collapsible via the native `<details>` disclosure (same pattern as the dev drawer / local-example-notes) — skippable, no forced first-run gate, always reachable afterward. No new persistence: "skippable and accessible" is satisfied without needing `WBP-12`.
- Ships the first tutorial deck, `engine-wasm/examples/source/your-first-deck.wml` ("Your First Deck"): a 4-card deck teaching Up/Down (focus movement), Select (fragment nav), and Back (engine card history) purely through normal WML fragment links — no bespoke tutorial engine. Covered by an executable story (`pnpm test:story WBP-04`, 2 flows: host-sample + waves-browser) exercising the full softkey sequence including a real history-stack `Back`.
- Consolidates three near-identical disclosure-widget CSS blocks (`.utility-rail-panel`, `.local-example-notes`, `.dev-drawer`) into one shared `.chrome-disclosure` class now that a fourth panel needs the same chrome (repo duplication policy, tier 1 — same file already being touched).

## Test plan

- [x] `pnpm --dir browser/frontend run typecheck`
- [x] `pnpm --dir browser/frontend run lint`
- [x] `pnpm --dir browser/frontend run format:check`
- [x] `pnpm --dir browser/frontend run test` (178 passed, incl. new welcome-help-control unit tests and shell-template wiring tests)
- [x] `pnpm --dir browser/frontend run build`
- [x] `pnpm --dir engine-wasm/host-sample run examples:check` (manifest in sync, 34 examples)
- [x] `pnpm test:story WBP-04` (2 passed) and `pnpm test:story all` (27 passed, no regressions from the new manifest entry)
- [x] Manually verified in-browser via `vite dev`: Welcome/Help panel renders with correct copy/buttons; clicking "Take the Tour" switches Mode to Local and selects "Your First Deck" through the ordinary select/button (deck render itself needs the Tauri IPC bridge, unavailable in this plain-vite preview — same known limitation confirmed in earlier WBP slices, not a regression here).
- [x] pre-commit/pre-push hooks passed (lint-staged, frontend typecheck, rust fmt/clippy across engine/transport/browser-tauri, host-sample build sanity)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
