### PR TITLE
docs(atlas): explain testing and verification model

### DIFF
--- a/docs-portal/src/layouts/BaseLayout.astro
+++ b/docs-portal/src/layouts/BaseLayout.astro
@@ -18,6 +18,7 @@ const nav = [
   ['Overview', '', 'overview'],
   ['Sources', 'sources', 'sources'],
   ['Compliance', 'compliance', 'compliance'],
+  ['Verification', 'verification', 'verification'],
   ['Planning', 'planning', 'planning'],
   ['Documents', 'docs', 'docs']
 ];

--- a/docs-portal/src/pages/compliance.astro
+++ b/docs-portal/src/pages/compliance.astro
@@ -31,6 +31,7 @@ import { route } from '../lib/routes';
         The selected profile resolves to SCR rows, then to normative clauses and fixtures. A
         work-item status is useful delivery evidence; it is not proof of standards conformance.
       </p>
+      <a class="text-link" href={route('verification')}>See how executable evidence is verified →</a>
     </div>
     <dl class="evidence-numbers">
       <div><dt>Selected SCR parents</dt><dd>{clauseManifest.summary.selectedParentCount}</dd></div>

--- a/docs-portal/src/pages/verification.astro
+++ b/docs-portal/src/pages/verification.astro
@@ -12,6 +12,7 @@ import { route } from '../lib/routes';
 
 const repository = 'https://github.com/dills122/wap-labs';
 const source = (path: string) => `${repository}/blob/main/${path}`;
+const tree = (path: string) => `${repository}/tree/main/${path}`;
 
 const confidenceLevels = [
   {
@@ -123,14 +124,15 @@ const lanes = [
     title: 'Merge gate and change selection',
     tags: ['required', 'path-scoped'],
     runs:
-      'Detect Changed Areas selects layer jobs for ordinary pull requests. Repo Hygiene always runs; CI Required Gate rejects failed or cancelled prerequisites and accepts intentional path skips.',
+      'Detect Changed Areas selects layer jobs for ordinary pull requests. Repo Hygiene always runs; CI Required Gate and Extended Quality Required Gate reject failed or cancelled selected prerequisites and accept intentional path skips. Compliance-affecting paths also select WAP Compliance and Status Drift.',
     proves:
-      'The required repository-wide checks ran and every layer selected for the diff completed successfully.',
+      'The required repository-wide checks and both aggregate gates ran, and every layer selected for the diff completed successfully.',
     doesNot:
       'A skipped layer was retested. Pushes to main, manual CI, and repository-owned Dependabot pull requests deliberately run the full matrix.',
-    command: 'pnpm typecheck:node && pnpm lint:node && pnpm format:check:node',
+    command: 'pnpm verify',
     links: [
       ['Workflow', source('.github/workflows/ci.yml')],
+      ['Extended quality', source('.github/workflows/extended-quality.yml')],
       ['Required-check policy', source('docs/ci/REQUIRED_CHECKS.md')]
     ]
   },
@@ -138,13 +140,16 @@ const lanes = [
     title: 'Native WaveNav engine',
     tags: ['required', 'path-scoped'],
     runs:
-      'Rust parser, runtime, navigation, focus, scripting, layout, render, fixture, and failure-path tests run under the engine coverage gate when engine paths change.',
+      'Rust parser, runtime, navigation, focus, scripting, layout, render, fixture, and failure-path tests run under the engine coverage gate when engine paths change. The Extended Quality aggregate also selects zero-warning Clippy for engine changes.',
     proves:
       'Native engine behavior is deterministic for the tested inputs and meets the configured line and function coverage floors.',
     doesNot:
       'The WASM binding, browser host, transport path, or an unselected normative clause behaves correctly.',
     command: 'cd engine-wasm/engine && cargo test',
-    links: [['Engine tests', source('engine-wasm/engine/src/engine_tests')]]
+    links: [
+      ['Engine tests', tree('engine-wasm/engine/src/engine_tests')],
+      ['Extended quality', source('.github/workflows/extended-quality.yml')]
+    ]
   },
   {
     title: 'Native/WASM boundary and executable stories',
@@ -180,12 +185,12 @@ const lanes = [
     title: 'Tauri host and browser frontend',
     tags: ['required', 'path-scoped'],
     runs:
-      'Tauri Rust library coverage exercises commands, engine flow, wrappers, and fetch adapters. Vitest covers frontend state and presentation; type, lint, format, capability, permission, and command-schema checks guard the host boundary.',
+      'Tauri Rust library coverage exercises commands, engine flow, wrappers, and fetch adapters. Local Vitest covers frontend state and presentation; GitHub CI owns the platform-sensitive coverage threshold. Type, lint, format, capability, permission, and command-schema checks guard the host boundary.',
     proves:
       'The tested native command adapters and frontend behavior agree with generated contracts and configured coverage floors.',
     doesNot:
       'A packaged desktop window, platform accessibility bridge, real remote gateway, or every operating-system integration was exercised.',
-    command: 'pnpm --dir browser run contracts:check && pnpm --dir browser/frontend run test:coverage',
+    command: 'pnpm --dir browser run tauri:generated:check && pnpm --dir browser/frontend test',
     links: [
       ['Browser host', source('browser/README.md')],
       ['Frontend checks', source('browser/frontend/README.md')]
@@ -195,7 +200,7 @@ const lanes = [
     title: 'Contracts, schemas, ledgers, and Atlas drift',
     tags: ['required', 'path-scoped'],
     runs:
-      'Rust-owned TypeScript projections, Tauri schemas, story manifests, Atlas JSON Schemas, transport evidence references, and the WAP knowledge graph are regenerated or validated against committed inputs.',
+      'Rust-owned TypeScript projections, Tauri schemas, story manifests, Atlas JSON Schemas, transport evidence references, requirement/status rollups, and the WAP knowledge graph are regenerated or validated against committed inputs. CI exposes a path-aware WAP Compliance and Status Drift job.',
     proves:
       'Consumers and projections match their canonical active sources, references resolve, ordering is stable, and generated views have not silently drifted.',
     doesNot:
@@ -210,12 +215,12 @@ const lanes = [
     title: 'Kannel real-stack smoke',
     tags: ['on-demand'],
     runs:
-      'The manual workflow starts Kannel and the WML server, then exercises ignored transport, browser-host, and native engine/render smoke tests against that stack.',
+      'Extended requires an already-running Kannel/WML stack, then exercises transport and browser-host smoke paths against it. The same real-stack lane is available through a manual GitHub workflow.',
     proves:
       'One real gateway path can fetch, hand off, load, render, and navigate the smoke scenario across process and protocol boundaries.',
     doesNot:
       'Broad gateway interoperability, production reliability, every transport profile, or a required pull-request gate.',
-    command: 'make smoke-transport-wap',
+    command: 'pnpm verify:extended',
     links: [['Manual workflow', source('.github/workflows/transport-wap-smoke.yml')]]
   },
   {
@@ -231,19 +236,33 @@ const lanes = [
     links: [['Fuzz workflow', source('.github/workflows/engine-fuzz.yml')]]
   },
   {
-    title: 'Accessibility and product baselines',
-    tags: ['on-demand', 'manual'],
+    title: 'Rendered accessibility',
+    tags: ['required', 'path-scoped'],
     runs:
-      'Rendered Chromium checks cover axe, target geometry, visible focus, overflow, and 200 percent layouts. A separate repeated-run baseline records startup, input, navigation, window, and keyboard evidence. Packaged macOS VoiceOver remains manual.',
+      'The Full and selected Change profiles run production-built Chromium checks for axe, target geometry, visible focus, overflow, and 200 percent layouts. GitHub repeats the gate for browser frontend and its engine, contract, and build inputs.',
     proves:
-      'The production-built deterministic browser surface meets the asserted web accessibility and reference-environment baselines at configured window sizes.',
+      'The production-built deterministic browser surface meets the asserted web accessibility behaviors at configured window sizes.',
     doesNot:
-      'A release performance budget, device compatibility, native macOS announcement timing, or platform-drawn chrome quality.',
-    command:
-      'pnpm --dir browser/frontend test:accessibility:rendered && WAVES_BASELINE_RUNS=20 pnpm test:baseline:waves',
+      'Device compatibility, native macOS announcement timing, platform-drawn chrome quality, or an accessibility certification.',
+    command: 'pnpm --dir browser/frontend run test:accessibility:rendered',
     links: [
       ['Accessibility evidence', source('docs/waves/WAVES_BROWSER_ACCESSIBILITY_EVIDENCE.md')],
-      ['Reference baseline', source('docs/waves/WAVES_BROWSER_BASELINE.md')]
+      ['Required workflow', source('.github/workflows/extended-quality.yml')]
+    ]
+  },
+  {
+    title: 'Browser stability baseline',
+    tags: ['scheduled', 'advisory', 'on-demand', 'manual'],
+    runs:
+      'The weekly/manual workflow records startup, input, navigation, window, and keyboard behavior with 20 runs by default. Extended reports a bounded three-run signal as advisory. Packaged macOS VoiceOver remains a separate manual observation.',
+    proves:
+      'Deterministic behavior assertions passed and the run retained reference-environment latency samples and screenshots.',
+    doesNot:
+      'A release performance budget, cross-device timing guarantee, or native accessibility behavior. Recorded latency has no pass/fail threshold.',
+    command: 'WAVES_BASELINE_RUNS=20 pnpm test:baseline:waves',
+    links: [
+      ['Reference baseline', source('docs/waves/WAVES_BROWSER_BASELINE.md')],
+      ['Advisory workflow', source('.github/workflows/extended-quality.yml')]
     ]
   },
   {

--- a/docs-portal/src/pages/verification.astro
+++ b/docs-portal/src/pages/verification.astro
@@ -1,0 +1,470 @@
+---
+import BaseLayout from '../layouts/BaseLayout.astro';
+import StatusPill from '../components/StatusPill.astro';
+import {
+  clauseManifest,
+  effectiveSpec,
+  program,
+  releaseManifest,
+  workItems
+} from '../lib/repository';
+import { route } from '../lib/routes';
+
+const repository = 'https://github.com/dills122/wap-labs';
+const source = (path: string) => `${repository}/blob/main/${path}`;
+
+const confidenceLevels = [
+  {
+    id: 'regression',
+    label: 'Regression-green',
+    summary:
+      'The required checks for this change passed: repository hygiene, the path-selected layer suites, security review, and CodeQL.',
+    boundary:
+      'It does not mean skipped layers ran, that a real gateway was exercised, or that a standards profile is conformant.'
+  },
+  {
+    id: 'integration',
+    label: 'Integration-green',
+    summary:
+      'The relevant seams passed together: native/WASM boundaries, generated contracts, fixtures or replays, host stories, and—when the claim needs it—the real Kannel stack.',
+    boundary:
+      'It proves only the exercised routes and environments. Deterministic browser adapters are not native Tauri, and Kannel smoke is not broad interoperability.'
+  },
+  {
+    id: 'conformance',
+    label: 'Conformance-green',
+    summary:
+      'A named selected profile or clause set has authoritative provenance, Class C/SCR selection, clause mappings, implementation evidence, and synchronized Atlas/graph projections.',
+    boundary:
+      'This is profile- and clause-scoped. The repository does not claim full WAP 1.2.1 conformance or certification.'
+  }
+];
+
+const verificationProfiles = [
+  {
+    name: 'Fast',
+    command: 'pnpm verify:fast',
+    scope:
+      'Runs the verification-orchestrator tests, Git whitespace check, and managed release-version check.'
+  },
+  {
+    name: 'Change',
+    command: 'pnpm verify · pnpm verify:change',
+    scope:
+      'Runs strict common checks plus every deterministic lane selected by committed, staged, unstaged, and untracked paths relative to origin/main.'
+  },
+  {
+    name: 'Full',
+    command: 'pnpm verify:full',
+    scope:
+      'Runs every deterministic offline lane: compliance/status and graph drift; native and WASM engine, contracts, and stories; transport; browser host, frontend, and rendered accessibility; Atlas; marketing; and WML server.'
+  },
+  {
+    name: 'Extended',
+    command: 'pnpm verify:extended',
+    scope:
+      'Runs Full, then requires the already-running Kannel/WML stack. The repeated browser baseline is reported as advisory, not a release budget.'
+  }
+];
+
+const verificationOutcomes = [
+  ['PASS', 'Every required command in the selected lane passed.'],
+  ['INTENTIONAL EXCLUSION', 'The profile or changed paths deliberately did not select the lane.'],
+  ['UNAVAILABLE PREREQUISITE', 'A selected required tool or dependency is missing; the command fails with remediation.'],
+  ['ADVISORY', 'The lane is intentionally non-blocking whether its evidence passes or fails.'],
+  ['FAILURE', 'A selected required command failed and the overall command exits nonzero.']
+];
+
+const evidenceChain = [
+  {
+    label: 'Specification provenance',
+    detail: `${releaseManifest.summary.memberCount} release members in the validated source manifest`,
+    href: route('sources')
+  },
+  {
+    label: 'Effective specification',
+    detail: `${effectiveSpec.summary.familyCount} base, amendment, SIN, and historical-family resolutions`,
+    href: route('sources')
+  },
+  {
+    label: 'Class C + SCR selection',
+    detail: `${clauseManifest.summary.selectedParentCount} selected SCR parent rows at build time`,
+    href: route('compliance')
+  },
+  {
+    label: 'Normative clauses',
+    detail: `${clauseManifest.summary.clauseCount} selected clauses; status remains clause-specific`,
+    href: route('compliance')
+  },
+  {
+    label: 'Requirements + work',
+    detail: `${workItems.length} program work items mapped from the active compliance plan`,
+    href: route('planning')
+  },
+  {
+    label: 'Implementation',
+    detail: 'Layer-owned Rust, WASM boundary, Tauri host, and frontend code',
+    href: source('AGENTS.md')
+  },
+  {
+    label: 'Executable evidence',
+    detail: 'Unit, fixture, contract, story, replay, smoke, and E2E results',
+    href: source('docs/waves/SPEC_TEST_COVERAGE.md')
+  },
+  {
+    label: 'Projection drift',
+    detail: 'Schema, ledger, knowledge-graph, and Atlas build verification',
+    href: source('docs/knowledge-graph/README.md')
+  }
+];
+
+const lanes = [
+  {
+    title: 'Merge gate and change selection',
+    tags: ['required', 'path-scoped'],
+    runs:
+      'Detect Changed Areas selects layer jobs for ordinary pull requests. Repo Hygiene always runs; CI Required Gate rejects failed or cancelled prerequisites and accepts intentional path skips.',
+    proves:
+      'The required repository-wide checks ran and every layer selected for the diff completed successfully.',
+    doesNot:
+      'A skipped layer was retested. Pushes to main, manual CI, and repository-owned Dependabot pull requests deliberately run the full matrix.',
+    command: 'pnpm typecheck:node && pnpm lint:node && pnpm format:check:node',
+    links: [
+      ['Workflow', source('.github/workflows/ci.yml')],
+      ['Required-check policy', source('docs/ci/REQUIRED_CHECKS.md')]
+    ]
+  },
+  {
+    title: 'Native WaveNav engine',
+    tags: ['required', 'path-scoped'],
+    runs:
+      'Rust parser, runtime, navigation, focus, scripting, layout, render, fixture, and failure-path tests run under the engine coverage gate when engine paths change.',
+    proves:
+      'Native engine behavior is deterministic for the tested inputs and meets the configured line and function coverage floors.',
+    doesNot:
+      'The WASM binding, browser host, transport path, or an unselected normative clause behaves correctly.',
+    command: 'cd engine-wasm/engine && cargo test',
+    links: [['Engine tests', source('engine-wasm/engine/src/engine_tests')]]
+  },
+  {
+    title: 'Native/WASM boundary and executable stories',
+    tags: ['required', 'path-scoped'],
+    runs:
+      'wasm-pack boundary tests, Rust-derived DTO drift checks, story-schema tests, and Playwright flows for the host sample and real Waves frontend.',
+    proves:
+      'Selected parity-critical state, render, trace, script, and host-session behavior survives the WASM boundary and works through production-built web surfaces.',
+    doesNot:
+      'Every native API has a live differential twin. Waves stories use a deterministic in-memory fetch adapter, not native Tauri transport or Kannel.',
+    command: 'pnpm test:story all',
+    links: [
+      ['Story runner', source('engine-wasm/host-sample/README.md#executable-stories')],
+      ['Coverage map', source('docs/waves/SPEC_TEST_COVERAGE.md')]
+    ]
+  },
+  {
+    title: 'Transport codecs, fixtures, and replay',
+    tags: ['required', 'path-scoped'],
+    runs:
+      'Lowband unit and integration tests cover WSP/WBXML codecs, deterministic mapped fixtures, constrained WDP delivery, WCMP behavior, and byte-exact interop replay seeds.',
+    proves:
+      'The selected synthetic and source-mapped packets produce fixed outcomes through transport-owned decode, mapping, reassembly, and replay paths.',
+    doesNot:
+      'All bearers, live network timing, general WSP/WTP activation, or full transport conformance. Conditional replay seeds remain scaffolding where the active profile says so.',
+    command: 'make test-rust-transport && make test-transport-fixtures',
+    links: [
+      ['Fixture contract', source('transport-rust/tests/fixtures/transport/README.md')],
+      ['Replay boundary', source('transport-rust/tests/network/interop/README.md')]
+    ]
+  },
+  {
+    title: 'Tauri host and browser frontend',
+    tags: ['required', 'path-scoped'],
+    runs:
+      'Tauri Rust library coverage exercises commands, engine flow, wrappers, and fetch adapters. Vitest covers frontend state and presentation; type, lint, format, capability, permission, and command-schema checks guard the host boundary.',
+    proves:
+      'The tested native command adapters and frontend behavior agree with generated contracts and configured coverage floors.',
+    doesNot:
+      'A packaged desktop window, platform accessibility bridge, real remote gateway, or every operating-system integration was exercised.',
+    command: 'pnpm --dir browser run contracts:check && pnpm --dir browser/frontend run test:coverage',
+    links: [
+      ['Browser host', source('browser/README.md')],
+      ['Frontend checks', source('browser/frontend/README.md')]
+    ]
+  },
+  {
+    title: 'Contracts, schemas, ledgers, and Atlas drift',
+    tags: ['required', 'path-scoped'],
+    runs:
+      'Rust-owned TypeScript projections, Tauri schemas, story manifests, Atlas JSON Schemas, transport evidence references, and the WAP knowledge graph are regenerated or validated against committed inputs.',
+    proves:
+      'Consumers and projections match their canonical active sources, references resolve, ordering is stable, and generated views have not silently drifted.',
+    doesNot:
+      'A graph edge, passing schema, ticket status, or prose acceptance statement is executable implementation evidence.',
+    command: 'pnpm wap-compliance:check && pnpm --dir docs-portal run test:data',
+    links: [
+      ['Atlas data contract', source('docs-portal/README.md')],
+      ['Knowledge graph contract', source('docs/knowledge-graph/README.md')]
+    ]
+  },
+  {
+    title: 'Kannel real-stack smoke',
+    tags: ['on-demand'],
+    runs:
+      'The manual workflow starts Kannel and the WML server, then exercises ignored transport, browser-host, and native engine/render smoke tests against that stack.',
+    proves:
+      'One real gateway path can fetch, hand off, load, render, and navigate the smoke scenario across process and protocol boundaries.',
+    doesNot:
+      'Broad gateway interoperability, production reliability, every transport profile, or a required pull-request gate.',
+    command: 'make smoke-transport-wap',
+    links: [['Manual workflow', source('.github/workflows/transport-wap-smoke.yml')]]
+  },
+  {
+    title: 'Engine fuzzing',
+    tags: ['scheduled', 'on-demand'],
+    runs:
+      'A weekly and manually configurable cargo-fuzz lane sends bounded arbitrary WML input to the engine target and retains crash artifacts.',
+    proves:
+      'The executed corpus and mutations did not expose a crash, hang beyond the configured timeout, or sanitizer-detected failure.',
+    doesNot:
+      'Exhaustive safety, semantic correctness, or WAP/WML conformance.',
+    command: 'cd engine-wasm/engine && cargo +nightly fuzz run engine_wml_fuzzer',
+    links: [['Fuzz workflow', source('.github/workflows/engine-fuzz.yml')]]
+  },
+  {
+    title: 'Accessibility and product baselines',
+    tags: ['on-demand', 'manual'],
+    runs:
+      'Rendered Chromium checks cover axe, target geometry, visible focus, overflow, and 200 percent layouts. A separate repeated-run baseline records startup, input, navigation, window, and keyboard evidence. Packaged macOS VoiceOver remains manual.',
+    proves:
+      'The production-built deterministic browser surface meets the asserted web accessibility and reference-environment baselines at configured window sizes.',
+    doesNot:
+      'A release performance budget, device compatibility, native macOS announcement timing, or platform-drawn chrome quality.',
+    command:
+      'pnpm --dir browser/frontend test:accessibility:rendered && WAVES_BASELINE_RUNS=20 pnpm test:baseline:waves',
+    links: [
+      ['Accessibility evidence', source('docs/waves/WAVES_BROWSER_ACCESSIBILITY_EVIDENCE.md')],
+      ['Reference baseline', source('docs/waves/WAVES_BROWSER_BASELINE.md')]
+    ]
+  },
+  {
+    title: 'CodeQL and dependency security',
+    tags: ['required', 'scheduled', 'on-demand'],
+    runs:
+      'Pull requests run JavaScript/TypeScript and Rust CodeQL plus dependency review and Rust/Node advisory audits. Code scanning and audits also run weekly and on demand.',
+    proves:
+      'The configured static queries and current advisory databases found no merge-blocking result in the scanned source and dependency graph.',
+    doesNot:
+      'Absence of vulnerabilities, runtime exploit resistance, or security of excluded generated/build paths and unmodeled environments.',
+    command: 'cargo audit && pnpm audit --audit-level high',
+    links: [
+      ['CodeQL', source('.github/workflows/codeql.yml')],
+      ['Dependency security', source('.github/workflows/security.yml')]
+    ]
+  },
+  {
+    title: 'Builds, deploys, and releases',
+    tags: ['required', 'path-scoped', 'on-demand'],
+    runs:
+      'Selected pull requests build product surfaces. Main-path changes rebuild and deploy the marketing site, simulator, and Atlas; milestone releases manually rebuild and package source and site artifacts.',
+    proves:
+      'The selected static applications and release bundles assemble successfully from pinned manifests and can be published by the configured workflow.',
+    doesNot:
+      'Passing product behavior, standards conformance, deployment availability after the workflow, or approval to promote a planned profile.',
+    command: 'pnpm build:node && pnpm --dir docs-portal run build',
+    links: [
+      ['Pages deploy', source('.github/workflows/pages.yml')],
+      ['Milestone release', source('.github/workflows/milestone-release.yml')]
+    ]
+  },
+  {
+    title: 'Story coverage advisory and manual evidence',
+    tags: ['advisory', 'manual'],
+    runs:
+      'The story-coverage report names examples without adjacent executable flows but never fails the build. Manual checklists cover only gaps that automation cannot observe and must name their environment and scope.',
+    proves:
+      'Known story gaps are visible, and a recorded manual run can support only the observations it explicitly captured.',
+    doesNot:
+      'Prose testing criteria, a ticket marked done, or an example file by itself is executable coverage. An unrecorded manual intention is no evidence at all.',
+    command: 'pnpm --dir engine-wasm/host-sample run examples:story-coverage',
+    links: [['Evidence policy', source('docs/agents/AGENT_STANDARDS.md#testing-expectations')]]
+  }
+];
+
+const badgeLabel = (tag: string) => tag.replace('-', ' ');
+---
+
+<BaseLayout
+  title="Testing and verification"
+  description="How WAP Labs turns specifications, implementation, and layered test evidence into bounded regression, integration, and conformance claims."
+  section="verification"
+>
+  <header class="page-header page-shell verification-header">
+    <p class="kicker">Evidence before claims</p>
+    <h1>Green has three meanings.</h1>
+    <p>
+      WAP Labs separates code regression confidence, cross-layer integration confidence, and
+      standards evidence. Each level needs its own proof; none silently upgrades into the next.
+    </p>
+  </header>
+
+  <section class="page-shell confidence-grid" aria-labelledby="confidence-heading">
+    <div class="section-heading verification-section-heading">
+      <div>
+        <p class="section-label">Confidence vocabulary</p>
+        <h2 id="confidence-heading">Say exactly what is green.</h2>
+      </div>
+    </div>
+    <div class="confidence-cards">
+      {confidenceLevels.map((level, index) => (
+        <article id={level.id}>
+          <span class="confidence-index">0{index + 1}</span>
+          <h3>{level.label}</h3>
+          <p>{level.summary}</p>
+          <p class="claim-boundary"><strong>Does not mean:</strong> {level.boundary}</p>
+        </article>
+      ))}
+    </div>
+  </section>
+
+  <section class="page-shell evidence-flow-section" aria-labelledby="evidence-flow-heading">
+    <div class="section-heading verification-section-heading">
+      <div>
+        <p class="section-label">Traceability chain</p>
+        <h2 id="evidence-flow-heading">From authority to auditable evidence.</h2>
+      </div>
+      <p class="snapshot-note">Build-time values come from validated Atlas inputs.</p>
+    </div>
+    <ol class="evidence-chain" aria-label="Specification-to-evidence verification chain">
+      {evidenceChain.map((step, index) => (
+        <li>
+          <span aria-hidden="true">{String(index + 1).padStart(2, '0')}</span>
+          <h3><a href={step.href}>{step.label}</a></h3>
+          <p>{step.detail}</p>
+        </li>
+      ))}
+    </ol>
+    <p class="evidence-rule">
+      <strong>Executable-evidence rule:</strong> implementation plus a passing, reproducible
+      evidence command may support a claim. Prose, graph edges, an example without a flow, or a
+      ticket status can describe intent and traceability, but never substitutes for execution.
+    </p>
+  </section>
+
+  <section class="page-shell verification-presets" aria-labelledby="presets-heading">
+    <div class="section-heading verification-section-heading">
+      <div>
+        <p class="section-label">Canonical local commands</p>
+        <h2 id="presets-heading">Choose scope without hiding exclusions.</h2>
+      </div>
+      <a href={source('docs/ci/LOCAL_VERIFICATION.md')}>Local verification contract ↗</a>
+    </div>
+    <div class="preset-grid">
+      {verificationProfiles.map((profile) => (
+        <article>
+          <span class="mono-id">{profile.name}</span>
+          <code>{profile.command}</code>
+          <p>{profile.scope}</p>
+        </article>
+      ))}
+    </div>
+    <div class="outcome-panel">
+      <div>
+        <p class="section-label">Result vocabulary</p>
+        <h3>Missing tools never become a silent success.</h3>
+        <p>
+          Full is the strict offline pre-PR profile. Live Kannel is an intentional exclusion there
+          and becomes required only in Extended; fuzzing, GitHub-hosted security/coverage, deploys,
+          releases, and native OS packaging remain separate environments.
+        </p>
+      </div>
+      <dl>
+        {verificationOutcomes.map(([outcome, meaning]) => (
+          <div><dt>{outcome}</dt><dd>{meaning}</dd></div>
+        ))}
+      </dl>
+    </div>
+  </section>
+
+  <section class="page-shell verification-status" aria-labelledby="status-heading">
+    <div>
+      <p class="section-label">Current claim boundary</p>
+      <h2 id="status-heading">Partial profiles stay partial.</h2>
+      <p>
+        Atlas renders the current compliance program as written. Families and clauses can be
+        selected, planned, partial, or assessed independently. “Conformance-green” is valid only
+        for a named selected slice whose complete evidence chain is green.
+      </p>
+    </div>
+    <dl>
+      <div><dt>Implementation claim</dt><dd>{program.target.implementationClaim}</dd></div>
+      <div><dt>Certification claim</dt><dd>{program.target.certificationClaim}</dd></div>
+      <div>
+        <dt>Assessed selected clauses</dt>
+        <dd>{clauseManifest.summary.assessedClauseCount} / {clauseManifest.summary.clauseCount}</dd>
+      </div>
+    </dl>
+    <ul class="profile-status-list" aria-label="Current compliance profile states">
+      {program.profiles.map((profile) => (
+        <li>
+          <span class="mono-id">{profile.id}</span>
+          <strong>{profile.role.replaceAll('-', ' ')}</strong>
+          <StatusPill status={profile.status} />
+        </li>
+      ))}
+    </ul>
+    <a class="button" href={route('compliance')}>Inspect the selected profile <span>→</span></a>
+  </section>
+
+  <section class="page-shell lane-catalog" aria-labelledby="lane-heading">
+    <div class="section-heading verification-section-heading">
+      <div>
+        <p class="section-label">Lane catalog</p>
+        <h2 id="lane-heading">What runs, and what it proves.</h2>
+      </div>
+    </div>
+    <div class="lane-legend" aria-label="Execution lane labels">
+      {['required', 'path-scoped', 'scheduled', 'advisory', 'on-demand', 'manual'].map((tag) => (
+        <span class:list={['lane-badge', `lane-${tag}`]}>{badgeLabel(tag)}</span>
+      ))}
+    </div>
+    <div class="lane-grid">
+      {lanes.map((lane) => (
+        <article class="lane-card">
+          <div class="lane-card-heading">
+            <h3>{lane.title}</h3>
+            <div class="lane-tags">
+              {lane.tags.map((tag) => (
+                <span class:list={['lane-badge', `lane-${tag}`]}>{badgeLabel(tag)}</span>
+              ))}
+            </div>
+          </div>
+          <p>{lane.runs}</p>
+          <dl class="proof-boundaries">
+            <div><dt>Proves</dt><dd>{lane.proves}</dd></div>
+            <div><dt>Does not prove</dt><dd>{lane.doesNot}</dd></div>
+          </dl>
+          <div class="lane-command"><span>Run locally</span><code>{lane.command}</code></div>
+          <ul class="lane-links">
+            {lane.links.map(([label, href]) => <li><a href={href}>{label} ↗</a></li>)}
+          </ul>
+        </article>
+      ))}
+    </div>
+  </section>
+
+  <section class="page-shell verification-close">
+    <div>
+      <p class="section-label">Release question</p>
+      <h2>Which claim are we trying to make?</h2>
+    </div>
+    <p>
+      Start with the claim, select the lanes that can actually observe it, preserve their results,
+      and then synchronize the active ledgers and graph. A green check is evidence only within its
+      stated boundary.
+    </p>
+    <div class="hero-actions">
+      <a class="button primary" href={source('docs/ci/CI_SETUP.md')}>Runbook <span>↗</span></a>
+      <a class="button" href={source('docs/waves/SPEC_TEST_COVERAGE.md')}>Coverage ledger</a>
+    </div>
+  </section>
+</BaseLayout>

--- a/docs-portal/src/styles/global.css
+++ b/docs-portal/src/styles/global.css
@@ -326,6 +326,9 @@ h1 {
   color: var(--ink-soft);
   font-size: 1.1rem;
 }
+.text-link {
+  font-weight: 750;
+}
 .progress-panel {
   padding: 2rem;
   background: var(--paper-light);
@@ -1032,6 +1035,378 @@ tbody tr:hover {
   text-transform: uppercase;
 }
 
+.verification-header h1 {
+  max-width: 10ch;
+}
+.verification-section-heading {
+  padding-top: 5rem;
+}
+.confidence-cards {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  margin-bottom: 7rem;
+}
+.confidence-cards article {
+  min-height: 24rem;
+  padding: 1.5rem;
+  background: var(--paper-light);
+  border: 1px solid var(--ink);
+  border-right: 0;
+}
+.confidence-cards article:last-child {
+  border-right: 1px solid var(--ink);
+}
+.confidence-cards article:nth-child(1) {
+  border-top: 7px solid var(--blue);
+}
+.confidence-cards article:nth-child(2) {
+  border-top: 7px solid var(--amber);
+}
+.confidence-cards article:nth-child(3) {
+  border-top: 7px solid var(--green);
+}
+.confidence-index {
+  color: var(--signal);
+  font: 800 2rem var(--font-mono);
+}
+.confidence-cards h3 {
+  margin: 2.4rem 0 1rem;
+  font-size: clamp(1.55rem, 2.4vw, 2.25rem);
+  line-height: 1;
+}
+.confidence-cards > article > p {
+  color: var(--ink-soft);
+}
+.claim-boundary {
+  padding-top: 1rem;
+  border-top: 1px solid var(--rule);
+  font-size: 0.88rem;
+}
+.snapshot-note {
+  max-width: 21rem;
+  margin-bottom: 0.7rem;
+  color: var(--ink-soft);
+  font: 0.7rem/1.4 var(--font-mono);
+  text-align: right;
+}
+.evidence-chain {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  padding: 0;
+  margin: 2rem 0;
+  list-style: none;
+  counter-reset: evidence;
+}
+.evidence-chain li {
+  position: relative;
+  min-height: 13.5rem;
+  padding: 1.1rem 1.5rem 1.1rem 1.1rem;
+  background: var(--paper-light);
+  border: 1px solid var(--ink);
+  border-right: 0;
+}
+.evidence-chain li:nth-child(4n) {
+  border-right: 1px solid var(--ink);
+}
+.evidence-chain li:nth-child(n + 5) {
+  border-top: 0;
+}
+.evidence-chain li:not(:nth-child(4n))::after {
+  position: absolute;
+  z-index: 1;
+  top: 50%;
+  right: -0.65rem;
+  display: grid;
+  width: 1.3rem;
+  height: 1.3rem;
+  place-items: center;
+  color: white;
+  background: var(--signal-dark);
+  border-radius: 50%;
+  content: '→';
+  font: 800 0.75rem var(--font-mono);
+}
+.evidence-chain li > span {
+  color: var(--signal-dark);
+  font: 800 0.72rem var(--font-mono);
+}
+.evidence-chain h3 {
+  margin: 2rem 0 0.6rem;
+  font-size: 1.05rem;
+  line-height: 1.15;
+}
+.evidence-chain p {
+  color: var(--ink-soft);
+  font-size: 0.82rem;
+  line-height: 1.45;
+}
+.evidence-rule {
+  margin-bottom: 7rem;
+  padding: 1.2rem 1.4rem;
+  color: #68420c;
+  background: #fae7bd;
+  border: 1px solid var(--amber);
+  border-left: 7px solid var(--amber);
+}
+.verification-presets {
+  padding-bottom: 7rem;
+}
+.preset-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  padding-block: 2rem;
+}
+.preset-grid article {
+  min-height: 15rem;
+  padding: 1.2rem;
+  background: var(--paper-light);
+  border: 1px solid var(--ink);
+  border-right: 0;
+}
+.preset-grid article:last-child {
+  border-right: 1px solid var(--ink);
+}
+.preset-grid code {
+  display: block;
+  margin: 2.4rem 0 1rem;
+  color: var(--ink);
+  font-size: 0.79rem;
+  font-weight: 800;
+}
+.preset-grid p {
+  color: var(--ink-soft);
+  font-size: 0.87rem;
+}
+.outcome-panel {
+  display: grid;
+  grid-template-columns: 0.8fr 1.2fr;
+  gap: 4rem;
+  padding: 2rem;
+  color: var(--terminal-copy);
+  background: var(--night-soft);
+}
+.outcome-panel h3 {
+  max-width: 18ch;
+  font-size: 1.8rem;
+  line-height: 1.05;
+}
+.outcome-panel > div > p:last-child {
+  color: var(--night-muted);
+}
+.outcome-panel dl {
+  margin: 0;
+  border-top: 1px solid #59645f;
+}
+.outcome-panel dl div {
+  display: grid;
+  grid-template-columns: 13.5rem 1fr;
+  gap: 1rem;
+  padding: 0.8rem 0;
+  border-bottom: 1px solid #59645f;
+}
+.outcome-panel dt {
+  color: var(--terminal-accent);
+  font: 800 0.68rem var(--font-mono);
+}
+.outcome-panel dd {
+  color: var(--terminal-copy);
+  font-size: 0.83rem;
+}
+.verification-status {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 2rem 5rem;
+  padding-block: 4rem;
+  border-block: 3px solid var(--ink);
+}
+.verification-status h2,
+.verification-close h2 {
+  max-width: 14ch;
+  font-size: clamp(2.2rem, 4vw, 4rem);
+  line-height: 0.95;
+  letter-spacing: -0.05em;
+}
+.verification-status > div > p:last-child {
+  max-width: 48rem;
+  color: var(--ink-soft);
+}
+.verification-status dl {
+  background: var(--paper-light);
+  border: 1px solid var(--ink);
+}
+.verification-status dl div {
+  padding: 1rem;
+  border-bottom: 1px solid var(--rule);
+}
+.verification-status dl div:last-child {
+  border-bottom: 0;
+}
+.verification-status dt,
+.proof-boundaries dt {
+  color: var(--ink-soft);
+  font: 700 0.64rem var(--font-mono);
+  text-transform: uppercase;
+}
+.verification-status dd {
+  margin-top: 0.35rem;
+  font-weight: 700;
+}
+.profile-status-list {
+  grid-column: 1 / -1;
+  padding: 0;
+  margin: 0;
+  list-style: none;
+}
+.profile-status-list li {
+  display: grid;
+  grid-template-columns: minmax(7rem, 0.3fr) minmax(14rem, 1fr) auto;
+  gap: 1rem;
+  align-items: center;
+  padding: 0.8rem;
+  border-bottom: 1px solid var(--rule);
+}
+.profile-status-list strong {
+  font-size: 0.9rem;
+  text-transform: capitalize;
+}
+.verification-status > .button {
+  grid-column: 2;
+  justify-self: end;
+}
+.lane-catalog {
+  padding-bottom: 7rem;
+}
+.lane-legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+  padding-block: 1rem 2rem;
+}
+.lane-badge {
+  display: inline-block;
+  width: fit-content;
+  padding: 0.35rem 0.48rem;
+  border: 1px solid currentColor;
+  font: 800 0.61rem/1 var(--font-mono);
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+.lane-required {
+  color: var(--green);
+  background: #e0f0e7;
+}
+.lane-path-scoped {
+  color: var(--blue);
+  background: #e1eaf6;
+}
+.lane-scheduled {
+  color: #6f4c05;
+  background: #f7ebd2;
+}
+.lane-advisory {
+  color: #73531c;
+  background: #f3e5c6;
+}
+.lane-on-demand {
+  color: #655383;
+  background: #ede5f6;
+}
+.lane-manual {
+  color: #6b453f;
+  background: #f4e2df;
+}
+.lane-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1rem;
+}
+.lane-card {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  padding: 1.4rem;
+  background: var(--paper-light);
+  border: 1px solid var(--ink);
+}
+.lane-card-heading {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  align-items: start;
+  min-height: 4.5rem;
+}
+.lane-card h3 {
+  max-width: 22rem;
+  font-size: 1.45rem;
+  line-height: 1.1;
+}
+.lane-card > p {
+  color: var(--ink-soft);
+}
+.lane-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+  justify-content: end;
+}
+.proof-boundaries {
+  margin-block: 0.5rem 1rem;
+}
+.proof-boundaries div {
+  padding: 0.85rem 0;
+  border-top: 1px solid var(--rule);
+}
+.proof-boundaries dd {
+  margin-top: 0.3rem;
+  font-size: 0.88rem;
+}
+.proof-boundaries div:last-child dt {
+  color: var(--signal-dark);
+}
+.lane-command {
+  margin-top: auto;
+  padding: 0.85rem;
+  color: var(--terminal-copy);
+  background: var(--night-soft);
+}
+.lane-command span {
+  display: block;
+  margin-bottom: 0.35rem;
+  color: var(--terminal-accent);
+  font: 700 0.6rem var(--font-mono);
+  text-transform: uppercase;
+}
+.lane-command code {
+  font-size: 0.71rem;
+  line-height: 1.5;
+}
+.lane-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  padding: 0;
+  margin: 1rem 0 0;
+  font: 700 0.68rem var(--font-mono);
+  list-style: none;
+  text-transform: uppercase;
+}
+.verification-close {
+  display: grid;
+  grid-template-columns: 0.8fr 1.2fr;
+  gap: 3rem 6rem;
+  align-items: end;
+  padding-block: 6rem;
+}
+.verification-close > p {
+  max-width: 45rem;
+  color: var(--ink-soft);
+  font-size: 1.15rem;
+}
+.verification-close .hero-actions {
+  grid-column: 2;
+  margin-top: -1rem;
+}
+
 .app-footer {
   display: flex;
   justify-content: space-between;
@@ -1075,7 +1450,10 @@ tbody tr:hover {
     padding-top: 2rem;
   }
   .split-section,
-  .strict-strip {
+  .strict-strip,
+  .verification-status,
+  .verification-close,
+  .outcome-panel {
     grid-template-columns: 1fr;
     gap: 2rem;
   }
@@ -1100,6 +1478,36 @@ tbody tr:hover {
   }
   .doc-toc ol {
     columns: 2;
+  }
+  .evidence-chain {
+    grid-template-columns: 1fr 1fr;
+  }
+  .evidence-chain li:nth-child(4n) {
+    border-right: 0;
+  }
+  .evidence-chain li:nth-child(2n) {
+    border-right: 1px solid var(--ink);
+  }
+  .evidence-chain li:nth-child(n + 3) {
+    border-top: 0;
+  }
+  .evidence-chain li:nth-child(2n)::after {
+    display: none;
+  }
+  .preset-grid {
+    grid-template-columns: 1fr 1fr;
+  }
+  .preset-grid article:nth-child(2) {
+    border-right: 1px solid var(--ink);
+  }
+  .preset-grid article:nth-child(n + 3) {
+    border-top: 0;
+  }
+  .verification-status > .button,
+  .verification-close .hero-actions {
+    grid-column: 1;
+    justify-self: start;
+    margin-top: 0;
   }
 }
 
@@ -1148,8 +1556,19 @@ tbody tr:hover {
   }
   .sprint-columns,
   .profile-grid,
-  .family-list {
+  .family-list,
+  .confidence-cards,
+  .lane-grid,
+  .preset-grid {
     grid-template-columns: 1fr;
+  }
+  .confidence-cards article {
+    min-height: 0;
+    border-right: 1px solid var(--ink);
+    border-bottom: 0;
+  }
+  .confidence-cards article:last-child {
+    border-bottom: 1px solid var(--ink);
   }
   .compact-list a {
     grid-template-columns: 4rem minmax(0, 1fr);
@@ -1206,6 +1625,59 @@ tbody tr:hover {
   }
   .doc-toc ol {
     columns: 1;
+  }
+  .snapshot-note {
+    text-align: left;
+  }
+  .evidence-chain {
+    grid-template-columns: 1fr;
+  }
+  .evidence-chain li,
+  .evidence-chain li:nth-child(4n),
+  .evidence-chain li:nth-child(2n) {
+    min-height: 0;
+    border-right: 1px solid var(--ink);
+    border-top: 0;
+  }
+  .evidence-chain li:first-child {
+    border-top: 1px solid var(--ink);
+  }
+  .evidence-chain li::after {
+    display: none !important;
+  }
+  .preset-grid article,
+  .preset-grid article:nth-child(2) {
+    min-height: 0;
+    border-right: 1px solid var(--ink);
+    border-top: 0;
+  }
+  .preset-grid article:first-child {
+    border-top: 1px solid var(--ink);
+  }
+  .outcome-panel {
+    padding: 1.2rem;
+  }
+  .outcome-panel dl div {
+    grid-template-columns: 1fr;
+    gap: 0.25rem;
+  }
+  .profile-status-list li {
+    grid-template-columns: 1fr auto;
+  }
+  .profile-status-list strong {
+    grid-column: 1;
+  }
+  .profile-status-list .status-pill {
+    grid-column: 2;
+    grid-row: 1 / span 2;
+  }
+  .lane-card-heading {
+    flex-direction: column;
+    min-height: 0;
+  }
+  .lane-tags {
+    justify-content: start;
+    margin-bottom: 1rem;
   }
   .app-footer {
     flex-direction: column;


### PR DESCRIPTION
## Summary

- add a public Project Atlas verification page that separates regression-green, integration-green, and conformance-green claims
- visualize the provenance-to-executable-evidence chain with canonical Atlas-derived values and explicit claim boundaries
- catalog required, path-scoped, scheduled, advisory, on-demand, and manual lanes with runnable commands and active evidence links
- add top-level Atlas navigation and a compliance-page entry point

## Verification

- `fnm exec --using=22.22.1 -- pnpm verify:fast`
- `fnm exec --using=22.22.1 -- pnpm verify`
- `fnm exec --using=22.22.1 -- pnpm --dir docs-portal run test:data`
- `fnm exec --using=22.22.1 -- pnpm --dir docs-portal run check`
- `fnm exec --using=22.22.1 -- pnpm --dir docs-portal run build`
- `fnm exec --using=22.22.1 -- pnpm wap-compliance:check`
- `fnm exec --using=22.22.1 -- pnpm wap-graph:check`
- `fnm exec --using=22.22.1 -- pnpm exec prettier --check docs-portal/src/styles/global.css`
- repository pre-push hooks, including engine/browser/transport Rust formatting, Clippy, and 314 native engine tests
- visual inspection at 1440x1000 and 390x844 with no document overflow or browser errors

## Claim boundary

The page does not claim full WAP 1.2.1 conformance or certification. Current counts and profile states are rendered from validated Atlas inputs; prose, graph edges, examples without flows, and ticket status are explicitly excluded as standalone executable evidence.
