### PR TITLE
feat(engine-wasm): add advisory story-coverage check

### DIFF
--- a/engine-wasm/host-sample/README.md
+++ b/engine-wasm/host-sample/README.md
@@ -75,6 +75,13 @@ pnpm --dir engine-wasm/host-sample run examples:check
 pnpm --dir engine-wasm/host-sample run test:story:unit
 ```
 
+`examples:story-coverage` is advisory only (never fails): it reports any `*.wml` example with no
+adjacent `*.flow.json` story, so a gap doesn't silently sit uncovered until the next manual audit.
+
+```bash
+pnpm --dir engine-wasm/host-sample run examples:story-coverage
+```
+
 The host sample also owns the developer commands for the engine's Rust-derived serialized DTO
 projection. `contracts:generate` refreshes `engine-wasm/contracts/generated/runtime-dtos.ts`, and
 `contracts:check` fails when the committed projection has drifted:

--- a/engine-wasm/host-sample/package.json
+++ b/engine-wasm/host-sample/package.json
@@ -10,6 +10,7 @@
     "contracts:check": "pnpm run contracts:generate && git diff --exit-code -- ../contracts/generated/runtime-dtos.ts",
     "examples:generate": "node ./scripts/generate-example-manifest.mjs",
     "examples:check": "node ./scripts/generate-example-manifest.mjs --check",
+    "examples:story-coverage": "node ./scripts/check-story-coverage.mjs",
     "predev": "pnpm run examples:generate",
     "dev": "vite",
     "prebuild": "pnpm run examples:generate",

--- a/engine-wasm/host-sample/scripts/check-story-coverage.mjs
+++ b/engine-wasm/host-sample/scripts/check-story-coverage.mjs
@@ -1,0 +1,49 @@
+#!/usr/bin/env node
+// Advisory check (never fails the build): reports engine-wasm/examples/source
+// *.wml files that have no adjacent *.flow.json executable story. Per
+// docs/agents/AGENT_STANDARDS.md, a stable host-visible example with a
+// deterministic testing-ac should get a story, and a gap should be "left
+// explicit rather than inferring coverage from prose testing-ac" -- this
+// script is that explicit signal. It intentionally reports rather than
+// fails: every current example's testing-ac is schema-required (see
+// parseExampleMetadata in generate-example-manifest.mjs), so there's no
+// existing way to distinguish a deliberately story-less "exploratory"
+// example from a genuine gap. If one is ever added on purpose, the right
+// fix is an explicit opt-out marker in the frontmatter schema (e.g. a
+// `story: manual-only` key) that this script would then honor -- not
+// something to build speculatively before any example actually needs it.
+
+import { readdirSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
+const EXAMPLES_SOURCE_DIR = path.resolve(SCRIPT_DIR, '..', '..', 'examples', 'source');
+
+const entries = readdirSync(EXAMPLES_SOURCE_DIR);
+const wmlBases = new Set(
+  entries.filter((name) => name.endsWith('.wml')).map((name) => name.replace(/\.wml$/, ''))
+);
+const flowBases = new Set(
+  entries
+    .filter((name) => name.endsWith('.flow.json'))
+    .map((name) => name.replace(/\.flow\.json$/, ''))
+);
+
+const missing = [...wmlBases].filter((base) => !flowBases.has(base)).sort();
+
+if (missing.length === 0) {
+  console.log(`Story coverage OK: all ${wmlBases.size} examples have an executable story.`);
+  process.exit(0);
+}
+
+console.log(
+  `Story coverage advisory: ${missing.length} of ${wmlBases.size} examples have no *.flow.json:`
+);
+for (const base of missing) {
+  console.log(`  - ${base}.wml`);
+}
+console.log(
+  'Not a build failure. If any of these are intentionally story-less, that should still be' +
+    ' left explicit (see docs/agents/AGENT_STANDARDS.md) rather than silently assumed covered.'
+);


### PR DESCRIPTION
## Summary

Fixes #389. Adds `engine-wasm/host-sample/scripts/check-story-coverage.mjs`, which reports any `*.wml` example with no adjacent `*.flow.json` executable story. The 10 examples missing coverage that #386 fixed were only found by a manual, ad hoc audit — this gives it an automated signal.

Deliberately **advisory only** (always exits 0), per the chosen design: every current example's `testing-ac` is schema-required (see `parseExampleMetadata` in `generate-example-manifest.mjs`), so there's currently no way to distinguish a deliberately story-less "exploratory" example (which `docs/agents/AGENT_STANDARDS.md` explicitly allows) from a genuine gap. Coverage is already complete today (34/34, post #386), so building that distinction now would be speculative machinery with no current use — noted in the script's own comment that the right fix, if a genuine manual-only example is ever added, is an explicit opt-out marker in the frontmatter schema for this script to honor at that point.

## Test plan

- [x] `pnpm --dir engine-wasm/host-sample run examples:story-coverage` — passes clean today (34/34)
- [x] Negative test: temporarily moved one example's `*.flow.json` aside, confirmed the script reported exactly that gap, then restored it
- [x] `node --check` on the new script

🤖 Generated with [Claude Code](https://claude.com/claude-code)