### PR TITLE
feat(scripts): add stale-file-reference checker for MAINTENANCE_WORK_ITEMS.md tickets

### DIFF
--- a/scripts/check-ticket-file-references.mjs
+++ b/scripts/check-ticket-file-references.mjs
@@ -1,0 +1,102 @@
+#!/usr/bin/env node
+// Checks that every path cited in a MAINTENANCE_WORK_ITEMS.md ticket's
+// `Files:` list still resolves in the repo tree. Scoped deliberately to that
+// one structured field (not free-form prose elsewhere in the doc) to keep
+// false positives near zero -- see docs/agents/AGENT_STANDARDS.md's Backlog
+// Lifecycle Policy and this repo's own M1-15/M1-24 stale-path incident.
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+const root = process.cwd();
+const docRelPath = 'docs/waves/MAINTENANCE_WORK_ITEMS.md';
+const docPath = path.join(root, docRelPath);
+
+const source = fs.readFileSync(docPath, 'utf8');
+
+const ticketRegex = /^### (M1-\d+)\s+.*$/gm;
+const tickets = [...source.matchAll(ticketRegex)].map((match, index, all) => {
+  const start = match.index;
+  const end = index + 1 < all.length ? all[index + 1].index : source.length;
+  return { id: match[1], body: source.slice(start, end) };
+});
+
+if (tickets.length === 0) {
+  console.error(`Unable to parse any M1-* tickets from ${docRelPath}`);
+  process.exit(1);
+}
+
+const filesFieldRegex = /\d+\.\s+`Files`:\n((?:- .+\n?)+)/;
+
+function extractPathCandidate(bulletLine) {
+  const firstBacktick = bulletLine.match(/`([^`]+)`/);
+  if (!firstBacktick) {
+    return null;
+  }
+  const candidate = firstBacktick[1].trim();
+  // Only treat it as a path if it looks like one -- avoids false positives on
+  // non-path backtick spans that could otherwise leak into this field.
+  if (!candidate.includes('/') && !candidate.includes('.')) {
+    return null;
+  }
+  return candidate;
+}
+
+function pathExists(candidate) {
+  // A trailing `/*` denotes "this directory generally", not a literal
+  // filename -- resolve it as a directory-existence check instead of trying
+  // to glob-match, which would always miss.
+  const target = candidate.endsWith('/*') ? candidate.slice(0, -2) : candidate;
+  return fs.existsSync(path.join(root, target));
+}
+
+// A ticket whose stale Files reference is already tracked by an additive
+// corrective follow-up (Backlog Lifecycle Policy: `done` tickets are never
+// edited in place) shouldn't fail this check forever -- that would make the
+// check permanently red for a known, already-resolved-elsewhere gap. Treat
+// any ticket named in another ticket's `Depends On` field as acknowledged.
+const dependsOnRegex = /`Depends On`:\s*`(M1-\d+)`/g;
+const acknowledgedStaleTickets = new Set(
+  [...source.matchAll(dependsOnRegex)].map((match) => match[1])
+);
+
+const failures = [];
+let checkedCount = 0;
+
+for (const ticket of tickets) {
+  const match = ticket.body.match(filesFieldRegex);
+  if (!match) {
+    continue;
+  }
+  const bulletLines = match[1].split('\n').filter((line) => line.trim().startsWith('- '));
+  for (const bulletLine of bulletLines) {
+    const candidate = extractPathCandidate(bulletLine);
+    if (!candidate) {
+      continue;
+    }
+    checkedCount += 1;
+    if (pathExists(candidate)) {
+      continue;
+    }
+    if (acknowledgedStaleTickets.has(ticket.id)) {
+      continue;
+    }
+    failures.push(`${ticket.id}: Files entry does not resolve: \`${candidate}\``);
+  }
+}
+
+if (failures.length) {
+  console.error(`Stale ticket file reference check failed (${docRelPath}).`);
+  for (const failure of failures) {
+    console.error(`- ${failure}`);
+  }
+  console.error(
+    'Per the Backlog Lifecycle Policy, do not edit a `done` ticket\'s Files list directly --' +
+      ' add an additive corrective follow-up ticket (see M1-24 for the precedent).'
+  );
+  process.exit(1);
+}
+
+console.log(
+  `Ticket file reference check OK (${tickets.length} tickets, ${checkedCount} paths checked)`
+);

--- a/scripts/verify-engine-parity.fish
+++ b/scripts/verify-engine-parity.fish
@@ -79,6 +79,7 @@ cd $ROOT
 
 run_step "Browser contract codegen drift check" "cd $ROOT; pnpm --dir browser run contracts:check"
 run_step "Worklist drift" "cd $ROOT; node scripts/check-worklist-drift.mjs"
+run_step "Ticket file reference drift" "cd $ROOT; node scripts/check-ticket-file-references.mjs"
 
 echo ""
 echo "All engine parity verification checks passed."


### PR DESCRIPTION
## Summary

Fixes #390. Adds `scripts/check-ticket-file-references.mjs`, scoped to just the structured `Files:` field in each `MAINTENANCE_WORK_ITEMS.md` ticket (per the "structured fields only" scope decision — avoids the false-positive risk of scanning every backtick-quoted string in the doc).

Handles two real edge cases surfaced while testing against the current doc:
- Trailing `/*` glob-style references (e.g. `browser/contracts/generated/*`) resolve as a directory-existence check, not a literal path match.
- A ticket whose stale reference is already tracked by an additive corrective follow-up (Backlog Lifecycle Policy: `done` tickets are never edited in place — see `M1-24`'s precedent for `M1-15`) is treated as acknowledged via that follow-up's `Depends On` field, so the check reaches a stable pass instead of failing forever on a known, already-resolved-elsewhere gap.

Wired into `scripts/verify-engine-parity.fish` alongside the existing `check-worklist-drift.mjs`, matching that script's precedent (a local verification step, not a hard CI gate — `check-worklist-drift.mjs` itself isn't wired into `.github/workflows/`, so this follows the same convention rather than introducing a new one).

## Test plan

- [x] `node scripts/check-ticket-file-references.mjs` — passes clean against current doc (19 tickets, 85 paths checked)
- [x] Negative test: temporarily replaced a real path with a fake one across 3 tickets, confirmed the checker correctly flagged all 3, then reverted and confirmed clean pass again
- [x] `fish -n scripts/verify-engine-parity.fish` — syntax valid after the new `run_step` line

🤖 Generated with [Claude Code](https://claude.com/claude-code)