### PR TITLE
docs(waves): recover historical browser profile evidence

### DIFF
--- a/docs/waves/HISTORICAL_BROWSER_PROFILE_SOURCE_BASELINE.md
+++ b/docs/waves/HISTORICAL_BROWSER_PROFILE_SOURCE_BASELINE.md
@@ -1,0 +1,202 @@
+# Historical Browser Profile Source Baseline
+
+Status: active research baseline; no named profile authorized
+Last updated: 2026-07-26
+Scope: period WAP handset-browser interaction evidence for future Waves compatibility profiles
+
+## Purpose and Boundary
+
+This baseline records recoverable primary historical evidence for future device/browser profiles. It
+does not define WAP requirements, alter the neutral `Class C Reference` runtime, or authorize a named
+profile. All sources here are `interop-reference` evidence under
+[Waves Source Authority Policy](SOURCE_AUTHORITY_POLICY.md); only the locked normative corpus may
+create or redefine `RQ-*` requirements.
+
+The research covers viewport metrics, typography, focus and roller behavior, softkeys and task
+placement, Options/menu ordering, editors and forms, history, timers, documented failures, and
+browser limitations. Archived folders and historical planning snapshots are outside this audit.
+
+## Evidence and Confidence Rules
+
+Evidence classes used below are:
+
+- `P1`: manufacturer/browser-vendor publication with internal publication identity and notices.
+- `P2`: contemporary operator or platform-owner guidance based on named devices and browser tests.
+- `S1`: third-party transcription, manual mirror, or contextual recollection without a recovered
+  publisher artifact. This can locate or corroborate evidence, but cannot close a profile gate alone.
+
+Claim confidence is separate from source class:
+
+- `high`: the recovered publisher artifact states the behavior directly, or two independent primary
+  publications agree.
+- `medium`: publisher-authored content is available only through a mirror/transcription, describes a
+  browser family rather than one handset, or leaves an implementation detail implicit.
+- `low`: only partial service documentation, a secondary account, or an unresolved conflict exists.
+
+An archived or mirrored payload establishes research availability, not permission to republish it.
+The recovered PDFs and extracted text remain outside Git. Hashes, sizes, publication identities,
+source routes, and research conclusions may be recorded here. No access controls were bypassed.
+
+## Recovered Source Index
+
+Retrieval and verification date for all rows is 2026-07-26.
+
+| ID           | Publisher source                                                                                                  | Retrieval and integrity                                                                                                                                                                                                                                                    | Class / provenance                                                                                  | Redistribution posture                                                                                             |
+| ------------ | ----------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| `OW-2000`    | Phone.com, _WML Application Style Guide: Designing and Developing WML Applications_, `WMLS-01-001`, August 2000   | [2003 archive capture of the original Openwave URL](https://web.archive.org/web/20030313113811id_/http://demo.openwave.com:80/pdf/styleguides/wml_style.pdf); 398,527 bytes; SHA-256 `de13b6c11fd4033813b8ed3144f12e6eb41fc73d12c9b76f3b60a230ac5cda11`; PDF 1.2, 78 pages | `P1`; high content identity, medium byte lineage because no publisher checksum survives             | Copyright notice reserves rights and restricts reproduction, modification, and distribution; private research only |
+| `OW-2001`    | Openwave, _Graphical Browser Application Style Guide_, Mobile Browser WAP Edition 5.0, `MBWS-50-002`, August 2001 | [public university SDK mirror](http://www1.lasalle.edu/~beatty/430/wireless/toolkit/client_tech_and_sdk/pdf/style_guide.pdf); 544,068 bytes; SHA-256 `d8a911ddb1a3de095fcdd7a387c2ad622153f47bd8f0f13a6db4cba3a3dda65b`; PDF 1.3, 86 pages                                 | `P1`; high content identity, medium byte lineage                                                    | Restricted copyright notice; private research only                                                                 |
+| `NK-7110`    | Nokia, _Service Developer's Guide for the Nokia 7110_, `9359203`, issue 3, November 1999                          | [public mirror](https://www.filibeto.org/mobile/files/sservice_dev_guide.pdf); 242,486 bytes; SHA-256 `9eb8a3a4d97266f31bd3806d53d60ea8661be656d647382d365b07bdc5e2fec4`; PDF 1.2, 34 pages                                                                                | `P1`; high content identity, medium byte lineage                                                    | Notice permits personal download/printing only; private research copy retained outside Git                         |
+| `NK-2000`    | Nokia, _WAP Service Designer's Guide to Nokia Handsets_, 16 June 2000                                             | [public university mirror](http://stl.cs.queensu.ca/~graham/cisc836/lectures/readings/nokia-designers-guide.pdf); 354,355 bytes; SHA-256 `7440173d99f7dbad2b08cc832d212bdeb53cf984fff87623e81a54462514241f`; PDF 1.3, 16 pages                                             | `P1`; high content identity, medium byte lineage; corroborates `NK-7110`                            | Notice permits personal download/printing only; private research copy retained outside Git                         |
+| `ER-R380`    | Ericsson, _R380s Design Guidelines for WAP Services_, `LZT 108 3339`, first edition, November 1999                | [public manual mirror](https://usermanual.wiki/Ericsson/EricssonR380UsersManual540796.930088381.pdf); 667,004 bytes; SHA-256 `904dd9511ecc5605dc2fbbb35fdb7fefd518af4ac23b19b2308f9540d49ef3b0`; PDF 1.3, 25 pages                                                         | `P1`; high content identity, medium byte lineage                                                    | All-rights-reserved notice and no redistribution grant; private research only                                      |
+| `ER-R320-WP` | Ericsson, _R320s White Paper_, `LZT 108 3714 R1A`, first edition, March 2000                                      | [full-text mirror](https://manualzz.com/doc/924263/ericsson-r320s-white-paper); publisher PDF not recovered                                                                                                                                                                | `S1` transcription of an identified `P1` publication; medium                                        | Mirror view only; no binary, checksum, or redistribution grant                                                     |
+| `ER-WAPIDE`  | Ericsson, _WapIDE 3.1 User's Guide_, 9 April 2001                                                                 | [full-text mirror](https://manualzilla.com/doc/6879776/user-s-guide); publisher PDF not recovered                                                                                                                                                                          | `S1` transcription of an identified `P1` publication; medium                                        | Mirror view only; no binary, checksum, or redistribution grant                                                     |
+| `MO-P7389`   | Motorola, _Timeport P7382i/P7389i Level III Service Manual_                                                       | [full-text mirror](https://manualzz.com/doc/1783019/motorola-timeport-p7389i-service-manual); publisher PDF not recovered                                                                                                                                                  | `S1` transcription of an identified `P1` service publication; low-to-medium for browser interaction | Mirror view only; no binary, checksum, or redistribution grant                                                     |
+| `GENIE-2001` | Genie, _Application Style Guide for Openwave, Nokia 7110/6210/6250, Mitsubishi Trium_, release 1.0, February 2001 | [page-by-page mirror](https://manualsdump.com/en/manuals/genie-7110model/52158/5); original publication was linked from Openwave's developer library; publisher PDF not recovered                                                                                          | `S1` mirror of an identified `P2` publication; medium corroboration only                            | No verified redistribution grant; do not promote mirror content                                                    |
+
+The Wayback CDX record for `OW-2000` reports a 240,928-byte capture record while the replayed PDF is
+398,527 bytes. The replayed file has a valid PDF structure, matching internal publication identity,
+period PDF metadata, and the original archived URL, but the size discrepancy prevents a high-confidence
+byte-lineage claim without a publisher checksum.
+
+For each recovered PDF, verification included file-signature and metadata inspection, page count,
+SHA-256, text extraction, and rendered-page review. The rendered Openwave softkey template, Nokia
+Options sequence, and Ericsson R380 browser layout were visually checked against the extracted text.
+Encrypted Nokia PDFs were inspected within their granted print permission; their copy restrictions
+were not removed.
+
+## Interaction Evidence Matrix
+
+`H`, `M`, and `L` are claim-confidence levels; `--` means the interaction does not apply to that form
+factor or no useful evidence was recovered.
+
+| Candidate                             | Viewport / type | Focus / controls |        Softkeys / menu | Editors / forms | History | Timers | Failures / limits |
+| ------------------------------------- | --------------: | ---------------: | ---------------------: | --------------: | ------: | -----: | ----------------: |
+| Nokia 7110                            |               H |                H |                      H |               H |       H |      L |                 H |
+| Phone.com/Openwave 4.x family         |               M |                M | H logical / L physical |               H |       H |      M |                 H |
+| Openwave Mobile Browser 5.0 graphical |               M |                M | H logical / L physical |               H |       H |      M |                 H |
+| Ericsson R320s                        |               H |                M |                      M |               M |       M |      L |                 M |
+| Ericsson R380s                        |               H |          H touch |                     -- |               H |       H |      M |                 H |
+| Motorola P7382i/P7389i                |               M |                L |                      L |               M |       L |      L |                 M |
+
+## Profile Assessments
+
+### Nokia 7110: ready for profile planning
+
+`NK-7110` and `NK-2000` agree on the profile-defining interaction model:
+
+- 96 by 65 pixels overall, with a 96 by 44-pixel content graphics area and four data lines;
+- proportional 8-pixel normal and bold fonts, header truncation, word wrapping, and underlined links
+  placed on their own lines;
+- inverse-video focus, line-by-line scrolling, roller movement, and roller press to select;
+- left `Options` and right `Back` during normal browsing;
+- fixed Options ordering: Home, Bookmarks, current Select/Edit action, card `do` actions in source
+  order, conditional Use Number, Empty Cache, then Exit with confirmation;
+- number, text, and password editors, with the right softkey changing between Back and Clear and
+  password characters becoming masked;
+- `prev`/Back history behavior and documented bookmark behavior;
+- concrete rendering limitations, including flattened tables, ignored emphasis, images constrained or
+  truncated to the 96 by 44 area, and no image-map links.
+
+This is sufficient to plan fixtures and profile-specific goldens. It is not authorization to begin
+implementation before the Class C, compatibility-registry, and frame/input gates. A 7110-specific
+timer cadence, firmware/version matrix, and reproducible failure corpus remain open and must be
+treated as explicit gaps rather than inferred from general WML behavior.
+
+### Phone.com/Openwave: browser-family behavior recovered, handset identity still open
+
+`OW-2000` is the missing primary browser-vendor guide and provides strong logical behavior:
+
+- a typical four-line display, 12 to 15 characters per line, with deployed phones ranging from two
+  to eight lines and using mostly variable-width fonts;
+- two programmable actions: the primary `accept` action and secondary `options` access, plus a fixed
+  Back/Back-Clear control;
+- overflow actions placed in a numbered options menu, short labels, compact menus, and a preference
+  for the common action on the primary binding;
+- complete guidance for text, numeric, password, and formatted fields, validation before acceptance,
+  selection lists, retained values, and clearing entry state;
+- default Back/history and cache behavior, including activity/delete patterns that deliberately
+  remove intermediate cards from history;
+- timer/image-loading races, unsupported-character substitution, no horizontal image scrolling, and
+  significant OEM variation in display and control characteristics.
+
+The guide's display template says `accept` is on the left and `options` on the right, while adjacent
+prose describes the primary key as the right softkey. `OW-2001` contains a comparable left/right
+inconsistency. Both guides also say handset manufacturers can vary browser characteristics. Therefore
+the logical primary/secondary precedence is high-confidence evidence, but a physical left/right
+mapping is not safe at browser-family level. A future profile must name one shipped handset and
+browser release, then pair the Openwave guide with that handset's manufacturer user/developer guide.
+
+`OW-2001` is valuable successor evidence for the 5.0 graphical browser: it documents three to eight
+display lines, mostly variable-width text, link styling, pop-up menus, buttons, radio controls, and
+the rule that an activated editor or pop-up consumes the programmable-softkey surface. It must not be
+silently projected backward onto Phone.com 4.x or onto a handset whose OEM controls differ.
+
+### Ericsson: R320 evidence is promising; R380 is a separate touch profile
+
+The R320 white paper provides a 101 by 65-pixel display, five full-screen rows including the header,
+four selection/input rows including the header, proportional font capacity, inverse link focus, an
+image focus frame, a 4 KB cache, and up to 25 bookmarks. The WapIDE guide adds short `YES` to follow or
+confirm, held `YES` for Options, short `NO` for Back/history, vertical scrolling, horizontal movement
+among table cells or multiple links, and a mixed menu of card actions plus fixed browser actions.
+
+These are publisher-authored sources, but only third-party text views were recoverable. The exact R320
+design guide, byte-verified developer PDFs, editor details, timer behavior, precise fixed-menu ordering,
+and firmware-specific failures remain open. The consumer manual also distinguishes `Suspend` in the
+browser menu from `Resume` in the phone's WAP Services menu; they must not be presented as one fixed
+Options sequence.
+
+`ER-R380` is a strong primary source for a different device class: a 360 by 120 touchscreen with a
+310 by 100 browser area, breadcrumb-like title/history display, toolbar navigation, proportional
+9/10/14-pixel fonts, touch focus, list and button controls, and on-screen keyboard or handwriting
+entry. It should inform a later R380 touch profile, not fill R320 keypad/softkey gaps.
+
+### Motorola: service evidence is not enough for a named profile
+
+`MO-P7389` establishes a 96 by 54 display, WAP 1.1 support, simplified alphabetic entry, partial
+display of oversized bitmaps, browser entry through Quick Access/menu paths, and pause/resume around
+incoming calls. It does not establish focus traversal, exact softkey precedence, Options ordering,
+history semantics, timers, or a complete editor model. A manufacturer browser/application developer
+guide and a byte-verified consumer manual are still required before planning a Motorola profile.
+
+## Conflicts and Non-Inferences
+
+1. Openwave's logical primary/secondary action model is supported; its physical left/right mapping is
+   unresolved and may be OEM-specific.
+2. Openwave 5.0 graphical-browser behavior is successor/delta evidence, not proof of 4.x behavior.
+3. Nokia 7110 and Nokia 6210/6250 corroboration does not make handset metrics interchangeable; the
+   comparative Nokia guide lists different display heights.
+4. Ericsson R320s keypad behavior and Ericsson R380s touchscreen behavior are separate profiles.
+5. `Suspend` and `Resume` are different R320 state transitions in different menus, not adjacent fixed
+   Options items.
+6. Service-manual facts and third-party recollections are candidate-fixture context, not a basis for
+   profile requirements.
+7. None of these sources may redefine the neutral `Class C Reference`, WML task semantics, or a
+   normative `RQ-*` item.
+
+## Readiness Decision and Future Work
+
+The Nokia 7110 is the first named profile ready to plan because two concordant Nokia publications
+cover every requested interaction domain except device-specific timer cadence and a reproducible
+failure/version matrix. Planning must preserve those gaps and the existing runtime gates.
+
+Openwave is next only as an evidence-lock task, not an implementation profile: select a representative
+shipping handset/browser version, recover its manufacturer interaction guide, resolve physical
+controls and editor modes, and establish device-specific viewport, timer, and failure fixtures. The
+browser-family guides alone do not justify a generic `Openwave` compatibility profile.
+
+Ericsson R320 and Motorola remain source-recovery candidates. R380 has adequate design-guide evidence
+but represents a materially different touch device and should follow, not substitute for, the keypad
+profiles prioritized by the current product direction.
+
+## Unresolved Primary-Source Queue
+
+1. A handset-specific Openwave/UP.Browser 4.x user or developer guide that names browser version,
+   physical softkeys, viewport, editors, and known failures.
+2. The publisher PDF for the Ericsson R320 design/developer guide, plus byte-verified R320 user and
+   WapIDE manuals.
+3. A Motorola application/browser developer guide for a representative WAP handset, plus a
+   byte-verified consumer manual.
+4. Device/firmware release notes or test reports for timer cadence, cache faults, network failure
+   presentation, and known browser defects across the selected profiles.
+5. Publisher checksums or authenticated archives for all mirrored PDFs, and explicit redistribution
+   permission before any binary or extracted derivative is proposed for Git.

--- a/docs/waves/WAVES_BROWSER_PRODUCT_IMPLEMENTATION_PLAN.md
+++ b/docs/waves/WAVES_BROWSER_PRODUCT_IMPLEMENTATION_PLAN.md
@@ -1,7 +1,7 @@
 # Waves Browser Product Implementation Plan
 
 Status: planning-ready
-Last updated: 2026-07-25
+Last updated: 2026-07-26
 Design source: [Waves Desktop Product and Interaction Design](WAVES_DESKTOP_PRODUCT_DESIGN.md)
 
 ## Purpose
@@ -22,13 +22,14 @@ permit browser work to infer unfinished engine or transport behavior.
 
 ## Source Plans and Ownership
 
-| Capability | Authoritative plan or backlog |
-|---|---|
-| Class C sequence and adoption gates | [WAP 1.2.1 planning baseline](WAP_1_2_1_PLANNING_BASELINE.md) |
-| Frame, Canvas, hit regions, typed input | [engine-host frame plan](ENGINE_HOST_FRAME_MIGRATION_PLAN.md) and [work items](ENGINE_HOST_FRAME_WORK_ITEMS.md) |
-| Welcome, help, tours, tutorials | [user onboarding plan](USER_ONBOARDING_EXPERIENCE_PLAN.md) |
-| Read-only runtime observation | [engine debug connector plan](ENGINE_DEBUG_CONNECTOR_PLAN.md) |
-| Existing host usability follow-ups | [usability and resilience backlog](USABILITY_RESILIENCE_BACKLOG.md) |
+| Capability                                 | Authoritative plan or backlog                                                                                   |
+| ------------------------------------------ | --------------------------------------------------------------------------------------------------------------- |
+| Class C sequence and adoption gates        | [WAP 1.2.1 planning baseline](WAP_1_2_1_PLANNING_BASELINE.md)                                                   |
+| Frame, Canvas, hit regions, typed input    | [engine-host frame plan](ENGINE_HOST_FRAME_MIGRATION_PLAN.md) and [work items](ENGINE_HOST_FRAME_WORK_ITEMS.md) |
+| Welcome, help, tours, tutorials            | [user onboarding plan](USER_ONBOARDING_EXPERIENCE_PLAN.md)                                                      |
+| Read-only runtime observation              | [engine debug connector plan](ENGINE_DEBUG_CONNECTOR_PLAN.md)                                                   |
+| Existing host usability follow-ups         | [usability and resilience backlog](USABILITY_RESILIENCE_BACKLOG.md)                                             |
+| Historical profile evidence and provenance | [historical browser profile source baseline](HISTORICAL_BROWSER_PROFILE_SOURCE_BASELINE.md)                     |
 
 When a slice starts, update the owning work-item ledger rather than creating a second status source in
 this document.
@@ -444,11 +445,29 @@ Accept:
 
 - `Depends On`: stable Class C reference profile, compatibility registry, completed frame/input path
 
-Build only from primary evidence. Cover viewport metrics, typography, focus, roller behavior, softkey
-mapping, Options ordering, editors, history, and documented failures with profile-specific goldens.
+Plan only from the two concordant Nokia publications locked in the historical source baseline. Cover
+viewport metrics, typography, focus, roller behavior, softkey mapping, exact Options ordering,
+editors, history, and documented limitations with profile-specific fixtures and goldens. Preserve
+device-specific timer cadence, firmware/version coverage, and reproducible failure behavior as
+explicit evidence gaps until primary material or physical-device traces close them.
 
-Do not start an Openwave, Ericsson, Motorola, or other named profile until comparable primary evidence
-and fixtures exist.
+Accept planning readiness only when every behavior maps to a cited primary source or an explicit gap;
+do not infer missing behavior from neutral Class C or another Nokia handset. Implementation remains
+blocked on the declared runtime dependencies.
+
+### WBP-16 Openwave 4.x handset target and evidence lock
+
+- `Depends On`: `WBP-15` evidence method; no runtime dependency because this is research-only
+
+Select one representative shipping handset and exact Phone.com/Openwave browser release. Pair the
+recovered browser-family style guide with that manufacturer's user/developer guide, then resolve
+viewport and typography, focus controls, physical softkey placement, overflow-menu ordering,
+editor modes, Back/history, timers, and documented failures. Record hashes, provenance, conflicts,
+availability, and redistribution constraints while keeping restricted payloads outside Git.
+
+Accept only an evidence-locked planning candidate. Do not add a generic `Openwave` profile, implement
+runtime behavior, or use the 5.0 graphical guide to fill 4.x/OEM gaps. Ericsson and Motorola remain
+source-recovery candidates until comparable primary evidence exists.
 
 ## Proposed Delivery Order
 
@@ -462,22 +481,23 @@ and fixtures exist.
 7. Integrate loading, recovery, and persistence (`WBP-11`, `WBP-12`).
 8. Land diagnostics/replay after both contract surfaces stabilize (`WBP-13`).
 9. Close MVP with complete-path evidence (`WBP-14`).
-10. Begin named compatibility profiles only after Class C reference behavior is stable (`WBP-15`).
+10. Begin named compatibility profiles only after Class C reference behavior is stable (`WBP-15`);
+    conduct the additive Openwave target/source lock independently as research (`WBP-16`).
 
 ## Parallel Ownership and Conflict Controls
 
-| Work | Safe parallel owner | High-conflict files or surfaces |
-|---|---|---|
-| Shell structure | Browser UI integrator | shell template, controller, global styles |
-| Theme and handset scaffold | Browser visual owner after shell seams exist | global tokens and handset component |
-| Onboarding content | Browser/docs owner | start-shell integration; example manifest generation |
-| Host accessibility | Browser accessibility owner | shared component templates and focus styles |
-| Frame contract | Engine-contract owner | engine contract, generated host types, Tauri engine adapter |
-| Canvas/input | Renderer owner after frame contract | presenter, controller, keyboard/input adapter |
-| Transport cancellation | Transport-contract owner | Rust exports, generated transport types, fetch host, navigation state |
-| Persistence | Browser/Tauri owner after history identity | bootstrap/session modules and settings UI |
-| Debug connector | Diagnostics owner after contracts stabilize | engine contract, Tauri adapter, developer drawer |
-| End-to-end evidence | Test owner | shared story manifest and test harness configuration |
+| Work                       | Safe parallel owner                          | High-conflict files or surfaces                                       |
+| -------------------------- | -------------------------------------------- | --------------------------------------------------------------------- |
+| Shell structure            | Browser UI integrator                        | shell template, controller, global styles                             |
+| Theme and handset scaffold | Browser visual owner after shell seams exist | global tokens and handset component                                   |
+| Onboarding content         | Browser/docs owner                           | start-shell integration; example manifest generation                  |
+| Host accessibility         | Browser accessibility owner                  | shared component templates and focus styles                           |
+| Frame contract             | Engine-contract owner                        | engine contract, generated host types, Tauri engine adapter           |
+| Canvas/input               | Renderer owner after frame contract          | presenter, controller, keyboard/input adapter                         |
+| Transport cancellation     | Transport-contract owner                     | Rust exports, generated transport types, fetch host, navigation state |
+| Persistence                | Browser/Tauri owner after history identity   | bootstrap/session modules and settings UI                             |
+| Debug connector            | Diagnostics owner after contracts stabilize  | engine contract, Tauri adapter, developer drawer                      |
+| End-to-end evidence        | Test owner                                   | shared story manifest and test harness configuration                  |
 
 Rules:
 

--- a/docs/waves/WAVES_DESKTOP_PRODUCT_DESIGN.md
+++ b/docs/waves/WAVES_DESKTOP_PRODUCT_DESIGN.md
@@ -1,7 +1,7 @@
 # Waves Desktop Product and Interaction Design
 
 Status: planning-ready
-Last updated: 2026-07-25
+Last updated: 2026-07-26
 Owner lane: `browser` with contract dependencies on `engine-wasm` and `transport-rust`
 
 ## Purpose
@@ -40,6 +40,7 @@ Implementation remains subordinate to:
 - [user onboarding experience plan](USER_ONBOARDING_EXPERIENCE_PLAN.md)
 - [engine debug connector plan](ENGINE_DEBUG_CONNECTOR_PLAN.md)
 - [usability and resilience backlog](USABILITY_RESILIENCE_BACKLOG.md)
+- [historical browser profile source baseline](HISTORICAL_BROWSER_PROFILE_SOURCE_BASELINE.md)
 
 Browser-only presentation work may proceed while core work continues when it preserves the current
 contracts and does not infer or hard-code future WML semantics. Contract-dependent capabilities must
@@ -89,11 +90,18 @@ imply one canonical handset skin. See the [OMA WML 1.3 specification](https://ww
 The Nokia 7110 is a useful later profile: its 96 by 65 display, small proportional font, inverse-video
 focus, left `Options` and right `Back` softkeys, and roller-based movement create a recognizable WAP
 interaction model. Those are Nokia-specific observations rather than generic Class C requirements.
-See the [Nokia 7110 Service Developer's Guide](https://www.filibeto.org/mobile/files/sservice_dev_guide.pdf).
+Two recovered Nokia publications now support detailed profile planning; see the
+[historical browser profile source baseline](HISTORICAL_BROWSER_PROFILE_SOURCE_BASELINE.md).
 
-Ericsson's R320 exposed a different service-menu rhythm, including Suspend, Resume, Reload, Add
-bookmark, and Exit. The difference reinforces the need for base behavior plus explicit device
-overlays. See the [Ericsson R320 user manual](https://manuals.plus/wp-content/uploads/2026/02/man-er-r320s-1.pdf).
+Phone.com/Openwave's recovered browser-vendor guidance defines a logical primary action, secondary
+options access, and fixed Back behavior, but it also documents broad OEM variation and conflicts on
+physical left/right placement. A generic browser-family skin would therefore overstate the evidence;
+one shipped handset and browser release must be selected before an Openwave profile is named.
+
+Ericsson's R320 exposed a different keypad and service-menu rhythm. Its browser Options menu includes
+content-dependent actions plus fixed actions such as Suspend, Reload, Add bookmark, and Exit, while
+Resume is reached later from the phone's WAP Services menu. The distinction reinforces the need for
+base behavior plus explicit device overlays rather than an inferred cross-OEM menu.
 
 Kannel distinguishes operational states such as Running, Suspended, Isolated, Full, and Shutdown.
 These are useful host diagnostics but are not handset-content states and must remain outside the WML
@@ -345,11 +353,15 @@ The `WBP-00` baseline adopts the following working decisions, with measurements 
 1. `WBP-08` owner: whether pointer assistance defaults on or is selected during first-run setup.
 2. `WBP-12`/`WBP-13` owners: persistence and redaction policy for form fields and diagnostic
    captures.
-3. `WBP-15` owner: evidence threshold required before naming and shipping a device-specific profile.
+3. `WBP-15` owner: apply the historical source baseline's provenance and coverage thresholds before
+   naming and shipping a device-specific profile.
 
 ## Evidence Gaps
 
-- Primary Openwave and several OEM interaction guides have not yet been recovered.
+- Primary Phone.com/Openwave browser guides and Nokia 7110 interaction guides are recovered for
+  private research; device-specific Openwave physical controls, byte-verified Ericsson R320
+  developer material, Motorola application guidance, firmware defects, and redistribution
+  permissions remain open.
 - Current stories do not provide broad automated coverage of the complete Tauri UI path.
 - Dynamic softkey order, menu overflow, modal form editing, and pointer acceleration need focused
   prototypes and user testing.


### PR DESCRIPTION
## Summary

- add an active historical browser-profile source baseline with source class, provenance,
  availability, hashes, confidence, redistribution constraints, and explicit conflicts
- assess recovered Phone.com/Openwave, Nokia, Ericsson, Motorola, and contemporary comparative
  material across viewport, typography, controls, softkeys, menus, editors, history, timers, failures,
  and limitations
- mark Nokia 7110 ready for profile planning behind its existing runtime gates and add a research-only
  Openwave handset-target/source-lock work item
- keep the neutral Class C runtime, normative requirements, and compatibility contracts unchanged

## Evidence decision

- Nokia 7110 is the strongest first named profile candidate because two concordant Nokia publications
  cover nearly every requested interaction domain.
- Openwave browser-family evidence supports logical primary/secondary action behavior, but internal
  left/right softkey conflicts and documented OEM variation require a specific shipped handset before
  a named profile can be planned.
- Ericsson R320 and Motorola remain source-recovery candidates; Ericsson R380 evidence belongs to a
  separate touchscreen profile.

## Source handling

Restricted recovered PDFs and extracted text remain outside Git. The committed baseline records only
permitted metadata, hashes, source routes, and research conclusions. No access controls were bypassed.

## Verification

- `pnpm run verify:change`
- repository pre-push checks, including engine/browser/transport Rust checks and 314 engine tests
- Prettier check for the three changed Markdown files
- Atlas data validation, Astro type/content checks, and 1,081-page production build
- WAP compliance/status drift, source-corpus drift, worklist/ticket references, and knowledge-graph
  projection
