### PR TITLE
fix(engine-wasm): auto-rebuild wasm pkg before test:story

### DIFF
--- a/engine-wasm/host-sample/package.json
+++ b/engine-wasm/host-sample/package.json
@@ -16,6 +16,7 @@
     "build": "vite build",
     "preview": "vite preview",
     "test": "pnpm run test:story:unit",
+    "pretest:story": "cd ../engine && wasm-pack build --target web --out-dir ../pkg",
     "test:story": "node ./scripts/test-story.mjs",
     "test:baseline:waves": "node ./scripts/measure-waves-baseline.mjs",
     "test:story:unit": "node --test ./scripts/tests/*.test.mjs",


### PR DESCRIPTION
## Summary

Fixes #388. Added a `pretest:story` hook (`engine-wasm/host-sample/package.json`) that runs `wasm-pack build --target web --out-dir ../pkg` before every `test:story` invocation, so local runs always match what CI already does on every fresh checkout (`ci.yml` runs the same build step unconditionally before `test:story`). Previously `test:story` just loaded whatever was already in the gitignored `engine-wasm/pkg/`, with no check it was built from current engine source — a stale local build silently tested old engine behavior.

## Test plan

- [x] Verified the hook actually fires: deleted `engine-wasm/pkg/wavenav_engine_bg.wasm` entirely, ran `pnpm test:story all` from repo root, confirmed it rebuilt the package and all 37 stories passed
- [x] Verified `pnpm --dir engine-wasm/host-sample run test:story:unit` (pure `node --test`, no wasm involved) is unaffected — still runs without triggering a rebuild, exit 0
- [x] Verified the hook works both via the direct `pnpm --dir engine-wasm/host-sample run test:story <arg>` call and the root-level `pnpm test:story <arg>` passthrough

🤖 Generated with [Claude Code](https://claude.com/claude-code)