### PR TITLE
fix(scripts): rewrite CI/Docker-invoked scripts from bash to POSIX sh

### DIFF
--- a/docker/kannel/start.sh
+++ b/docker/kannel/start.sh
@@ -1,13 +1,21 @@
-#!/usr/bin/env bash
-set -euo pipefail
+#!/usr/bin/env sh
+set -eu
 
 echo "Starting Kannel bearerbox..."
 bearerbox /etc/kannel/kannel.conf &
+bearerbox_pid=$!
 
 # Give bearerbox a moment to initialize before starting wapbox.
 sleep 2
 
 echo "Starting Kannel wapbox..."
 wapbox /etc/kannel/kannel.conf &
+wapbox_pid=$!
 
-wait -n
+# POSIX sh has no `wait -n` (wait for whichever background job exits first).
+# Poll instead so the container exits as soon as either process dies, rather
+# than staying up silently with a crashed peer.
+while kill -0 "$bearerbox_pid" 2>/dev/null && kill -0 "$wapbox_pid" 2>/dev/null; do
+    sleep 1
+done
+wait

--- a/scripts/dev-wavenav-host.sh
+++ b/scripts/dev-wavenav-host.sh
@@ -1,7 +1,7 @@
-#!/usr/bin/env bash
-set -euo pipefail
+#!/usr/bin/env sh
+set -eu
 
-ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 
 if ! command -v wasm-pack >/dev/null 2>&1; then
   echo "error: wasm-pack is required but not installed."

--- a/scripts/init-refresh.sh
+++ b/scripts/init-refresh.sh
@@ -1,7 +1,7 @@
-#!/usr/bin/env bash
-set -euo pipefail
+#!/usr/bin/env sh
+set -eu
 
-ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 AUTO_INSTALL_RUST_TOOLS="${AUTO_INSTALL_RUST_TOOLS:-0}"
 SKIP_NODE_INSTALLS="${SKIP_NODE_INSTALLS:-0}"
 SKIP_HOOKS="${SKIP_HOOKS:-0}"
@@ -15,7 +15,7 @@ warn() {
 }
 
 need_cmd() {
-  local cmd="$1"
+  cmd="$1"
   if ! command -v "${cmd}" >/dev/null 2>&1; then
     warn "missing required command: ${cmd}"
     return 1
@@ -24,12 +24,12 @@ need_cmd() {
 }
 
 ensure_rust_tool() {
-  local check_cmd="$1"
-  local install_cmd="$2"
+  check_cmd="$1"
+  install_cmd="$2"
   if command -v "${check_cmd}" >/dev/null 2>&1; then
     return 0
   fi
-  if [[ "${AUTO_INSTALL_RUST_TOOLS}" != "1" ]]; then
+  if [ "${AUTO_INSTALL_RUST_TOOLS}" != "1" ]; then
     warn "${check_cmd} not found (set AUTO_INSTALL_RUST_TOOLS=1 to auto-install)"
     return 0
   fi
@@ -38,15 +38,15 @@ ensure_rust_tool() {
 }
 
 ensure_tauri_cli() {
-  local expected_version="2.10.0"
-  local actual_version=""
+  expected_version="2.10.0"
+  actual_version=""
   if command -v cargo-tauri >/dev/null 2>&1; then
     actual_version="$(cargo tauri --version 2>/dev/null || true)"
   fi
-  if [[ "${actual_version}" == "tauri-cli ${expected_version}" ]]; then
+  if [ "${actual_version}" = "tauri-cli ${expected_version}" ]; then
     return 0
   fi
-  if [[ "${AUTO_INSTALL_RUST_TOOLS}" != "1" ]]; then
+  if [ "${AUTO_INSTALL_RUST_TOOLS}" != "1" ]; then
     warn "tauri-cli ${expected_version} required (found: ${actual_version:-missing}; set AUTO_INSTALL_RUST_TOOLS=1 to install)"
     return 0
   fi
@@ -65,7 +65,7 @@ if command -v cargo >/dev/null 2>&1; then
   ensure_tauri_cli
 fi
 
-if [[ "${SKIP_NODE_INSTALLS}" != "1" ]]; then
+if [ "${SKIP_NODE_INSTALLS}" != "1" ]; then
   if command -v pnpm >/dev/null 2>&1; then
     log "pnpm install (workspace)"
     (cd "${ROOT_DIR}" && pnpm install)
@@ -73,12 +73,12 @@ if [[ "${SKIP_NODE_INSTALLS}" != "1" ]]; then
     log "install browser frontend dependencies"
     (cd "${ROOT_DIR}" && pnpm --dir browser/frontend install)
 
-    if [[ -f "${ROOT_DIR}/engine-wasm/host-sample/package.json" ]]; then
+    if [ -f "${ROOT_DIR}/engine-wasm/host-sample/package.json" ]; then
       log "install host-sample dependencies"
       (cd "${ROOT_DIR}" && pnpm --dir engine-wasm/host-sample install --ignore-workspace)
     fi
 
-    if [[ -f "${ROOT_DIR}/marketing-site/package.json" ]]; then
+    if [ -f "${ROOT_DIR}/marketing-site/package.json" ]; then
       log "install marketing-site dependencies"
       (cd "${ROOT_DIR}" && pnpm --dir marketing-site --ignore-workspace install)
     fi
@@ -87,7 +87,7 @@ if [[ "${SKIP_NODE_INSTALLS}" != "1" ]]; then
     warn "pnpm not found; skipping node installs"
   fi
 
-  if command -v npm >/dev/null 2>&1 && [[ -f "${ROOT_DIR}/wml-server/package.json" ]]; then
+  if command -v npm >/dev/null 2>&1 && [ -f "${ROOT_DIR}/wml-server/package.json" ]; then
     log "install wml-server dependencies"
     (cd "${ROOT_DIR}" && npm --prefix wml-server install)
   else
@@ -97,7 +97,7 @@ else
   log "skipping node installs (SKIP_NODE_INSTALLS=1)"
 fi
 
-if [[ "${SKIP_HOOKS}" != "1" ]]; then
+if [ "${SKIP_HOOKS}" != "1" ]; then
   if command -v pre-commit >/dev/null 2>&1; then
     log "installing repo hooks"
     (cd "${ROOT_DIR}" && make hooks-install)

--- a/scripts/preview-pages.sh
+++ b/scripts/preview-pages.sh
@@ -1,7 +1,7 @@
-#!/usr/bin/env bash
-set -euo pipefail
+#!/usr/bin/env sh
+set -eu
 
-ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 PORT="4173"
 SERVE="1"
 INSTALL_MODE="auto"
@@ -29,10 +29,10 @@ require_cmd() {
   fi
 }
 
-while [[ $# -gt 0 ]]; do
+while [ $# -gt 0 ]; do
   case "$1" in
     --port)
-      if [[ $# -lt 2 ]]; then
+      if [ $# -lt 2 ]; then
         echo "error: --port requires a value" >&2
         exit 1
       fi
@@ -68,14 +68,14 @@ require_cmd wasm-pack
 require_cmd python3
 
 should_install() {
-  local dir="$1"
-  if [[ "$INSTALL_MODE" == "force" ]]; then
+  dir="$1"
+  if [ "$INSTALL_MODE" = "force" ]; then
     return 0
   fi
-  if [[ "$INSTALL_MODE" == "skip" ]]; then
+  if [ "$INSTALL_MODE" = "skip" ]; then
     return 1
   fi
-  [[ ! -d "$dir/node_modules" ]]
+  [ ! -d "$dir/node_modules" ]
 }
 
 if should_install "$ROOT_DIR/marketing-site"; then
@@ -132,7 +132,7 @@ rm -rf "$PREVIEW_ROOT"
 mkdir -p "$PREVIEW_ROOT/wap-labs"
 cp -R "$ROOT_DIR/_site/." "$PREVIEW_ROOT/wap-labs/"
 
-if [[ "$SERVE" == "0" ]]; then
+if [ "$SERVE" = "0" ]; then
   echo "    Preview:   $PREVIEW_ROOT/wap-labs/index.html"
   echo "==> Done (no server started)"
   exit 0

--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -1,7 +1,7 @@
-#!/usr/bin/env bash
-set -euo pipefail
+#!/usr/bin/env sh
+set -eu
 
-ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 
 require_cmd() {
   if ! command -v "$1" >/dev/null 2>&1; then
@@ -13,16 +13,17 @@ require_cmd() {
 require_cmd curl
 
 wait_for_http() {
-  local url="$1"
-  local retries="${2:-40}"
-  local sleep_seconds="${3:-1}"
-  local i
+  url="$1"
+  retries="${2:-40}"
+  sleep_seconds="${3:-1}"
+  i=1
 
-  for ((i = 1; i <= retries; i += 1)); do
+  while [ "$i" -le "$retries" ]; do
     if curl -fsS --connect-timeout 2 --max-time 3 "$url" >/dev/null 2>&1; then
       return 0
     fi
     sleep "$sleep_seconds"
+    i=$((i + 1))
   done
 
   echo "Timeout waiting for $url" >&2
@@ -50,7 +51,7 @@ LOGIN_RESP="$(curl -fsS --connect-timeout 2 --max-time 5 -X POST 'http://localho
   -H 'Content-Type: application/x-www-form-urlencoded' \
   --data 'username=demo&pin=1234')"
 SID="$(echo "$LOGIN_RESP" | sed -n 's/.*portal?sid=\([a-f0-9]\{16\}\).*/\1/p' | head -n 1)"
-if [[ -z "$SID" ]]; then
+if [ -z "$SID" ]; then
   echo "Unable to extract session ID from login response" >&2
   exit 1
 fi

--- a/scripts/transport-wap-smoke.sh
+++ b/scripts/transport-wap-smoke.sh
@@ -1,7 +1,7 @@
-#!/usr/bin/env bash
-set -euo pipefail
+#!/usr/bin/env sh
+set -eu
 
-ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 KANNEL_ADMIN_URL="${KANNEL_ADMIN_URL:-http://localhost:13000/status?password=changeme}"
 WML_HEALTH_URL="${WML_HEALTH_URL:-http://localhost:3000/health}"
 WAP_SMOKE_URL="${WAP_SMOKE_URL:-wap://localhost/}"
@@ -10,9 +10,22 @@ TRANSPORT_WAP_TIMEOUT_MS="${TRANSPORT_WAP_TIMEOUT_MS:-15000}"
 TRANSPORT_WAP_RETRIES="${TRANSPORT_WAP_RETRIES:-1}"
 SMOKE_ARTIFACT_DIR="$(mktemp -d "${TMPDIR:-/tmp}/transport-wap-smoke.XXXXXX")"
 
+# Run a piped command and fail if the *command* (not `tee`) exited nonzero.
+# POSIX sh has no `pipefail`/`PIPESTATUS`, so the command's real exit code is
+# written to a scratch file from inside the pipeline and read back afterward.
+run_and_tee() {
+  log_file="$1"
+  shift
+  status_file="$(mktemp "${TMPDIR:-/tmp}/transport-wap-smoke-status.XXXXXX")"
+  { "$@"; echo "$?" >"$status_file"; } | tee "$log_file"
+  cmd_status="$(cat "$status_file")"
+  rm -f "$status_file"
+  return "$cmd_status"
+}
+
 print_failure_diagnostics() {
-  local exit_code="$?"
-  if [[ "${exit_code}" -eq 0 ]]; then
+  exit_code="$?"
+  if [ "$exit_code" -eq 0 ]; then
     echo "transport-wap-smoke artifacts: ${SMOKE_ARTIFACT_DIR}"
     return 0
   fi
@@ -44,16 +57,17 @@ print_failure_diagnostics() {
 trap print_failure_diagnostics EXIT
 
 wait_for_http() {
-  local url="$1"
-  local retries="${2:-40}"
-  local sleep_seconds="${3:-1}"
-  local i
+  url="$1"
+  retries="${2:-40}"
+  sleep_seconds="${3:-1}"
+  i=1
 
-  for ((i = 1; i <= retries; i += 1)); do
+  while [ "$i" -le "$retries" ]; do
     if curl -fsS --connect-timeout 2 --max-time 5 "$url" >/dev/null 2>&1; then
       return 0
     fi
     sleep "$sleep_seconds"
+    i=$((i + 1))
   done
 
   echo "Timeout waiting for $url" >&2
@@ -70,35 +84,28 @@ wait_for_http "${WML_HEALTH_URL}"
 echo "==> Running transport-rust WAP smoke integration test"
 (
   cd "${ROOT_DIR}/transport-rust"
-  WAP_SMOKE_URL="${WAP_SMOKE_URL}" \
-    WAP_SMOKE_LOGIN_URL="${WAP_SMOKE_LOGIN_URL}" \
-    TRANSPORT_WAP_TIMEOUT_MS="${TRANSPORT_WAP_TIMEOUT_MS}" \
-    TRANSPORT_WAP_RETRIES="${TRANSPORT_WAP_RETRIES}" \
-    RUST_TEST_THREADS=1 \
-    cargo test --test kannel_smoke -- --ignored --test-threads=1 \
-    | tee "${SMOKE_ARTIFACT_DIR}/transport-kannel-smoke.log"
+  export WAP_SMOKE_URL WAP_SMOKE_LOGIN_URL TRANSPORT_WAP_TIMEOUT_MS TRANSPORT_WAP_RETRIES
+  export RUST_TEST_THREADS=1
+  run_and_tee "${SMOKE_ARTIFACT_DIR}/transport-kannel-smoke.log" \
+    cargo test --test kannel_smoke -- --ignored --test-threads=1
 )
 
 echo "==> Running browser host native Kannel smoke unit test"
 (
   cd "${ROOT_DIR}/browser/src-tauri"
-  WAP_SMOKE_URL="${WAP_SMOKE_URL}" \
-    TRANSPORT_WAP_TIMEOUT_MS="${TRANSPORT_WAP_TIMEOUT_MS}" \
-    TRANSPORT_WAP_RETRIES="${TRANSPORT_WAP_RETRIES}" \
-    RUST_TEST_THREADS=1 \
-    cargo test host_fetch_deck_command_native_wap_home_smoke_succeeds --lib -- --ignored --test-threads=1 \
-    | tee "${SMOKE_ARTIFACT_DIR}/browser-host-native-smoke.log"
+  export WAP_SMOKE_URL TRANSPORT_WAP_TIMEOUT_MS TRANSPORT_WAP_RETRIES
+  export RUST_TEST_THREADS=1
+  run_and_tee "${SMOKE_ARTIFACT_DIR}/browser-host-native-smoke.log" \
+    cargo test host_fetch_deck_command_native_wap_home_smoke_succeeds --lib -- --ignored --test-threads=1
 )
 
 echo "==> Running browser engine/render native Kannel smoke integration test"
 (
   cd "${ROOT_DIR}/browser/src-tauri"
-  WAP_SMOKE_URL="${WAP_SMOKE_URL}" \
-    TRANSPORT_WAP_TIMEOUT_MS="${TRANSPORT_WAP_TIMEOUT_MS}" \
-    TRANSPORT_WAP_RETRIES="${TRANSPORT_WAP_RETRIES}" \
-    RUST_TEST_THREADS=1 \
-    cargo test kannel_fetch_deck_smoke_navigates_into_menu_card -- --ignored --test-threads=1 \
-    | tee "${SMOKE_ARTIFACT_DIR}/browser-render-native-smoke.log"
+  export WAP_SMOKE_URL TRANSPORT_WAP_TIMEOUT_MS TRANSPORT_WAP_RETRIES
+  export RUST_TEST_THREADS=1
+  run_and_tee "${SMOKE_ARTIFACT_DIR}/browser-render-native-smoke.log" \
+    cargo test kannel_fetch_deck_smoke_navigates_into_menu_card -- --ignored --test-threads=1
 )
 
 echo "transport-wap-smoke: PASS (artifacts: ${SMOKE_ARTIFACT_DIR})"


### PR DESCRIPTION
## Summary

Fixes #354. Six scripts used bash-only shebangs/syntax despite being shared/CI/Docker-invoked automation, contradicting `docs/agents/SHELL_STEERING.md`'s POSIX-first policy (Fish is reserved for local-dev-only scripts). No functional break today — CI runners and the kannel Docker image both ship bash — but this was a real portability risk if the kannel image ever moves to Alpine or these scripts get reused in a BusyBox-only environment.

Files: `docker/kannel/start.sh`, `scripts/smoke.sh`, `scripts/transport-wap-smoke.sh`, `scripts/init-refresh.sh`, `scripts/dev-wavenav-host.sh`, `scripts/preview-pages.sh`.

Two things worth flagging specifically since they're not mechanical search/replace:

1. **`docker/kannel/start.sh`'s `wait -n`** (bash-only: wait for whichever background job exits first) has no POSIX equivalent. Replaced with a polling loop (`kill -0` on both PIDs) that exits as soon as either `bearerbox` or `wapbox` dies, preserving the original fail-fast container behavior.
2. **`scripts/transport-wap-smoke.sh`'s `pipefail`** was load-bearing: three `cargo test | tee log` pipelines relied on it to fail the script when `cargo test` failed. Without it, POSIX `$status` after a pipe reflects `tee`'s exit code (always 0), silently swallowing test failures — the same bug class as #352. Added a `run_and_tee()` helper that captures the piped command's real exit code via a scratch file.

## Test plan

- [x] `dash -n <file>` (real POSIX/ash-like shell, not just `bash --posix`) on all 6 files — all pass
- [x] `shellcheck -s sh <file>` — clean except pre-existing, unrelated `SC2034` (unused var, not introduced here)
- [x] Functionally verified under `dash`, not just syntax-checked:
  - `run_and_tee` helper correctly propagates a failing command's exit code through the `tee` pipe, and correctly reports success for a passing command
  - The `wait_for_http` POSIX retry loop correctly iterates and returns
  - The `start.sh` poll-based `wait -n` replacement correctly exits as soon as one of two background jobs finishes, with the trailing plain `wait` reaping the other
- [x] `scripts/preview-pages.sh --help` and an unknown-flag case both behave correctly under `sh`
- Full integration runs (`make smoke`, `make smoke-transport-wap`, actual kannel container boot) need the external Kannel/WML-server stack and weren't run here — the changes are pure shell-portability rewrites with no change to the commands being invoked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)