### PR TITLE
test(coverage): close low-hanging coverage gaps in transport-rust and engine-wasm

### DIFF
--- a/engine-wasm/engine/src/engine_tests/script_runtime.rs
+++ b/engine-wasm/engine/src/engine_tests/script_runtime.rs
@@ -1074,3 +1074,155 @@ fn convert_script_call_args_maps_number_to_int_when_whole() {
         ]
     );
 }
+
+#[test]
+fn convert_script_call_args_maps_invalid_false_to_empty_string() {
+    let args = vec![ScriptCallArgLiteral::Invalid { invalid: false }];
+    let converted = convert_script_call_args(&args);
+    assert_eq!(converted, vec![ScriptValue::String(String::new())]);
+}
+
+#[test]
+fn format_decode_error_covers_every_variant() {
+    use crate::wavescript::decoder::DecodeError;
+
+    assert_eq!(
+        super::super::format_decode_error(DecodeError::EmptyUnit),
+        "decode: empty compilation unit"
+    );
+    assert_eq!(
+        super::super::format_decode_error(DecodeError::UnitTooLarge { size: 10, limit: 5 }),
+        "decode: unit too large (size=10, limit=5)"
+    );
+    assert_eq!(
+        super::super::format_decode_error(DecodeError::UnsupportedOpcode {
+            pc: 1,
+            opcode: 0xff
+        }),
+        "decode: unsupported opcode 0xff at pc=1"
+    );
+    assert_eq!(
+        super::super::format_decode_error(DecodeError::TruncatedImmediate {
+            pc: 2,
+            opcode: 0x03
+        }),
+        "decode: truncated immediate for opcode 0x03 at pc=2"
+    );
+    assert_eq!(
+        super::super::format_decode_error(DecodeError::InvalidLocalIndex {
+            pc: 3,
+            index: 9,
+            limit: 4
+        }),
+        "decode: invalid local index 9 at pc=3 (limit=4)"
+    );
+    assert_eq!(
+        super::super::format_decode_error(DecodeError::InvalidCallArity {
+            pc: 4,
+            arg_count: 2,
+            local_count: 1,
+            frame_locals: 3,
+            limit: 8
+        }),
+        "decode: invalid call arity at pc=4 (args=2, locals=1, frame=3, limit=8)"
+    );
+    assert_eq!(
+        super::super::format_decode_error(DecodeError::InvalidHostArgCount {
+            pc: 5,
+            arg_count: 6,
+            limit: 4
+        }),
+        "decode: invalid host arg count at pc=5 (args=6, limit=4)"
+    );
+    assert_eq!(
+        super::super::format_decode_error(DecodeError::InvalidCallTarget { pc: 6, target: 99 }),
+        "decode: invalid call target 99 from pc=6"
+    );
+}
+
+#[test]
+fn format_vm_trap_covers_every_variant() {
+    assert_eq!(
+        crate::engine_script_types::format_vm_trap(VmTrap::EmptyUnit),
+        "vm: empty unit"
+    );
+    assert_eq!(
+        crate::engine_script_types::format_vm_trap(VmTrap::InvalidEntryPoint { entry_pc: 7 }),
+        "vm: invalid entry point (7)"
+    );
+    assert_eq!(
+        crate::engine_script_types::format_vm_trap(VmTrap::UnsupportedOpcode(0xab)),
+        "vm: unsupported opcode 0xab"
+    );
+    assert_eq!(
+        crate::engine_script_types::format_vm_trap(VmTrap::TruncatedImmediate { opcode: 0x02 }),
+        "vm: truncated immediate for opcode 0x02"
+    );
+    assert_eq!(
+        crate::engine_script_types::format_vm_trap(VmTrap::StackOverflow { limit: 64 }),
+        "vm: stack overflow (limit=64)"
+    );
+    assert_eq!(
+        crate::engine_script_types::format_vm_trap(VmTrap::InvalidLocalIndex { index: 3 }),
+        "vm: invalid local index (3)"
+    );
+    assert_eq!(
+        crate::engine_script_types::format_vm_trap(VmTrap::InvalidCallTarget { target: 12 }),
+        "vm: invalid call target (12)"
+    );
+    assert_eq!(
+        crate::engine_script_types::format_vm_trap(VmTrap::CallDepthExceeded { limit: 8 }),
+        "vm: call depth exceeded (limit=8)"
+    );
+    assert_eq!(
+        crate::engine_script_types::format_vm_trap(VmTrap::ExecutionLimitExceeded { limit: 1000 }),
+        "vm: execution step limit exceeded (1000)"
+    );
+    assert_eq!(
+        crate::engine_script_types::format_vm_trap(VmTrap::Utf8ImmediateDecode),
+        "vm: invalid utf-8 string immediate"
+    );
+    assert_eq!(
+        crate::engine_script_types::format_vm_trap(VmTrap::HostCallUnavailable { function_id: 4 }),
+        "vm: host call unavailable (function=4)"
+    );
+    assert_eq!(
+        crate::engine_script_types::format_vm_trap(VmTrap::HostCallError {
+            function_id: 5,
+            message: "boom".to_string()
+        }),
+        "vm: host call error (function=5, message=boom)"
+    );
+}
+
+#[test]
+fn script_dialog_request_to_literal_maps_confirm_and_prompt() {
+    use crate::runtime::events::ScriptDialogRequest;
+
+    assert_eq!(
+        super::super::script_dialog_request_to_literal(&ScriptDialogRequest::Confirm {
+            message: "sure?".to_string()
+        }),
+        ScriptDialogRequestLiteral::Confirm {
+            message: "sure?".to_string()
+        }
+    );
+    assert_eq!(
+        super::super::script_dialog_request_to_literal(&ScriptDialogRequest::Prompt {
+            message: "name?".to_string(),
+            default_value: Some("anon".to_string())
+        }),
+        ScriptDialogRequestLiteral::Prompt {
+            message: "name?".to_string(),
+            default_value: Some("anon".to_string())
+        }
+    );
+}
+
+#[test]
+fn is_valid_var_name_rejects_empty_and_bad_leading_char() {
+    assert!(!super::super::is_valid_var_name(""));
+    assert!(!super::super::is_valid_var_name("1abc"));
+    assert!(super::super::is_valid_var_name("_abc"));
+    assert!(super::super::is_valid_var_name("a.b-c"));
+}

--- a/transport-rust/src/network/wcmp/message.rs
+++ b/transport-rust/src/network/wcmp/message.rs
@@ -126,3 +126,43 @@ impl WcmpMessage {
         matches!(self.type_class(), WcmpTypeClass::Error)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn destination_unreachable_code_roundtrips_every_variant() {
+        let codes = [
+            WcmpDestinationUnreachableCode::NoRouteToDestination,
+            WcmpDestinationUnreachableCode::CommunicationAdministrativelyProhibited,
+            WcmpDestinationUnreachableCode::AddressUnreachable,
+            WcmpDestinationUnreachableCode::PortUnreachable,
+        ];
+        for code in codes {
+            let byte = code.to_u8();
+            assert_eq!(WcmpDestinationUnreachableCode::from_u8(byte), Some(code));
+        }
+        assert_eq!(WcmpDestinationUnreachableCode::from_u8(2), None);
+    }
+
+    #[test]
+    fn message_type_class_matches_error_and_informational_ranges() {
+        let unreachable = WcmpMessage::DestinationUnreachable {
+            code: WcmpDestinationUnreachableCode::NoRouteToDestination,
+            destination_port: 1,
+            originator_port: 2,
+            address: WcmpAddress::cdpd_ipv4([10, 0, 0, 1]),
+        };
+        assert_eq!(unreachable.type_class(), WcmpTypeClass::Error);
+        assert!(unreachable.is_error());
+
+        let echo_request = WcmpMessage::EchoRequest {
+            identifier: 1,
+            sequence_number: 1,
+            data: vec![],
+        };
+        assert_eq!(echo_request.type_class(), WcmpTypeClass::Informational);
+        assert!(!echo_request.is_error());
+    }
+}

--- a/transport-rust/src/network/wcmp/profile.rs
+++ b/transport-rust/src/network/wcmp/profile.rs
@@ -190,4 +190,76 @@ mod tests {
         ));
         assert!(encode_wdp_control_message(WdpControlProfile::CdpdIpv4Strict, &icmp, 64).is_ok());
     }
+
+    #[test]
+    fn wdp_control_error_display_messages_are_descriptive() {
+        let encode_mismatch = WdpControlEncodeError::ProfileMismatch {
+            profile: WdpControlProfile::CdpdIpv4Strict,
+            message_family: "general WCMP",
+        };
+        assert_eq!(
+            encode_mismatch.to_string(),
+            "general WCMP control message is unavailable for CdpdIpv4Strict"
+        );
+        assert!(
+            WdpControlEncodeError::Icmpv4(Icmpv4EncodeError::LengthOverflow)
+                .to_string()
+                .contains("ICMPv4 encode failed")
+        );
+        assert!(
+            WdpControlEncodeError::GeneralWcmp(WcmpEncodeError::LengthOverflow)
+                .to_string()
+                .contains("general WCMP encode failed")
+        );
+
+        assert!(
+            WdpControlDecodeError::Icmpv4(Icmpv4DecodeError::InvalidChecksum)
+                .to_string()
+                .contains("ICMPv4 decode failed")
+        );
+        assert!(
+            WdpControlDecodeError::GeneralWcmp(WcmpDecodeError::LengthOverflow)
+                .to_string()
+                .contains("general WCMP decode failed")
+        );
+
+        assert!(WdpControlHandlingError::Icmpv4(Icmpv4HandlingError::Decode(
+            Icmpv4DecodeError::InvalidChecksum
+        ))
+        .to_string()
+        .contains("ICMPv4 handling failed"));
+        assert!(
+            WdpControlHandlingError::GeneralWcmp(WcmpHandlingError::Decode(
+                WcmpDecodeError::LengthOverflow
+            ))
+            .to_string()
+            .contains("general WCMP handling failed")
+        );
+    }
+
+    #[test]
+    fn handle_wdp_control_message_routes_general_wcmp_profile() {
+        let echo = WdpControlMessage::GeneralWcmp(WcmpMessage::EchoRequest {
+            identifier: 1,
+            sequence_number: 2,
+            data: vec![9, 9],
+        });
+        let encoded =
+            encode_wdp_control_message(WdpControlProfile::GeneralWcmpNonIp, &echo, 64).unwrap();
+
+        let outcome = handle_wdp_control_message(
+            WdpControlProfile::GeneralWcmpNonIp,
+            &encoded,
+            WdpControlHandlingPolicy {
+                permit_echo_reply: true,
+                max_non_ip_bearer_fragment_bytes: 64,
+            },
+        )
+        .expect("general WCMP echo request should be handled");
+
+        assert!(matches!(
+            outcome,
+            WdpControlHandlingOutcome::GeneralWcmp(WcmpHandlingOutcome::EchoReplyGenerated { .. })
+        ));
+    }
 }

--- a/transport-rust/src/network/wcmp/tests.rs
+++ b/transport-rust/src/network/wcmp/tests.rs
@@ -218,6 +218,47 @@ fn echo_reply_truncates_only_data_to_return_path_fragment_size() {
 }
 
 #[test]
+fn incoming_echo_reply_is_reported_not_re_replied() {
+    let fixture = fixture();
+    let reply = fixture_case(&fixture, "echo-reply");
+    let outcome = handle_wcmp(
+        &reply.encoded,
+        WcmpHandlingPolicy {
+            max_bearer_fragment_bytes: 64,
+            permit_echo_reply: true,
+        },
+    )
+    .expect("echo reply should decode");
+
+    let WcmpMessage::EchoReply {
+        identifier,
+        sequence_number,
+        data,
+    } = expected_message(&fixture, "echo-reply")
+    else {
+        panic!("fixture echo-reply case should decode to an EchoReply message");
+    };
+    assert_eq!(
+        outcome,
+        WcmpHandlingOutcome::EchoReplyReceived {
+            identifier,
+            sequence_number,
+            data,
+        }
+    );
+}
+
+#[test]
+fn wcmp_handling_error_display_wraps_decode_and_encode_causes() {
+    assert!(WcmpHandlingError::from(WcmpDecodeError::LengthOverflow)
+        .to_string()
+        .contains("WCMP decode failed"));
+    assert!(WcmpHandlingError::from(WcmpEncodeError::LengthOverflow)
+        .to_string()
+        .contains("WCMP reply generation failed"));
+}
+
+#[test]
 fn echo_reply_rate_limit_is_explicit_and_deterministic() {
     let fixture = fixture();
     let request = fixture_case(&fixture, "echo-request");
@@ -278,6 +319,64 @@ fn generation_maps_port_and_buffer_failures_to_selected_messages() {
                 .clone(),
         }
     );
+}
+
+#[test]
+fn reported_destination_unreachable_maps_remaining_codes_to_wdp_errors() {
+    let fixture = fixture();
+    let address = fixture_address(&fixture);
+    let reported = |code| WcmpReportedError::DestinationUnreachable {
+        code,
+        destination_port: 9200,
+        originator_port: 49_152,
+        address: address.clone(),
+    };
+
+    assert_eq!(
+        reported(WcmpDestinationUnreachableCode::NoRouteToDestination).to_wdp_error(),
+        WdpError::NoRouteToDestination
+    );
+    assert_eq!(
+        reported(WcmpDestinationUnreachableCode::CommunicationAdministrativelyProhibited)
+            .to_wdp_error(),
+        WdpError::CommunicationAdministrativelyProhibited
+    );
+    assert_eq!(
+        reported(WcmpDestinationUnreachableCode::AddressUnreachable).to_wdp_error(),
+        WdpError::AddressUnreachable
+    );
+}
+
+#[test]
+fn generation_maps_remaining_destination_unreachable_failures() {
+    let cases = [
+        (
+            WcmpGenerationFailure::NoRouteToDestination,
+            WcmpDestinationUnreachableCode::NoRouteToDestination,
+        ),
+        (
+            WcmpGenerationFailure::CommunicationAdministrativelyProhibited,
+            WcmpDestinationUnreachableCode::CommunicationAdministrativelyProhibited,
+        ),
+        (
+            WcmpGenerationFailure::AddressUnreachable,
+            WcmpDestinationUnreachableCode::AddressUnreachable,
+        ),
+    ];
+
+    for (failure, expected_code) in cases {
+        let outcome = generate_wcmp_error(&generation_request(failure))
+            .expect("destination-unreachable failure should generate WCMP");
+        match outcome {
+            WcmpGenerationOutcome::Generated { message, .. } => match message {
+                WcmpMessage::DestinationUnreachable { code, .. } => {
+                    assert_eq!(code, expected_code);
+                }
+                other => panic!("expected DestinationUnreachable, got {other:?}"),
+            },
+            other => panic!("expected Generated outcome, got {other:?}"),
+        }
+    }
 }
 
 #[test]

--- a/transport-rust/src/network/wdp/transport_trait.rs
+++ b/transport-rust/src/network/wdp/transport_trait.rs
@@ -241,4 +241,93 @@ mod tests {
         let error = WdpError::DestinationPortUnsupported(9999);
         assert!(error.to_string().contains("9999"));
     }
+
+    #[test]
+    fn wdp_error_display_covers_remaining_variants() {
+        let cases: Vec<(WdpError, &str)> = vec![
+            (
+                WdpError::TransportUnavailable("no socket".to_string()),
+                "transport unavailable: no socket",
+            ),
+            (
+                WdpError::AddressTypeUnsupported,
+                "address type unsupported by WDP transport",
+            ),
+            (
+                WdpError::AddressUnresolvable("bad host".to_string()),
+                "address unresolvable: bad host",
+            ),
+            (WdpError::NoRouteToDestination, "no route to destination"),
+            (
+                WdpError::CommunicationAdministrativelyProhibited,
+                "communication administratively prohibited",
+            ),
+            (
+                WdpError::AddressUnreachable,
+                "destination address unreachable",
+            ),
+            (
+                WdpError::PeerMessageTooBig { max: 1500 },
+                "peer maximum message size is 1500",
+            ),
+            (
+                WdpError::Ipv4LargeDatagramUnassured {
+                    actual: 2000,
+                    baseline: 576,
+                },
+                "IPv4 datagram size 2000 exceeds baseline 576 without destination assurance",
+            ),
+            (
+                WdpError::Ipv4DontFragmentMtuExceeded {
+                    actual: 2000,
+                    mtu: 1500,
+                },
+                "IPv4 datagram size 2000 exceeds path MTU 1500 with DF set",
+            ),
+            (
+                WdpError::Ipv4FragmentationNeeded {
+                    actual: 2000,
+                    next_hop_mtu: Some(1500),
+                },
+                "IPv4 datagram size 2000 requires fragmentation but DF is set; next-hop MTU is 1500",
+            ),
+            (
+                WdpError::Ipv4FragmentationNeeded {
+                    actual: 2000,
+                    next_hop_mtu: None,
+                },
+                "IPv4 datagram size 2000 requires fragmentation but DF is set; next-hop MTU was not reported",
+            ),
+            (
+                WdpError::Ipv4ReassemblyCapacityExceeded {
+                    actual: 10,
+                    max: 8,
+                },
+                "IPv4 pending reassembly count 10 exceeds configured limit 8",
+            ),
+            (
+                WdpError::Ipv4ReassemblyBufferExceeded {
+                    actual: 4096,
+                    max: 2048,
+                },
+                "IPv4 reassembly buffer size 4096 exceeds configured limit 2048",
+            ),
+            (
+                WdpError::Ipv4ReassemblyPolicyInvalid,
+                "invalid IPv4 reassembly policy",
+            ),
+            (
+                WdpError::CorruptOrMalformed,
+                "corrupt or malformed datagram",
+            ),
+            (
+                WdpError::Internal("state machine desync".to_string()),
+                "internal transport error: state machine desync",
+            ),
+        ];
+
+        for (error, expected) in cases {
+            assert_eq!(error.to_string(), expected);
+        }
+    }
 }

--- a/transport-rust/src/tests/fetch_mapping.rs
+++ b/transport-rust/src/tests/fetch_mapping.rs
@@ -27,6 +27,28 @@ fn transport_fetch_invalid_method_maps_invalid_request() {
 }
 
 #[test]
+fn transport_fetch_with_profile_invalid_method_maps_invalid_request_for_each_profile() {
+    for profile in [
+        FetchTransportProfile::GatewayBridged,
+        FetchTransportProfile::WapNetCore,
+    ] {
+        let response = fetch_deck_in_process_with_profile(
+            FetchDeckRequest {
+                method: Some("POST".to_string()),
+                request_id: Some("req-invalid-method-profile".to_string()),
+                ..basic_request("http://example.test".to_string())
+            },
+            profile,
+        );
+        assert!(!response.ok);
+        assert_eq!(
+            response.error.as_ref().map(|err| err.code.as_str()),
+            Some("INVALID_REQUEST")
+        );
+    }
+}
+
+#[test]
 fn transport_fetch_invalid_url_maps_invalid_request() {
     let response = fetch_deck_in_process(FetchDeckRequest {
         request_id: Some("req-invalid-url".to_string()),

--- a/transport-rust/src/tests/mod.rs
+++ b/transport-rust/src/tests/mod.rs
@@ -1,5 +1,5 @@
 pub(super) use super::{
-    fetch_deck_in_process,
+    fetch_deck_in_process, fetch_deck_in_process_with_profile,
     network::wtp::{
         duplicate_cache::{WtpDuplicateCacheState, WtpDuplicateDecision, WtpDuplicatePolicy},
         retransmission::{
@@ -18,8 +18,8 @@ pub(super) use super::{
         WtpResponderState, WtpResponderTidDecision,
     },
     FetchCacheControlPolicy, FetchDeckRequest, FetchDeckResponse, FetchDestinationPolicy,
-    FetchPostContext, FetchRequestPolicy, FetchUaCapabilityProfile, MAX_RESPONSE_BODY_BYTES,
-    MAX_URI_OCTETS,
+    FetchPostContext, FetchRequestPolicy, FetchTransportProfile, FetchUaCapabilityProfile,
+    MAX_RESPONSE_BODY_BYTES, MAX_URI_OCTETS,
 };
 pub(super) use crate::fetch_policy::{
     apply_request_policy, classify_destination_host, classify_ip, resolve_fetch_destination_policy,

--- a/transport-rust/src/wbxml.rs
+++ b/transport-rust/src/wbxml.rs
@@ -30,3 +30,15 @@ pub(crate) fn decode_wbxml_for_content_type(
 pub fn preflight_wbxml_decoder() -> Result<String, String> {
     Ok(WML13_DECODER_ID.to_string())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn decode_wbxml_for_content_type_rejects_media_types_without_a_token_table() {
+        let error = decode_wbxml_for_content_type(&[], "application/json")
+            .expect_err("unsupported media type should be rejected before decoding");
+        assert!(error.contains("no selected token table"));
+    }
+}


### PR DESCRIPTION
## Summary

Coverage audit against the current CI gates (`cargo llvm-cov`):

- **engine-wasm/engine**: gate 90% lines / 85% functions — already passing at 95.36%/92.72%.
- **transport-rust**: gate 85% lines / 84% functions — already passing at 88.53%/88.10%.

Neither crate was failing its gate, so this is a proactive close of low-hanging gaps: pure
functions and match arms with zero direct test coverage, reachable only through deep runtime
paths (or never reached at all).

Closed gaps:

- `Display` impls on `WdpError`, `WcmpHandlingError`, `WdpControlEncodeError`/`DecodeError`/
  `HandlingError` — several variants were never formatted in any test.
- `handle_wcmp`'s `EchoReply`-received match arm — every existing test only fed it
  `EchoRequest` packets, so the received-reply path was never exercised.
- `generate_wcmp_error` / `WcmpReportedError::to_wdp_error` — 3 of 4 `DestinationUnreachable`
  codes (`NoRouteToDestination`, `CommunicationAdministrativelyProhibited`,
  `AddressUnreachable`) were never generated or mapped in tests.
- `WcmpMessage::type_class()` / `is_error()` and `WcmpDestinationUnreachableCode` to/from `u8`
  roundtrip — unused-in-tests public API surface.
- `fetch_deck_in_process_with_profile` — only exercised by `#[ignore]`d live-Kannel tests;
  added a deterministic unit test for both `FetchTransportProfile` variants.
- `format_decode_error` / `format_vm_trap` — added coverage for every `DecodeError`/`VmTrap`
  variant (previously only the variants that existing VM-execution tests happened to trigger).
- `script_dialog_request_to_literal` (`Confirm`/`Prompt`), `is_valid_var_name` reject paths,
  `convert_script_call_args`'s `Invalid { invalid: false }` arm.
- `decode_wbxml_for_content_type`'s unsupported-media-type branch.

### Results

| Crate | Gate (lines/fn) | Before | After |
|---|---|---|---|
| engine-wasm/engine | 90% / 85% | 95.36% / 92.72% | 95.83% / 92.77% |
| transport-rust | 85% / 84% | 88.53% / 88.10% | 90.10% / 90.12% |

Deliberately left uncovered (deeper, multi-fixture work, not low-hanging):
`wbxml_decoder.rs` (82.82%), `network/wcmp/icmpv4.rs`, `fetch_runtime/execution.rs`,
`engine_public_api.rs`, `wavescript/stdlib/wmlbrowser.rs`. Also left
`classify_vm_trap_outcome`'s `None`/`NonFatal` branches alone — an existing code comment
documents these as unreachable until a future non-fatal VM opcode exists.

No production code changed — test-only diff.

## Test plan

- [x] `cargo fmt --check` (engine-wasm/engine, transport-rust)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` (transport-rust)
- [x] `cargo test` — engine-wasm/engine: 312 passed
- [x] `cargo test -- --test-threads=1` — transport-rust: 249 lib tests + integration suites passed
- [x] `cargo llvm-cov --fail-under-lines/--fail-under-functions` — both gates pass with margin
- [x] Full repo `pre-push` hook suite passed (fmt/clippy/test/coverage across engine-wasm,
      transport-rust, browser tauri)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
