### PR TITLE
docs(compliance): sync post-WML-302 active evidence rollups

### DIFF
--- a/docs/waves/SOURCE_MATERIAL_MASTER_AUDIT.md
+++ b/docs/waves/SOURCE_MATERIAL_MASTER_AUDIT.md
@@ -166,9 +166,9 @@ Cross-source selected-profile accounting is now executable:
 - every selected row has an owner and work-item mapping;
 - all 198 selected rows now expand into 762 deduplicated nested clauses with
   source anchors and fixture plans;
-- 190 WML, WBXML, WDP, and WCMP clauses are directly fixture-backed; direct
+- 208 WML, WBXML, WDP, and WCMP clauses are directly fixture-backed; direct
   conformance fixture implementation remains the principal evidence gap for
-  the other 572.
+  the other 554.
 
 The family-level WAP 1.2.1 base/SIN precedence graph now exists at
 `spec-processing/source-manifests/wap-1.2.1-effective-spec.json`. It establishes

--- a/docs/waves/WAP_1_2_1_COMPLIANCE_PROGRAM.md
+++ b/docs/waves/WAP_1_2_1_COMPLIANCE_PROGRAM.md
@@ -215,9 +215,10 @@ closes `SRC-004` without changing the redistribution boundary.
 
 The program status now reflects those facts directly: `CONF-1` is complete;
 `SRC-0` is blocked only by `SRC-006`; runtime sprints are `todo` or
-`in-progress` according to their child work items. The validator derives and
-checks each sprint status so planning rollups cannot drift from work-item
-state.
+`in-progress` according to their child work items. The validator checks each
+sprint status against child-work constraints while allowing completed
+foundation items in a not-yet-started sprint, so planning rollups cannot drift
+from work-item state.
 
 ## Source blockers
 

--- a/docs/waves/WAP_1_2_1_NORMATIVE_CLAUSE_LEDGER.md
+++ b/docs/waves/WAP_1_2_1_NORMATIVE_CLAUSE_LEDGER.md
@@ -91,17 +91,23 @@ Each clause records:
 
 A planned fixture is not test evidence. An implemented fixture must name its
 fixture path, test path, and command, and clause implementation status changes
-only after that direct evidence is reviewed. The current ledger records 190
-implemented clauses with reviewed direct evidence and keeps 572 clauses
+only after that direct evidence is reviewed. The current ledger records 208
+implemented clauses with reviewed direct evidence and keeps 554 clauses
 `not-assessed`. The WML-203 slice contributes 47 implemented WBXML clauses and
 21 implemented WML clauses covering alternate-DTD behavior, the mandatory
 text prologue, and selected DTD structures; WML-204 adds 23 implemented WML
-clauses, WML-205 adds three implemented error-policy clauses, WML-C-24 adds the inline line-break clause, and WML-202 adds 30
-root/head/access, template, task-shadowing, card-context, and newcontext clauses. WML-303 now has 27
-directly mapped action/event clauses; shared clauses across these completed slices are deduplicated in
-the ledger totals. The validator allowlists the 14-clause
+clauses, WML-205 adds three implemented error-policy clauses, WML-C-24 adds the
+inline line-break clause, and WML-202 adds 30 root/head/access, template,
+task-shadowing, card-context, and newcontext clauses. WML-302 and WML-303 add
+their reviewed variable/substitution and action/event evidence; shared clauses
+across these completed slices are deduplicated in the ledger totals. The
+validator allowlists the 14-clause
 `TRN-702` direct-work-item overlay so a broad parent-row mapping cannot
 silently substitute for slice adoption.
+
+The generated WML graph has 225 directly mapped clause nodes. That projection
+count describes planning relationships and is not the 208-clause assessed
+evidence count.
 
 WML-201 directly maps all 175 selected WML clauses for family ownership and
 retrieval. That mapping is not fixture evidence: clause assessment remains

--- a/docs/waves/WAP_1_2_1_PLANNING_BASELINE.md
+++ b/docs/waves/WAP_1_2_1_PLANNING_BASELINE.md
@@ -28,7 +28,7 @@ explicit capability/mode.
 | Selected obligations | 712 effective source rows reduce to 198 selected parent rows across nine mandatory families |
 | Nested clauses | The 198 parents expand into 762 clauses: 722 required, 29 recommended, and 11 permitted |
 | Crosswalk | Every selected parent has source anchors, strict disposition, requirement IDs, owner layers, work items, and an evidence state |
-| Fixtures | All 762 clause fixtures have target locations; 190 clauses now have direct conformance assessment and 572 remain unassessed |
+| Fixtures | All 762 clause fixtures have target locations; 208 clauses now have direct conformance assessment and 554 remain unassessed |
 | Successor delta | All 198 selected rows are classified; 17 have successor-derived foundations, with 2 compatible and 15 requiring strict correction |
 | External dependencies | 43 authority-locked dependencies have 48 private artifacts; 60 residual labels are explicitly non-blocking for Class C and profile-activated |
 | Execution program | 13 dependency-ordered sprints contain 82 unique work items plus the machine-checked `TRN-7-CL-C` selected-profile completion gate |
@@ -57,7 +57,7 @@ Parent-level status is an audit snapshot, not a compliance percentage:
 | WSP | 8 | 57 | 0 | 8 | 0 |
 | **Total** | **198** | **762** | **24** | **76** | **98** |
 
-Parent-row status is not a substitute for direct clause evidence. With 190 of
+Parent-row status is not a substitute for direct clause evidence. With 208 of
 762 clauses assessed, the project remains `pre-conformance` until every
 selected obligation is implemented or retains an explicit, release-blocking
 gap.
@@ -112,8 +112,8 @@ claim.
 
 The remaining build work is now measurable:
 
-1. close or correct the 77 partial and 98 missing parent rows;
-2. implement and assess the remaining 589 direct clause fixtures;
+1. close or correct the 76 partial and 98 missing parent rows;
+2. implement and assess the remaining 554 direct clause fixtures;
 3. correct the 15 successor-derived foundations that are not yet proven
    strict-target compatible;
 4. preserve native Rust/WASM behavior parity and generated contract

--- a/docs/waves/WAP_1_2_1_WML_SCR_LEDGER.md
+++ b/docs/waves/WAP_1_2_1_WML_SCR_LEDGER.md
@@ -29,7 +29,7 @@ pnpm wap-graph:check
 
 The generated WML-201 projection treats this ledger as the direct 76-row
 matrix authority. Every row retains its spec anchor and one conservative
-evidence state: 29 `direct-test-linked`, 18 `gap-work-item-mapped`, or 29
+evidence state: 30 `direct-test-linked`, 17 `gap-work-item-mapped`, or 29
 `optional-not-assessed`. All 175 selected WML clauses directly map to
 `WML-201`; the graph does not infer implementation from family ownership or
 prose.
@@ -134,11 +134,11 @@ still have separate gates.
 
 The first `CONF-003` slice now expands all 39 selected WML rows into 175
 deduplicated, section-hash-anchored clauses. Every clause has an inherited
-owner/work mapping and a direct fixture plan. Seventy-one clauses now have
-reviewed direct evidence, including the `WML-C-24` line-break clause, the two `WML-C-17` unknown-DTD clauses,
-the completed 23-clause WML-204 field/control tranche, and the completed 30-clause WML-202 root/head/access,
-template, task-shadowing, card-context, and newcontext tranche, plus the three WML-205 error-policy clauses; the remaining clauses stay `not-assessed`. The
-parent-row implementation audit remains conservative.
+owner/work mapping and a direct fixture plan. The WML family now has 103
+implemented clause fixtures with reviewed direct evidence, including the
+completed WML-202 through WML-205 slices and the WML-302/WML-303 runtime
+slices; shared clauses are deduplicated. The other 72 clauses stay
+`not-assessed`, and the parent-row implementation audit remains conservative.
 
 Outside the 39 required Class C rows, `WML-C-34` (`meta`) behavior and the
 `WML-C-72` mutually exclusive property identity rule now have parser tests.

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "scripts": {
     "codex:links": "node scripts/setup-codex-links.mjs",
     "wap-compliance:regenerate": "node spec-processing/scripts/generate-wap-effective-spec.mjs && node spec-processing/scripts/generate-wap-knowledge-graph.mjs",
-    "wap-compliance:check": "node --test spec-processing/scripts/generate-wap-effective-spec.test.mjs && node spec-processing/scripts/check-wap-effective-spec.mjs && node scripts/check-wap-selected-normative-clauses.mjs && node scripts/check-wap-transport-conformance-ledgers.mjs && node scripts/check-active-compliance-facts.mjs && node scripts/check-requirement-status-drift.mjs && node scripts/check-wap-knowledge-graph.mjs",
+    "wap-compliance:check": "node --test spec-processing/scripts/generate-wap-effective-spec.test.mjs scripts/tests/check-active-compliance-facts.test.mjs scripts/tests/check-wap-compliance-program.test.mjs && node spec-processing/scripts/check-wap-effective-spec.mjs && node scripts/check-wap-selected-normative-clauses.mjs && node scripts/check-wap-transport-conformance-ledgers.mjs && node scripts/check-wap-compliance-program.mjs && node scripts/check-active-compliance-facts.mjs && node scripts/check-requirement-status-drift.mjs && node scripts/check-wap-knowledge-graph.mjs",
     "docling:check": "node --test spec-processing/scripts/tests/docling-provenance.test.mjs && ./spec-processing/scripts/generate-docling-provenance.sh --check && ./spec-processing/scripts/check-docling-cleaned-quality.sh --strict",
     "docling:provenance:generate": "./spec-processing/scripts/generate-docling-provenance.sh --write",
     "wap-graph:generate": "node spec-processing/scripts/generate-wap-knowledge-graph.mjs",

--- a/scripts/check-active-compliance-facts.mjs
+++ b/scripts/check-active-compliance-facts.mjs
@@ -30,11 +30,15 @@ function normalizedDocument(relativePath) {
 const failures = [];
 const clauses = readJson(`${manifestDirectory}/wap-1.2.1-selected-normative-clauses.json`);
 const effectiveSpec = readJson(`${manifestDirectory}/wap-1.2.1-effective-spec.json`);
+const releaseManifest = readJson(`${manifestDirectory}/wap-1.2.1-release.json`);
 const wmlGraph = readJson(`${manifestDirectory}/wap-1.2.1-wml-2-knowledge-graph.json`);
+const complianceProgram = readJson('docs/waves/wap-1.2.1-compliance-program.json');
 
 let sourceRowCount = 0;
 let selectedParentCount = 0;
 let selectedClauseCount = 0;
+const clauseStatusCounts = { implemented: 0, 'not-assessed': 0 };
+const parentStatusCounts = { implemented: 0, partial: 0, missing: 0 };
 for (const family of clauses.families ?? []) {
   const ledger = readJson(family.parentLedger);
   const selectedObligations = (ledger.obligations ?? []).filter(
@@ -46,6 +50,22 @@ for (const family of clauses.families ?? []) {
   sourceRowCount += ledger.obligations?.length ?? 0;
   selectedParentCount += parentIds.length;
   selectedClauseCount += family.clauses?.length ?? 0;
+  for (const clause of family.clauses ?? []) {
+    const status = clause.mapping?.clauseImplementationStatus;
+    if (!(status in clauseStatusCounts)) {
+      failures.push(`${clause.id}: unknown clause implementation status ${status}`);
+    } else {
+      clauseStatusCounts[status] += 1;
+    }
+  }
+  for (const parent of family.parents ?? []) {
+    const status = parent.implementationStatus;
+    if (!(status in parentStatusCounts)) {
+      failures.push(`${parent.id}: unknown parent implementation status ${status}`);
+    } else {
+      parentStatusCounts[status] += 1;
+    }
+  }
 
   if (!sameValues(parentIds, selectedIds)) {
     failures.push(`${family.family}: selected parent IDs drift from the canonical SCR disposition`);
@@ -64,8 +84,18 @@ if (clauses.summary?.selectedParentCount !== selectedParentCount) {
 if (clauses.summary?.clauseCount !== selectedClauseCount) {
   failures.push('selected-clause aggregate clause total drift');
 }
+if (clauses.summary?.assessedClauseCount !== clauseStatusCounts.implemented) {
+  failures.push('selected-clause assessed total drift');
+}
 
 const wmlFamily = clauses.families?.find((family) => family.family === 'wml');
+const wmlImplementedClauseCount = (wmlFamily?.clauses ?? []).filter(
+  (clause) => clause.mapping?.clauseImplementationStatus === 'implemented'
+).length;
+const wmlUnassessedClauseCount = (wmlFamily?.clauses ?? []).filter(
+  (clause) => clause.mapping?.clauseImplementationStatus === 'not-assessed'
+).length;
+const graphMappedClauseCount = wmlGraph.nodes.filter((node) => node.type === 'clause').length;
 const wml201Clauses = wmlGraph.nodes.filter(
   (node) => node.type === 'clause' && node.properties.workItems?.includes('WML-201')
 );
@@ -95,6 +125,71 @@ if (wml201WmlCount !== wmlFamily?.clauseCount) {
 }
 if (wml201DirectCount !== wml201WmlCount + wml201WaeCount) {
   failures.push('WML-201 direct total must be the WML plus WAE clause totals');
+}
+if (wmlGraph.summary?.nodesByType?.clause !== graphMappedClauseCount) {
+  failures.push('WML graph mapped-clause node summary drift');
+}
+
+const atlasSprintCount = complianceProgram.sprints?.length ?? 0;
+const atlasWorkItems = (complianceProgram.sprints ?? []).flatMap(
+  (sprint) => sprint.workItems ?? []
+);
+const atlasWorkItemCount = new Set(atlasWorkItems.map((workItem) => workItem.id)).size;
+const atlasSourceCount = releaseManifest.members?.length ?? 0;
+const atlasFamilyCount = effectiveSpec.families?.length ?? 0;
+if (atlasWorkItemCount !== atlasWorkItems.length) {
+  failures.push('Atlas compliance program contains duplicate work-item IDs');
+}
+if (releaseManifest.summary?.memberCount !== atlasSourceCount) {
+  failures.push('Atlas release source summary drift');
+}
+if (effectiveSpec.summary?.familyCount !== atlasFamilyCount) {
+  failures.push('Atlas effective-family summary drift');
+}
+
+const assessedClauseCount = clauseStatusCounts.implemented;
+const unassessedClauseCount = clauseStatusCounts['not-assessed'];
+const activeRollupFragments = new Map([
+  [
+    'docs/waves/WAP_1_2_1_PLANNING_BASELINE.md',
+    [
+      `${assessedClauseCount} clauses now have direct conformance assessment and ${unassessedClauseCount} remain unassessed`,
+      `With ${assessedClauseCount} of ${selectedClauseCount} clauses assessed`,
+      `${parentStatusCounts.partial} partial and ${parentStatusCounts.missing} missing parent rows`,
+      `remaining ${unassessedClauseCount} direct clause fixtures`
+    ]
+  ],
+  [
+    'docs/waves/SOURCE_MATERIAL_MASTER_AUDIT.md',
+    [
+      `${assessedClauseCount} WML, WBXML, WDP, and WCMP clauses are directly fixture-backed`,
+      `the other ${unassessedClauseCount}`
+    ]
+  ],
+  [
+    'docs/waves/WAP_1_2_1_NORMATIVE_CLAUSE_LEDGER.md',
+    [
+      `current ledger records ${assessedClauseCount} implemented clauses`,
+      `keeps ${unassessedClauseCount} clauses \`not-assessed\``,
+      `generated WML graph has ${graphMappedClauseCount} directly mapped clause nodes`,
+      `not the ${assessedClauseCount}-clause assessed evidence count`
+    ]
+  ],
+  [
+    'docs/waves/WAP_1_2_1_WML_SCR_LEDGER.md',
+    [
+      `WML family now has ${wmlImplementedClauseCount} implemented clause fixtures`,
+      `other ${wmlUnassessedClauseCount} clauses stay \`not-assessed\``
+    ]
+  ]
+]);
+for (const [relativePath, fragments] of activeRollupFragments) {
+  const document = normalizedDocument(relativePath);
+  for (const fragment of fragments) {
+    if (!document.includes(fragment)) {
+      failures.push(`${relativePath}: missing or stale derived rollup "${fragment}"`);
+    }
+  }
 }
 
 const derivedFact =
@@ -160,5 +255,14 @@ console.log(
 );
 console.log(
   `PASS WML-201 direct clauses = ${wml201DirectCount} (${wml201WmlCount} WML + ${wml201WaeCount} WAE)`
+);
+console.log(
+  `PASS evidence = ${assessedClauseCount}/${selectedClauseCount} assessed, ${unassessedClauseCount} unassessed; WML = ${wmlImplementedClauseCount}/${wmlFamily.clauseCount} implemented`
+);
+console.log(
+  `PASS parent snapshot = ${parentStatusCounts.implemented} implemented / ${parentStatusCounts.partial} partial / ${parentStatusCounts.missing} missing; graph mappings = ${graphMappedClauseCount}`
+);
+console.log(
+  `PASS Atlas = ${atlasSprintCount} sprints / ${atlasWorkItemCount} work items / ${atlasSourceCount} sources / ${atlasFamilyCount} families / ${selectedClauseCount} clauses`
 );
 console.log('PASS active docs preserve RFC 792 ICMP applicability without copied volatile totals');

--- a/scripts/check-requirement-status-drift.mjs
+++ b/scripts/check-requirement-status-drift.mjs
@@ -347,7 +347,7 @@ const requiredDocumentFragments = new Map([
     'docs/waves/SOURCE_MATERIAL_MASTER_AUDIT.md',
     [
       'all 198 selected rows now expand into 762',
-      '190 WML, WBXML, WDP, and WCMP clauses are directly fixture-backed'
+      '208 WML, WBXML, WDP, and WCMP clauses are directly fixture-backed'
     ]
   ],
   [

--- a/scripts/check-wap-compliance-program.mjs
+++ b/scripts/check-wap-compliance-program.mjs
@@ -139,17 +139,24 @@ for (const sprint of program.sprints ?? []) {
   }
 
   const workStatuses = sprint.workItems.map((item) => item.status);
-  const expectedSprintStatus = workStatuses.every((status) => status === 'done')
-    ? 'done'
-    : workStatuses.some((status) => status === 'in-progress')
-      ? 'in-progress'
-      : workStatuses.some((status) => status === 'blocked') &&
-          workStatuses.every((status) => ['done', 'blocked'].includes(status))
-        ? 'blocked'
-        : 'todo';
-  if (sprint.status !== expectedSprintStatus) {
+  let allowedSprintStatuses;
+  if (workStatuses.every((status) => status === 'done')) {
+    allowedSprintStatuses = ['done'];
+  } else if (workStatuses.some((status) => status === 'in-progress')) {
+    allowedSprintStatuses = ['in-progress'];
+  } else if (
+    workStatuses.some((status) => status === 'blocked') &&
+    workStatuses.every((status) => ['done', 'blocked'].includes(status))
+  ) {
+    allowedSprintStatuses = ['blocked'];
+  } else if (workStatuses.some((status) => status === 'done')) {
+    allowedSprintStatuses = ['todo', 'in-progress'];
+  } else {
+    allowedSprintStatuses = ['todo'];
+  }
+  if (!allowedSprintStatuses.includes(sprint.status)) {
     failures.push(
-      `${sprint.id}: status=${sprint.status}; expected ${expectedSprintStatus} from work items`
+      `${sprint.id}: status=${sprint.status}; expected ${allowedSprintStatuses.join(' or ')} from work items`
     );
   }
 
@@ -647,6 +654,16 @@ if (
   )
 ) {
   failures.push('WML-203 must retain exact WBXML:MCF closure evidence');
+}
+const wmlRuntimeSprint = program.sprints.find((sprint) => sprint.id === 'WML-3');
+const wml302 = wmlRuntimeSprint?.workItems.find((workItem) => workItem.id === 'WML-302');
+const wml303 = wmlRuntimeSprint?.workItems.find((workItem) => workItem.id === 'WML-303');
+if (
+  wmlRuntimeSprint?.status !== 'in-progress' ||
+  wml302?.status !== 'done' ||
+  wml303?.status !== 'done'
+) {
+  failures.push('WML-3 must remain in progress after the evidence-backed WML-302/WML-303 closures');
 }
 
 if (failures.length > 0) {

--- a/scripts/tests/check-active-compliance-facts.test.mjs
+++ b/scripts/tests/check-active-compliance-facts.test.mjs
@@ -1,0 +1,77 @@
+import assert from 'node:assert/strict';
+import { cpSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { spawnSync } from 'node:child_process';
+import test from 'node:test';
+
+const repositoryRoot = resolve(dirname(fileURLToPath(import.meta.url)), '../..');
+const clauseManifestPath =
+  'spec-processing/source-manifests/wap-1.2.1-selected-normative-clauses.json';
+
+function copyFixtureFile(fixtureRoot, relativePath) {
+  const destination = join(fixtureRoot, relativePath);
+  mkdirSync(dirname(destination), { recursive: true });
+  cpSync(join(repositoryRoot, relativePath), destination);
+}
+
+function createFixture() {
+  const fixtureRoot = mkdtempSync(join(tmpdir(), 'wap-active-compliance-facts-'));
+  const clauses = JSON.parse(readFileSync(join(repositoryRoot, clauseManifestPath), 'utf8'));
+  const fixturePaths = new Set([
+    'scripts/check-active-compliance-facts.mjs',
+    clauseManifestPath,
+    'spec-processing/source-manifests/wap-1.2.1-effective-spec.json',
+    'spec-processing/source-manifests/wap-1.2.1-release.json',
+    'spec-processing/source-manifests/wap-1.2.1-wml-2-knowledge-graph.json',
+    'spec-processing/source-manifests/README.md',
+    'docs/waves/wap-1.2.1-compliance-program.json',
+    'docs/knowledge-graph/README.md',
+    'docs/wml-engine/work-items.md',
+    'docs/waves/SPEC_TEST_COVERAGE.md',
+    'docs/waves/WAP_1_2_1_PLANNING_BASELINE.md',
+    'docs/waves/SOURCE_MATERIAL_MASTER_AUDIT.md',
+    'docs/waves/WAP_1_2_1_NORMATIVE_CLAUSE_LEDGER.md',
+    'docs/waves/WAP_1_2_1_WML_SCR_LEDGER.md',
+    ...(clauses.families ?? []).map((family) => family.parentLedger)
+  ]);
+
+  for (const relativePath of fixturePaths) {
+    copyFixtureFile(fixtureRoot, relativePath);
+  }
+
+  return { clauses, fixtureRoot };
+}
+
+function runCheck(fixtureRoot) {
+  return spawnSync(process.execPath, ['scripts/check-active-compliance-facts.mjs'], {
+    cwd: fixtureRoot,
+    encoding: 'utf8'
+  });
+}
+
+test('active rollup guard derives prose assertions from canonical manifests', (context) => {
+  const { clauses, fixtureRoot } = createFixture();
+  context.after(() => rmSync(fixtureRoot, { recursive: true, force: true }));
+
+  const baseline = runCheck(fixtureRoot);
+  assert.equal(baseline.status, 0, baseline.stderr);
+
+  const planningPath = join(fixtureRoot, 'docs/waves/WAP_1_2_1_PLANNING_BASELINE.md');
+  const assessed = clauses.summary.assessedClauseCount;
+  const unassessed = clauses.summary.clauseCount - assessed;
+  const currentFragment =
+    `${assessed} clauses now have direct conformance assessment and ` +
+    `${unassessed} remain unassessed`;
+  const staleFragment =
+    `${assessed - 1} clauses now have direct conformance assessment and ` +
+    `${unassessed + 1} remain unassessed`;
+  const planning = readFileSync(planningPath, 'utf8');
+  assert.ok(planning.includes(currentFragment));
+  writeFileSync(planningPath, planning.replace(currentFragment, staleFragment));
+
+  const stale = runCheck(fixtureRoot);
+  assert.notEqual(stale.status, 0);
+  assert.match(stale.stderr, /WAP_1_2_1_PLANNING_BASELINE\.md: missing or stale derived rollup/);
+});

--- a/scripts/tests/check-wap-compliance-program.test.mjs
+++ b/scripts/tests/check-wap-compliance-program.test.mjs
@@ -1,0 +1,48 @@
+import assert from 'node:assert/strict';
+import { cpSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { spawnSync } from 'node:child_process';
+import test from 'node:test';
+
+const repositoryRoot = resolve(dirname(fileURLToPath(import.meta.url)), '../..');
+const programPath = 'docs/waves/wap-1.2.1-compliance-program.json';
+
+function copyFixtureFile(fixtureRoot, relativePath) {
+  const destination = join(fixtureRoot, relativePath);
+  mkdirSync(dirname(destination), { recursive: true });
+  cpSync(join(repositoryRoot, relativePath), destination);
+}
+
+function runCheck(fixtureRoot) {
+  return spawnSync(process.execPath, ['scripts/check-wap-compliance-program.mjs'], {
+    cwd: fixtureRoot,
+    encoding: 'utf8'
+  });
+}
+
+test('program validator accepts and protects the evidence-backed WML-3 status', (context) => {
+  const fixtureRoot = mkdtempSync(join(tmpdir(), 'wap-compliance-program-'));
+  context.after(() => rmSync(fixtureRoot, { recursive: true, force: true }));
+  for (const relativePath of [
+    'scripts/check-wap-compliance-program.mjs',
+    programPath,
+    'spec-processing/source-manifests/wap-1.2.1-effective-spec.json',
+    'spec-processing/source-manifests/wap-1.2.1-class-conformance.json'
+  ]) {
+    copyFixtureFile(fixtureRoot, relativePath);
+  }
+
+  const baseline = runCheck(fixtureRoot);
+  assert.equal(baseline.status, 0, baseline.stderr);
+
+  const fixtureProgramPath = join(fixtureRoot, programPath);
+  const program = JSON.parse(readFileSync(fixtureProgramPath, 'utf8'));
+  program.sprints.find((sprint) => sprint.id === 'WML-3').status = 'todo';
+  writeFileSync(fixtureProgramPath, `${JSON.stringify(program, null, 2)}\n`);
+
+  const stale = runCheck(fixtureRoot);
+  assert.notEqual(stale.status, 0);
+  assert.match(stale.stderr, /WML-3 must remain in progress/);
+});

--- a/scripts/tests/verify.test.mjs
+++ b/scripts/tests/verify.test.mjs
@@ -138,8 +138,9 @@ test('unselected lane is reported as an intentional exclusion', () => {
   assert.match(lines[0], /INTENTIONAL EXCLUSION/);
 });
 
-test('root compliance wrapper and CI both enforce requirement status drift', () => {
+test('root compliance wrapper and CI enforce program and requirement status drift', () => {
   const packageJson = JSON.parse(fs.readFileSync('package.json', 'utf8'));
+  assert.match(packageJson.scripts['wap-compliance:check'], /check-wap-compliance-program\.mjs/);
   assert.match(packageJson.scripts['wap-compliance:check'], /check-requirement-status-drift\.mjs/);
 
   const workflow = fs.readFileSync('.github/workflows/ci.yml', 'utf8');


### PR DESCRIPTION
## Summary

- synchronize active WAP 1.2.1 rollups with the post-WML-302 canonical manifest totals
- distinguish the 225 graph mapping nodes from the 208 assessed clause fixtures
- derive and guard global evidence, WML-family, parent-status, graph, and Atlas totals
- correct the WML-3 sprint-status validator and include the compliance-program validator in the canonical wrapper/CI path

## Why

The selected normative manifest had advanced to 208 assessed clauses after WML-302, while four active human rollups still reported the earlier 190/572/589/71 counts. Separately, the compliance-program validator used an overly strict child-status derivation that rejected the evidence-backed in-progress WML-3 sprint, and the canonical compliance wrapper did not invoke that validator.

## Impact

Active documentation now reports 208/762 assessed clauses, 554 unassessed clauses, 103/175 implemented WML clause fixtures, and the unchanged 24 implemented / 76 partial / 98 missing parent snapshot. No implementation, canonical evidence, graph generator, or context target changed.

## Verification

- `pnpm run wap-compliance:check`
- `node scripts/check-requirement-status-drift.mjs`
- `node scripts/check-ticket-file-references.mjs`
- `node scripts/check-worklist-drift.mjs`
- `pnpm run verify:test`
- `pnpm --dir docs-portal run test:data`
- `pnpm --dir docs-portal run check`
- `pnpm --dir docs-portal run build`
- pre-push repository suite, including 337 engine tests and engine/browser/transport clippy checks
- `git diff --check`
