### PR TITLE
fix(kannel): honor connectionless Encoding-Version

### DIFF
--- a/.github/workflows/transport-wap-smoke.yml
+++ b/.github/workflows/transport-wap-smoke.yml
@@ -42,6 +42,15 @@ jobs:
       - name: Start Kannel + WML stack
         run: docker compose up -d --build kannel wml-server
 
+      - name: Install Linux Tauri build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libayatana-appindicator3-dev \
+            librsvg2-dev \
+            libwebkit2gtk-4.1-dev \
+            pkg-config
+
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
 

--- a/.github/workflows/transport-wap-smoke.yml
+++ b/.github/workflows/transport-wap-smoke.yml
@@ -24,6 +24,7 @@ permissions:
   contents: read
 
 env:
+  NODE_VERSION: '22.22.1'
   RUST_SHARED_KEY: wavenav-rust
   TRANSPORT_WAP_SMOKE_ARTIFACT_DIR: ${{ github.workspace }}/test-results/transport-wap-smoke
   WML_DTD_VERSION: '1.3'
@@ -50,6 +51,22 @@ jobs:
             librsvg2-dev \
             libwebkit2gtk-4.1-dev \
             pkg-config
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
+
+      - name: Setup Node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'pnpm'
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Install Node dependencies
+        run: pnpm install --frozen-lockfile --ignore-scripts
+
+      - name: Build browser frontend
+        run: pnpm --dir browser/frontend build
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable

--- a/browser/frontend/scripts/native-tauri-kannel-e2e.mjs
+++ b/browser/frontend/scripts/native-tauri-kannel-e2e.mjs
@@ -157,7 +157,8 @@ const run = async () => {
   await capture('01-startup');
 
   await driver.findElement(By.css('#btn-fetch-url')).click();
-  const homeViewport = await waitForText('#viewport', 'Local WAP training environment.');
+  const homeViewport = await waitForText('#viewport', 'Local WAP training');
+  assert.match(await homeViewport.getText(), /environment\./);
   assert.match(await homeViewport.getText(), /Open Menu/);
   assert.equal(await body.getAttribute('data-boot-phase'), 'deck-ready');
   recordAssertion('gateway deck render', 'wap://localhost/ rendered the Kannel-served home deck');
@@ -178,7 +179,8 @@ const run = async () => {
 
   await replaceInput('#fetch-url', 'wap://localhost/');
   await driver.findElement(By.css('#btn-fetch-url')).click();
-  const recoveredViewport = await waitForText('#viewport', 'Local WAP training environment.');
+  const recoveredViewport = await waitForText('#viewport', 'Local WAP training');
+  assert.match(await recoveredViewport.getText(), /environment\./);
   assert.match(await recoveredViewport.getText(), /Open Menu/);
   recordAssertion('failure recovery', 'a subsequent native Kannel load restored the home deck');
   await capture('05-recovered-home');

--- a/browser/src-tauri/src/tests/fetch_commands.rs
+++ b/browser/src-tauri/src/tests/fetch_commands.rs
@@ -475,8 +475,14 @@ fn fetch_deck_command_gateway_fallback_cannot_be_redirected_by_fallback_env_valu
 #[ignore = "runs against external Kannel dev stack (make up)"]
 fn host_fetch_deck_command_native_wap_home_smoke_succeeds() {
     let _guard = env_lock().lock().expect("env lock should succeed");
+    let previous_destination =
+        std::env::var(super::waves_config::FETCH_DESTINATION_POLICY_ENV).ok();
     let previous_profile = std::env::var(super::waves_config::FETCH_TRANSPORT_PROFILE_ENV).ok();
     let previous_fallback = std::env::var(super::waves_config::FETCH_TRANSPORT_FALLBACK_ENV).ok();
+    std::env::set_var(
+        super::waves_config::FETCH_DESTINATION_POLICY_ENV,
+        super::waves_config::FETCH_DESTINATION_POLICY_ALLOW_PRIVATE,
+    );
     std::env::set_var(
         super::waves_config::FETCH_TRANSPORT_PROFILE_ENV,
         super::waves_config::FETCH_TRANSPORT_PROFILE_WAP_NET_CORE,
@@ -502,6 +508,11 @@ fn host_fetch_deck_command_native_wap_home_smoke_succeeds() {
         }),
     });
 
+    if let Some(old) = previous_destination {
+        std::env::set_var(super::waves_config::FETCH_DESTINATION_POLICY_ENV, old);
+    } else {
+        std::env::remove_var(super::waves_config::FETCH_DESTINATION_POLICY_ENV);
+    }
     if let Some(old) = previous_profile {
         std::env::set_var(super::waves_config::FETCH_TRANSPORT_PROFILE_ENV, old);
     } else {
@@ -529,8 +540,14 @@ fn host_fetch_deck_command_native_wap_home_smoke_succeeds() {
 #[ignore = "runs against external Kannel dev stack (make up)"]
 fn host_fetch_deck_command_native_wap_post_smoke_registers_and_logs_in() {
     let _guard = env_lock().lock().expect("env lock should succeed");
+    let previous_destination =
+        std::env::var(super::waves_config::FETCH_DESTINATION_POLICY_ENV).ok();
     let previous_profile = std::env::var(super::waves_config::FETCH_TRANSPORT_PROFILE_ENV).ok();
     let previous_fallback = std::env::var(super::waves_config::FETCH_TRANSPORT_FALLBACK_ENV).ok();
+    std::env::set_var(
+        super::waves_config::FETCH_DESTINATION_POLICY_ENV,
+        super::waves_config::FETCH_DESTINATION_POLICY_ALLOW_PRIVATE,
+    );
     std::env::set_var(
         super::waves_config::FETCH_TRANSPORT_PROFILE_ENV,
         super::waves_config::FETCH_TRANSPORT_PROFILE_WAP_NET_CORE,
@@ -600,6 +617,11 @@ fn host_fetch_deck_command_native_wap_post_smoke_registers_and_logs_in() {
         }),
     });
 
+    if let Some(old) = previous_destination {
+        std::env::set_var(super::waves_config::FETCH_DESTINATION_POLICY_ENV, old);
+    } else {
+        std::env::remove_var(super::waves_config::FETCH_DESTINATION_POLICY_ENV);
+    }
     if let Some(old) = previous_profile {
         std::env::set_var(super::waves_config::FETCH_TRANSPORT_PROFILE_ENV, old);
     } else {

--- a/docker/kannel/connectionless-wbxml-version.patch
+++ b/docker/kannel/connectionless-wbxml-version.patch
@@ -1,3 +1,16 @@
+--- a/wap/wsp_headers.c
++++ b/wap/wsp_headers.c
+@@ -1159,6 +1159,10 @@ void wsp_unpack_well_known_field(List *unpacked, int field_type,
+                  warning(0, "Unknown Accept-Application field name 0x%02x.", val);
+              break;
+
++        case WSP_HEADER_ENCODING_VERSION:
++            decoded = wsp_unpack_version_value(val);
++            break;
++
+         default:
+             if (headername) {
+                 warning(0, "Did not expect short-integer with "
 --- a/gw/wap-appl.c
 +++ b/gw/wap-appl.c
 @@ -912,3 +912,8 @@ static void return_reply(int status, Octstr *content_body, List *headers,

--- a/docs/ci/CI_SETUP.md
+++ b/docs/ci/CI_SETUP.md
@@ -293,8 +293,9 @@ Behavior:
 
 - starts Docker services (`kannel`, `wml-server`)
 - serves WML 1.3 through an explicit test-only DTD setting; the server default remains WML 1.1
-- sends `Encoding-Version: 1.3` at the WSP client boundary, and uses the locally patched Kannel
-  connectionless path to carry that request negotiation into WML compilation
+- sends `Encoding-Version: 1.3` as the WSP-defined short-integer version-value, and uses the
+  locally patched Kannel connectionless path to decode and carry that request negotiation into WML
+  compilation
 - runs `make smoke-transport-wap`
 - executes:
   - transport-rust ignored Kannel smoke tests

--- a/scripts/native-tauri-kannel-e2e.sh
+++ b/scripts/native-tauri-kannel-e2e.sh
@@ -98,7 +98,10 @@ export WEBKIT_DISABLE_COMPOSITING_MODE="${WEBKIT_DISABLE_COMPOSITING_MODE:-1}"
 } >"${ARTIFACT_DIR}/environment.txt"
 
 echo "==> Building the production Tauri frontend and debug application binary"
-pnpm --dir browser run tauri:build -- --no-bundle
+(
+  cd "${ROOT_DIR}/browser/src-tauri"
+  cargo tauri build --debug --no-bundle
+)
 
 echo "==> Driving the native Waves window through tauri-driver"
 pnpm --dir browser/frontend run test:native-kannel:ui

--- a/scripts/native-tauri-kannel-e2e.sh
+++ b/scripts/native-tauri-kannel-e2e.sh
@@ -87,7 +87,7 @@ export NATIVE_E2E_ARTIFACT_DIR="${ARTIFACT_DIR}"
 export WEBKIT_DISABLE_COMPOSITING_MODE="${WEBKIT_DISABLE_COMPOSITING_MODE:-1}"
 
 {
-  echo "tauri-driver: $(tauri-driver --version)"
+  echo "tauri-driver: $(cargo install --list | sed -n '/^tauri-driver /{p;q;}')"
   echo "WebKitWebDriver: $(WebKitWebDriver --version 2>&1 | head -n 1)"
   echo "rustc: $(rustc --version)"
   echo "node: $(node --version)"
@@ -98,7 +98,7 @@ export WEBKIT_DISABLE_COMPOSITING_MODE="${WEBKIT_DISABLE_COMPOSITING_MODE:-1}"
 } >"${ARTIFACT_DIR}/environment.txt"
 
 echo "==> Building the production Tauri frontend and debug application binary"
-pnpm --dir browser run tauri:build -- --debug --no-bundle
+pnpm --dir browser run tauri:build -- --no-bundle
 
 echo "==> Driving the native Waves window through tauri-driver"
 pnpm --dir browser/frontend run test:native-kannel:ui

--- a/transport-rust/README.md
+++ b/transport-rust/README.md
@@ -15,9 +15,10 @@ dependency. WBXML parsing remains transport-owned, and the engine receives
 only normalized textual WML plus the original bytes as metadata.
 
 The native connectionless WSP profile advertises `Encoding-Version: 1.3` as a compact
-version-value. The local Kannel image carries a narrow connectionless-path patch so that this
-device request header selects Kannel's WBXML compiler version just as it does for a session-bound
-request; the decoder remains strict about the selected WBXML 1.3 envelope and WML 1.3 public ID.
+version-value. The local Kannel image carries a narrow connectionless-path patch so Kannel accepts
+that spec-valid short-integer value and carries the device request header into WML compilation,
+just as it does for a session-bound request. The decoder remains strict about the selected WBXML
+1.3 envelope and WML 1.3 public ID.
 
 ## Engine Handoff Normalization Guarantees (`T0-02`)
 


### PR DESCRIPTION
## Summary

- repair the Kannel 1.4.5 connectionless header decoder so the WSP-defined short-integer Encoding-Version value is retained
- carry that decoded request value into the existing WML compiler selection path when no session machine exists
- keep Lowband's WBXML 1.3 decoder strict and preserve every production network-policy boundary

## Root cause

PR #400 correctly emits the WSP 1.3 request bytes c3 93. Kannel 1.4.5 recognizes the Encoding-Version field name but its unpacker only handled that field in the alternate value-length branch, so it discarded the valid direct Version-value. Its connectionless application path also lacked the session state used by connection-oriented requests. The result was Kannel's default WBXML 1.1 byte 01 despite the WML 1.3 deck.

This narrow source patch handles the spec-valid short-integer in Kannel's existing header decoder and supplies the decoded device header to WML compilation. It does not broaden accepted WBXML envelopes.

## Verification

- patch dry-run against the Ubuntu Kannel 1.4.5 source
- exact Rust wire regression confirms c3 93
- canonical pnpm verify:full passed on PR #400 before merge
- canonical pnpm verify:fast passed after this focused repair
- repository pre-commit and pre-push hooks passed

The path-scoped Transport WAP Smoke workflow is the required provisioned regression for this repair. Do not merge until it proves Kannel emits WBXML 1.3 and all three live transport tests pass.
