### PR TITLE
fix(engine): prevent CardTaskAction::WithSetVars from nesting

### DIFF
--- a/engine-wasm/engine/src/runtime/card.rs
+++ b/engine-wasm/engine/src/runtime/card.rs
@@ -35,14 +35,33 @@ pub enum CardTaskAction {
 }
 
 impl CardTaskAction {
+    // Merges into an existing `WithSetVars` instead of nesting one inside
+    // another, so `WithSetVars.action` is never itself a `WithSetVars`. This
+    // is a structural guarantee, not just a call-site convention: every
+    // `base_and_set_vars()` caller matches out a single non-`WithSetVars`
+    // base action and treats the wrapped case as unreachable, so a nested
+    // wrapper would panic on ordinary WML deck content instead of merely
+    // being unreachable today by coincidence of there being exactly one
+    // `with_set_vars()` call per parsed task element.
     pub fn with_set_vars(self, set_vars: Vec<CardSetVar>) -> Self {
         if set_vars.is_empty() {
-            self
-        } else {
+            return self;
+        }
+        match self {
             Self::WithSetVars {
-                action: Box::new(self),
-                set_vars,
+                action,
+                set_vars: mut existing,
+            } => {
+                existing.extend(set_vars);
+                Self::WithSetVars {
+                    action,
+                    set_vars: existing,
+                }
             }
+            action => Self::WithSetVars {
+                action: Box::new(action),
+                set_vars,
+            },
         }
     }
 
@@ -51,6 +70,57 @@ impl CardTaskAction {
             Self::WithSetVars { action, set_vars } => (action, set_vars),
             action => (action, &[]),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn with_set_vars_merges_instead_of_nesting_when_called_twice() {
+        let action = CardTaskAction::Go {
+            href: "#next".to_string(),
+            method: None,
+            post_fields: Vec::new(),
+        }
+        .with_set_vars(vec![CardSetVar {
+            name: "a".to_string(),
+            value: "1".to_string(),
+        }])
+        .with_set_vars(vec![CardSetVar {
+            name: "b".to_string(),
+            value: "2".to_string(),
+        }]);
+
+        let (base, set_vars) = action.base_and_set_vars();
+        assert_eq!(
+            base,
+            &CardTaskAction::Go {
+                href: "#next".to_string(),
+                method: None,
+                post_fields: Vec::new(),
+            }
+        );
+        assert_eq!(
+            set_vars,
+            &[
+                CardSetVar {
+                    name: "a".to_string(),
+                    value: "1".to_string(),
+                },
+                CardSetVar {
+                    name: "b".to_string(),
+                    value: "2".to_string(),
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn with_set_vars_is_a_noop_for_an_empty_list() {
+        let action = CardTaskAction::Prev.with_set_vars(Vec::new());
+        assert_eq!(action, CardTaskAction::Prev);
     }
 }
 


### PR DESCRIPTION
## Summary

Found while reviewing the recently-merged WML-302 (#412) diff during a
repo-wide clean-up/quality audit pass.

- `CardTaskAction::with_set_vars()` could wrap an already-`WithSetVars`
  action inside another `WithSetVars`, since nothing prevented calling it
  twice on the same value.
- `base_and_set_vars()` only strips one layer, and both of its callers
  (`engine_runtime_internal.rs`'s onpick handler, `navigation.rs`'s go/prev/
  refresh dispatch) `unreachable!()` on a residual `WithSetVars` after
  unwrapping — so a nested wrapper would **panic during ordinary
  onpick/go/prev/refresh handling**, not just on malformed input.
- Today this holds only because the 3 parser call sites in `actions.rs`
  each call `with_set_vars()` exactly once, directly on a freshly built base
  action — a **call-site convention**, not a type-level guarantee. Any
  future call site that (accidentally) wraps twice reintroduces a live
  panic-on-deck-content bug.

Fix: make `with_set_vars()` merge into an existing wrapper instead of
nesting, so `WithSetVars.action` can never itself be `WithSetVars` —
matching the "must not panic on user-provided deck content" rule in
`docs/agents/RUST_ENGINE_STEERING.md`. No call-site changes anywhere else;
both `unreachable!()` arms are now unreachable **by construction** instead
of by convention.

No behavior change on any currently-reachable path (verified by the full
existing suite), plus two new tests pinning `with_set_vars()`'s
merge-not-nest and empty-noop behavior directly on `CardTaskAction`.

## Test plan

- [x] `cargo build` / `cargo fmt --check` / `cargo clippy --all-targets --all-features -- -D warnings` (`engine-wasm/engine`) — clean
- [x] `cargo test` (`engine-wasm/engine`) — 339 tests pass (was 325 pre-WML-302, +14 from WML-302, +2 new here)
- [x] Full repo `pre-push` hook suite passed (fmt/clippy across engine-wasm, transport-rust, browser tauri)

🤖 Generated with [Claude Code](https://claude.com/claude-code)