### PR TITLE
fix(lint): repo-wide sweep of blanket #[allow(dead_code/unused_imports)]

### DIFF
--- a/browser/src-tauri/src/command_contract.rs
+++ b/browser/src-tauri/src/command_contract.rs
@@ -324,6 +324,9 @@ macro_rules! with_tauri_commands {
     };
 }
 
+// Required to make the macro_rules! macro path-addressable as
+// `crate::command_contract::with_tauri_commands!` from bootstrap.rs; the
+// lint can't see that cross-module macro-path usage from this re-export.
 #[allow(unused_imports)]
 pub(crate) use with_tauri_commands;
 

--- a/transport-rust/src/network/wdp/datagram.rs
+++ b/transport-rust/src/network/wdp/datagram.rs
@@ -1,5 +1,3 @@
-#![allow(dead_code)]
-
 use serde::{Deserialize, Serialize};
 use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr};
 

--- a/transport-rust/src/network/wdp/mod.rs
+++ b/transport-rust/src/network/wdp/mod.rs
@@ -1,6 +1,3 @@
-#![allow(dead_code)]
-#![allow(unused_imports)]
-
 pub mod datagram;
 pub mod ipv4_reassembly;
 pub mod ipv4_udp;

--- a/transport-rust/src/network/wdp/transport_trait.rs
+++ b/transport-rust/src/network/wdp/transport_trait.rs
@@ -1,5 +1,3 @@
-#![allow(dead_code)]
-
 use crate::network::wdp::datagram::WdpDatagram;
 use serde::{Deserialize, Serialize};
 

--- a/transport-rust/src/network/wdp/udp_adapter.rs
+++ b/transport-rust/src/network/wdp/udp_adapter.rs
@@ -1,5 +1,3 @@
-#![allow(dead_code)]
-
 use crate::network::wdp::datagram::{
     WdpAddress, WdpDatagram, WdpServicePort, WDP_MAX_UDP_PAYLOAD_BYTES,
 };
@@ -24,7 +22,6 @@ impl Default for UdpDatagramTransportConfig {
 
 pub struct UdpDatagramTransport {
     socket: UdpSocket,
-    read_timeout_ms: Option<u64>,
 }
 
 impl UdpDatagramTransport {
@@ -36,10 +33,7 @@ impl UdpDatagramTransport {
                 .set_read_timeout(Some(Duration::from_millis(timeout_ms)))
                 .map_err(|error| WdpError::TransportUnavailable(error.to_string()))?;
         }
-        Ok(Self {
-            socket,
-            read_timeout_ms: config.read_timeout_ms,
-        })
+        Ok(Self { socket })
     }
 
     pub fn local_addr(&self) -> SocketAddr {

--- a/transport-rust/src/network/wsp.rs
+++ b/transport-rust/src/network/wsp.rs
@@ -1,5 +1,3 @@
-#![allow(unused_imports)]
-
 pub mod connectionless;
 pub mod decoder;
 pub mod encoder;

--- a/transport-rust/src/network/wsp/encoding_version.rs
+++ b/transport-rust/src/network/wsp/encoding_version.rs
@@ -1,5 +1,3 @@
-#![allow(dead_code)]
-
 use crate::network::wsp::header_registry::is_negotiated_extension_page;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]

--- a/transport-rust/src/network/wsp/header_block.rs
+++ b/transport-rust/src/network/wsp/header_block.rs
@@ -1,5 +1,3 @@
-#![allow(dead_code)]
-
 use crate::network::wsp::decoder::{
     HeaderStreamDecodePolicy, UnsupportedCodePageBehavior, WspHeaderStreamDecodeError,
 };

--- a/transport-rust/src/network/wsp/pdu.rs
+++ b/transport-rust/src/network/wsp/pdu.rs
@@ -1,5 +1,3 @@
-#![allow(dead_code)]
-
 use crate::network::wsp::header_block::{
     decode_header_block, encode_header_block, WspHeaderBlock, WspHeaderBlockDecodeError,
     WspHeaderBlockDecodePolicy, WspHeaderBlockEncodeError, WspHeaderBlockEncodePolicy,

--- a/transport-rust/src/network/wsp/session.rs
+++ b/transport-rust/src/network/wsp/session.rs
@@ -1,5 +1,3 @@
-#![allow(dead_code)]
-
 use crate::network::wsp::header_block::{WspHeaderBlockDecodePolicy, WspHeaderBlockEncodePolicy};
 use crate::network::wsp::pdu::{
     decode_wsp_pdu, encode_wsp_pdu, WspConnectPdu, WspConnectReplyPdu, WspPdu, WspPduDecodeError,

--- a/transport-rust/src/network/wtls.rs
+++ b/transport-rust/src/network/wtls.rs
@@ -1,5 +1,3 @@
-#![allow(unused_imports)]
-
 pub mod alerts;
 pub mod handshake;
 pub mod record;

--- a/transport-rust/src/network/wtls/handshake.rs
+++ b/transport-rust/src/network/wtls/handshake.rs
@@ -5,6 +5,10 @@ use crate::network::wtp::retransmission::{
     decide_retransmission, WtpRetransmissionDecision, WtpRetransmissionEvent,
     WtpRetransmissionPolicy, WtpRetransmissionState, WtpRetransmissionTrace,
 };
+// unused_imports false positive: only consumed transitively via `mod tests`'s
+// `use super::*`, which brings this into scope for its `#[derive(Deserialize)]`
+// fixtures below. The lint can't see usage through that cross-module glob.
+#[allow(unused_imports)]
 use serde::Deserialize;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/transport-rust/src/network/wtp/duplicate_cache.rs
+++ b/transport-rust/src/network/wtp/duplicate_cache.rs
@@ -1,5 +1,3 @@
-#![allow(dead_code)]
-
 use serde::{Deserialize, Serialize};
 use std::collections::VecDeque;
 

--- a/transport-rust/src/network/wtp/retransmission.rs
+++ b/transport-rust/src/network/wtp/retransmission.rs
@@ -1,5 +1,3 @@
-#![allow(dead_code)]
-
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]

--- a/transport-rust/src/tests/mod.rs
+++ b/transport-rust/src/tests/mod.rs
@@ -256,6 +256,9 @@ struct WtpReplayPolicyInput {
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct WtpReplayPolicyFixture {
+    // Deserialized to keep the fixture schema self-documenting alongside
+    // `initiator_policy`, but the responder test cases below construct their
+    // own policy directly rather than reading this field back.
     #[allow(dead_code)]
     responder_policy: WtpReplayPolicyInput,
     responder_cases: Vec<WtpResponderFixtureCase>,


### PR DESCRIPTION
## Summary

Fixes #391. Extends the 3-file fix from #374 to a full sweep of `transport-rust`, `engine-wasm/engine`, and `browser/src-tauri` (`engine-wasm` had nothing further — already covered).

Every site was verified empirically — temporarily removed the allow, rebuilt with both `cargo build --lib` and `cargo build --tests` (lib-only vs lib+test targets can disagree on what's "unused"), and only then decided the fix. Results:

- **11 blanket `#![allow(dead_code)]`/`#![allow(unused_imports)]` module-level attributes** across `network::wdp`/`wsp`/`wtls`/`wtp` were pure dead weight — nothing in those modules was actually unused, even with tests compiled in. Removed entirely, no replacement needed.
- **One genuinely orphaned field**: `UdpDatagramTransport.read_timeout_ms` was set at construction and never read again (the socket timeout is already applied via `set_read_timeout` at construction time). Removed rather than suppressed.
- **Two real, narrow rustc lint false positives**, documented in place rather than removed (verified removing them breaks the build):
  - `network/wtls/handshake.rs`: `use serde::Deserialize` is only consumed transitively through a child `mod tests { use super::*; }`'s `#[derive(Deserialize)]` fixtures — the lint can't see usage through that cross-module glob.
  - `browser/src-tauri/src/command_contract.rs`: a `macro_rules!` re-export needed so `bootstrap.rs` can call it as `crate::command_contract::with_tauri_commands!` — same class of lint blind spot for cross-module macro-path usage.
- `transport-rust/src/tests/mod.rs`'s already-narrow single-field allow just needed the rationale comment the steering doc asks for.

## Test plan

- [x] `make lint-rust-transport` (fmt + clippy `-D warnings`) passes
- [x] `make test-rust-transport` — 238 passed
- [x] `cargo test` in `engine-wasm/engine` — 303 passed (no changes needed there, confirmed clean)
- [x] `cargo test` in `browser/src-tauri` — full suite passes, 3 kannel-smoke tests correctly ignored
- [x] Every removal/change verified individually by removing the allow and rebuilding before deciding the fix, not assumed

🤖 Generated with [Claude Code](https://claude.com/claude-code)