### PR TITLE
fix(docs-portal): restore Astro cookie compatibility

### DIFF
--- a/docs-portal/package.json
+++ b/docs-portal/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@astrojs/check": "^0.9.6",
     "ajv": "8.20.0",
-    "astro": "7.1.3",
+    "astro": "7.1.1",
     "typescript": "^6.0.3"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -133,8 +133,8 @@ importers:
         specifier: 8.20.0
         version: 8.20.0
       astro:
-        specifier: 7.1.3
-        version: 7.1.3(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.3)(@types/node@26.1.1)(yaml@2.9.0)
+        specifier: 7.1.1
+        version: 7.1.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.3)(@types/node@26.1.1)(yaml@2.9.0)
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
@@ -1251,8 +1251,8 @@ packages:
   ast-v8-to-istanbul@1.0.4:
     resolution: {integrity: sha512-0bC0/4bTSrnwdhU3IsZDwEdojvuPrSg59OYZfKsLRtJZ0u8VBx9DebfqqG8bRdCC0I7vjgxmPi41P0lpkhJHtA==}
 
-  astro@7.1.3:
-    resolution: {integrity: sha512-4dhPyAAXthf3xLEYnG8SeL7yr/nTPPABfY7e9YF0yuO+vK9Xp+8Q5j4xzsmL3GueukQv4oNwGNTBepLOiDGeJA==}
+  astro@7.1.1:
+    resolution: {integrity: sha512-yfKhuvbz+DORHihJRL1DHcxyLcX9uTrxvz2nCSTzHH54k2DdACBfuOu2OAAAhdUC9xlu2IRXAiagqcPL3DftCg==}
     engines: {node: '>=22.12.0', npm: '>=9.6.5', pnpm: '>=7.1.0'}
     hasBin: true
     peerDependencies:
@@ -1343,9 +1343,9 @@ packages:
   cookie-es@1.2.3:
     resolution: {integrity: sha512-lXVyvUvrNXblMqzIRrxHb57UUVmqsSWlxqt3XIjCkUP0wDAf6uicO6KMbEgYrMNtEvWgWHwe42CKxPu9MYAnWw==}
 
-  cookie@2.0.1:
-    resolution: {integrity: sha512-yuToqVvRrj6pfDXREyQAAv8SkAEk/8GS3jQRTiUMm66TVtBYmqQeoEjL2Lmq8Rpo6271vH76InTChTitEAm65w==}
-    engines: {node: '>=22'}
+  cookie@1.1.1:
+    resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
+    engines: {node: '>=18'}
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -1922,8 +1922,8 @@ packages:
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
-  neotraverse@1.0.1:
-    resolution: {integrity: sha512-WmmLty1YWwJl9yZi77v2dVIV6X2kuYV8YYBI/G3LWGKdGHmHUvL1z7FW0iDvEvGAwNEoc5x1tOOOyDnf5jJw/w==}
+  neotraverse@0.6.18:
+    resolution: {integrity: sha512-Z4SmBUweYa09+o6pG+eASabEpP6QkQ70yHj351pQoEXIs8uHbaU2DWVmzBANKgflPa47A50PtB2+NgRpQvr7vA==}
     engines: {node: '>= 10'}
 
   nlcst-to-string@4.0.0:
@@ -3683,7 +3683,7 @@ snapshots:
       estree-walker: 3.0.3
       js-tokens: 10.0.0
 
-  astro@7.1.3(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.3)(@types/node@26.1.1)(yaml@2.9.0):
+  astro@7.1.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.3)(@types/node@26.1.1)(yaml@2.9.0):
     dependencies:
       '@astrojs/compiler-rs': 0.3.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.3)
       '@astrojs/internal-helpers': 0.10.1
@@ -3699,7 +3699,7 @@ snapshots:
       ci-info: 4.4.0
       clsx: 2.1.1
       common-ancestor-path: 2.0.0
-      cookie: 2.0.1
+      cookie: 1.1.1
       devalue: 5.8.2
       diff: 8.0.4
       dset: 3.1.4
@@ -3716,7 +3716,7 @@ snapshots:
       magic-string: 0.30.21
       magicast: 0.5.3
       mrmime: 2.0.1
-      neotraverse: 1.0.1
+      neotraverse: 0.6.18
       obug: 2.1.4
       p-limit: 7.3.1
       p-queue: 9.3.3
@@ -3835,7 +3835,7 @@ snapshots:
 
   cookie-es@1.2.3: {}
 
-  cookie@2.0.1: {}
+  cookie@1.1.1: {}
 
   cross-spawn@7.0.6:
     dependencies:
@@ -4438,7 +4438,7 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
-  neotraverse@1.0.1: {}
+  neotraverse@0.6.18: {}
 
   nlcst-to-string@4.0.0:
     dependencies:


### PR DESCRIPTION
## Summary

- pin Project Atlas to Astro 7.1.1, the last 7.1 release before Astro upgraded to cookie v2
- update the frozen workspace lockfile from Astro 7.1.3 / cookie 2.0.1 to Astro 7.1.1 / cookie 1.1.1
- leave Atlas commands, generated output policy, CI, and Pages workflow behavior unchanged

## Root cause

Astro 7.1.2 upgraded its cookie dependency to v2, and Astro 7.1.3's prerender path imports the new named `parseCookie` export. In the affected Node 22.22.1 installation, Node resolved that package as CommonJS and rejected the named export before static prerendering.

Astro 7.1.1 is the supported pre-upgrade package pair: it uses cookie 1.1.1 and imports that version's `parse` / `serialize` API. This avoids the failing v2 interop surface without patching `node_modules`, changing the build command, or masking prerender failures.

PR #376's Atlas schema fix remains intact.

## Verification

- `fnm exec --using=22.22.1 -- pnpm install --frozen-lockfile`
- `fnm exec --using=22.22.1 -- pnpm --dir docs-portal run test:data` (11/11)
- `fnm exec --using=22.22.1 -- pnpm --dir docs-portal run check` (0 diagnostics)
- `fnm exec --using=22.22.1 -- pnpm --dir docs-portal run build` (1,077 pages)
- `fnm exec --using=22.22.1 -- pnpm wap-compliance:check`
- `fnm exec --using=22.22.1 -- pnpm wap-graph:check`
- `fnm exec --using=22.22.1 -- pnpm format:check:node`
- `fnm exec --using=22.22.1 -- pnpm version:check`
- `git diff --check`
- mandatory pre-push suite, including engine tests and Rust clippy checks

## CI / deploy note

A clean frozen install in this worktree and the latest main CI/Pages runs currently succeed with Astro 7.1.3, so the reported failure is environment-sensitive rather than universal. Both CI's Project Atlas job and the Pages deployment invoke the same workspace-frozen production build covered by this dependency rollback; no workflow-only workaround is needed.
