### PR TITLE
fix(docs-portal): align Atlas effective-spec validation with v2

### DIFF
--- a/docs-portal/schemas/effective-spec.schema.json
+++ b/docs-portal/schemas/effective-spec.schema.json
@@ -11,18 +11,19 @@
     "governingConformanceDocument",
     "governingClassProfileDocument",
     "classProfileLedger",
+    "strictTransportProfile",
     "graphStatus",
     "semantics",
     "summary",
     "families"
   ],
   "properties": {
-    "schemaVersion": { "const": 1 },
+    "schemaVersion": { "const": 2 },
     "releaseId": {
       "$ref": "https://wap-labs.dev/schemas/atlas-common.schema.json#/$defs/identifier"
     },
     "generatedFrom": {
-      "const": "spec-processing/source-manifests/wap-1.2.1-release.json"
+      "$ref": "#/$defs/generatedFrom"
     },
     "governingConformanceDocument": {
       "$ref": "https://wap-labs.dev/schemas/atlas-common.schema.json#/$defs/identifier"
@@ -32,6 +33,9 @@
     },
     "classProfileLedger": {
       "$ref": "https://wap-labs.dev/schemas/atlas-common.schema.json#/$defs/nonEmptyString"
+    },
+    "strictTransportProfile": {
+      "$ref": "#/$defs/strictTransportProfile"
     },
     "graphStatus": {
       "$ref": "https://wap-labs.dev/schemas/atlas-common.schema.json#/$defs/nonEmptyString"
@@ -76,6 +80,211 @@
     }
   },
   "$defs": {
+    "generatedFrom": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["generator", "inputs"],
+      "properties": {
+        "generator": {
+          "const": "spec-processing/scripts/generate-wap-effective-spec.mjs"
+        },
+        "inputs": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "release",
+            "classConformance",
+            "ingestion",
+            "externalDependencies",
+            "externalIngestion"
+          ],
+          "properties": {
+            "release": {
+              "$ref": "#/$defs/releaseInput"
+            },
+            "classConformance": {
+              "$ref": "#/$defs/classConformanceInput"
+            },
+            "ingestion": {
+              "$ref": "#/$defs/ingestionInput"
+            },
+            "externalDependencies": {
+              "$ref": "#/$defs/externalDependenciesInput"
+            },
+            "externalIngestion": {
+              "$ref": "#/$defs/externalIngestionInput"
+            }
+          }
+        }
+      }
+    },
+    "releaseInput": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["path", "sha256"],
+      "properties": {
+        "path": {
+          "const": "spec-processing/source-manifests/wap-1.2.1-release.json"
+        },
+        "sha256": {
+          "$ref": "https://wap-labs.dev/schemas/atlas-common.schema.json#/$defs/sha256"
+        }
+      }
+    },
+    "classConformanceInput": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["path", "sha256"],
+      "properties": {
+        "path": {
+          "const": "spec-processing/source-manifests/wap-1.2.1-class-conformance.json"
+        },
+        "sha256": {
+          "$ref": "https://wap-labs.dev/schemas/atlas-common.schema.json#/$defs/sha256"
+        }
+      }
+    },
+    "ingestionInput": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["path", "sha256"],
+      "properties": {
+        "path": {
+          "const": "spec-processing/source-manifests/wap-1.2.1-ingestion-status.json"
+        },
+        "sha256": {
+          "$ref": "https://wap-labs.dev/schemas/atlas-common.schema.json#/$defs/sha256"
+        }
+      }
+    },
+    "externalDependenciesInput": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["path", "sha256"],
+      "properties": {
+        "path": {
+          "const": "spec-processing/source-manifests/wap-1.2.1-external-dependencies.json"
+        },
+        "sha256": {
+          "$ref": "https://wap-labs.dev/schemas/atlas-common.schema.json#/$defs/sha256"
+        }
+      }
+    },
+    "externalIngestionInput": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["path", "sha256"],
+      "properties": {
+        "path": {
+          "const": "spec-processing/source-manifests/wap-1.2.1-external-ingestion-status.json"
+        },
+        "sha256": {
+          "$ref": "https://wap-labs.dev/schemas/atlas-common.schema.json#/$defs/sha256"
+        }
+      }
+    },
+    "strictTransportProfile": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["profileId", "deviceRole", "deviceClass", "selectedBearer", "families"],
+      "properties": {
+        "profileId": {
+          "$ref": "https://wap-labs.dev/schemas/atlas-common.schema.json#/$defs/identifier"
+        },
+        "deviceRole": { "const": "client" },
+        "deviceClass": { "const": "C" },
+        "selectedBearer": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "id",
+            "networkProtocol",
+            "datagramProtocol",
+            "sourceDocument",
+            "sourceSection",
+            "externalContext"
+          ],
+          "properties": {
+            "id": { "const": "cdpd-ipv4" },
+            "networkProtocol": { "const": "ipv4" },
+            "datagramProtocol": { "const": "udp" },
+            "sourceDocument": { "const": "WAP-200-WDP" },
+            "sourceSection": { "const": "5.4.3" },
+            "externalContext": { "const": "tiaeia-is-732-cdpd-set" }
+          }
+        },
+        "families": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["wdp", "wcmp", "wsp", "wtp"],
+          "properties": {
+            "wdp": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["selectedFeatureGroup", "selectedPath", "sourceDocuments"],
+              "properties": {
+                "selectedFeatureGroup": { "const": "WDP:MCF" },
+                "selectedPath": { "const": "udp-over-ipv4" },
+                "sourceDocuments": {
+                  "const": ["WAP-200-WDP", "rfc-768", "rfc-791"]
+                }
+              }
+            },
+            "wcmp": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "selectedFeatureGroup",
+                "selectedPath",
+                "sourceDocument",
+                "sourceSection",
+                "normativeDependency",
+                "generalWcmpDisposition"
+              ],
+              "properties": {
+                "selectedFeatureGroup": { "const": "WCMP:MCF" },
+                "selectedPath": { "const": "rfc-792-icmpv4" },
+                "sourceDocument": { "const": "WAP-202-WCMP" },
+                "sourceSection": { "const": "5.3" },
+                "normativeDependency": { "const": "rfc-792" },
+                "generalWcmpDisposition": {
+                  "const": "capability-gated-non-ip-bearer"
+                }
+              }
+            },
+            "wsp": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "selectedFeatureGroup",
+                "selectedPath",
+                "sourceDocument",
+                "connectionOrientedDisposition"
+              ],
+              "properties": {
+                "selectedFeatureGroup": { "const": "WSP:MCF" },
+                "selectedPath": { "const": "connectionless" },
+                "sourceDocument": { "const": "WAP-203-WSP" },
+                "connectionOrientedDisposition": {
+                  "const": "conditional-capability"
+                }
+              }
+            },
+            "wtp": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["selected", "activationCondition"],
+              "properties": {
+                "selected": { "const": false },
+                "activationCondition": {
+                  "const": "connection-oriented-wsp-selected"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "family": {
       "type": "object",
       "additionalProperties": false,
@@ -178,6 +387,21 @@
             },
             "selectedFeatureGroup": {
               "$ref": "https://wap-labs.dev/schemas/atlas-common.schema.json#/$defs/nonEmptyString"
+            },
+            "applicability": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["profile", "family"],
+              "properties": {
+                "profile": { "const": "#/strictTransportProfile" },
+                "family": {
+                  "enum": [
+                    "#/strictTransportProfile/families/wdp",
+                    "#/strictTransportProfile/families/wcmp",
+                    "#/strictTransportProfile/families/wsp"
+                  ]
+                }
+              }
             },
             "note": {
               "$ref": "https://wap-labs.dev/schemas/atlas-common.schema.json#/$defs/nonEmptyString"

--- a/docs-portal/test/atlas-data.test.mjs
+++ b/docs-portal/test/atlas-data.test.mjs
@@ -27,15 +27,51 @@ test('current Atlas inputs pass schema, reference, and ordering validation', () 
 
   assert.equal(atlas.program.schemaVersion, 1);
   assert.equal(atlas.releaseManifest.schemaVersion, 1);
-  assert.equal(atlas.effectiveSpec.schemaVersion, 1);
+  assert.equal(atlas.effectiveSpec.schemaVersion, 2);
   assert.equal(atlas.clauseManifest.schemaVersion, 1);
 });
 
-test('unknown schema versions fail before portal assembly', () => {
+test('unknown compliance-program schema versions fail before portal assembly', () => {
   const data = clone(baseline());
   data.program.schemaVersion = 2;
 
   assertValidationFailure(data, /compliance-program\.json \/schemaVersion/);
+});
+
+test('stale and unknown effective-spec schema versions fail before portal assembly', () => {
+  for (const schemaVersion of [1, 3]) {
+    const data = clone(baseline());
+    data.effectiveSpec.schemaVersion = schemaVersion;
+
+    assertValidationFailure(data, /wap-1\.2\.1-effective-spec\.json \/schemaVersion/);
+  }
+});
+
+test('stale effective-spec generator provenance fails before portal assembly', () => {
+  const data = clone(baseline());
+  data.effectiveSpec.generatedFrom.generator =
+    'spec-processing/scripts/legacy-generate-wap-effective-spec.mjs';
+
+  assertValidationFailure(
+    data,
+    /wap-1\.2\.1-effective-spec\.json \/generatedFrom\/generator: must be equal to constant/
+  );
+});
+
+test('unintended effective-spec fields fail before portal assembly', () => {
+  const rootData = clone(baseline());
+  rootData.effectiveSpec.unexpected = true;
+  assertValidationFailure(
+    rootData,
+    /wap-1\.2\.1-effective-spec\.json \/: must NOT have additional properties/
+  );
+
+  const nestedData = clone(baseline());
+  nestedData.effectiveSpec.strictTransportProfile.selectedBearer.unexpected = true;
+  assertValidationFailure(
+    nestedData,
+    /wap-1\.2\.1-effective-spec\.json \/strictTransportProfile\/selectedBearer: must NOT have additional properties/
+  );
 });
 
 test('missing required portal fields fail before portal assembly', () => {


### PR DESCRIPTION
## Summary

- align Project Atlas effective-spec validation with the canonical generator-owned v2 manifest
- model v2 provenance, strict Class C transport profile, and SCR applicability anchors without weakening closed-object validation
- add regression coverage for canonical v2 input, stale/unknown versions, stale generator provenance, and unintended fields

## Root cause

PR #362 introduced strict Atlas source-data schemas against the then-current effective-spec v1 shape. PR #360 later regenerated the canonical effective-spec as v2 with hashed multi-input provenance, a top-level `strictTransportProfile`, and per-family `scrExtraction.applicability` links. The merges landed in an order that left Atlas validating the v2 manifest with the older v1 schema, breaking both Project Atlas Build and Pages deployment on `main`.

## Impact

Restores the Atlas data validation, Astro check/build, and Pages build path while preserving strict rejection of stale or unmodeled input shapes. No runtime, WML parser, browser adapter, or generated compliance artifact changes are included.

## Verification

- `pnpm --dir docs-portal run test:data`
- `pnpm --dir docs-portal run check`
- `pnpm --dir docs-portal run build`
- `pnpm wap-compliance:check`
- `pnpm wap-graph:check`
- `pnpm exec prettier --check docs-portal/schemas/effective-spec.schema.json docs-portal/test/atlas-data.test.mjs`
- `git diff --check`
- repository pre-push hook (engine/browser/transport Rust formatting, clippy, and engine tests)
