### PR TITLE
fix(transport): dedupe wcmp/icmpv4 length-guard helper

### DIFF
--- a/transport-rust/src/network/wcmp/codec.rs
+++ b/transport-rust/src/network/wcmp/codec.rs
@@ -196,13 +196,10 @@ pub fn encode_wcmp(
 }
 
 fn require_len(input: &[u8], needed: usize) -> Result<(), WcmpDecodeError> {
-    if input.len() < needed {
-        return Err(WcmpDecodeError::Truncated {
-            needed,
-            actual: input.len(),
-        });
-    }
-    Ok(())
+    super::require_min_len(input, needed, |needed, actual| WcmpDecodeError::Truncated {
+        needed,
+        actual,
+    })
 }
 
 fn read_u16(input: &[u8], offset: usize) -> Result<u16, WcmpDecodeError> {

--- a/transport-rust/src/network/wcmp/icmpv4.rs
+++ b/transport-rust/src/network/wcmp/icmpv4.rs
@@ -223,13 +223,9 @@ struct QuotedDatagramMetadata {
 }
 
 fn require_len(input: &[u8], needed: usize) -> Result<(), Icmpv4DecodeError> {
-    if input.len() < needed {
-        return Err(Icmpv4DecodeError::Truncated {
-            needed,
-            actual: input.len(),
-        });
-    }
-    Ok(())
+    super::require_min_len(input, needed, |needed, actual| {
+        Icmpv4DecodeError::Truncated { needed, actual }
+    })
 }
 
 fn quoted_datagram_metadata(

--- a/transport-rust/src/network/wcmp/mod.rs
+++ b/transport-rust/src/network/wcmp/mod.rs
@@ -29,5 +29,19 @@ pub use profile::{
     WdpControlHandlingOutcome, WdpControlHandlingPolicy, WdpControlMessage, WdpControlProfile,
 };
 
+// Shared by `codec` and `icmpv4`, whose decoders each require a minimum
+// input length before reading fixed-width fields, only differing in which
+// `Truncated`-shaped error variant they report.
+pub(super) fn require_min_len<E>(
+    input: &[u8],
+    needed: usize,
+    truncated: impl FnOnce(usize, usize) -> E,
+) -> Result<(), E> {
+    if input.len() < needed {
+        return Err(truncated(needed, input.len()));
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests;


### PR DESCRIPTION
## Summary

- Found during a repo-wide clean-up/quality audit pass (fmt/clippy/coverage/
  cargo-audit/stale-doc-refs all clean; this was the one real finding).
- `icmpv4.rs` and `codec.rs` (siblings in `transport-rust/src/network/wcmp/`)
  each hand-rolled an identical `require_len` bounds check, differing only in
  which `Truncated`-shaped error variant they returned
  (`Icmpv4DecodeError` vs `WcmpDecodeError`).
- Per this repo's duplication policy (tier 1: same-file/module family),
  extracted the shared check into `network::wcmp::require_min_len`,
  parameterized by an error-constructor closure. Each file's `require_len` is
  now a one-line wrapper, so every existing call site is unchanged.
- Pure refactor, no behavior change.

## Test plan

- [x] `cargo build` — clean
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo test -- --test-threads=1` (`transport-rust`) — 250 lib tests +
      integration suites pass
- [x] Full repo `pre-push` hook suite passed (fmt/clippy across engine-wasm,
      transport-rust, browser tauri)

🤖 Generated with [Claude Code](https://claude.com/claude-code)