### PR TITLE
fix(scripts): pin wasm-pack to 0.13.1 in local bootstrap, matching CI

### DIFF
--- a/scripts/init-refresh.sh
+++ b/scripts/init-refresh.sh
@@ -23,18 +23,25 @@ need_cmd() {
   return 0
 }
 
-ensure_rust_tool() {
-  check_cmd="$1"
-  install_cmd="$2"
-  if command -v "${check_cmd}" >/dev/null 2>&1; then
+ensure_wasm_pack() {
+  # Pinned to match .github/workflows/{ci,pages,milestone-release}.yml, which
+  # all install wasm-pack 0.13.1 explicitly. Local bootstrap previously
+  # installed unpinned latest, so a local wasm-pack build could differ from
+  # CI's output inventory without any repository change signaling it.
+  expected_version="0.13.1"
+  actual_version=""
+  if command -v wasm-pack >/dev/null 2>&1; then
+    actual_version="$(wasm-pack --version 2>/dev/null || true)"
+  fi
+  if [ "${actual_version}" = "wasm-pack ${expected_version}" ]; then
     return 0
   fi
   if [ "${AUTO_INSTALL_RUST_TOOLS}" != "1" ]; then
-    warn "${check_cmd} not found (set AUTO_INSTALL_RUST_TOOLS=1 to auto-install)"
+    warn "wasm-pack ${expected_version} required (found: ${actual_version:-missing}; set AUTO_INSTALL_RUST_TOOLS=1 to install)"
     return 0
   fi
-  log "installing ${check_cmd}"
-  eval "${install_cmd}"
+  log "installing wasm-pack ${expected_version}"
+  cargo install wasm-pack --version "${expected_version}" --locked --force
 }
 
 ensure_tauri_cli() {
@@ -61,7 +68,7 @@ need_cmd pnpm || true
 need_cmd cargo || true
 
 if command -v cargo >/dev/null 2>&1; then
-  ensure_rust_tool wasm-pack "cargo install wasm-pack --locked"
+  ensure_wasm_pack
   ensure_tauri_cli
 fi
 


### PR DESCRIPTION
## Summary

Closes the one still-open loose end from `docs/architecture/code-generation-audit.md`'s P3 findings (all 7 numbered remediation slices already landed and independently re-verified this session; this specific finding never got a numbered slice).

`init-refresh.sh` installed wasm-pack unpinned (`cargo install wasm-pack --locked`, whatever's latest), while every CI workflow (`ci.yml`, `pages.yml`, `milestone-release.yml`) pins `0.13.1` explicitly. A local wasm-pack build's output inventory could silently differ from CI's without any repository change signaling it.

`ensure_wasm_pack()` mirrors the existing `ensure_tauri_cli()` pattern already in this file: check the actually-installed version (not just presence), reinstall on mismatch when `AUTO_INSTALL_RUST_TOOLS=1`, otherwise warn with the expected/found versions. Also removes the now-unused generic `ensure_rust_tool()` helper (no other callers).

The other loose end from the audit (an ambiguous "174" figure in `docs/waves/WAP_1_2_1_WML_SCR_LEDGER.md`) was investigated and found to likely be a different, legitimately distinct metric from what the audit flagged elsewhere (that flagged 4 specific other documents, not this one) — not touched, to avoid guessing at a compliance-evidence number.

## Test plan

- [x] `dash -n scripts/init-refresh.sh` and `shellcheck -s sh scripts/init-refresh.sh` both clean
- [x] Functional: with local wasm-pack `0.14.0` installed, running the script correctly emits the version-mismatch warning (`wasm-pack 0.13.1 required (found: wasm-pack 0.14.0; ...)`) instead of silently proceeding

🤖 Generated with [Claude Code](https://claude.com/claude-code)