### PR TITLE
fix(verify): use valid browser baseline sample count

### DIFF
--- a/docs/ci/LOCAL_VERIFICATION.md
+++ b/docs/ci/LOCAL_VERIFICATION.md
@@ -3,12 +3,12 @@
 The canonical local verification family is exposed through root `pnpm` scripts and matching Make
 targets:
 
-| Profile  | Command                               | Contract                                                                                                                                                                                                                                    |
-| -------- | ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Fast     | `pnpm verify:fast`                    | Runs the verification-orchestrator tests, whitespace check, and managed-version check.                                                                                                                                                      |
-| Change   | `pnpm verify` or `pnpm verify:change` | Runs strict common checks plus every deterministic lane selected by changed paths relative to `origin/main`. Override the base with `WAP_VERIFY_BASE=<ref>` or `--base <ref>`.                                                              |
+| Profile  | Command                               | Contract                                                                                                                                                                                                                                         |
+| -------- | ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Fast     | `pnpm verify:fast`                    | Runs the verification-orchestrator tests, whitespace check, and managed-version check.                                                                                                                                                           |
+| Change   | `pnpm verify` or `pnpm verify:change` | Runs strict common checks plus every deterministic lane selected by changed paths relative to `origin/main`. Override the base with `WAP_VERIFY_BASE=<ref>` or `--base <ref>`.                                                                   |
 | Full     | `pnpm verify:full`                    | Runs every deterministic offline lane, including compliance/status drift, graph drift, native and WASM engine checks, contracts, stories, transport, browser host/frontend unit/rendered accessibility, Atlas, marketing, and WML server checks. |
-| Extended | `pnpm verify:extended`                | Runs the full profile, then requires the already-running live Kannel/WML stack and runs the browser baseline as a non-blocking stability signal.                                                                                            |
+| Extended | `pnpm verify:extended`                | Runs the full profile, then requires the already-running live Kannel/WML stack and runs the browser baseline as a non-blocking stability signal.                                                                                                 |
 
 Equivalent Make targets are `verify-fast`, `verify-change`, `verify-full`, and `verify-extended`.
 `make ci-local` is retained only as a deprecated compatibility alias. It prints an advisory and
@@ -42,7 +42,7 @@ The `full` profile is the ordinary pre-PR command. It deliberately excludes:
 
 - the live Kannel/browser smoke, which requires Docker services and is run by
   `pnpm verify:extended` or the manual `Transport WAP Smoke (Kannel)` workflow;
-- scheduled/advisory performance trends beyond the bounded three-run extended baseline;
+- scheduled/advisory performance trends beyond the bounded five-run extended baseline;
 - fuzz campaigns, which remain explicit time-bounded commands;
 - GitHub-hosted dependency, CodeQL, coverage-threshold, release, deployment, and OS-packaging
   jobs.

--- a/engine-wasm/host-sample/scripts/measure-waves-baseline.mjs
+++ b/engine-wasm/host-sample/scripts/measure-waves-baseline.mjs
@@ -7,6 +7,11 @@ import { promisify } from 'node:util';
 import { fileURLToPath } from 'node:url';
 import { chromium } from '@playwright/test';
 import { startVitePreview } from './vite-preview-harness.mjs';
+import {
+  WAVES_BASELINE_DEFAULT_RUNS,
+  WAVES_BASELINE_MAX_RUNS,
+  WAVES_BASELINE_MIN_RUNS
+} from './waves-baseline-run-policy.mjs';
 
 const execFileAsync = promisify(execFile);
 const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
@@ -15,10 +20,15 @@ const REPO_ROOT = path.resolve(HOST_SAMPLE_DIR, '..', '..');
 const BROWSER_FRONTEND_DIR = path.join(REPO_ROOT, 'browser', 'frontend');
 const TAURI_CONFIG_PATH = path.join(REPO_ROOT, 'browser', 'src-tauri', 'tauri.conf.json');
 const DEFAULT_OUTPUT_DIR = path.join(HOST_SAMPLE_DIR, 'test-results', 'waves-baseline');
-const RUNS = Number.parseInt(process.env.WAVES_BASELINE_RUNS ?? '20', 10);
+const RUNS = Number.parseInt(
+  process.env.WAVES_BASELINE_RUNS ?? String(WAVES_BASELINE_DEFAULT_RUNS),
+  10
+);
 
-if (!Number.isInteger(RUNS) || RUNS < 5 || RUNS > 100) {
-  throw new Error('WAVES_BASELINE_RUNS must be an integer from 5 through 100');
+if (!Number.isInteger(RUNS) || RUNS < WAVES_BASELINE_MIN_RUNS || RUNS > WAVES_BASELINE_MAX_RUNS) {
+  throw new Error(
+    `WAVES_BASELINE_RUNS must be an integer from ${WAVES_BASELINE_MIN_RUNS} through ${WAVES_BASELINE_MAX_RUNS}`
+  );
 }
 
 const requestedOutputDir = process.env.WAVES_BASELINE_OUTPUT_DIR;

--- a/engine-wasm/host-sample/scripts/waves-baseline-run-policy.mjs
+++ b/engine-wasm/host-sample/scripts/waves-baseline-run-policy.mjs
@@ -1,0 +1,3 @@
+export const WAVES_BASELINE_MIN_RUNS = 5;
+export const WAVES_BASELINE_MAX_RUNS = 100;
+export const WAVES_BASELINE_DEFAULT_RUNS = 20;

--- a/scripts/tests/verify.test.mjs
+++ b/scripts/tests/verify.test.mjs
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict';
 import fs from 'node:fs';
 import test from 'node:test';
+import { WAVES_BASELINE_MIN_RUNS } from '../../engine-wasm/host-sample/scripts/waves-baseline-run-policy.mjs';
 import { buildPlan, executePlan, OUTCOMES } from '../verify-lib.mjs';
 
 function byId(plan, id) {
@@ -55,18 +56,25 @@ test('full builds the WASM package before workspace typecheck', () => {
 
 test('full keeps the platform-sensitive frontend coverage threshold in GitHub CI', () => {
   const browser = byId(buildPlan('full', []), 'browser');
-  const frontend = browser.commands.find((command) =>
-    command.label.startsWith('browser frontend')
-  );
+  const frontend = browser.commands.find((command) => command.label.startsWith('browser frontend'));
   assert.equal(frontend.label, 'browser frontend unit tests');
   assert.deepEqual(frontend.args, ['--dir', 'browser/frontend', 'test']);
 });
 
 test('extended selects live smoke and keeps baseline advisory', () => {
   const plan = buildPlan('extended', []);
-  assert.equal(byId(plan, 'live-kannel').selected, true);
-  assert.equal(byId(plan, 'browser-baseline').selected, true);
-  assert.equal(byId(plan, 'browser-baseline').advisory, true);
+  const liveKannel = byId(plan, 'live-kannel');
+  const browserBaseline = byId(plan, 'browser-baseline');
+  const baselineCommand = browserBaseline.commands[0];
+
+  assert.equal(liveKannel.selected, true);
+  assert.notEqual(liveKannel.advisory, true);
+  assert.equal(browserBaseline.selected, true);
+  assert.equal(browserBaseline.advisory, true);
+  assert.equal(baselineCommand.label, 'minimum supported browser baseline (5 runs)');
+  assert.equal(baselineCommand.executable, 'pnpm');
+  assert.deepEqual(baselineCommand.args, ['run', 'test:baseline:waves']);
+  assert.equal(baselineCommand.env.WAVES_BASELINE_RUNS, String(WAVES_BASELINE_MIN_RUNS));
 });
 
 test('missing required prerequisite is unavailable and fails the run', () => {

--- a/scripts/verify-lib.mjs
+++ b/scripts/verify-lib.mjs
@@ -2,6 +2,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { spawnSync } from 'node:child_process';
 import { createRequire } from 'node:module';
+import { WAVES_BASELINE_MIN_RUNS } from '../engine-wasm/host-sample/scripts/waves-baseline-run-policy.mjs';
 
 export const OUTCOMES = Object.freeze({
   pass: 'PASS',
@@ -243,11 +244,7 @@ export const LANES = Object.freeze([
       command('browser host tests', 'cargo', ['test', '--locked'], {
         cwd: 'browser/src-tauri'
       }),
-      command('browser frontend unit tests', 'pnpm', [
-        '--dir',
-        'browser/frontend',
-        'test'
-      ]),
+      command('browser frontend unit tests', 'pnpm', ['--dir', 'browser/frontend', 'test']),
       command('rendered accessibility', 'pnpm', [
         '--dir',
         'browser/frontend',
@@ -321,9 +318,14 @@ export const LANES = Object.freeze([
     advisory: true,
     prerequisites: [prerequisite('pnpm', 'run ./scripts/init-refresh.sh'), workspaceDependencies],
     commands: [
-      command('three-run browser baseline', 'pnpm', ['run', 'test:baseline:waves'], {
-        env: { WAVES_BASELINE_RUNS: '3' }
-      })
+      command(
+        `minimum supported browser baseline (${WAVES_BASELINE_MIN_RUNS} runs)`,
+        'pnpm',
+        ['run', 'test:baseline:waves'],
+        {
+          env: { WAVES_BASELINE_RUNS: String(WAVES_BASELINE_MIN_RUNS) }
+        }
+      )
     ]
   }
 ]);


### PR DESCRIPTION
## Summary

- centralize the browser baseline run-count policy used by the measurer and verification orchestrator
- run the local extended baseline with the accepted minimum of five samples and update its label
- assert the exact extended command/environment while preserving the advisory baseline and required live-Kannel lane
- update active local-verification documentation from three runs to five

## Root cause

`scripts/verify-lib.mjs` hardcoded `WAVES_BASELINE_RUNS=3`, while the baseline measurer accepts only 5 through 100. As a result, `pnpm verify:extended` selected an advisory command that failed before it could produce evidence. The standalone Extended Quality workflow's 20-run default remains unchanged.

## Verification

- `pnpm verify:test`
- `pnpm verify:fast`
- `pnpm run format:check:node`
- `pnpm run lint:node`
- pinned Prettier 3.9.6 check for all changed files
- dry-run plan assertion: extended selects `WAVES_BASELINE_RUNS=5`, keeps the baseline advisory, and keeps live Kannel required
- `wasm-pack build --target web --out-dir ../pkg`
- all pre-push hooks, including 337 engine tests and engine/browser/transport Clippy

The real five-run baseline accepts the new sample count and reaches browser assertions. It currently reports an existing advisory keyboard-order mismatch because `btn-back` appears before `btn-reload`; this PR intentionally does not change baseline measurement or browser behavior.
