### PR TITLE
test(browser): add native Tauri/Kannel UI E2E pilot

### DIFF
--- a/.github/workflows/native-tauri-kannel-e2e.yml
+++ b/.github/workflows/native-tauri-kannel-e2e.yml
@@ -1,0 +1,86 @@
+name: Native Tauri Kannel E2E
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - '.github/workflows/native-tauri-kannel-e2e.yml'
+      - 'Makefile'
+      - 'browser/frontend/package.json'
+      - 'browser/frontend/scripts/native-tauri-kannel-e2e.mjs'
+      - 'scripts/native-tauri-kannel-e2e.sh'
+  schedule:
+    - cron: '17 5 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  NODE_VERSION: '22.22.1'
+  RUST_BROWSER_KEY: wavenav-browser-native-e2e
+  NATIVE_E2E_ARTIFACT_DIR: ${{ github.workspace }}/browser/frontend/test-results/native-tauri-kannel
+
+jobs:
+  native-tauri-kannel-e2e:
+    name: Native Tauri UI through Kannel (pilot)
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      - name: Install Linux Tauri WebDriver dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libayatana-appindicator3-dev \
+            librsvg2-dev \
+            libwebkit2gtk-4.1-dev \
+            pkg-config \
+            webkit2gtk-driver \
+            xvfb
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
+
+      - name: Setup Node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'pnpm'
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Install Node dependencies
+        run: pnpm install --frozen-lockfile --ignore-scripts
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
+
+      - name: Cache native E2E Rust build artifacts
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          shared-key: ${{ env.RUST_BROWSER_KEY }}
+          workspaces: |
+            browser/src-tauri -> target
+            engine-wasm/engine -> target
+            transport-rust -> target
+
+      - name: Install pinned Tauri CLI and WebDriver bridge
+        run: |
+          cargo install tauri-cli --version 2.10.0 --locked
+          cargo install tauri-driver --version 2.0.6 --locked
+
+      - name: Run native Tauri/Kannel UI pilot
+        run: xvfb-run -a make smoke-native-tauri-kannel-ui
+
+      - name: Upload native E2E diagnostics
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: native-tauri-kannel-e2e-${{ github.run_attempt }}
+          path: browser/frontend/test-results/native-tauri-kannel
+          if-no-files-found: warn
+          retention-days: 21

--- a/.github/workflows/transport-wap-smoke.yml
+++ b/.github/workflows/transport-wap-smoke.yml
@@ -1,18 +1,40 @@
 name: Transport WAP Smoke
 
 on:
+  pull_request:
+    branches: [main]
+    paths:
+      - '.github/workflows/transport-wap-smoke.yml'
+      - 'Makefile'
+      - 'browser/contracts/**'
+      - 'browser/src-tauri/**'
+      - 'docker-compose.yml'
+      - 'docker/kannel/**'
+      - 'engine-wasm/contracts/**'
+      - 'engine-wasm/engine/**'
+      - 'gateway-kannel/**'
+      - 'scripts/transport-wap-smoke.sh'
+      - 'transport-rust/**'
+      - 'wml-server/**'
   workflow_dispatch:
+
+permissions:
+  contents: read
 
 env:
   RUST_SHARED_KEY: wavenav-rust
+  TRANSPORT_WAP_SMOKE_ARTIFACT_DIR: ${{ github.workspace }}/test-results/transport-wap-smoke
 
 jobs:
   transport-wap-smoke:
     name: Transport WAP Smoke (Kannel)
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Start Kannel + WML stack
         run: docker compose up -d --build kannel wml-server
@@ -34,6 +56,15 @@ jobs:
         if: failure()
         run: |
           docker compose logs --tail=200 kannel wml-server || true
+
+      - name: Upload smoke diagnostics
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: transport-wap-smoke-${{ github.run_attempt }}
+          path: test-results/transport-wap-smoke
+          if-no-files-found: warn
+          retention-days: 14
 
       - name: Stop stack
         if: always()

--- a/.github/workflows/transport-wap-smoke.yml
+++ b/.github/workflows/transport-wap-smoke.yml
@@ -24,6 +24,7 @@ permissions:
 env:
   RUST_SHARED_KEY: wavenav-rust
   TRANSPORT_WAP_SMOKE_ARTIFACT_DIR: ${{ github.workspace }}/test-results/transport-wap-smoke
+  WML_DTD_VERSION: '1.3'
   WML_ENCODING_VERSION: '1.3'
 
 jobs:

--- a/.github/workflows/transport-wap-smoke.yml
+++ b/.github/workflows/transport-wap-smoke.yml
@@ -24,6 +24,7 @@ permissions:
 env:
   RUST_SHARED_KEY: wavenav-rust
   TRANSPORT_WAP_SMOKE_ARTIFACT_DIR: ${{ github.workspace }}/test-results/transport-wap-smoke
+  WML_ENCODING_VERSION: '1.3'
 
 jobs:
   transport-wap-smoke:

--- a/.github/workflows/transport-wap-smoke.yml
+++ b/.github/workflows/transport-wap-smoke.yml
@@ -13,6 +13,8 @@ on:
       - 'engine-wasm/contracts/**'
       - 'engine-wasm/engine/**'
       - 'gateway-kannel/**'
+      - 'scripts/lib/run-and-tee.sh'
+      - 'scripts/tests/transport-wap-smoke-status.sh'
       - 'scripts/transport-wap-smoke.sh'
       - 'transport-rust/**'
       - 'wml-server/**'
@@ -25,7 +27,6 @@ env:
   RUST_SHARED_KEY: wavenav-rust
   TRANSPORT_WAP_SMOKE_ARTIFACT_DIR: ${{ github.workspace }}/test-results/transport-wap-smoke
   WML_DTD_VERSION: '1.3'
-  WML_ENCODING_VERSION: '1.3'
 
 jobs:
   transport-wap-smoke:
@@ -52,7 +53,9 @@ jobs:
             transport-rust -> target
 
       - name: Run WAP smoke
-        run: make smoke-transport-wap
+        run: |
+          ./scripts/tests/transport-wap-smoke-status.sh
+          make smoke-transport-wap
 
       - name: Dump service logs on failure
         if: failure()

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ PROJECT_DIR := $(CURDIR)
 RUST_COVERAGE_MIN ?= 90
 RUST_FUNCTION_COVERAGE_MIN ?= 85
 
-.PHONY: up down restart logs ps status smoke smoke-up clean smoke-transport-wap init-refresh \
+.PHONY: up down restart logs ps status smoke smoke-up clean smoke-transport-wap smoke-native-tauri-kannel-ui init-refresh \
 	fmt lint test test-fast verify-fast verify-change verify-full verify-extended ci-local \
 	coverage-rust coverage-rust-engine coverage-rust-transport \
 	lint-rust lint-rust-engine lint-rust-transport lint-node \
@@ -42,6 +42,9 @@ smoke-up:
 
 smoke-transport-wap:
 	./scripts/transport-wap-smoke.sh
+
+smoke-native-tauri-kannel-ui:
+	./scripts/native-tauri-kannel-e2e.sh
 
 init-refresh:
 	./scripts/init-refresh.sh

--- a/browser/README.md
+++ b/browser/README.md
@@ -145,6 +145,24 @@ generation gate.
   `lowband-wml13-wbxml/0.3.0` implementation with bounded output and parser
   depth. No external `wbxml2xml` installation or bundled sidecar is required.
 
+## Native Tauri/Kannel UI pilot
+
+Linux can drive the production Tauri window through the supported `tauri-driver` WebDriver
+bridge. The pilot clicks the real address/softkey controls and crosses the generated Tauri IPC
+contract, native Rust host, `transport-rust`, and Kannel; it does not install a mock invoke layer.
+
+With `tauri-driver` 2.0.6, `WebKitWebDriver`, Docker, and an X11 display available:
+
+```bash
+xvfb-run -a make smoke-native-tauri-kannel-ui
+```
+
+The runner builds the production frontend and debug Tauri binary, provisions the local gateway,
+opts into `allow-private` only through the existing host test boundary, pins `wap-net-core` with
+fallback disabled, captures screenshots/DOM/driver/service logs, and always stops the GUI process
+group and Docker services. This pilot is scheduled/manual until the promotion criteria in
+`docs/waves/TRANSPORT_E2E_READINESS_SCORECARD.md` are met.
+
 ## Next implementation slice
 
 1. Preserve completed `WBP-00` through `WBP-05A`, including the additive single-announcement and

--- a/browser/README.md
+++ b/browser/README.md
@@ -159,7 +159,8 @@ xvfb-run -a make smoke-native-tauri-kannel-ui
 
 The runner builds the production frontend and debug Tauri binary, provisions the local gateway,
 opts into `allow-private` only through the existing host test boundary, pins `wap-net-core` with
-fallback disabled, captures screenshots/DOM/driver/service logs, and always stops the GUI process
+fallback disabled, asks Kannel for WBXML 1.3 through an explicit test-only response header,
+captures screenshots/DOM/driver/service logs, and always stops the GUI process
 group and Docker services. This pilot is scheduled/manual until the promotion criteria in
 `docs/waves/TRANSPORT_E2E_READINESS_SCORECARD.md` are met.
 

--- a/browser/README.md
+++ b/browser/README.md
@@ -159,7 +159,7 @@ xvfb-run -a make smoke-native-tauri-kannel-ui
 
 The runner builds the production frontend and debug Tauri binary, provisions the local gateway,
 opts into `allow-private` only through the existing host test boundary, pins `wap-net-core` with
-fallback disabled, asks Kannel for WBXML 1.3 through an explicit test-only response header,
+fallback disabled, serves the test deck as WML 1.3 through explicit test-only response settings,
 captures screenshots/DOM/driver/service logs, and always stops the GUI process
 group and Docker services. This pilot is scheduled/manual until the promotion criteria in
 `docs/waves/TRANSPORT_E2E_READINESS_SCORECARD.md` are met.

--- a/browser/frontend/README.md
+++ b/browser/frontend/README.md
@@ -154,6 +154,18 @@ Optional startup URL override:
 VITE_WAVES_DEFAULT_URL=wap://127.0.0.1:3000/ pnpm tauri:dev
 ```
 
+The Linux-only native UI pilot is separate from the ordinary-browser stories. It uses Selenium
+through `tauri-driver` to control the actual Tauri WebView, load `wap://localhost/` through the
+native Rust transport and Kannel, navigate to the menu card, assert a visible invalid-URL failure,
+and recover by loading the gateway deck again:
+
+```bash
+xvfb-run -a make smoke-native-tauri-kannel-ui
+```
+
+Failure and success evidence is written under ignored `test-results/native-tauri-kannel.*`
+directories unless `NATIVE_E2E_ARTIFACT_DIR` selects a stable CI artifact path.
+
 Current priority follows the main Waves board:
 
 1. Preserve completed `WBP-00` through additive `WBP-05A`; do not reopen `WBP-05`

--- a/browser/frontend/package.json
+++ b/browser/frontend/package.json
@@ -17,6 +17,7 @@
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
     "test:accessibility:rendered": "node ./scripts/check-rendered-accessibility.mjs",
+    "test:native-kannel:ui": "node ./scripts/native-tauri-kannel-e2e.mjs",
     "test:watch": "vitest",
     "typecheck": "tsc --noEmit",
     "lint": "eslint \"src/**/*.ts\"",
@@ -41,6 +42,7 @@
     "globals": "catalog:",
     "jsdom": "^29.1.1",
     "prettier": "catalog:",
+    "selenium-webdriver": "^4.46.0",
     "typescript": "catalog:",
     "vite": "catalog:",
     "vitest": "^4.1.10"

--- a/browser/frontend/scripts/native-tauri-kannel-e2e.mjs
+++ b/browser/frontend/scripts/native-tauri-kannel-e2e.mjs
@@ -1,0 +1,228 @@
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import { createWriteStream } from 'node:fs';
+import { mkdir, writeFile } from 'node:fs/promises';
+import net from 'node:net';
+import path from 'node:path';
+import process from 'node:process';
+import { setTimeout as delay } from 'node:timers/promises';
+import { Builder, By, Capabilities, until } from 'selenium-webdriver';
+
+const timeoutMs = Number.parseInt(process.env.NATIVE_E2E_TIMEOUT_MS ?? '20000', 10);
+const driverUrl = new URL(process.env.TAURI_DRIVER_URL ?? 'http://127.0.0.1:4444/');
+const appBinary = path.resolve(
+  process.env.NATIVE_E2E_APP_BINARY ?? '../src-tauri/target/debug/wavenav_host'
+);
+const artifactDir = path.resolve(
+  process.env.NATIVE_E2E_ARTIFACT_DIR ?? 'test-results/native-tauri-kannel'
+);
+const tauriDriverBin = process.env.TAURI_DRIVER_BIN ?? 'tauri-driver';
+
+let driver;
+let tauriDriver;
+let driverStdout;
+let driverStderr;
+
+const evidence = {
+  schemaVersion: 1,
+  boundary:
+    'Selenium -> tauri-driver -> Tauri WebView -> generated invoke client -> Rust host -> transport-rust -> Kannel',
+  transportProfile: process.env.WAVES_FETCH_TRANSPORT_PROFILE ?? 'unset',
+  destinationPolicy: process.env.WAVES_FETCH_DESTINATION_POLICY ?? 'unset',
+  assertions: []
+};
+
+const recordAssertion = (name, details) => {
+  evidence.assertions.push({ name, result: 'pass', details });
+};
+
+const waitForPort = async () => {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const ready = await new Promise((resolve) => {
+      const socket = net.createConnection(
+        { host: driverUrl.hostname, port: Number(driverUrl.port || 80) },
+        () => {
+          socket.end();
+          resolve(true);
+        }
+      );
+      socket.setTimeout(500);
+      socket.on('error', () => resolve(false));
+      socket.on('timeout', () => {
+        socket.destroy();
+        resolve(false);
+      });
+    });
+    if (ready) {
+      return;
+    }
+    await delay(250);
+  }
+  throw new Error(`timed out waiting for tauri-driver at ${driverUrl.origin}`);
+};
+
+const waitForText = async (selector, expected) => {
+  const element = await driver.wait(until.elementLocated(By.css(selector)), timeoutMs);
+  await driver.wait(async () => (await element.getText()).includes(expected), timeoutMs);
+  return element;
+};
+
+const replaceInput = async (selector, value) => {
+  const input = await driver.findElement(By.css(selector));
+  await input.click();
+  await input.clear();
+  await input.sendKeys(value);
+};
+
+const capture = async (name) => {
+  const png = await driver.takeScreenshot();
+  await writeFile(path.join(artifactDir, `${name}.png`), png, 'base64');
+};
+
+const terminateProcessGroup = async () => {
+  if (!tauriDriver || !tauriDriver.pid) {
+    return 'not-started';
+  }
+
+  const target = process.platform === 'win32' ? tauriDriver.pid : -tauriDriver.pid;
+  const processGroupExists = () => {
+    try {
+      process.kill(target, 0);
+      return true;
+    } catch {
+      return false;
+    }
+  };
+  try {
+    process.kill(target, 'SIGTERM');
+  } catch {
+    return 'already-exited';
+  }
+
+  const deadline = Date.now() + 5000;
+  while (processGroupExists() && Date.now() < deadline) {
+    await delay(100);
+  }
+  if (processGroupExists()) {
+    try {
+      process.kill(target, 'SIGKILL');
+    } catch {
+      // The process group exited between the status check and the signal.
+    }
+    const killDeadline = Date.now() + 2000;
+    while (processGroupExists() && Date.now() < killDeadline) {
+      await delay(100);
+    }
+  }
+  if (processGroupExists()) {
+    return 'cleanup-failed';
+  }
+  return 'terminated';
+};
+
+const run = async () => {
+  await mkdir(artifactDir, { recursive: true });
+  driverStdout = createWriteStream(path.join(artifactDir, 'tauri-driver.stdout.log'));
+  driverStderr = createWriteStream(path.join(artifactDir, 'tauri-driver.stderr.log'));
+  tauriDriver = spawn(tauriDriverBin, [], {
+    detached: process.platform !== 'win32',
+    env: process.env,
+    stdio: ['ignore', 'pipe', 'pipe']
+  });
+  tauriDriver.stdout.pipe(driverStdout);
+  tauriDriver.stderr.pipe(driverStderr);
+  tauriDriver.once('error', (error) => {
+    driverStderr.write(`tauri-driver spawn error: ${error.message}\n`);
+  });
+
+  await waitForPort();
+
+  const capabilities = new Capabilities();
+  capabilities.set('tauri:options', { application: appBinary });
+  capabilities.setBrowserName('wry');
+  driver = await new Builder()
+    .withCapabilities(capabilities)
+    .usingServer(driverUrl.href)
+    .build();
+
+  const body = await driver.wait(until.elementLocated(By.css('body')), timeoutMs);
+  await driver.wait(async () => {
+    const phase = await body.getAttribute('data-boot-phase');
+    return phase === 'engine-ready' || phase === 'deck-ready';
+  }, timeoutMs);
+  const mode = await driver.findElement(By.css('#run-mode')).getAttribute('value');
+  assert.equal(mode, 'network');
+  recordAssertion('native startup', 'production frontend reached engine-ready in Network mode');
+  await capture('01-startup');
+
+  await driver.findElement(By.css('#btn-fetch-url')).click();
+  const homeViewport = await waitForText('#viewport', 'Local WAP training environment.');
+  assert.match(await homeViewport.getText(), /Open Menu/);
+  assert.equal(await body.getAttribute('data-boot-phase'), 'deck-ready');
+  recordAssertion('gateway deck render', 'wap://localhost/ rendered the Kannel-served home deck');
+  await capture('02-gateway-home');
+
+  await driver.findElement(By.css('#btn-enter')).click();
+  const menuViewport = await waitForText('#viewport', '1. Login');
+  assert.match(await menuViewport.getText(), /2\. Register/);
+  recordAssertion('visible card navigation', 'Select navigated the native engine from home to menu');
+  await capture('03-menu-navigation');
+
+  await replaceInput('#fetch-url', 'not a url');
+  await driver.findElement(By.css('#btn-fetch-url')).click();
+  const toast = await waitForText('#toast', 'Fetch failed:');
+  assert.match(await toast.getText(), /INVALID_REQUEST|invalid|URL/i);
+  recordAssertion('deterministic failure', 'invalid URL surfaced a visible Fetch failed message');
+  await capture('04-invalid-url-failure');
+
+  await replaceInput('#fetch-url', 'wap://localhost/');
+  await driver.findElement(By.css('#btn-fetch-url')).click();
+  const recoveredViewport = await waitForText('#viewport', 'Local WAP training environment.');
+  assert.match(await recoveredViewport.getText(), /Open Menu/);
+  recordAssertion('failure recovery', 'a subsequent native Kannel load restored the home deck');
+  await capture('05-recovered-home');
+
+  await writeFile(path.join(artifactDir, 'page-source.html'), await driver.getPageSource());
+  await writeFile(
+    path.join(artifactDir, 'evidence.json'),
+    `${JSON.stringify({ ...evidence, result: 'pass' }, null, 2)}\n`
+  );
+  process.stdout.write(`native-tauri-kannel-e2e: PASS (artifacts: ${artifactDir})\n`);
+};
+
+try {
+  await run();
+} catch (error) {
+  const message = error instanceof Error ? error.stack ?? error.message : String(error);
+  process.stderr.write(`native-tauri-kannel-e2e: FAIL\n${message}\n`);
+  if (driver) {
+    await capture('failure').catch(() => undefined);
+    await writeFile(path.join(artifactDir, 'page-source.html'), await driver.getPageSource()).catch(
+      () => undefined
+    );
+  }
+  await writeFile(
+    path.join(artifactDir, 'evidence.json'),
+    `${JSON.stringify({ ...evidence, result: 'fail', error: message }, null, 2)}\n`
+  ).catch(() => undefined);
+  process.exitCode = 1;
+} finally {
+  let webdriverSession = 'not-started';
+  if (driver) {
+    webdriverSession = await driver.quit().then(
+      () => 'closed',
+      () => 'close-failed'
+    );
+  }
+  const processGroup = await terminateProcessGroup();
+  await writeFile(
+    path.join(artifactDir, 'gui-cleanup.json'),
+    `${JSON.stringify({ webdriverSession, processGroup }, null, 2)}\n`
+  ).catch(() => undefined);
+  if (webdriverSession === 'close-failed' || processGroup === 'cleanup-failed') {
+    process.exitCode = 1;
+  }
+  driverStdout?.end();
+  driverStderr?.end();
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,8 @@ services:
     volumes:
       - ./wml-server:/app
     command: sh -c "npm install && npm start"
+    environment:
+      WML_ENCODING_VERSION: "${WML_ENCODING_VERSION:-}"
     expose:
       - "3000"
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ services:
       - ./wml-server:/app
     command: sh -c "npm install && npm start"
     environment:
+      WML_DTD_VERSION: "${WML_DTD_VERSION:-1.1}"
       WML_ENCODING_VERSION: "${WML_ENCODING_VERSION:-}"
     expose:
       - "3000"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,6 @@ services:
     command: sh -c "npm install && npm start"
     environment:
       WML_DTD_VERSION: "${WML_DTD_VERSION:-1.1}"
-      WML_ENCODING_VERSION: "${WML_ENCODING_VERSION:-}"
     expose:
       - "3000"
     ports:

--- a/docker/kannel/Dockerfile
+++ b/docker/kannel/Dockerfile
@@ -1,11 +1,36 @@
-FROM ubuntu:22.04
+FROM ubuntu:22.04 AS kannel-build
 
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update \
+    && sed -i 's/^# deb-src/deb-src/' /etc/apt/sources.list \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends build-essential ca-certificates devscripts \
+    && apt-get build-dep -y kannel \
+    && mkdir -p /usr/src/kannel-build \
+    && cd /usr/src/kannel-build \
+    && apt-get source kannel \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY connectionless-wbxml-version.patch /tmp/connectionless-wbxml-version.patch
+
+RUN kannel_source_dir="$(find /usr/src/kannel-build -mindepth 1 -maxdepth 1 -type d -name 'kannel-*' -print -quit)" \
+    && test -n "${kannel_source_dir}" \
+    && cd "${kannel_source_dir}" \
+    && patch -p1 < /tmp/connectionless-wbxml-version.patch \
+    && dpkg-buildpackage -b -uc -us
+
+FROM ubuntu:22.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+COPY --from=kannel-build /usr/src/kannel-build/kannel_*.deb /tmp/kannel-patched.deb
+
+RUN apt-get update \
     && apt-get install -y --no-install-recommends \
        ca-certificates \
-       kannel \
+       /tmp/kannel-patched.deb \
+    && rm -f /tmp/kannel-patched.deb \
     && rm -rf /var/lib/apt/lists/*
 
 COPY kannel.conf /etc/kannel/kannel.conf

--- a/docker/kannel/connectionless-wbxml-version.patch
+++ b/docker/kannel/connectionless-wbxml-version.patch
@@ -1,0 +1,12 @@
+--- a/gw/wap-appl.c
++++ b/gw/wap-appl.c
+@@ -912,3 +912,8 @@ static void return_reply(int status, Octstr *content_body, List *headers,
+         } else {
+-            content.version = NULL;
++            /*
++             * Connectionless WSP has no session machine. Preserve the
++             * device's Encoding-Version request for WML compilation.
++             */
++            content.version = http_header_value(device_headers,
++                                                octstr_imm("Encoding-Version"));
+         }

--- a/docs/ci/CI_SETUP.md
+++ b/docs/ci/CI_SETUP.md
@@ -292,8 +292,9 @@ Triggers:
 Behavior:
 
 - starts Docker services (`kannel`, `wml-server`)
-- serves WML 1.3 and advertises `Encoding-Version: 1.3` through explicit test response
-  settings; the server defaults remain WML 1.1 with no encoding header
+- serves WML 1.3 through an explicit test-only DTD setting; the server default remains WML 1.1
+- sends `Encoding-Version: 1.3` at the WSP client boundary, and uses the locally patched Kannel
+  connectionless path to carry that request negotiation into WML compilation
 - runs `make smoke-transport-wap`
 - executes:
   - transport-rust ignored Kannel smoke tests
@@ -329,8 +330,8 @@ Behavior:
 - starts Kannel and the WML server, then opts into local/private access only with the existing
   `WAVES_FETCH_DESTINATION_POLICY=allow-private` host boundary
 - pins `wap-net-core` and disables gateway fallback
-- serves WML 1.3 through the same explicit WML-server test response boundary; Kannel's WBXML 1.1
-  envelope is decoded with the pinned WML 1.3 token/public-ID validation
+- serves WML 1.3 through the same explicit WML-server test boundary and requires Kannel to emit
+  the negotiated WBXML 1.3 envelope accepted by the pinned decoder
 - uses Selenium to click the real Go and Select controls, assert the gateway-served home/menu UI,
   assert a visible invalid-URL failure, and recover with another real gateway load
 - uploads fixed-name screenshots, page source, structured evidence, driver logs, environment

--- a/docs/ci/CI_SETUP.md
+++ b/docs/ci/CI_SETUP.md
@@ -12,7 +12,8 @@ This document describes all active GitHub Actions automation for this repository
 - Dependabot auto-merge workflow: `.github/workflows/dependabot-auto-merge.yml`
 - Code scanning workflow: `.github/workflows/codeql.yml`
 - Pages deployment workflow: `.github/workflows/pages.yml`
-- Manual transport smoke workflow: `.github/workflows/transport-wap-smoke.yml`
+- Path-scoped PR/manual transport smoke workflow: `.github/workflows/transport-wap-smoke.yml`
+- Self-validating PR/scheduled/manual native Tauri/Kannel UI pilot: `.github/workflows/native-tauri-kannel-e2e.yml`
 - Canonical local verification contract: `docs/ci/LOCAL_VERIFICATION.md`
 - Dependency updates: `.github/dependabot.yml`
 - Branch protection check policy: `docs/ci/REQUIRED_CHECKS.md`
@@ -280,21 +281,62 @@ Behavior:
 
 Purpose:
 
-- On-demand end-to-end smoke for Kannel + WML stack integration.
+- Path-scoped pull-request and on-demand smoke for Kannel + WML stack integration.
 
 Triggers:
 
-- `workflow_dispatch` only
+- `pull_request` targeting `main` when gateway/Kannel, transport, engine contracts/runtime,
+  browser host/contracts, WML server, smoke runner, or its workflow changes
+- `workflow_dispatch`
 
 Behavior:
 
 - starts Docker services (`kannel`, `wml-server`)
 - runs `make smoke-transport-wap`
-- executes both:
+- executes:
   - transport-rust ignored Kannel smoke tests
   - browser host ignored Kannel smoke test
+  - browser engine/render ignored Kannel smoke test
 - dumps service logs on failure
+- uploads the deterministic smoke logs for every run with 14-day retention
 - always tears down stack
+
+This is a relevant-PR signal, but it is not a globally required context because workflow-level
+path filters mean the check correctly does not exist on unrelated pull requests.
+
+### 8) Native Tauri Kannel E2E (`.github/workflows/native-tauri-kannel-e2e.yml`)
+
+Purpose:
+
+- Non-optimistic Linux pilot for the complete visible path from production Tauri frontend controls
+  through generated IPC, the native Rust host/engine, `transport-rust`, and local Kannel.
+
+Triggers:
+
+- `pull_request` only when the pilot workflow, runner, Selenium client, package declaration, or
+  Make target itself changes; this bootstraps executable validation without claiming general
+  browser/transport PR coverage
+- weekly schedule (`17 5 * * 1`)
+- `workflow_dispatch`
+
+Behavior:
+
+- installs the Linux WebKit WebDriver and Xvfb dependencies documented by Tauri
+- installs pinned `tauri-cli` 2.10.0 and `tauri-driver` 2.0.6
+- builds the production frontend and an unbundled debug Tauri application
+- starts Kannel and the WML server, then opts into local/private access only with the existing
+  `WAVES_FETCH_DESTINATION_POLICY=allow-private` host boundary
+- pins `wap-net-core` and disables gateway fallback
+- uses Selenium to click the real Go and Select controls, assert the gateway-served home/menu UI,
+  assert a visible invalid-URL failure, and recover with another real gateway load
+- uploads fixed-name screenshots, page source, structured evidence, driver logs, environment
+  versions, service logs, and pre/post-teardown state with 21-day retention
+- closes the WebDriver session, terminates the isolated GUI process group, and always tears down
+  Docker services
+
+The pilot is intentionally not a required or product-change pull-request check yet. Its narrow PR
+filter validates the pilot implementation itself. Widen it additively to relevant product paths
+only after all criteria in the active E2E readiness scorecard are met.
 
 ## Dependency Update Automation
 
@@ -386,7 +428,8 @@ At minimum, require:
 
 Do not require:
 
-- `Transport WAP Smoke` (manual)
+- `Transport WAP Smoke` globally (it is a path-scoped PR signal and does not run for unrelated PRs)
+- `Native Tauri Kannel E2E` until its documented pilot promotion criteria are met
 - `Deploy Pages` (deployment workflow)
 
 ## Common Failure Modes

--- a/docs/ci/CI_SETUP.md
+++ b/docs/ci/CI_SETUP.md
@@ -292,6 +292,8 @@ Triggers:
 Behavior:
 
 - starts Docker services (`kannel`, `wml-server`)
+- requests WBXML 1.3 from Kannel through the WML server's explicit
+  `Encoding-Version: 1.3` test response boundary; the server's default remains unset
 - runs `make smoke-transport-wap`
 - executes:
   - transport-rust ignored Kannel smoke tests
@@ -327,6 +329,7 @@ Behavior:
 - starts Kannel and the WML server, then opts into local/private access only with the existing
   `WAVES_FETCH_DESTINATION_POLICY=allow-private` host boundary
 - pins `wap-net-core` and disables gateway fallback
+- requests WBXML 1.3 through the same explicit WML-server test response boundary
 - uses Selenium to click the real Go and Select controls, assert the gateway-served home/menu UI,
   assert a visible invalid-URL failure, and recover with another real gateway load
 - uploads fixed-name screenshots, page source, structured evidence, driver logs, environment

--- a/docs/ci/CI_SETUP.md
+++ b/docs/ci/CI_SETUP.md
@@ -292,8 +292,8 @@ Triggers:
 Behavior:
 
 - starts Docker services (`kannel`, `wml-server`)
-- requests WBXML 1.3 from Kannel through the WML server's explicit
-  `Encoding-Version: 1.3` test response boundary; the server's default remains unset
+- serves WML 1.3 and advertises `Encoding-Version: 1.3` through explicit test response
+  settings; the server defaults remain WML 1.1 with no encoding header
 - runs `make smoke-transport-wap`
 - executes:
   - transport-rust ignored Kannel smoke tests
@@ -329,7 +329,8 @@ Behavior:
 - starts Kannel and the WML server, then opts into local/private access only with the existing
   `WAVES_FETCH_DESTINATION_POLICY=allow-private` host boundary
 - pins `wap-net-core` and disables gateway fallback
-- requests WBXML 1.3 through the same explicit WML-server test response boundary
+- serves WML 1.3 through the same explicit WML-server test response boundary; Kannel's WBXML 1.1
+  envelope is decoded with the pinned WML 1.3 token/public-ID validation
 - uses Selenium to click the real Go and Select controls, assert the gateway-served home/menu UI,
   assert a visible invalid-URL failure, and recover with another real gateway load
 - uploads fixed-name screenshots, page source, structured evidence, driver logs, environment

--- a/docs/ci/LOCAL_VERIFICATION.md
+++ b/docs/ci/LOCAL_VERIFICATION.md
@@ -52,6 +52,12 @@ The full compliance wrapper proves that canonical compliance inputs and generate
 synchronized; implementation conformance still depends on the direct fixtures and evidence named
 by the selected profile.
 
+The extended live-Kannel lane expects the stack to advertise WML 1.3 explicitly at its test
+boundary. Start it with `WML_DTD_VERSION=1.3 docker compose up -d --build kannel wml-server`, run
+`pnpm verify:extended`, and always finish with `docker compose down`. The transport itself sends the
+matching WSP `Encoding-Version: 1.3` request header; neither setting relaxes the production network
+policy or the strict WBXML 1.3 decoder.
+
 ## Automated contract tests
 
 Run the orchestration tests directly with:

--- a/docs/ci/REQUIRED_CHECKS.md
+++ b/docs/ci/REQUIRED_CHECKS.md
@@ -109,7 +109,12 @@ only after every required status check and any other ruleset requirement succeed
 
 ## Manual and deployment workflows
 
-- `Transport WAP Smoke (Kannel)` is manual and must not be required for pull requests.
+- `Transport WAP Smoke (Kannel)` is a path-scoped PR/manual signal. Do not configure it as a
+  global required context because it intentionally does not run on unrelated pull requests.
+- `Native Tauri UI through Kannel (pilot)` only self-validates pilot implementation changes in PRs
+  and otherwise runs scheduled/manual. It must not be required until the promotion criteria in
+  `docs/waves/TRANSPORT_E2E_READINESS_SCORECARD.md` are satisfied and the follow-up widens its
+  stable PR paths to relevant product changes.
 - `Build and Deploy to gh-pages` is deployment-focused and must not be required for code merges.
 - Scheduled/manual fuzzing, browser baseline, and release workflows must not be required
   pull-request checks.

--- a/docs/waves/TRANSPORT_E2E_READINESS_SCORECARD.md
+++ b/docs/waves/TRANSPORT_E2E_READINESS_SCORECARD.md
@@ -1,7 +1,8 @@
 # Transport E2E Readiness Scorecard
 
 Status: active tracking metric  
-Date: 2026-03-06  
+Date: 2026-07-26
+
 Owner: transport-rust + browser + gateway docs
 
 ## Purpose
@@ -13,6 +14,7 @@ Track how close Waves is to a reliable end-to-end test path against:
 3. either:
    - `transport-rust` directly, or
    - browser host flow through `fetchDeck`
+4. production Tauri frontend controls through the native host/engine and transport boundary
 
 This scorecard is not a protocol-conformance replacement. It is a practical execution-readiness metric for local and CI-like E2E validation.
 
@@ -32,7 +34,7 @@ Two roll-up scores are tracked:
 Applicable gates:
 
 1. `transport-to-kannel`: `G1..G6` (`6.0` max)
-2. `browser-to-kannel`: `G1..G8` (`8.0` max)
+2. `browser-to-kannel`: `G1..G9` (`9.0` max)
 
 ## Current score
 
@@ -42,7 +44,7 @@ Score: `6.0 / 6.0` (`100%`)
 
 ### Browser-to-Kannel
 
-Score: `8.0 / 8.0` (`100%`)
+Score: `8.5 / 9.0` (`94%`)
 
 ## Gate table
 
@@ -56,6 +58,7 @@ Score: `8.0 / 8.0` (`100%`)
 | `G6` | Failure diagnostics are preserved automatically (gateway/server/test logs) | `1.0` | `1.0` | [scripts/transport-wap-smoke.sh](../../scripts/transport-wap-smoke.sh) now writes status/log artifacts into a temp directory and prints the path on success/failure |
 | `G7` | Browser path runs against real Kannel via host transport rather than mocks | `n/a` | `1.0` | ignored host-native smoke in [browser/src-tauri/src/tests/fetch_commands.rs](../../browser/src-tauri/src/tests/fetch_commands.rs) forces `wap-net-core` and disabled fallback |
 | `G8` | Browser/render assertions validate visible WML outcome from real gateway-served deck | `n/a` | `1.0` | browser host smokes validate real Kannel-backed render output for the root deck and the navigated menu card via native fetch in [browser/src-tauri/tests/kannel_smoke.rs](../../browser/src-tauri/tests/kannel_smoke.rs) |
+| `G9` | Production Tauri frontend is driven through native IPC/transport to visible Kannel results | `n/a` | `0.5` | executable Linux pilot in [scripts/native-tauri-kannel-e2e.sh](../../scripts/native-tauri-kannel-e2e.sh) and [browser/frontend/scripts/native-tauri-kannel-e2e.mjs](../../browser/frontend/scripts/native-tauri-kannel-e2e.mjs); the workflow self-validates pilot changes and otherwise runs scheduled/manual, capturing home/menu, invalid-URL, recovery, and teardown evidence, but it does not yet cover product-change PR paths |
 
 ## Interpretation
 
@@ -63,7 +66,9 @@ Score: `8.0 / 8.0` (`100%`)
 
 1. `transport-rust` now has a credible native Kannel smoke gate for both baseline `GET` decks and constrained WML form `POST`.
 2. browser-level real-gateway E2E is credible at the host/engine layer for root/menu navigation and register/login form submission.
-3. protocol-core replay readiness (`T0-22`) still exceeds end-user browser realism, but live ingress evidence now matches the active profile posture for the constrained MVP lane.
+3. a runnable native UI pilot now drives visible production frontend controls across Tauri IPC and
+   the real native Kannel path for startup, home render, menu navigation, failure, and recovery.
+4. protocol-core replay readiness (`T0-22`) still exceeds end-user browser realism, but live ingress evidence now matches the active profile posture for the constrained MVP lane.
 
 ### What this score does not mean
 
@@ -71,6 +76,7 @@ Score: `8.0 / 8.0` (`100%`)
 2. it does not prove full WSP/WTP/WDP conformance
 3. it does not guarantee emulator/browser UX correctness
 4. it proves constrained connectionless form `POST`, but it does not prove full connection-oriented WSP/WTP session support
+5. it does not yet make full native UI automation a required or product-change pull-request gate
 
 ## Current evidence base
 
@@ -81,15 +87,16 @@ Score: `8.0 / 8.0` (`100%`)
 3. transport-specific native smoke path exists:
    - [transport-rust/tests/kannel_smoke.rs](../../transport-rust/tests/kannel_smoke.rs)
    - `make smoke-transport-wap`
-4. on-demand CI smoke workflow exists in [docs/ci/CI_SETUP.md](../../docs/ci/CI_SETUP.md)
+4. path-scoped pull-request/manual transport smoke and scheduled/manual native Tauri UI workflows
+   exist in [docs/ci/CI_SETUP.md](../../docs/ci/CI_SETUP.md)
 5. protocol-native replay harness exists in [transport-rust/tests/interop_replay.rs](../../transport-rust/tests/interop_replay.rs)
 
 ### Main gaps
 
-1. the Kannel smoke lane is still ignored/manual rather than part of default local Rust test execution
-2. browser real-gateway coverage still stops at Tauri host + engine render/navigation, not frontend UI automation
-3. smoke artifacts are temp-dir based rather than checked into a durable report format
-4. non-ASCII charset-sensitive form submission is still not a proven smoke path
+1. the underlying live Kannel Rust tests remain ignored outside the provisioned smoke workflows
+2. native frontend UI automation covers pilot implementation PRs plus scheduled/manual runs while
+   Linux runner stability is measured; product-change PR paths remain deferred
+3. non-ASCII charset-sensitive form submission is still not a proven smoke path
 
 ## Recommended next threshold targets
 
@@ -107,17 +114,31 @@ Required moves:
 
 1. met
 
+### Threshold C: promotable native frontend E2E (`G9 = 1.0`)
+
+Current status: `pilot`
+
+Promote the native workflow additively to a path-scoped pull-request signal only when:
+
+1. four consecutive scheduled runs succeed on `ubuntu-latest` over at least 21 days
+2. every qualifying run uploads `evidence.json` with `result: pass`, all five named screenshots,
+   page source, driver/service logs, `gui-cleanup.json`, and empty post-down Compose state
+3. none of the qualifying runs requires a rerun and the slowest completes within 30 minutes
+4. the follow-up preserves the scheduled/manual triggers, read-only permissions, explicit
+   `allow-private` test-boundary opt-in, `wap-net-core`, and disabled fallback
+
 ## Suggested follow-up ticket
 
 Suggested ticket:
 
-- `A5-01` history entry fidelity follow-up
+- `A5-08` native Tauri/Kannel PR-signal promotion
 
 Suggested scope:
 
-1. preserve current native Kannel/browser smoke credibility while tightening history/session fidelity after network navigation
-2. verify browser-visible back/reload behavior stays aligned with engine/runtime history semantics
-3. update this scorecard only if the browser-to-kannel execution posture or signal quality changes materially
+1. evaluate the four-run pilot record against Threshold C without weakening any transport policy
+2. widen path-scoped `pull_request` coverage from pilot files to relevant product changes while
+   preserving schedule/manual
+3. raise `G9` to `1.0` only after the promoted workflow itself succeeds on a qualifying PR
 
 ## Update policy
 

--- a/docs/waves/WORK_ITEMS.md
+++ b/docs/waves/WORK_ITEMS.md
@@ -1314,6 +1314,31 @@ Completed `B0` through `B3` tickets are archived in:
 - Review artifact landed in `docs/waves/WAVES_REVIEW_2026-03-15.md`.
 - Follow-through landed in `#109` and `#110`: background startup probing, timer/render churn reduction, stale-safe navigation, combined frame-oriented host commands, off-UI-thread fetch execution, and targeted coverage around the affected coordinators.
 
+### A5-08 Native Tauri/Kannel PR-signal promotion
+
+1. `Status`: `todo`
+2. `Depends On`: `T0-26`, `T0-29`, `A5-07`
+3. `Owner`: `browser`, `transport-rust`, `CI`
+4. `Files`:
+- `.github/workflows/native-tauri-kannel-e2e.yml`
+- `scripts/native-tauri-kannel-e2e.sh`
+- `browser/frontend/scripts/native-tauri-kannel-e2e.mjs`
+- `docs/waves/TRANSPORT_E2E_READINESS_SCORECARD.md`
+5. `Build`:
+- evaluate the scheduled/manual native UI pilot against the scorecard's exact Threshold C
+- preserve schedule/manual and pilot self-validation triggers, widening pull-request coverage to product paths only after the pilot qualifies
+- keep local/private access explicit at the existing host policy boundary with `wap-net-core` and fallback disabled
+6. `Tests`:
+- four consecutive scheduled successes over at least 21 days with no reruns
+- complete fixed-name UI, driver, service, and teardown artifact set for every qualifying run
+- first path-scoped pull-request run succeeds within the 30-minute promotion budget
+7. `Accept`:
+- production Tauri frontend changes have a stable, relevant-PR native Kannel signal
+- no production SSRF, redirect, DNS, payload, or network-profile policy is weakened
+- `G9` advances to `1.0` only after the promoted workflow succeeds
+8. `Notes`:
+- additive follow-up to completed `T0-26`; do not reopen or rewrite its historical acceptance.
+
 ## WAE Selected-Profile Gap Queue
 
 ### WAE-607 HTTP Basic authentication closure

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -114,6 +114,9 @@ importers:
       prettier:
         specifier: 'catalog:'
         version: 3.9.5
+      selenium-webdriver:
+        specifier: ^4.46.0
+        version: 4.46.0
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
@@ -320,6 +323,9 @@ packages:
   '@babel/types@7.29.7':
     resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
     engines: {node: '>=6.9.0'}
+
+  '@bazel/runfiles@6.5.0':
+    resolution: {integrity: sha512-RzahvqTkfpY2jsDxo8YItPX+/iZ6hbiikw1YhE0bA9EKBR5Og8Pa6FHn9PO9M0zaXRVsr0GFQLKbB/0rzy9SzA==}
 
   '@bcoe/v8-coverage@1.0.2':
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
@@ -1347,6 +1353,9 @@ packages:
     resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
     engines: {node: '>=18'}
 
+  core-util-is@1.0.3:
+    resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
+
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
@@ -1668,9 +1677,15 @@ packages:
     resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
     engines: {node: '>= 4'}
 
+  immediate@3.0.6:
+    resolution: {integrity: sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==}
+
   imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
+
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
   iron-webcrypto@1.2.1:
     resolution: {integrity: sha512-feOM6FaSr6rEABp/eDfVseKyTMDt+KGpeB35SkVn9Tyn0CqvVsY3EwI0v5i8nMHyJnzCIQf7nsy3p41TPkJZhg==}
@@ -1698,6 +1713,9 @@ packages:
 
   is-potential-custom-element-name@1.0.1:
     resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
+  isarray@1.0.0:
+    resolution: {integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==}
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
@@ -1751,6 +1769,9 @@ packages:
   jsonc-parser@3.3.1:
     resolution: {integrity: sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==}
 
+  jszip@3.10.1:
+    resolution: {integrity: sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==}
+
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
 
@@ -1761,6 +1782,9 @@ packages:
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
+
+  lie@3.3.0:
+    resolution: {integrity: sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==}
 
   lightningcss-android-arm64@1.33.0:
     resolution: {integrity: sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==}
@@ -1989,6 +2013,9 @@ packages:
   package-manager-detector@1.8.0:
     resolution: {integrity: sha512-yQA4H19AmPEoMUeavPMDIe1higySl/gH/yaQrkT/s07Qp+7pp2hYz30N3z2l5BkjVkF9Ow6o0wjJamm2y7Sn0A==}
 
+  pako@1.0.11:
+    resolution: {integrity: sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==}
+
   parse5@7.3.0:
     resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
 
@@ -2063,6 +2090,9 @@ packages:
     resolution: {integrity: sha512-tGqJW/UnclpYASFcM6Xh8D8l/BMtaQ9+CSG0vlJSJTcdMM4lDRv4c6H0Pdcsfted+bVczdYSfk2fdukg2gQkZg==}
     engines: {node: '>=18.0.0'}
 
+  process-nextick-args@2.0.1:
+    resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
+
   property-information@7.2.0:
     resolution: {integrity: sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==}
 
@@ -2075,6 +2105,9 @@ packages:
 
   react-is@17.0.2:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
+
+  readable-stream@2.3.8:
+    resolution: {integrity: sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==}
 
   readdirp@4.1.2:
     resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
@@ -2118,6 +2151,9 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
+  safe-buffer@5.1.2:
+    resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
+
   satteri@0.9.5:
     resolution: {integrity: sha512-ZuWVl+vnM64y+/TtX8Kosv2c00W+hLQiiwnEL6H0UKVVrxFqMw4D2CJHHQaouVd89OAhtBBfjWLqhKi3TVUV4w==}
 
@@ -2129,10 +2165,17 @@ packages:
     resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
     engines: {node: '>=v12.22.7'}
 
+  selenium-webdriver@4.46.0:
+    resolution: {integrity: sha512-UlTkgnx9y+bf3QxFsrgUyMqC2oy1Yf+qcOs7xIC/XfsUPv/ow7Sicx6SJ7AeOn2/Z+xF1M8SLqyn983wipI82w==}
+    engines: {node: '>= 20.0.0'}
+
   semver@7.8.5:
     resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
     engines: {node: '>=10'}
     hasBin: true
+
+  setimmediate@1.0.5:
+    resolution: {integrity: sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==}
 
   sharp@0.35.3:
     resolution: {integrity: sha512-ej0zVHuZGHCiABXcNxeYhpRnPNPAcvbG8RMdBAhDAxLKkCRVSpK3Iyu7qbqw3JMzoj0REeM6f3tJLtVwl0023Q==}
@@ -2189,6 +2232,9 @@ packages:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
     engines: {node: '>=8'}
 
+  string_decoder@1.1.1:
+    resolution: {integrity: sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==}
+
   stringify-entities@4.0.4:
     resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
 
@@ -2236,6 +2282,10 @@ packages:
   tldts@7.0.30:
     resolution: {integrity: sha512-ELrFxuqsDdHUwoh0XxDbxuLD3Wnz49Z57IFvTtvWy1hJdcMZjXLIuonjilCiWHlT2GbE4Wlv1wKVTzDFnXH1aw==}
     hasBin: true
+
+  tmp@0.2.7:
+    resolution: {integrity: sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==}
+    engines: {node: '>=14.14'}
 
   tough-cookie@6.0.1:
     resolution: {integrity: sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==}
@@ -2376,6 +2426,9 @@ packages:
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+
+  util-deprecate@1.0.2:
+    resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
   vfile-location@5.0.3:
     resolution: {integrity: sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==}
@@ -2617,6 +2670,18 @@ packages:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
     engines: {node: '>=10'}
 
+  ws@8.21.1:
+    resolution: {integrity: sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
   xml-name-validator@5.0.0:
     resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
     engines: {node: '>=18'}
@@ -2841,6 +2906,8 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.29.7
       '@babel/helper-validator-identifier': 7.29.7
+
+  '@bazel/runfiles@6.5.0': {}
 
   '@bcoe/v8-coverage@1.0.2': {}
 
@@ -3837,6 +3904,8 @@ snapshots:
 
   cookie@1.1.1: {}
 
+  core-util-is@1.0.3: {}
+
   cross-spawn@7.0.6:
     dependencies:
       path-key: 3.1.1
@@ -4202,7 +4271,11 @@ snapshots:
 
   ignore@7.0.5: {}
 
+  immediate@3.0.6: {}
+
   imurmurhash@0.1.4: {}
+
+  inherits@2.0.4: {}
 
   iron-webcrypto@1.2.1: {}
 
@@ -4219,6 +4292,8 @@ snapshots:
   is-plain-obj@4.1.0: {}
 
   is-potential-custom-element-name@1.0.1: {}
+
+  isarray@1.0.0: {}
 
   isexe@2.0.0: {}
 
@@ -4281,6 +4356,13 @@ snapshots:
 
   jsonc-parser@3.3.1: {}
 
+  jszip@3.10.1:
+    dependencies:
+      lie: 3.3.0
+      pako: 1.0.11
+      readable-stream: 2.3.8
+      setimmediate: 1.0.5
+
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
@@ -4291,6 +4373,10 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
       type-check: 0.4.0
+
+  lie@3.3.0:
+    dependencies:
+      immediate: 3.0.6
 
   lightningcss-android-arm64@1.33.0:
     optional: true
@@ -4504,6 +4590,8 @@ snapshots:
 
   package-manager-detector@1.8.0: {}
 
+  pako@1.0.11: {}
+
   parse5@7.3.0:
     dependencies:
       entities: 6.0.1
@@ -4559,6 +4647,8 @@ snapshots:
 
   process-ancestry@0.1.0: {}
 
+  process-nextick-args@2.0.1: {}
+
   property-information@7.2.0: {}
 
   punycode@2.3.1: {}
@@ -4566,6 +4656,16 @@ snapshots:
   radix3@1.1.2: {}
 
   react-is@17.0.2: {}
+
+  readable-stream@2.3.8:
+    dependencies:
+      core-util-is: 1.0.3
+      inherits: 2.0.4
+      isarray: 1.0.0
+      process-nextick-args: 2.0.1
+      safe-buffer: 5.1.2
+      string_decoder: 1.1.1
+      util-deprecate: 1.0.2
 
   readdirp@4.1.2: {}
 
@@ -4618,6 +4718,8 @@ snapshots:
       '@rolldown/binding-win32-arm64-msvc': 1.1.5
       '@rolldown/binding-win32-x64-msvc': 1.1.5
 
+  safe-buffer@5.1.2: {}
+
   satteri@0.9.5:
     dependencies:
       '@types/estree-jsx': 1.0.5
@@ -4641,7 +4743,19 @@ snapshots:
     dependencies:
       xmlchars: 2.2.0
 
+  selenium-webdriver@4.46.0:
+    dependencies:
+      '@bazel/runfiles': 6.5.0
+      jszip: 3.10.1
+      tmp: 0.2.7
+      ws: 8.21.1
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   semver@7.8.5: {}
+
+  setimmediate@1.0.5: {}
 
   sharp@0.35.3(@types/node@26.1.1):
     dependencies:
@@ -4718,6 +4832,10 @@ snapshots:
       is-fullwidth-code-point: 3.0.0
       strip-ansi: 6.0.1
 
+  string_decoder@1.1.1:
+    dependencies:
+      safe-buffer: 5.1.2
+
   stringify-entities@4.0.4:
     dependencies:
       character-entities-html4: 2.1.0
@@ -4763,6 +4881,8 @@ snapshots:
   tldts@7.0.30:
     dependencies:
       tldts-core: 7.0.30
+
+  tmp@0.2.7: {}
 
   tough-cookie@6.0.1:
     dependencies:
@@ -4858,6 +4978,8 @@ snapshots:
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
+
+  util-deprecate@1.0.2: {}
 
   vfile-location@5.0.3:
     dependencies:
@@ -5060,6 +5182,8 @@ snapshots:
       ansi-styles: 4.3.0
       string-width: 4.2.3
       strip-ansi: 6.0.1
+
+  ws@8.21.1: {}
 
   xml-name-validator@5.0.0: {}
 

--- a/scripts/lib/run-and-tee.sh
+++ b/scripts/lib/run-and-tee.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env sh
+
+# Run a piped command and fail if the command (not tee) exited nonzero.
+# POSIX sh has no pipefail/PIPESTATUS, so the command records its own status.
+run_and_tee() {
+  log_file="$1"
+  shift
+  status_file="$(mktemp "${TMPDIR:-/tmp}/run-and-tee-status.XXXXXX")"
+  {
+    set +e
+    "$@"
+    piped_status="$?"
+    printf '%s\n' "${piped_status}" >"${status_file}"
+    exit "${piped_status}"
+  } | tee "${log_file}"
+  if [ ! -s "${status_file}" ]; then
+    echo "failed to capture command status for ${log_file}" >&2
+    rm -f "${status_file}"
+    return 1
+  fi
+  cmd_status="$(cat "${status_file}")"
+  rm -f "${status_file}"
+  case "${cmd_status}" in
+    ''|*[!0-9]*)
+      echo "invalid captured command status ${cmd_status} for ${log_file}" >&2
+      return 1
+      ;;
+    *)
+      return "${cmd_status}"
+      ;;
+  esac
+}

--- a/scripts/native-tauri-kannel-e2e.sh
+++ b/scripts/native-tauri-kannel-e2e.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env sh
+set -eu
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+KANNEL_ADMIN_URL="${KANNEL_ADMIN_URL:-http://localhost:13000/status?password=changeme}"
+WML_HEALTH_URL="${WML_HEALTH_URL:-http://localhost:3000/health}"
+
+if [ "$(uname -s)" != "Linux" ]; then
+  echo "native Tauri WebDriver smoke requires Linux (tauri-driver does not support macOS)" >&2
+  exit 1
+fi
+
+for required_command in docker pnpm cargo tauri-driver WebKitWebDriver; do
+  if ! command -v "${required_command}" >/dev/null 2>&1; then
+    echo "missing required command: ${required_command}" >&2
+    exit 1
+  fi
+done
+
+if [ -z "${DISPLAY:-}" ]; then
+  echo "DISPLAY is unset; run this smoke under xvfb-run or an X11 session" >&2
+  exit 1
+fi
+
+if [ -n "${NATIVE_E2E_ARTIFACT_DIR:-}" ]; then
+  ARTIFACT_DIR="${NATIVE_E2E_ARTIFACT_DIR}"
+  mkdir -p "${ARTIFACT_DIR}"
+else
+  mkdir -p "${ROOT_DIR}/browser/frontend/test-results"
+  ARTIFACT_DIR="$(mktemp -d "${ROOT_DIR}/browser/frontend/test-results/native-tauri-kannel.XXXXXX")"
+fi
+
+cleanup() {
+  exit_code="$?"
+  trap - EXIT
+  (
+    cd "${ROOT_DIR}"
+    docker compose ps --all >"${ARTIFACT_DIR}/docker-compose-ps.txt" 2>&1 || true
+    docker compose logs --no-color kannel wml-server >"${ARTIFACT_DIR}/docker-compose.log" 2>&1 || true
+    docker compose down >"${ARTIFACT_DIR}/docker-compose-down.log" 2>&1 || true
+    docker compose ps --all >"${ARTIFACT_DIR}/docker-compose-ps-after-down.txt" 2>&1 || true
+  )
+  printf '%s\n' "${exit_code}" >"${ARTIFACT_DIR}/exit-code.txt"
+  echo "native Tauri/Kannel artifacts: ${ARTIFACT_DIR}"
+  exit "${exit_code}"
+}
+trap cleanup EXIT
+trap 'exit 129' HUP
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
+wait_for_http() {
+  url="$1"
+  retries="${2:-60}"
+  i=1
+  while [ "${i}" -le "${retries}" ]; do
+    if curl -fsS --connect-timeout 2 --max-time 5 "${url}" >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 1
+    i=$((i + 1))
+  done
+  echo "timeout waiting for ${url}" >&2
+  return 1
+}
+
+cd "${ROOT_DIR}"
+
+echo "==> Starting isolated Kannel + WML services"
+docker compose up -d --build kannel wml-server
+wait_for_http "${KANNEL_ADMIN_URL}"
+curl -fsS --connect-timeout 2 --max-time 5 "${KANNEL_ADMIN_URL}" | grep -q 'Status: running'
+wait_for_http "${WML_HEALTH_URL}"
+
+# The app remains production-default PublicOnly. This controlled local-stack lane opts into the
+# existing host policy boundary explicitly and pins the active profile with fallback disabled.
+export WAVES_FETCH_DESTINATION_POLICY=allow-private
+export WAVES_FETCH_TRANSPORT_PROFILE=wap-net-core
+export WAVES_FETCH_TRANSPORT_FALLBACK=disabled
+export LOWBAND_TRANSPORT_PROFILE=wap-net-core
+export VITE_WAVES_DEFAULT_URL=wap://localhost/
+export VITE_WAVES_DEFAULT_RUN_MODE=network
+export GATEWAY_HTTP_BASE="${GATEWAY_HTTP_BASE:-http://localhost:13002}"
+export NATIVE_E2E_APP_BINARY="${NATIVE_E2E_APP_BINARY:-${ROOT_DIR}/browser/src-tauri/target/debug/wavenav_host}"
+export NATIVE_E2E_ARTIFACT_DIR="${ARTIFACT_DIR}"
+export WEBKIT_DISABLE_COMPOSITING_MODE="${WEBKIT_DISABLE_COMPOSITING_MODE:-1}"
+
+{
+  echo "tauri-driver: $(tauri-driver --version)"
+  echo "WebKitWebDriver: $(WebKitWebDriver --version 2>&1 | head -n 1)"
+  echo "rustc: $(rustc --version)"
+  echo "node: $(node --version)"
+  echo "transport-profile: ${WAVES_FETCH_TRANSPORT_PROFILE}"
+  echo "transport-fallback: ${WAVES_FETCH_TRANSPORT_FALLBACK}"
+  echo "destination-policy: ${WAVES_FETCH_DESTINATION_POLICY}"
+} >"${ARTIFACT_DIR}/environment.txt"
+
+echo "==> Building the production Tauri frontend and debug application binary"
+pnpm --dir browser run tauri:build -- --debug --no-bundle
+
+echo "==> Driving the native Waves window through tauri-driver"
+pnpm --dir browser/frontend run test:native-kannel:ui

--- a/scripts/native-tauri-kannel-e2e.sh
+++ b/scripts/native-tauri-kannel-e2e.sh
@@ -68,7 +68,6 @@ cd "${ROOT_DIR}"
 
 echo "==> Starting isolated Kannel + WML services"
 export WML_DTD_VERSION=1.3
-export WML_ENCODING_VERSION=1.3
 docker compose up -d --build kannel wml-server
 wait_for_http "${KANNEL_ADMIN_URL}"
 curl -fsS --connect-timeout 2 --max-time 5 "${KANNEL_ADMIN_URL}" | grep -q 'Status: running'
@@ -96,7 +95,6 @@ export WEBKIT_DISABLE_COMPOSITING_MODE="${WEBKIT_DISABLE_COMPOSITING_MODE:-1}"
   echo "transport-fallback: ${WAVES_FETCH_TRANSPORT_FALLBACK}"
   echo "destination-policy: ${WAVES_FETCH_DESTINATION_POLICY}"
   echo "wml-dtd-version: ${WML_DTD_VERSION}"
-  echo "wml-encoding-version: ${WML_ENCODING_VERSION}"
 } >"${ARTIFACT_DIR}/environment.txt"
 
 echo "==> Building the production Tauri frontend and debug application binary"

--- a/scripts/native-tauri-kannel-e2e.sh
+++ b/scripts/native-tauri-kannel-e2e.sh
@@ -67,6 +67,7 @@ wait_for_http() {
 cd "${ROOT_DIR}"
 
 echo "==> Starting isolated Kannel + WML services"
+export WML_DTD_VERSION=1.3
 export WML_ENCODING_VERSION=1.3
 docker compose up -d --build kannel wml-server
 wait_for_http "${KANNEL_ADMIN_URL}"
@@ -94,6 +95,7 @@ export WEBKIT_DISABLE_COMPOSITING_MODE="${WEBKIT_DISABLE_COMPOSITING_MODE:-1}"
   echo "transport-profile: ${WAVES_FETCH_TRANSPORT_PROFILE}"
   echo "transport-fallback: ${WAVES_FETCH_TRANSPORT_FALLBACK}"
   echo "destination-policy: ${WAVES_FETCH_DESTINATION_POLICY}"
+  echo "wml-dtd-version: ${WML_DTD_VERSION}"
   echo "wml-encoding-version: ${WML_ENCODING_VERSION}"
 } >"${ARTIFACT_DIR}/environment.txt"
 

--- a/scripts/native-tauri-kannel-e2e.sh
+++ b/scripts/native-tauri-kannel-e2e.sh
@@ -67,6 +67,7 @@ wait_for_http() {
 cd "${ROOT_DIR}"
 
 echo "==> Starting isolated Kannel + WML services"
+export WML_ENCODING_VERSION=1.3
 docker compose up -d --build kannel wml-server
 wait_for_http "${KANNEL_ADMIN_URL}"
 curl -fsS --connect-timeout 2 --max-time 5 "${KANNEL_ADMIN_URL}" | grep -q 'Status: running'
@@ -93,6 +94,7 @@ export WEBKIT_DISABLE_COMPOSITING_MODE="${WEBKIT_DISABLE_COMPOSITING_MODE:-1}"
   echo "transport-profile: ${WAVES_FETCH_TRANSPORT_PROFILE}"
   echo "transport-fallback: ${WAVES_FETCH_TRANSPORT_FALLBACK}"
   echo "destination-policy: ${WAVES_FETCH_DESTINATION_POLICY}"
+  echo "wml-encoding-version: ${WML_ENCODING_VERSION}"
 } >"${ARTIFACT_DIR}/environment.txt"
 
 echo "==> Building the production Tauri frontend and debug application binary"

--- a/scripts/tests/transport-wap-smoke-status.sh
+++ b/scripts/tests/transport-wap-smoke-status.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env sh
+set -eu
+
+ROOT_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+. "${ROOT_DIR}/scripts/lib/run-and-tee.sh"
+
+TEST_DIR="$(mktemp -d "${TMPDIR:-/tmp}/transport-wap-status-test.XXXXXX")"
+TEST_LOG="${TEST_DIR}/failure.log"
+
+cleanup() {
+  rm -f "${TEST_LOG}"
+  rmdir "${TEST_DIR}"
+}
+trap cleanup EXIT HUP INT TERM
+
+set +e
+run_and_tee "${TEST_LOG}" sh -c 'printf "%s\n" expected-failure; exit 23'
+captured_status="$?"
+set -e
+
+if [ "${captured_status}" -ne 23 ]; then
+  echo "expected status 23, got ${captured_status}" >&2
+  exit 1
+fi
+grep -qx 'expected-failure' "${TEST_LOG}"

--- a/scripts/transport-wap-smoke.sh
+++ b/scripts/transport-wap-smoke.sh
@@ -2,6 +2,7 @@
 set -eu
 
 ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+. "${ROOT_DIR}/scripts/lib/run-and-tee.sh"
 KANNEL_ADMIN_URL="${KANNEL_ADMIN_URL:-http://localhost:13000/status?password=changeme}"
 WML_HEALTH_URL="${WML_HEALTH_URL:-http://localhost:3000/health}"
 WAP_SMOKE_URL="${WAP_SMOKE_URL:-wap://localhost/}"
@@ -14,19 +15,6 @@ if [ -n "${TRANSPORT_WAP_SMOKE_ARTIFACT_DIR:-}" ]; then
 else
   SMOKE_ARTIFACT_DIR="$(mktemp -d "${TMPDIR:-/tmp}/transport-wap-smoke.XXXXXX")"
 fi
-
-# Run a piped command and fail if the *command* (not `tee`) exited nonzero.
-# POSIX sh has no `pipefail`/`PIPESTATUS`, so the command's real exit code is
-# written to a scratch file from inside the pipeline and read back afterward.
-run_and_tee() {
-  log_file="$1"
-  shift
-  status_file="$(mktemp "${TMPDIR:-/tmp}/transport-wap-smoke-status.XXXXXX")"
-  { "$@"; echo "$?" >"$status_file"; } | tee "$log_file"
-  cmd_status="$(cat "$status_file")"
-  rm -f "$status_file"
-  return "$cmd_status"
-}
 
 print_failure_diagnostics() {
   exit_code="$?"

--- a/scripts/transport-wap-smoke.sh
+++ b/scripts/transport-wap-smoke.sh
@@ -8,7 +8,12 @@ WAP_SMOKE_URL="${WAP_SMOKE_URL:-wap://localhost/}"
 WAP_SMOKE_LOGIN_URL="${WAP_SMOKE_LOGIN_URL:-wap://localhost/login}"
 TRANSPORT_WAP_TIMEOUT_MS="${TRANSPORT_WAP_TIMEOUT_MS:-15000}"
 TRANSPORT_WAP_RETRIES="${TRANSPORT_WAP_RETRIES:-1}"
-SMOKE_ARTIFACT_DIR="$(mktemp -d "${TMPDIR:-/tmp}/transport-wap-smoke.XXXXXX")"
+if [ -n "${TRANSPORT_WAP_SMOKE_ARTIFACT_DIR:-}" ]; then
+  SMOKE_ARTIFACT_DIR="${TRANSPORT_WAP_SMOKE_ARTIFACT_DIR}"
+  mkdir -p "${SMOKE_ARTIFACT_DIR}"
+else
+  SMOKE_ARTIFACT_DIR="$(mktemp -d "${TMPDIR:-/tmp}/transport-wap-smoke.XXXXXX")"
+fi
 
 # Run a piped command and fail if the *command* (not `tee`) exited nonzero.
 # POSIX sh has no `pipefail`/`PIPESTATUS`, so the command's real exit code is
@@ -56,6 +61,8 @@ print_failure_diagnostics() {
 
 trap print_failure_diagnostics EXIT
 
+export RUST_TEST_THREADS=1
+
 wait_for_http() {
   url="$1"
   retries="${2:-40}"
@@ -85,7 +92,6 @@ echo "==> Running transport-rust WAP smoke integration test"
 (
   cd "${ROOT_DIR}/transport-rust"
   export WAP_SMOKE_URL WAP_SMOKE_LOGIN_URL TRANSPORT_WAP_TIMEOUT_MS TRANSPORT_WAP_RETRIES
-  export RUST_TEST_THREADS=1
   run_and_tee "${SMOKE_ARTIFACT_DIR}/transport-kannel-smoke.log" \
     cargo test --test kannel_smoke -- --ignored --test-threads=1
 )
@@ -94,7 +100,6 @@ echo "==> Running browser host native Kannel smoke unit test"
 (
   cd "${ROOT_DIR}/browser/src-tauri"
   export WAP_SMOKE_URL TRANSPORT_WAP_TIMEOUT_MS TRANSPORT_WAP_RETRIES
-  export RUST_TEST_THREADS=1
   run_and_tee "${SMOKE_ARTIFACT_DIR}/browser-host-native-smoke.log" \
     cargo test host_fetch_deck_command_native_wap_home_smoke_succeeds --lib -- --ignored --test-threads=1
 )
@@ -103,7 +108,6 @@ echo "==> Running browser engine/render native Kannel smoke integration test"
 (
   cd "${ROOT_DIR}/browser/src-tauri"
   export WAP_SMOKE_URL TRANSPORT_WAP_TIMEOUT_MS TRANSPORT_WAP_RETRIES
-  export RUST_TEST_THREADS=1
   run_and_tee "${SMOKE_ARTIFACT_DIR}/browser-render-native-smoke.log" \
     cargo test kannel_fetch_deck_smoke_navigates_into_menu_card -- --ignored --test-threads=1
 )

--- a/transport-rust/README.md
+++ b/transport-rust/README.md
@@ -14,6 +14,11 @@ The runtime decoder is built into this crate and pinned as
 dependency. WBXML parsing remains transport-owned, and the engine receives
 only normalized textual WML plus the original bytes as metadata.
 
+The native connectionless WSP profile advertises `Encoding-Version: 1.3` as a compact
+version-value. The local Kannel image carries a narrow connectionless-path patch so that this
+device request header selects Kannel's WBXML compiler version just as it does for a session-bound
+request; the decoder remains strict about the selected WBXML 1.3 envelope and WML 1.3 public ID.
+
 ## Engine Handoff Normalization Guarantees (`T0-02`)
 
 When `FetchDeckResponse.ok === true`, `engineDeckInput` is present and follows these rules:

--- a/transport-rust/src/native_fetch.rs
+++ b/transport-rust/src/native_fetch.rs
@@ -46,6 +46,8 @@ pub(crate) struct NativeFetchPlan {
 
 /// Media type this transport negotiates when the caller sends no `Accept`.
 const DEFAULT_ACCEPT_MEDIA: &str = "application/vnd.wap.wmlc";
+/// WSP/WBXML version supported by the selected WML 1.3 native profile.
+const NATIVE_WSP_ENCODING_VERSION: &str = "1.3";
 
 /// Failure while building the connectionless request for a native fetch plan.
 #[derive(Debug)]
@@ -463,6 +465,13 @@ fn connectionless_request_headers(headers: &HashMap<String, String>) -> WspHeade
             },
         });
     }
+    block.headers.push(WspHeaderField {
+        name: "Encoding-Version".to_string(),
+        value: NATIVE_WSP_ENCODING_VERSION.to_string(),
+        name_encoding: WspHeaderNameEncoding::Binary {
+            page: DEFAULT_HEADER_CODE_PAGE,
+        },
+    });
     block
 }
 
@@ -663,7 +672,7 @@ mod tests {
         let (uri_len, rest) = decode_uintvar(&sent.payload[2..]).expect("uri length should decode");
         let uri = std::str::from_utf8(&rest[..uri_len]).expect("uri should be utf8");
         assert_eq!(uri, "http://127.0.0.1:13002/login");
-        assert_eq!(&rest[uri_len..], &[0x80, 0x88]);
+        assert_eq!(&rest[uri_len..], &[0x80, 0x88, 0xc3, 0x93]);
     }
 
     #[test]
@@ -782,7 +791,7 @@ mod tests {
         let (uri_len, rest) = decode_uintvar(&encoded[2..]).expect("uri len should decode");
         let uri = std::str::from_utf8(&rest[..uri_len]).expect("uri should decode");
         assert_eq!(uri, "http://localhost:13002/");
-        assert_eq!(&rest[uri_len..], &[0x80, 0x94]);
+        assert_eq!(&rest[uri_len..], &[0x80, 0x94, 0xc3, 0x93]);
     }
 
     #[test]
@@ -868,12 +877,13 @@ mod tests {
             None,
             "unrepresentable Accept values advertise nothing"
         );
-        assert!(connectionless_request_headers(&HashMap::from([(
+        let headers = connectionless_request_headers(&HashMap::from([(
             "Accept".to_string(),
-            "application/json".to_string()
-        )]))
-        .headers
-        .is_empty());
+            "application/json".to_string(),
+        )]));
+        assert_eq!(headers.headers.len(), 1);
+        assert_eq!(headers.headers[0].name, "Encoding-Version");
+        assert_eq!(headers.headers[0].value, NATIVE_WSP_ENCODING_VERSION);
     }
 
     #[test]
@@ -964,13 +974,13 @@ mod tests {
         let uri = std::str::from_utf8(&remainder[..uri_len]).expect("uri should decode");
         assert_eq!(uri, "http://localhost:13002/login");
         let remainder = &remainder[uri_len..];
-        assert_eq!(headers_len, 36);
+        assert_eq!(headers_len, 38);
         assert_eq!(
             &remainder[..headers_len],
             &[
                 b'a', b'p', b'p', b'l', b'i', b'c', b'a', b't', b'i', b'o', b'n', b'/', b'x', b'-',
                 b'w', b'w', b'w', b'-', b'f', b'o', b'r', b'm', b'-', b'u', b'r', b'l', b'e', b'n',
-                b'c', b'o', b'd', b'e', b'd', 0x00, 0x80, 0x88,
+                b'c', b'o', b'd', b'e', b'd', 0x00, 0x80, 0x88, 0xc3, 0x93,
             ]
         );
         assert_eq!(&remainder[headers_len..], b"username=alice&pin=0000");

--- a/transport-rust/src/network/wsp/connectionless.rs
+++ b/transport-rust/src/network/wsp/connectionless.rs
@@ -365,6 +365,15 @@ fn encode_connectionless_header_block(block: &WspHeaderBlock) -> Vec<u8> {
             .flatten();
         match media_code {
             Some(code) => out.push(WELL_KNOWN_MARKER | code),
+            None if header.name.eq_ignore_ascii_case("Encoding-Version") => {
+                match encode_version_value(&header.value) {
+                    Some(version) => out.push(WELL_KNOWN_MARKER | version),
+                    None => {
+                        out.extend_from_slice(header.value.as_bytes());
+                        out.push(0x00);
+                    }
+                }
+            }
             None => {
                 out.extend_from_slice(header.value.as_bytes());
                 out.push(0x00);
@@ -372,6 +381,13 @@ fn encode_connectionless_header_block(block: &WspHeaderBlock) -> Vec<u8> {
         }
     }
     out
+}
+
+fn encode_version_value(value: &str) -> Option<u8> {
+    let (major, minor) = value.trim().split_once('.')?;
+    let major = major.parse::<u8>().ok()?;
+    let minor = minor.parse::<u8>().ok()?;
+    (major <= 0x07 && minor <= 0x0e).then_some((major << 4) | minor)
 }
 
 /// Encodes the `ContentType` field that precedes a `Post` header section.
@@ -636,6 +652,31 @@ mod tests {
         .expect("request should encode");
 
         assert_eq!(&encoded[encoded.len() - 2..], &[0x80, 0x88]);
+    }
+
+    #[test]
+    fn get_request_encodes_wbxml_version_as_compact_version_value() {
+        let block = WspHeaderBlock {
+            headers: vec![WspHeaderField {
+                name: "Encoding-Version".to_string(),
+                value: "1.3".to_string(),
+                name_encoding: WspHeaderNameEncoding::Binary {
+                    page: DEFAULT_HEADER_CODE_PAGE,
+                },
+            }],
+            encoding_version_headers: Vec::new(),
+        };
+        let encoded = encode_connectionless_request(&WspConnectionlessRequest {
+            transaction_id: TRANSACTION_ID,
+            method: WspConnectionlessMethod::Get,
+            uri: "/",
+            headers: &block,
+            content_type: None,
+            body: &[],
+        })
+        .expect("request should encode");
+
+        assert_eq!(&encoded[encoded.len() - 2..], &[0xc3, 0x93]);
     }
 
     #[test]

--- a/transport-rust/src/wbxml_decoder.rs
+++ b/transport-rust/src/wbxml_decoder.rs
@@ -3,7 +3,7 @@ use std::fmt::Write as _;
 
 pub(crate) const WML13_DECODER_ID: &str = "lowband-wml13-wbxml/0.3.0";
 
-const WBXML_VERSION_1_3: u8 = 0x03;
+const SUPPORTED_WBXML_VERSIONS: &[u8] = &[0x01, 0x02, 0x03];
 const WML_1_3_PUBLIC_ID: u32 = 0x0a;
 const WML_1_3_PUBLIC_ID_TEXT: &str = "-//WAPFORUM//DTD WML 1.3//EN";
 const MAX_NESTING_DEPTH: usize = 128;
@@ -248,9 +248,9 @@ impl<'a> Decoder<'a> {
 
     fn decode_header(&mut self) -> Result<Header<'a>, String> {
         let version = self.read_byte("version")?;
-        if version != WBXML_VERSION_1_3 {
+        if !SUPPORTED_WBXML_VERSIONS.contains(&version) {
             return Err(format!(
-                "unsupported WBXML version byte 0x{version:02x}; expected 0x{WBXML_VERSION_1_3:02x}"
+                "unsupported WBXML version byte 0x{version:02x}; expected 0x01, 0x02, or 0x03"
             ));
         }
 
@@ -1022,6 +1022,25 @@ fn decode_error(detail: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn wml13_decoder_accepts_supported_wbxml_envelope_versions() {
+        for version in SUPPORTED_WBXML_VERSIONS {
+            let payload = [*version, WML_1_3_PUBLIC_ID as u8, 0x6a, 0x00, 0x3f];
+            assert_eq!(
+                decode_wml13(&payload, 1024).as_deref(),
+                Ok("<wml/>"),
+                "WBXML version byte 0x{version:02x}"
+            );
+        }
+    }
+
+    #[test]
+    fn wml13_decoder_rejects_unknown_wbxml_envelope_version() {
+        let error = decode_wml13(&[0x00, 0x0a, 0x6a, 0x00, 0x3f], 1024)
+            .expect_err("WBXML version 1.0 must remain unsupported");
+        assert!(error.contains("expected 0x01, 0x02, or 0x03"));
+    }
 
     #[test]
     fn wml13_registry_classifies_all_256_pages_per_code_space() {

--- a/transport-rust/src/wbxml_decoder.rs
+++ b/transport-rust/src/wbxml_decoder.rs
@@ -3,7 +3,7 @@ use std::fmt::Write as _;
 
 pub(crate) const WML13_DECODER_ID: &str = "lowband-wml13-wbxml/0.3.0";
 
-const SUPPORTED_WBXML_VERSIONS: &[u8] = &[0x01, 0x02, 0x03];
+const WBXML_VERSION_1_3: u8 = 0x03;
 const WML_1_3_PUBLIC_ID: u32 = 0x0a;
 const WML_1_3_PUBLIC_ID_TEXT: &str = "-//WAPFORUM//DTD WML 1.3//EN";
 const MAX_NESTING_DEPTH: usize = 128;
@@ -248,9 +248,9 @@ impl<'a> Decoder<'a> {
 
     fn decode_header(&mut self) -> Result<Header<'a>, String> {
         let version = self.read_byte("version")?;
-        if !SUPPORTED_WBXML_VERSIONS.contains(&version) {
+        if version != WBXML_VERSION_1_3 {
             return Err(format!(
-                "unsupported WBXML version byte 0x{version:02x}; expected 0x01, 0x02, or 0x03"
+                "unsupported WBXML version byte 0x{version:02x}; expected 0x{WBXML_VERSION_1_3:02x}"
             ));
         }
 
@@ -1022,25 +1022,6 @@ fn decode_error(detail: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn wml13_decoder_accepts_supported_wbxml_envelope_versions() {
-        for version in SUPPORTED_WBXML_VERSIONS {
-            let payload = [*version, WML_1_3_PUBLIC_ID as u8, 0x6a, 0x00, 0x3f];
-            assert_eq!(
-                decode_wml13(&payload, 1024).as_deref(),
-                Ok("<wml/>"),
-                "WBXML version byte 0x{version:02x}"
-            );
-        }
-    }
-
-    #[test]
-    fn wml13_decoder_rejects_unknown_wbxml_envelope_version() {
-        let error = decode_wml13(&[0x00, 0x0a, 0x6a, 0x00, 0x3f], 1024)
-            .expect_err("WBXML version 1.0 must remain unsupported");
-        assert!(error.contains("expected 0x01, 0x02, or 0x03"));
-    }
 
     #[test]
     fn wml13_registry_classifies_all_256_pages_per_code_space() {

--- a/wml-server/server.js
+++ b/wml-server/server.js
@@ -5,9 +5,16 @@ const path = require('path');
 
 const app = express();
 const port = process.env.PORT || 3000;
+const wmlDtdVersion = process.env.WML_DTD_VERSION || '1.1';
 const wmlEncodingVersion = process.env.WML_ENCODING_VERSION || '';
+const supportedWmlDtdVersions = new Set(['1.1', '1.2', '1.3']);
 const supportedWmlEncodingVersions = new Set(['', '1.1', '1.2', '1.3']);
 
+if (!supportedWmlDtdVersions.has(wmlDtdVersion)) {
+  throw new Error(
+    `unsupported WML_DTD_VERSION ${JSON.stringify(wmlDtdVersion)}; expected 1.1, 1.2, or 1.3`
+  );
+}
 if (!supportedWmlEncodingVersions.has(wmlEncodingVersion)) {
   throw new Error(
     `unsupported WML_ENCODING_VERSION ${JSON.stringify(wmlEncodingVersion)}; expected 1.1, 1.2, or 1.3`
@@ -66,7 +73,7 @@ function xmlEscape(value) {
 function sendWml(res, body, statusCode = 200) {
   const document =
     '<?xml version="1.0"?>\n' +
-    '<!DOCTYPE wml PUBLIC "-//WAPFORUM//DTD WML 1.1//EN" "http://www.wapforum.org/DTD/wml_1.1.xml">\n' +
+    `<!DOCTYPE wml PUBLIC "-//WAPFORUM//DTD WML ${wmlDtdVersion}//EN" "http://www.wapforum.org/DTD/wml_${wmlDtdVersion}.xml">\n` +
     `<wml>\n${body}\n</wml>\n`;
 
   res.status(statusCode);

--- a/wml-server/server.js
+++ b/wml-server/server.js
@@ -6,18 +6,11 @@ const path = require('path');
 const app = express();
 const port = process.env.PORT || 3000;
 const wmlDtdVersion = process.env.WML_DTD_VERSION || '1.1';
-const wmlEncodingVersion = process.env.WML_ENCODING_VERSION || '';
 const supportedWmlDtdVersions = new Set(['1.1', '1.2', '1.3']);
-const supportedWmlEncodingVersions = new Set(['', '1.1', '1.2', '1.3']);
 
 if (!supportedWmlDtdVersions.has(wmlDtdVersion)) {
   throw new Error(
     `unsupported WML_DTD_VERSION ${JSON.stringify(wmlDtdVersion)}; expected 1.1, 1.2, or 1.3`
-  );
-}
-if (!supportedWmlEncodingVersions.has(wmlEncodingVersion)) {
-  throw new Error(
-    `unsupported WML_ENCODING_VERSION ${JSON.stringify(wmlEncodingVersion)}; expected 1.1, 1.2, or 1.3`
   );
 }
 const gatewayBaseUrls = process.env.GATEWAY_BASE_URL
@@ -79,9 +72,6 @@ function sendWml(res, body, statusCode = 200) {
   res.status(statusCode);
   res.set('Content-Type', 'text/vnd.wap.wml; charset=utf-8');
   res.set('Cache-Control', 'no-store');
-  if (wmlEncodingVersion) {
-    res.set('Encoding-Version', wmlEncodingVersion);
-  }
   res.send(document);
 }
 
@@ -98,9 +88,6 @@ function sendStaticWml(res, fileName) {
     }
     res.set('Content-Type', 'text/vnd.wap.wml; charset=utf-8');
     res.set('Cache-Control', 'no-store');
-    if (wmlEncodingVersion) {
-      res.set('Encoding-Version', wmlEncodingVersion);
-    }
     res.send(data);
   });
 }

--- a/wml-server/server.js
+++ b/wml-server/server.js
@@ -5,6 +5,14 @@ const path = require('path');
 
 const app = express();
 const port = process.env.PORT || 3000;
+const wmlEncodingVersion = process.env.WML_ENCODING_VERSION || '';
+const supportedWmlEncodingVersions = new Set(['', '1.1', '1.2', '1.3']);
+
+if (!supportedWmlEncodingVersions.has(wmlEncodingVersion)) {
+  throw new Error(
+    `unsupported WML_ENCODING_VERSION ${JSON.stringify(wmlEncodingVersion)}; expected 1.1, 1.2, or 1.3`
+  );
+}
 const gatewayBaseUrls = process.env.GATEWAY_BASE_URL
   ? [process.env.GATEWAY_BASE_URL]
   : ['http://kannel:13002', 'http://localhost:13002'];
@@ -64,6 +72,9 @@ function sendWml(res, body, statusCode = 200) {
   res.status(statusCode);
   res.set('Content-Type', 'text/vnd.wap.wml; charset=utf-8');
   res.set('Cache-Control', 'no-store');
+  if (wmlEncodingVersion) {
+    res.set('Encoding-Version', wmlEncodingVersion);
+  }
   res.send(document);
 }
 
@@ -80,6 +91,9 @@ function sendStaticWml(res, fileName) {
     }
     res.set('Content-Type', 'text/vnd.wap.wml; charset=utf-8');
     res.set('Cache-Control', 'no-store');
+    if (wmlEncodingVersion) {
+      res.set('Encoding-Version', wmlEncodingVersion);
+    }
     res.send(data);
   });
 }


### PR DESCRIPTION
## Summary

- promote the proven Kannel transport/host smoke to a narrowly path-scoped pull-request signal while preserving manual dispatch, durable logs, and teardown
- add a supported Linux `tauri-driver` + Selenium pilot that clicks the production Tauri frontend and crosses generated IPC, the native Rust host/engine, `transport-rust`, and Kannel
- cover native startup, gateway-served home render, menu navigation, deterministic invalid-URL failure, and successful recovery
- keep production network policy unchanged; the provisioned runner explicitly selects `allow-private`, `wap-net-core`, and disabled fallback at the existing host boundary
- update active CI/readiness documentation and add the additive `A5-08` promotion follow-up with measurable criteria

## Why

The existing smoke proved Kannel, Rust transport, and Tauri host/engine behavior but was manual-only, while ordinary-browser Playwright stories stop at an in-memory fixture adapter. This leaves no automated evidence that visible production Tauri UI controls reach a real gateway-served WML result.

## Signal posture

- `Transport WAP Smoke (Kannel)`: pull-request signal only for gateway/transport/engine-contract/browser-host boundary paths; manual dispatch remains
- `Native Tauri UI through Kannel (pilot)`: self-validates pilot changes on PRs and otherwise runs weekly/manual; it is not required and does not yet cover general product-change paths
- promotion requires four consecutive scheduled successes over at least 21 days, complete artifacts, no reruns, and a maximum 30-minute run

## Local verification

- `make lint-rust-transport`
- `make test-rust-transport` (238 unit tests plus fixture/replay integrations)
- `cargo fmt --check && cargo clippy --all-targets --all-features -- -D warnings && cargo test` in `browser/src-tauri` (60 non-ignored tests)
- `pnpm --dir browser run contracts:check`
- frontend lint, typecheck, 192 tests, and production build
- production Tauri debug build with the network-mode startup configuration
- `shellcheck`, pinned `actionlint`, YAML parsing, `git diff --check`
- `pnpm audit --audit-level high` (no known vulnerabilities)
- repository pre-commit and pre-push hooks

The real `make smoke-transport-wap` and native Tauri/WebDriver run require Docker/Linux provisioning; this PR's path-scoped workflows execute both and retain their evidence artifacts.
