### PR TITLE
fix(transport): validate UDP reply source and correct uintvar range ceiling

### DIFF
--- a/transport-rust/src/native_fetch.rs
+++ b/transport-rust/src/native_fetch.rs
@@ -216,6 +216,19 @@ pub(crate) fn execute_native_wap_request_with_transport(
         match transport.receive() {
             Ok(reply_datagram) => {
                 let elapsed_ms = send_start.elapsed().as_secs_f64() * 1000.0;
+                if reply_datagram.src_addr != WdpAddress::from_socket_addr(peer)
+                    || reply_datagram.src_port != peer.port()
+                {
+                    failure.record(
+                        format!(
+                            "discarded reply from unexpected source (expected {peer}, got {:?}:{})",
+                            reply_datagram.src_addr, reply_datagram.src_port
+                        ),
+                        true,
+                        elapsed_ms,
+                    );
+                    continue;
+                }
                 let reply =
                     match decode_connectionless_reply(transaction_id, &reply_datagram.payload) {
                         Ok(reply) => reply,
@@ -683,6 +696,68 @@ mod tests {
         assert_eq!(
             detail_string(&response, "requestId").as_deref(),
             Some("req-native-timeout")
+        );
+    }
+
+    #[test]
+    fn native_fetch_discards_reply_from_unexpected_source() {
+        let request_url = "wap://127.0.0.1/login".to_string();
+        let peer: SocketAddr = "127.0.0.1:9200".parse().expect("literal should parse");
+        let encoded_reply = build_connectionless_reply_wire(
+            CONNECTIONLESS_INITIAL_TRANSACTION_ID,
+            0x20,
+            0x08,
+            br#"<?xml version="1.0"?><wml><card id="forged"/></wml>"#,
+        );
+        // Same payload a legitimate gateway reply would carry, but arriving from a
+        // different source than the peer the request was sent to (spoofed sender).
+        let spoofed_reply = WdpDatagram {
+            src_addr: WdpAddress::ipv4([10, 0, 0, 66]),
+            dst_addr: WdpAddress::ipv4([127, 0, 0, 1]),
+            src_port: 9200,
+            dst_port: 49152,
+            payload: encoded_reply,
+        };
+        let mut transport = FakeDatagramTransport {
+            sent: Vec::new(),
+            next_receive: Ok(spoofed_reply),
+        };
+
+        let response = execute_native_wap_request_with_transport(
+            &mut transport,
+            peer,
+            NativeFetchPlan {
+                request_url: request_url.clone(),
+                method: "GET".to_string(),
+                outbound_headers: HashMap::new(),
+                post_body: None,
+                post_content_type: None,
+                timeout_ms: 100,
+                attempts: 2,
+                request_id: Some("req-native-spoofed".to_string()),
+                destination_policy: FetchDestinationPolicy::AllowPrivate,
+            },
+        );
+
+        assert!(!response.ok);
+        assert!(
+            response.wml.is_none(),
+            "forged deck body must never surface as engine input"
+        );
+        assert_eq!(
+            response.error.as_ref().map(|error| error.code.as_str()),
+            Some("GATEWAY_TIMEOUT")
+        );
+        assert!(response
+            .error
+            .as_ref()
+            .expect("error should be present")
+            .message
+            .contains("unexpected source"));
+        assert_eq!(
+            transport.sent.len(),
+            2,
+            "every attempt should retry, not accept the spoofed reply"
         );
     }
 

--- a/transport-rust/src/network/wsp/connectionless.rs
+++ b/transport-rust/src/network/wsp/connectionless.rs
@@ -24,8 +24,10 @@ use crate::network::wsp::header_registry::{
 
 /// High bit marking a well-known (binary) WSP field name or short-integer value.
 const WELL_KNOWN_MARKER: u8 = 0x80;
-/// Largest value representable by the five-octet `uintvar` form.
-const MAX_UINTVAR_VALUE: usize = 0x0FFF_FFFF;
+/// Largest value representable by the five-octet `uintvar` form (WAP-230-WSP
+/// caps `uintvar` at 32 bits; 5 octets of 7 bits each provide 35 bits of
+/// capacity, so the full 32-bit range fits).
+const MAX_UINTVAR_VALUE: usize = 0xFFFF_FFFF;
 /// Highest first octet still interpreted as a content-type short-length prefix.
 const MAX_SHORT_LENGTH: u8 = 30;
 /// WSP length-quote introducing a `uintvar` length.


### PR DESCRIPTION
## Summary

- Fixes #349: the native WAP UDP fetch path accepted a connectionless reply from **any** UDP source, letting an off-path attacker on the ephemeral port spoof/inject deck content. `execute_native_wap_request_with_transport` now validates the reply datagram's source address/port against the resolved gateway peer before decoding; a mismatch is treated as a retryable failure (mapped to `GATEWAY_TIMEOUT`), not a successful response.
- Fixes #371: `MAX_UINTVAR_VALUE` claimed to be the largest 5-octet `uintvar` value but was actually only 4 octets/28 bits (`0x0FFF_FFFF`), rejecting spec-legal 32-bit `uintvar` lengths per WAP-230-WSP. Corrected to `0xFFFF_FFFF`.

## Test plan

- [x] `cargo test` in `transport-rust` — 238 passed (237 + 1 new regression test for the spoofed-reply case)
- [x] New test `native_fetch_discards_reply_from_unexpected_source` asserts a forged reply from a non-peer address is rejected across all retry attempts, never surfaces as `response.wml`, and reports `GATEWAY_TIMEOUT`
- [x] `make lint-rust-transport` (fmt + clippy `-D warnings`) passes
- [x] `make test-rust-transport` passes in full

🤖 Generated with [Claude Code](https://claude.com/claude-code)
