### PR TITLE
docs(transport): clarify wap-net-ext "gated" means promotion gates, not a build flag

### DIFF
--- a/docs/waves/NETWORK_PROFILE_DECISION_RECORD.md
+++ b/docs/waves/NETWORK_PROFILE_DECISION_RECORD.md
@@ -60,6 +60,15 @@ Fixture lane:
   WSP/WTP, Push, and advanced session features.
 - Promotion requires explicit additional gates beyond the protocol-core baseline.
 - Activation must remain contract-compatible or ship with explicit contract changes.
+- "Gated" here means gated by the promotion process above (`T0-*` gates), not a
+  Cargo compile-time feature flag — none exists today. The `network::wtp`,
+  `network::wcmp`, `wsp_registry.rs`, `wsp_capability.rs`, and
+  `network::wsp::pdu`/`session` modules that back this profile are compiled
+  unconditionally into `transport-rust`; they are simply unwired from the live
+  fetch path, which is the only thing keeping them out of production traffic
+  today. A future change that wires any of this in must go through the
+  promotion gates above rather than relying on a build flag to have kept it
+  inert.
 
 ## Promotion gates
 


### PR DESCRIPTION
## Summary

- Fixes #367: `docs/waves/NETWORK_PROFILE_DECISION_RECORD.md` and `RUST_TRANSPORT_STEERING.md` describe `wap-net-ext` as "gated," which reads ambiguously as either the documented promotion-gate process or a Cargo compile-time feature flag. Verified via grep that `transport-rust/Cargo.toml` has no `[features]` section and the `wap-net-ext`-backing modules (`network::wtp`, `network::wcmp`, `wsp_registry.rs`, `wsp_capability.rs`, `network::wsp::pdu`/`session`) compile unconditionally — nothing calls them from the live fetch path today, but there's no build-time gate enforcing that.
- Chose the docs-only fix over adding a real Cargo feature flag: the modules themselves were independently reviewed and found well-hardened (checked arithmetic, `Result`-based decoding, spec-cited state machines with dedicated tests), so this is a documentation-clarity gap, not a live risk. Adding a real feature flag would be a bigger, riskier change to the crate's build surface for a problem that's actually just an ambiguous sentence.

## Test plan

- No code changes; docs-only.
- Re-verified via `grep -rn "cfg(feature" transport-rust/src/` that the claim in the new doc text is still accurate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)