### PR TITLE
feat(browser): host accessibility baseline (WBP-05)

### DIFF
--- a/browser/frontend/package.json
+++ b/browser/frontend/package.json
@@ -33,6 +33,7 @@
     "@typescript-eslint/eslint-plugin": "catalog:",
     "@typescript-eslint/parser": "catalog:",
     "@vitest/coverage-v8": "^4.1.10",
+    "axe-core": "^4.12.1",
     "eslint": "catalog:",
     "eslint-config-prettier": "catalog:",
     "globals": "catalog:",

--- a/browser/frontend/src/app/accessibility-audit.test.ts
+++ b/browser/frontend/src/app/accessibility-audit.test.ts
@@ -1,0 +1,33 @@
+import axe from 'axe-core';
+import { describe, expect, it } from 'vitest';
+import { registerBrowserComponents } from '../components';
+import { mountBrowserShell } from './browser-shell-template';
+
+// jsdom has no real layout engine (getBoundingClientRect returns zeros) and
+// no <canvas> 2D context, so the two rules that depend on actual rendered
+// geometry/pixels -- color-contrast and target-size -- cannot run
+// meaningfully here. Those were checked manually against the live rendered
+// shell instead (see the WBP-05 PR description); every other axe rule stays
+// enabled because it only depends on DOM/ARIA structure, which jsdom models
+// correctly.
+const JSDOM_UNSUPPORTED_RULES = ['color-contrast', 'target-size'];
+
+describe('host-chrome accessibility baseline', () => {
+  it('has no automatically-detectable violations in the mounted shell', async () => {
+    document.body.innerHTML = '<div id="app"></div>';
+    registerBrowserComponents();
+    mountBrowserShell('wap://localhost/start.wml', 'local');
+
+    const results = await axe.run(document.body, {
+      rules: Object.fromEntries(JSDOM_UNSUPPORTED_RULES.map((id) => [id, { enabled: false }]))
+    });
+
+    const summary = results.violations.map((violation) => ({
+      id: violation.id,
+      impact: violation.impact,
+      nodes: violation.nodes.map((node) => node.target.join(' '))
+    }));
+
+    expect(summary).toEqual([]);
+  });
+});

--- a/browser/frontend/src/app/keyboard-reachability.test.ts
+++ b/browser/frontend/src/app/keyboard-reachability.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from 'vitest';
+import { registerBrowserComponents } from '../components';
+import { mountBrowserShell } from './browser-shell-template';
+
+// WBP-05 accept criterion: "all browser-owned actions are keyboard reachable
+// with visible focus." The visible-focus half is covered by the
+// :focus-visible CSS override in styles.css and verified against the live
+// rendered shell (see the WBP-05 PR description); this test covers the
+// "reachable" half -- every action a mouse user can click must also be a
+// real, non-disabled, tabbable element that a keyboard user can .focus().
+const expectFocusable = (selector: string): void => {
+  const el = document.querySelector<HTMLElement>(selector);
+  expect(el, `expected ${selector} to exist`).not.toBeNull();
+  if (!el) {
+    return;
+  }
+  expect(el.hasAttribute('disabled'), `${selector} must not be disabled`).toBe(false);
+  expect(el.tabIndex, `${selector} must have a non-negative tabIndex`).toBeGreaterThanOrEqual(0);
+  el.focus();
+  expect(document.activeElement, `${selector} did not actually receive focus`).toBe(el);
+};
+
+describe('keyboard reachability of host-chrome actions', () => {
+  it('reaches every navigation-toolbar control', () => {
+    document.body.innerHTML = '<div id="app"></div>';
+    registerBrowserComponents();
+    mountBrowserShell('wap://localhost/start.wml', 'local');
+
+    for (const selector of [
+      '#btn-back',
+      '#btn-reload',
+      '#fetch-url',
+      '#btn-fetch-url',
+      '#run-mode',
+      '#local-example',
+      '#btn-load-local'
+    ]) {
+      expectFocusable(selector);
+    }
+  });
+
+  it('reaches the softkey row', () => {
+    document.body.innerHTML = '<div id="app"></div>';
+    registerBrowserComponents();
+    mountBrowserShell('wap://localhost/start.wml', 'local');
+
+    for (const selector of ['#btn-up', '#btn-enter', '#btn-down']) {
+      expectFocusable(selector);
+    }
+  });
+
+  it('reaches the open utility rail, Welcome/Help panel, and its actions', () => {
+    document.body.innerHTML = '<div id="app"></div>';
+    registerBrowserComponents();
+    mountBrowserShell('wap://localhost/start.wml', 'local');
+
+    expect(document.querySelector<HTMLDetailsElement>('#utility-rail-panel')?.open).toBe(true);
+    expect(document.querySelector<HTMLDetailsElement>('#welcome-help-panel')?.open).toBe(true);
+
+    for (const selector of [
+      '#viewport-cols',
+      '#handset-scale-select',
+      '#btn-start-tour',
+      '#btn-try-local-examples',
+      '#btn-connect-network'
+    ]) {
+      expectFocusable(selector);
+    }
+  });
+
+  it('reaches the developer drawer actions once opened, as a keyboard user would open it', () => {
+    document.body.innerHTML = '<div id="app"></div>';
+    registerBrowserComponents();
+    mountBrowserShell('wap://localhost/start.wml', 'local');
+
+    const drawer = document.querySelector<HTMLDetailsElement>('#dev-drawer');
+    expect(drawer).not.toBeNull();
+    // Collapsed by default, matching native <details> semantics -- its
+    // content is intentionally out of the tab order until opened.
+    expect(drawer?.open).toBe(false);
+    if (drawer) {
+      drawer.open = true;
+    }
+
+    for (const selector of [
+      '#btn-health',
+      '#btn-render',
+      '#btn-snapshot',
+      '#btn-clear-intent',
+      '#btn-export-timeline',
+      '#btn-clear-timeline',
+      '#btn-load-context'
+    ]) {
+      expectFocusable(selector);
+    }
+  });
+});

--- a/browser/frontend/src/app/shell/handset-stage-template.ts
+++ b/browser/frontend/src/app/shell/handset-stage-template.ts
@@ -1,5 +1,11 @@
 import { WAVES_COPY } from '../waves-copy';
 
+// #viewport is tabindex="0" so keyboard/softkey input reaches the engine,
+// and gets a minimal aria-label so it isn't a silently unnamed stop in the
+// tab order. It is still a plain rendered box, not an accessible tree of the
+// deck's cards/focus/actions -- that semantic frame adapter is WBP-09's
+// scope (see WAVES_DESKTOP_PRODUCT_DESIGN.md "Accessibility Model"), not
+// this host-chrome baseline slice (WBP-05).
 export const handsetStageTemplate = () => `
   <section class="handset-stage" aria-label="Handset display">
     <div class="handset-housing">
@@ -12,6 +18,7 @@ export const handsetStageTemplate = () => `
           id="viewport"
           class="viewport viewport-skeleton"
           aria-busy="true"
+          aria-label="${WAVES_COPY.shell.deckViewport}"
           tabindex="0"
         >
           <div class="skeleton-line"></div>

--- a/browser/frontend/src/app/waves-copy.ts
+++ b/browser/frontend/src/app/waves-copy.ts
@@ -11,6 +11,7 @@ const locale = {
     reload: 'Reload',
     go: 'Go',
     deckView: 'Deck View',
+    deckViewport: 'Deck viewport',
     idle: 'idle',
     up: 'Up',
     select: 'Select',

--- a/browser/frontend/src/styles.css
+++ b/browser/frontend/src/styles.css
@@ -44,6 +44,11 @@
   /* Deterministic integer display-scale step; never changes engine-computed
      rows/columns/wrapping, only the rendered pixel size of the handset frame. */
   --handset-scale: 1;
+
+  /* Host-chrome keyboard-focus ring (WBP-05). Kept as one semantic token so
+     the win95 vendor theme's outline suppression can be overridden in a
+     single place instead of per selector. */
+  --focus-ring-color: #ffbf47;
 }
 
 * {
@@ -163,12 +168,30 @@ body[data-boot-phase='deck-ready'] .wv-shell-window {
 button,
 .btn {
   padding: 2px 10px 4px;
-  min-height: 23px;
+  /* WCAG 2.2 SC 2.5.8 Target Size (Minimum): 24 CSS px. */
+  min-height: 24px;
 }
 
 .browser-chrome .chrome-btn.primary {
   padding-left: 12px;
   padding-right: 12px;
+}
+
+/* The win95 vendor theme suppresses the default focus outline on buttons and
+   form fields (`outline: 0 !important`) in favor of a subtle inset-border
+   treatment. That's too easy to miss under keyboard navigation, so restore
+   an explicit, high-contrast focus-visible ring on top of it (WBP-05: "all
+   browser-owned actions are keyboard reachable with visible focus"). This
+   must stay `!important` and after the win95 import to win the cascade. */
+button:focus-visible,
+.btn:focus-visible,
+select:focus-visible,
+input:focus-visible,
+textarea:focus-visible,
+summary:focus-visible,
+[tabindex]:focus-visible {
+  outline: 2px solid var(--focus-ring-color) !important;
+  outline-offset: 2px !important;
 }
 
 .browser-main {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -93,6 +93,9 @@ importers:
       '@vitest/coverage-v8':
         specifier: ^4.1.10
         version: 4.1.10(vitest@4.1.10)
+      axe-core:
+        specifier: ^4.12.1
+        version: 4.12.1
       eslint:
         specifier: 'catalog:'
         version: 10.7.0
@@ -1251,6 +1254,10 @@ packages:
     peerDependenciesMeta:
       '@astrojs/markdown-remark':
         optional: true
+
+  axe-core@4.12.1:
+    resolution: {integrity: sha512-s7iGf5GaVMxEG0ENN9x+xTr7GFZCb1ZP/1uATUpCEK2X78nDB3RwbtFCo9pGAf9ru+VwoQ464DkaLEeRM08wJA==}
+    engines: {node: '>=4'}
 
   axobject-query@4.1.0:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
@@ -3761,6 +3768,8 @@ snapshots:
       - tsx
       - uploadthing
       - yaml
+
+  axe-core@4.12.1: {}
 
   axobject-query@4.1.0: {}
 


### PR DESCRIPTION
## Summary

- Implements `WBP-05` from `docs/waves/WAVES_BROWSER_PRODUCT_IMPLEMENTATION_PLAN.md`, the host accessibility baseline over the shell landed in `WBP-01`–`WBP-04` (#343, #344, #346, #347).
- Ran an automated `axe-core` scan (added as a devDependency — the standard tool for this rather than hand-rolling checks) against the fully mounted shell, plus a manual review, and fixed the two concrete gaps found:
  - **Focus visibility**: the win95 vendor theme sets `outline: 0 !important` on `.btn:focus` and form fields, relying only on a subtle inset-border shift. Added an explicit `:focus-visible` ring (new `--focus-ring-color` token) layered on top — kept `!important` and placed after the vendor import so it wins the cascade without touching the vendor file. Verified live: Tab-focusing "Reload" shows a clear amber ring; a plain mouse click correctly does *not* show it (that's `:focus-visible`'s designed behavior, not a bug).
  - **Target size**: `button, .btn` was `min-height: 23px`, one pixel under the WCAG 2.2 SC 2.5.8 (Target Size Minimum) 24px floor. Bumped to 24px.
- Gave the always-focusable `#viewport` a minimal `aria-label` ("Deck viewport") so it isn't a silently unnamed stop in the tab order, with a code comment pointing at `WBP-09` as the actual owner of exposing real card/focus/action structure to assistive tech — this slice intentionally does not attempt that (per the plan's guardrail against a second runtime representation of deck semantics).
- Everything else `axe-core` checks (landmarks, names, live regions, roles, duplicate IDs, form labeling) was already clean — the WBP-01–04 work had already gotten this mostly right.

## Test plan

- [x] `pnpm --dir browser/frontend run typecheck`
- [x] `pnpm --dir browser/frontend run lint`
- [x] `pnpm --dir browser/frontend run format:check`
- [x] `pnpm --dir browser/frontend run test` (183 passed, incl. 2 new files: `accessibility-audit.test.ts` — axe-core scan of the mounted shell with `color-contrast`/`target-size` disabled since jsdom has no real layout/canvas to evaluate them — and `keyboard-reachability.test.ts` — every toolbar/softkey/rail/Welcome-Help/developer-drawer action is confirmed focusable, including the drawer's contents once opened)
- [x] `pnpm --dir browser/frontend run build`
- [x] Manually verified in-browser via `vite dev`: Tab navigation shows the new focus ring; toggled `document.body.style.zoom = '2'` (200%) — layout reflows cleanly with no clipping/overlap and all controls remain usable and focus-visible.
- [x] pre-commit/pre-push hooks passed (lint-staged, frontend typecheck, rust fmt/clippy across engine/transport/browser-tauri, host-sample build sanity)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
