### PR TITLE
fix(engine-wasm): stale script outcome on nav failure; panic-wrap executeScriptUnit

### DIFF
--- a/engine-wasm/engine/src/engine_public_api.rs
+++ b/engine-wasm/engine/src/engine_public_api.rs
@@ -403,8 +403,15 @@ impl WmlEngine {
     }
 
     /// Execute a raw bytecode unit with no runtime host bindings.
+    ///
+    /// Wrapped in the same panic-containment boundary as every other
+    /// script-execution entry point (see [`Self::execute_script_contained`]),
+    /// so a defensive-programming bug in the decoder or VM degrades to a
+    /// typed `ScriptExecutionOutcome::fatal` instead of unwinding raw through
+    /// the `#[wasm_bindgen]` boundary as an uncaught JS exception.
     pub fn execute_script_unit(&self, bytes: Vec<u8>) -> ScriptExecutionOutcome {
-        self.execute_script_unit_internal(&bytes)
+        catch_engine_panic(|| self.execute_script_unit_internal(&bytes))
+            .unwrap_or_else(contained_panic_script_outcome)
     }
 
     /// Register a bytecode unit by source key.

--- a/engine-wasm/engine/src/engine_runtime_internal.rs
+++ b/engine-wasm/engine/src/engine_runtime_internal.rs
@@ -130,7 +130,18 @@ impl WmlEngine {
                 .unwrap_or_else(|| "script invocation failed".to_string()));
         }
 
-        self.apply_pending_script_effects()?;
+        if let Err(message) = self.apply_pending_script_effects() {
+            // The script's own execution succeeded, but the navigation it
+            // requested (e.g. `WMLBrowser.go("#missing")`) failed. The outcome
+            // recorded above still reflects the script's success and must be
+            // overwritten, or `lastScriptExecutionOk()`/error-class queries
+            // would contradict the `Err` this function is about to return.
+            self.last_script_outcome = Some(ScriptExecutionOutcome::fatal(
+                message.clone(),
+                ScriptErrorCategoryLiteral::HostBinding,
+            ));
+            return Err(message);
+        }
         Ok(ScriptInvocationOutcome::from_execution(&outcome))
     }
 

--- a/engine-wasm/engine/src/engine_tests/script_runtime.rs
+++ b/engine-wasm/engine/src/engine_tests/script_runtime.rs
@@ -789,6 +789,45 @@ fn invoke_script_ref_fatal_trap_after_go_discards_deferred_navigation_effects() 
 }
 
 #[test]
+fn invoke_script_ref_go_to_missing_card_reports_failure_not_stale_success() {
+    // The VM itself halts cleanly here (no trap) — the failure is entirely in
+    // applying the deferred `go()` navigation effect against a target that
+    // doesn't exist. `last_script_outcome` must reflect that failure, not the
+    // script's own successful execution, or `lastScriptExecutionOk()` would
+    // contradict the `Err` this call returns.
+    let mut engine = WmlEngine::new();
+    let xml = r##"
+        <wml>
+          <card id="home"><p>Home</p></card>
+        </wml>
+        "##;
+    engine.load_deck(xml).expect("deck should load");
+
+    let mut unit = Vec::new();
+    push_string(&mut unit, "#missing");
+    unit.push(0x20);
+    unit.push(0x03);
+    unit.push(0x01); // go("#missing")
+    unit.push(0x00);
+    engine.register_script_unit("bad-nav.wmlsc".to_string(), unit);
+
+    let err = engine
+        .invoke_script_ref_internal("bad-nav.wmlsc", "main", &[])
+        .expect_err("navigation to a missing card must surface as a failure");
+    assert!(err.contains("Card id not found"));
+    assert_eq!(engine.active_card_id().expect("active card"), "home");
+    assert_eq!(engine.last_script_execution_ok(), Some(false));
+    assert_eq!(
+        engine.last_script_execution_error_class().as_deref(),
+        Some("fatal")
+    );
+    assert_eq!(
+        engine.last_script_execution_trap().as_deref(),
+        Some("Card id not found")
+    );
+}
+
+#[test]
 fn fatal_invocation_failure_keeps_engine_recoverable() {
     let mut engine = WmlEngine::new();
     let xml = r##"


### PR DESCRIPTION
## Summary

- Fixes #368: `invoke_script_ref_internal` froze `last_script_outcome` from the script's own successful VM result *before* applying its requested navigation effect. If the effect then failed (e.g. `WMLBrowser.go("#missing")`), the call correctly returned `Err`, but `lastScriptExecutionOk()`/error-class queries still reported success — directly contradictory host-visible state. `last_script_outcome` is now overwritten with a `fatal` outcome when `apply_pending_script_effects` fails.
  - The `go()`/`prev()` asymmetry also noted in #368 (`prev()` already swallows identical entry-task failures via the existing, tested back-navigation contract) is intentionally left alone — fixing it would require changing the public `navigateBack(): boolean` contract, out of scope here.
- Fixes #370: `executeScriptUnit` was the one method in the script-execution family with no panic-containment wrapper. Now wrapped in the same `catch_engine_panic` boundary as every sibling method, so a defensive-programming bug in the decoder/VM degrades to a typed `ScriptExecutionOutcome::fatal` instead of unwinding raw through the `#[wasm_bindgen]` boundary.
- #350 (contract drift between `wml-engine.ts` and the Rust `ScriptExecutionOutcome`/`ScriptInvocationOutcome` shape) was already fixed upstream by #361 before this audit's fixes landed — verified and closed separately, no change needed here.

## Test plan

- [x] `cargo test` in `engine-wasm/engine` — 303 passed (302 + 1 new regression test)
- [x] New test `invoke_script_ref_go_to_missing_card_reports_failure_not_stale_success` asserts a script that halts cleanly but requests navigation to a missing card returns `Err`, and `last_script_execution_ok()`/`error_class()`/`trap()` all correctly reflect the failure (not stale success)
- [x] `cargo fmt --check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
