### PR TITLE
ci: add extended deterministic quality gates

### DIFF
--- a/.github/workflows/extended-quality.yml
+++ b/.github/workflows/extended-quality.yml
@@ -147,6 +147,7 @@ jobs:
 
       - name: Rendered accessibility gate
         env:
+          WAVES_ACCESSIBILITY_BASE_REVISION: ${{ github.event.pull_request.base.sha || github.sha }}
           WAVES_ACCESSIBILITY_OUTPUT_DIR: browser/frontend/test-results/wbp-05a
         run: pnpm --dir browser/frontend run test:accessibility:rendered
 

--- a/.github/workflows/extended-quality.yml
+++ b/.github/workflows/extended-quality.yml
@@ -1,0 +1,267 @@
+name: Extended Quality - Required Path Gates + Advisory Baseline
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  schedule:
+    - cron: '17 7 * * 0'
+  workflow_dispatch:
+    inputs:
+      baseline_runs:
+        description: Latency samples per browser baseline metric (5-100)
+        required: false
+        default: '20'
+
+permissions:
+  contents: read
+
+env:
+  NODE_VERSION: '22'
+  RUST_SHARED_KEY: wavenav-rust
+  WASM_PACK_VERSION: '0.13.1'
+
+jobs:
+  changes:
+    name: Classify Required Quality Paths
+    if: ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    outputs:
+      engine_clippy: ${{ steps.filter.outputs.engine_clippy }}
+      rendered_accessibility: ${{ steps.filter.outputs.rendered_accessibility }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      - name: Detect extended quality paths
+        id: filter
+        uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4
+        with:
+          filters: |
+            engine_clippy:
+              - ".github/workflows/extended-quality.yml"
+              - "engine-wasm/engine/**"
+            rendered_accessibility:
+              - ".github/workflows/extended-quality.yml"
+              - "browser/contracts/**"
+              - "browser/frontend/**"
+              - "browser/src-tauri/tauri.conf.json"
+              - "engine-wasm/engine/**"
+              - "engine-wasm/examples/**"
+              - "pnpm-lock.yaml"
+              - "pnpm-workspace.yaml"
+              - "tsconfig.base.json"
+
+  engine-clippy:
+    name: Required - Engine Clippy (path-scoped)
+    needs: [changes]
+    if: ${{ needs.changes.outputs.engine_clippy == 'true' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      - name: Setup Rust with Clippy
+        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
+        with:
+          components: clippy
+
+      - name: Cache Rust build artifacts
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          shared-key: ${{ env.RUST_SHARED_KEY }}
+          workspaces: |
+            engine-wasm/engine -> target
+
+      - name: Verify engine Cargo.lock
+        working-directory: engine-wasm/engine
+        run: cargo metadata --locked --format-version 1 --no-deps >/dev/null
+
+      - name: Engine Clippy with zero-warning policy
+        working-directory: engine-wasm/engine
+        run: cargo clippy --all-targets --all-features -- -D warnings
+
+  rendered-accessibility:
+    name: Required - Rendered Accessibility (path-scoped)
+    needs: [changes]
+    if: ${{ needs.changes.outputs.rendered_accessibility == 'true' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
+
+      - name: Cache Rust build artifacts
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          shared-key: ${{ env.RUST_SHARED_KEY }}
+          workspaces: |
+            engine-wasm/engine -> target
+
+      - name: Cache wasm-pack binary
+        id: cache-wasm-pack-accessibility
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
+        with:
+          path: ~/.cargo/bin/wasm-pack
+          key: ${{ runner.os }}-wasm-pack-${{ env.WASM_PACK_VERSION }}
+          restore-keys: |
+            ${{ runner.os }}-wasm-pack-
+
+      - name: Install wasm-pack (if cache miss)
+        if: steps.cache-wasm-pack-accessibility.outputs.cache-hit != 'true'
+        run: cargo install wasm-pack --version "${WASM_PACK_VERSION}" --locked
+
+      - name: Build WaveNav WASM package
+        working-directory: engine-wasm/engine
+        run: wasm-pack build --target web --out-dir ../pkg
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
+
+      - name: Setup Node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'pnpm'
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Install workspace dependencies
+        run: pnpm install --frozen-lockfile --ignore-scripts
+
+      - name: Install pinned Playwright Chromium
+        run: pnpm --dir browser/frontend exec playwright install --with-deps chromium
+
+      - name: Deterministic accessibility unit tests
+        run: pnpm --dir browser/frontend exec vitest run src/app/accessibility-audit.test.ts
+
+      - name: Rendered accessibility gate
+        env:
+          WAVES_ACCESSIBILITY_OUTPUT_DIR: browser/frontend/test-results/wbp-05a
+        run: pnpm --dir browser/frontend run test:accessibility:rendered
+
+      - name: Upload rendered accessibility failure evidence
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: rendered-accessibility-failure-evidence
+          path: browser/frontend/test-results/wbp-05a
+          if-no-files-found: ignore
+          retention-days: 14
+
+  required-gate:
+    name: Extended Quality Required Gate
+    if: ${{ always() && (github.event_name == 'pull_request' || github.event_name == 'push') }}
+    permissions: {}
+    needs: [changes, engine-clippy, rendered-accessibility]
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Verify selected required gates
+        env:
+          CHANGES_RESULT: ${{ needs.changes.result }}
+          ENGINE_CLIPPY_SELECTED: ${{ needs.changes.outputs.engine_clippy }}
+          ENGINE_CLIPPY_RESULT: ${{ needs.engine-clippy.result }}
+          ACCESSIBILITY_SELECTED: ${{ needs.changes.outputs.rendered_accessibility }}
+          ACCESSIBILITY_RESULT: ${{ needs.rendered-accessibility.result }}
+        run: |
+          if [ "${CHANGES_RESULT}" != "success" ]; then
+            echo "Quality path classification concluded: ${CHANGES_RESULT}"
+            exit 1
+          fi
+
+          verify_selected_gate() {
+            selected="$1"
+            result="$2"
+            label="$3"
+            if [ "${selected}" = "true" ] && [ "${result}" != "success" ]; then
+              echo "${label} was selected but concluded: ${result}"
+              exit 1
+            fi
+            if [ "${selected}" != "true" ] && [ "${result}" != "skipped" ]; then
+              echo "${label} was not selected but concluded: ${result}"
+              exit 1
+            fi
+          }
+
+          verify_selected_gate "${ENGINE_CLIPPY_SELECTED}" "${ENGINE_CLIPPY_RESULT}" "Engine Clippy"
+          verify_selected_gate "${ACCESSIBILITY_SELECTED}" "${ACCESSIBILITY_RESULT}" "Rendered Accessibility"
+
+  browser-baseline:
+    name: Advisory - Browser Stability Baseline (scheduled/manual)
+    if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    env:
+      WAVES_BASELINE_RUNS: ${{ inputs.baseline_runs || '20' }}
+      WAVES_BASELINE_OUTPUT_DIR: engine-wasm/host-sample/test-results/waves-baseline
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
+
+      - name: Cache Rust build artifacts
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          shared-key: ${{ env.RUST_SHARED_KEY }}
+          workspaces: |
+            engine-wasm/engine -> target
+
+      - name: Cache wasm-pack binary
+        id: cache-wasm-pack-baseline
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
+        with:
+          path: ~/.cargo/bin/wasm-pack
+          key: ${{ runner.os }}-wasm-pack-${{ env.WASM_PACK_VERSION }}
+          restore-keys: |
+            ${{ runner.os }}-wasm-pack-
+
+      - name: Install wasm-pack (if cache miss)
+        if: steps.cache-wasm-pack-baseline.outputs.cache-hit != 'true'
+        run: cargo install wasm-pack --version "${WASM_PACK_VERSION}" --locked
+
+      - name: Build WaveNav WASM package
+        working-directory: engine-wasm/engine
+        run: wasm-pack build --target web --out-dir ../pkg
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
+
+      - name: Setup Node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'pnpm'
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Install workspace dependencies
+        run: pnpm install --frozen-lockfile --ignore-scripts
+
+      - name: Install pinned Playwright Chromium
+        run: pnpm --dir engine-wasm/host-sample exec playwright install --with-deps chromium
+
+      - name: Measure deterministic browser baseline
+        run: pnpm test:baseline:waves
+
+      - name: Upload browser baseline evidence
+        if: ${{ always() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: waves-browser-baseline-${{ github.run_id }}
+          path: engine-wasm/host-sample/test-results/waves-baseline
+          if-no-files-found: ignore
+          retention-days: 14

--- a/browser/frontend/scripts/check-rendered-accessibility.mjs
+++ b/browser/frontend/scripts/check-rendered-accessibility.mjs
@@ -21,6 +21,7 @@ const outputDir = requestedOutputDir
     ? requestedOutputDir
     : path.resolve(REPO_ROOT, requestedOutputDir)
   : DEFAULT_OUTPUT_DIR;
+const requestedBaseRevision = process.env.WAVES_ACCESSIBILITY_BASE_REVISION?.trim();
 const tempRoot = await mkdtemp(path.join(os.tmpdir(), 'waves-accessibility-build-'));
 const tauriConfig = JSON.parse(await readFile(TAURI_CONFIG_PATH, 'utf8'));
 const windowConfig = tauriConfig.app.windows[0];
@@ -59,6 +60,21 @@ const openAllDisclosures = async (page) => {
       details.open = true;
     }
   });
+};
+
+const resolveBaseRevision = async () => {
+  if (requestedBaseRevision) {
+    assert.match(
+      requestedBaseRevision,
+      /^[0-9a-f]{40}$/,
+      'WAVES_ACCESSIBILITY_BASE_REVISION must be a full Git commit SHA'
+    );
+    return requestedBaseRevision;
+  }
+  const { stdout } = await execFileAsync('git', ['merge-base', 'HEAD', 'origin/main'], {
+    cwd: REPO_ROOT
+  });
+  return stdout.trim();
 };
 
 const auditRenderedPage = async (page, name, windowEvidence) => {
@@ -262,15 +278,15 @@ try {
     }
   }
 
-  const [{ stdout: revision }, browserVersion] = await Promise.all([
-    execFileAsync('git', ['merge-base', 'HEAD', 'origin/main'], { cwd: REPO_ROOT }),
+  const [baseRevision, browserVersion] = await Promise.all([
+    resolveBaseRevision(),
     browser.version()
   ]);
   const result = {
     schemaVersion: 1,
     workItem: 'WBP-05A',
     capturedAt: new Date().toISOString(),
-    baseRevision: revision.trim(),
+    baseRevision,
     sourceState: 'feature working tree including WBP-05A changes',
     path: 'production-built Waves browser-story entry with real WaveNav WASM and deterministic local fixture fetch',
     zoomModel:

--- a/browser/frontend/scripts/check-rendered-accessibility.mjs
+++ b/browser/frontend/scripts/check-rendered-accessibility.mjs
@@ -190,28 +190,30 @@ const auditRenderedPage = async (page, name, windowEvidence) => {
 };
 
 await mkdir(outputDir, { recursive: true });
-await build({
-  root: FRONTEND_DIR,
-  configFile: path.join(FRONTEND_DIR, 'vite.config.ts'),
-  build: {
-    outDir: tempRoot,
-    emptyOutDir: true,
-    rollupOptions: { input: path.join(FRONTEND_DIR, 'browser-story.html') }
-  }
-});
-const previewServer = await preview({
-  root: FRONTEND_DIR,
-  configFile: path.join(FRONTEND_DIR, 'vite.config.ts'),
-  build: { outDir: tempRoot },
-  preview: { host: '127.0.0.1', port: 0, strictPort: false }
-});
-const baseUrl = previewServer.resolvedUrls?.local[0];
-if (!baseUrl) {
-  throw new Error('Vite preview did not expose a local URL');
-}
-
+const failureArtifacts = {};
+let previewServer;
 let browser;
 try {
+  await build({
+    root: FRONTEND_DIR,
+    configFile: path.join(FRONTEND_DIR, 'vite.config.ts'),
+    build: {
+      outDir: tempRoot,
+      emptyOutDir: true,
+      rollupOptions: { input: path.join(FRONTEND_DIR, 'browser-story.html') }
+    }
+  });
+  previewServer = await preview({
+    root: FRONTEND_DIR,
+    configFile: path.join(FRONTEND_DIR, 'vite.config.ts'),
+    build: { outDir: tempRoot },
+    preview: { host: '127.0.0.1', port: 0, strictPort: false }
+  });
+  const baseUrl = previewServer.resolvedUrls?.local[0];
+  if (!baseUrl) {
+    throw new Error('Vite preview did not expose a local URL');
+  }
+
   browser = await chromium.launch({ headless: true });
   const windowEvidence = {};
   for (const [name, dimensions] of Object.entries(windows)) {
@@ -221,13 +223,43 @@ try {
       reducedMotion: 'reduce'
     });
     const page = await context.newPage();
-    await page.goto(new URL('browser-story.html', baseUrl).href, {
-      waitUntil: 'domcontentloaded'
-    });
-    await waitForReady(page);
-    await openAllDisclosures(page);
-    windowEvidence[name] = await auditRenderedPage(page, name, dimensions);
-    await context.close();
+    let tracing = false;
+    try {
+      await context.tracing.start({ screenshots: true, snapshots: true, sources: true });
+      tracing = true;
+      await page.goto(new URL('browser-story.html', baseUrl).href, {
+        waitUntil: 'domcontentloaded'
+      });
+      await waitForReady(page);
+      await openAllDisclosures(page);
+      windowEvidence[name] = await auditRenderedPage(page, name, dimensions);
+      await context.tracing.stop();
+      tracing = false;
+    } catch (error) {
+      const screenshot = `${name}-failure.png`;
+      const trace = `${name}-trace.zip`;
+      const screenshotSaved = await page
+        .screenshot({ path: path.join(outputDir, screenshot), fullPage: true })
+        .then(() => true)
+        .catch(() => false);
+      const traceSaved = tracing
+        ? await context.tracing
+            .stop({ path: path.join(outputDir, trace) })
+            .then(() => true)
+            .catch(() => false)
+        : false;
+      tracing = false;
+      failureArtifacts[name] = {
+        screenshot: screenshotSaved ? screenshot : null,
+        trace: traceSaved ? trace : null
+      };
+      throw error;
+    } finally {
+      if (tracing) {
+        await context.tracing.stop().catch(() => undefined);
+      }
+      await context.close();
+    }
   }
 
   const [{ stdout: revision }, browserVersion] = await Promise.all([
@@ -258,8 +290,23 @@ try {
   await writeFile(resultPath, `${JSON.stringify(result, null, 2)}\n`);
   console.log('PASS WBP-05A rendered accessibility at default and minimum windows');
   console.log(`RESULT ${resultPath}`);
+} catch (error) {
+  const failurePath = path.join(outputDir, 'rendered-accessibility-failure.json');
+  const failure = {
+    schemaVersion: 1,
+    workItem: 'WBP-05A',
+    capturedAt: new Date().toISOString(),
+    error: {
+      name: error instanceof Error ? error.name : 'Error',
+      message: error instanceof Error ? error.message : String(error)
+    },
+    artifacts: failureArtifacts
+  };
+  await writeFile(failurePath, `${JSON.stringify(failure, null, 2)}\n`);
+  console.error(`FAILURE EVIDENCE ${failurePath}`);
+  throw error;
 } finally {
   await browser?.close();
-  await previewServer.close();
+  await previewServer?.close();
   await rm(tempRoot, { recursive: true, force: true });
 }

--- a/browser/frontend/vitest.config.ts
+++ b/browser/frontend/vitest.config.ts
@@ -11,7 +11,11 @@ export default defineConfig({
       include: ['src/**/*.ts'],
       exclude: [
         'src/**/*.test.ts',
-        'src/main.ts'
+        'src/main.ts',
+        // Browser-only E2E harnesses are executed by the rendered Playwright gates.
+        'src/browser-test-main.ts',
+        'src/test-support/wasm-browser-test-host.ts',
+        'src/test-support/waves-story-observation.ts'
       ],
       thresholds: {
         lines: 80,

--- a/docs/agents/RUST_ENGINE_STEERING.md
+++ b/docs/agents/RUST_ENGINE_STEERING.md
@@ -228,9 +228,13 @@ CI also enforces engine coverage through `cargo llvm-cov` with the current thres
 1. 90% line coverage
 2. 85% function coverage
 
-Optional/disabled gate (enable intentionally later):
+Required path-scoped gate in `.github/workflows/extended-quality.yml`:
 
 1. `cargo clippy --all-targets --all-features -- -D warnings`
+
+The primary coverage job in `.github/workflows/ci.yml` does not duplicate this command. The
+stable `Extended Quality Required Gate` aggregate selects the Clippy job whenever engine or
+extended-quality workflow paths change.
 
 Rustdoc lint escalation remains optional for later public-crate hardening.
 

--- a/docs/ci/CI_SETUP.md
+++ b/docs/ci/CI_SETUP.md
@@ -5,6 +5,7 @@ This document describes all active GitHub Actions automation for this repository
 ## Quick Reference
 
 - Main validation workflow: `.github/workflows/ci.yml`
+- Extended deterministic quality workflow: `.github/workflows/extended-quality.yml`
 - Release branch preparation workflow: `.github/workflows/release-prepare.yml`
 - Milestone GitHub release workflow: `.github/workflows/milestone-release.yml`
 - Security workflow: `.github/workflows/security.yml`
@@ -96,7 +97,43 @@ Caching:
 - Rust build artifact cache (`Swatinem/rust-cache`)
 - `wasm-pack` binary cache (`actions/cache`)
 
-### 2) Security (`.github/workflows/security.yml`)
+### 2) Extended Quality (`.github/workflows/extended-quality.yml`)
+
+Purpose:
+
+- Required, path-scoped engine lint and rendered browser accessibility gates.
+- Scheduled and manually dispatchable advisory browser stability measurements.
+
+Triggers and classification:
+
+- `pull_request` and `push` to `main`
+  - `Required - Engine Clippy (path-scoped)` runs for engine or workflow changes and enforces
+    `cargo clippy --all-targets --all-features -- -D warnings` without warning suppression.
+  - `Required - Rendered Accessibility (path-scoped)` runs for browser frontend and its
+    engine/contract/build inputs. It preserves the deterministic unit accessibility test and adds
+    the production-built Chromium/axe rendered check.
+  - `Extended Quality Required Gate` is the stable required aggregate. It succeeds when selected
+    jobs pass and permits only intentional path-filter skips.
+- Weekly schedule (`17 7 * * 0`) and `workflow_dispatch`
+  - `Advisory - Browser Stability Baseline (scheduled/manual)` exercises startup, navigation,
+    input/render, layout, and keyboard behavior with `WAVES_BASELINE_RUNS` (20 by default; manual
+    runs accept 5 through 100).
+  - Deterministic behavior assertions can fail the advisory run. Recorded latency samples have no
+    pass/fail threshold until the project accepts a stable reference, so timing variability never
+    blocks a pull request.
+
+Prerequisites and artifacts:
+
+- Uses the repository Node 22 and pnpm lockfile, stable Rust, pinned `wasm-pack` 0.13.1, and the
+  Playwright-lockfile Chromium version.
+- Rendered accessibility failures upload JSON, screenshots, and Playwright traces when a page was
+  available. The dedicated failure artifact is retained for 14 days.
+- Baseline runs always attempt to upload the JSON and screenshots produced before completion for
+  14 days. These runtime outputs remain ignored local/generated evidence and are not committed.
+- All actions are pinned to full commit SHAs, permissions are read-only, and checkout credentials
+  are not persisted.
+
+### 3) Security (`.github/workflows/security.yml`)
 
 Purpose:
 
@@ -130,7 +167,7 @@ Caching:
 - pnpm cache for workspace audit
 - npm cache for `wml-server` audit
 
-### 3) Release Prepare (`.github/workflows/release-prepare.yml`)
+### 4) Release Prepare (`.github/workflows/release-prepare.yml`)
 
 Purpose:
 
@@ -148,7 +185,7 @@ Behavior:
 - commits the release version bump only if needed
 - pushes a new `release/vX.Y.Z` branch and fails if it already exists
 
-### 4) Milestone Release (`.github/workflows/milestone-release.yml`)
+### 5) Milestone Release (`.github/workflows/milestone-release.yml`)
 
 Purpose:
 
@@ -166,7 +203,7 @@ Behavior:
 - creates an annotated `vX.Y.Z` tag
 - publishes a GitHub release with downloadable source and site-bundle assets
 
-### 5) CodeQL (`.github/workflows/codeql.yml`)
+### 6) CodeQL (`.github/workflows/codeql.yml`)
 
 Purpose:
 
@@ -200,7 +237,7 @@ Config:
   - includes core source paths: `browser`, `engine-wasm`, `transport-rust`, `wml-server`, `scripts`
   - excludes generated/build paths such as `target`, `dist`, `node_modules`, `engine-wasm/pkg`, and generated browser contracts
 
-### 6) Deploy Pages (`.github/workflows/pages.yml`)
+### 7) Deploy Pages (`.github/workflows/pages.yml`)
 
 Purpose:
 
@@ -225,7 +262,7 @@ Behavior:
 - assembles the three applications under `/`, `/simulator/`, and `/atlas/`
 - deploys to `gh-pages` branch with `peaceiris/actions-gh-pages`
 
-### 7) Transport WAP Smoke (`.github/workflows/transport-wap-smoke.yml`)
+### 8) Transport WAP Smoke (`.github/workflows/transport-wap-smoke.yml`)
 
 Purpose:
 
@@ -329,6 +366,7 @@ For immutable release branches, use `docs/ci/RELEASE_BRANCH_RULESET.md` as the s
 At minimum, require:
 
 - `CI Required Gate` from `ci.yml`
+- `Extended Quality Required Gate` from `extended-quality.yml`
 - Security jobs from `security.yml`
 - CodeQL matrix checks from `codeql.yml`
 

--- a/docs/ci/REQUIRED_CHECKS.md
+++ b/docs/ci/REQUIRED_CHECKS.md
@@ -10,6 +10,7 @@ For workflow details, see `docs/ci/CI_SETUP.md`. For immutable release-branch go
 Configure the active `main` ruleset to require these exact GitHub Actions check names:
 
 - `CI Required Gate`
+- `Extended Quality Required Gate`
 - `Dependency Review`
 - `Rust Advisory Audit`
 - `Node Dependency Audit`
@@ -37,6 +38,17 @@ to conclude `success`.
 The security checks come from `.github/workflows/security.yml`. The CodeQL checks come from the
 repository-controlled advanced setup in `.github/workflows/codeql.yml`.
 
+`Extended Quality Required Gate` is the stable aggregate from
+`.github/workflows/extended-quality.yml`. For pull requests and pushes to `main`, it selects:
+
+- `Required - Engine Clippy (path-scoped)` for engine and extended-quality workflow changes.
+- `Required - Rendered Accessibility (path-scoped)` for browser frontend and its
+  engine/contract/build inputs.
+
+The aggregate accepts intentional path-filter skips and fails if any selected gate fails or is
+cancelled. The scheduled/manual `Advisory - Browser Stability Baseline (scheduled/manual)` is not
+part of this aggregate and must not be configured as a required check.
+
 ## Ruleset configuration
 
 In **Settings > Rules > Rulesets > main**:
@@ -44,7 +56,7 @@ In **Settings > Rules > Rulesets > main**:
 1. Keep the ruleset active and targeted at the default branch.
 2. Keep pull requests required and squash as the allowed merge method.
 3. Keep bypass actors empty.
-4. Under required status checks, require the six exact contexts above and select the GitHub
+4. Under required status checks, require the seven exact contexts above and select the GitHub
    Actions app as the expected source.
 5. Enable the strict/up-to-date option if every pull request must be tested against the latest
    `main` before merge.
@@ -98,7 +110,8 @@ only after every required status check and any other ruleset requirement succeed
 
 - `Transport WAP Smoke (Kannel)` is manual and must not be required for pull requests.
 - `Build and Deploy to gh-pages` is deployment-focused and must not be required for code merges.
-- Scheduled/manual fuzzing and release workflows must not be required pull-request checks.
+- Scheduled/manual fuzzing, browser baseline, and release workflows must not be required
+  pull-request checks.
 
 ## Maintenance notes
 


### PR DESCRIPTION
## Summary

- add a separate extended-quality workflow with a stable required aggregate
- require full engine `cargo clippy --all-targets --all-features -- -D warnings` on engine/workflow paths
- require deterministic unit accessibility plus production-built rendered Chromium/axe accessibility checks on browser-relevant paths
- capture rendered accessibility failure JSON, screenshots, and Playwright traces for 14 days
- add a weekly/manual `WAVES_BASELINE_RUNS` startup/navigation/input/layout/keyboard stability signal with recorded-only timing
- document exact required/path-scoped/scheduled/advisory classifications and branch-protection context

## Gate classification

| Gate | Classification | Trigger |
| --- | --- | --- |
| Engine Clippy | Required, path-scoped | pull request / push to main |
| Rendered Accessibility | Required, path-scoped | pull request / push to main |
| Extended Quality Required Gate | Required stable aggregate | pull request / push to main |
| Browser Stability Baseline | Advisory | weekly schedule / manual dispatch |

Timing samples are not thresholded and cannot block pull requests. Deterministic baseline assertions still make scheduled/manual failures visible.

## Coverage scope

The unit coverage threshold remains unchanged. Browser-story entrypoint/WASM observation adapters are excluded from unit coverage because the rendered Playwright lane executes those E2E-only files directly.

## Validation

- engine `cargo fmt --check`
- engine `cargo test` (309 passed after rebase)
- engine `cargo clippy --all-targets --all-features -- -D warnings`
- frontend coverage (194 passed; 87.10% lines, 84.02% functions)
- frontend build, typecheck, lint, and format checks
- deterministic accessibility unit test
- rendered accessibility at default/minimum 200%-zoom windows
- representative `WAVES_BASELINE_RUNS=5` execution
- browser contract drift and example-manifest drift checks
- actionlint, yamllint, full-SHA action pin checks, and focused GitHub Actions security review
- full repository pre-push hook

## Follow-up policy

After this PR produces the new context, configure `Extended Quality Required Gate` in the active main ruleset as documented in `docs/ci/REQUIRED_CHECKS.md`. No accepted timing reference exists yet; adopting performance thresholds remains explicit future work.
