### PR TITLE
fix(browser): infer error tone for deck-parse and script-execution failures

### DIFF
--- a/browser/frontend/src/app/waves-copy.ts
+++ b/browser/frontend/src/app/waves-copy.ts
@@ -76,6 +76,8 @@ const locale = {
   statusPrefix: {
     error: 'Error:',
     fetchFailed: 'Fetch failed:',
+    deckParseFailed: 'Deck parse failed:',
+    scriptExecutionFailed: 'Script error (',
     loading: 'Loading ',
     followingExternalIntent: 'Following external intent:',
     checkingGateway: 'Checking WAP gateway',

--- a/browser/frontend/src/ui-helpers.test.ts
+++ b/browser/frontend/src/ui-helpers.test.ts
@@ -18,6 +18,13 @@ describe('ui-helpers', () => {
     expect(inferStatusTone('Rendered current card.')).toBe('idle');
   });
 
+  it('infers error tone for deck-parse and script-execution failures', () => {
+    expect(inferStatusTone(WAVES_COPY.status.deckParseFailed('unexpected token'))).toBe('error');
+    expect(
+      inferStatusTone(WAVES_COPY.status.scriptExecutionFailed('integrity', 'bad opcode'))
+    ).toBe('error');
+  });
+
   it('builds stable status classes', () => {
     expect(statusClassName('idle')).toBe('status status-idle');
     expect(statusClassName('loading')).toBe('status status-loading');

--- a/browser/frontend/src/ui-helpers.ts
+++ b/browser/frontend/src/ui-helpers.ts
@@ -24,7 +24,9 @@ export const uiEvents = createNanoEvents<UiEvents>();
 export const inferStatusTone = (message: string): StatusTone => {
   if (
     message.startsWith(WAVES_COPY.statusPrefix.error) ||
-    message.startsWith(WAVES_COPY.statusPrefix.fetchFailed)
+    message.startsWith(WAVES_COPY.statusPrefix.fetchFailed) ||
+    message.startsWith(WAVES_COPY.statusPrefix.deckParseFailed) ||
+    message.startsWith(WAVES_COPY.statusPrefix.scriptExecutionFailed)
   ) {
     return 'error';
   }


### PR DESCRIPTION
## Summary

- Fixes #351: `inferStatusTone()` only recognized the `"Error:"` and `"Fetch failed:"` prefixes, so a failed deck parse (`"Deck parse failed: ..."`) or a WMLScript fatal trap (`"Script error (...): ..."`) fell through to the `'idle'` tone by default. The status panel rendered neutral styling for what is actually a failed navigation, even though the accompanying toast correctly showed red. Added `statusPrefix` entries for both messages and included them in the error-tone check.

## Test plan

- [x] `pnpm --dir frontend run test` — 189 passed (34 test files)
- [x] New test asserts *tone*, not just text, for both `deckParseFailed` and `scriptExecutionFailed` — the existing suite only asserted status text via a mock that discarded the tone argument, which is why this gap wasn't caught originally
- [x] `pnpm --dir frontend run typecheck` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
