### PR TITLE
fix(frontend): enable typescript-eslint recommended, remove test any casts

### DIFF
--- a/browser/frontend/src/app/browser-controller.behavior.test.ts
+++ b/browser/frontend/src/app/browser-controller.behavior.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { FetchResponse, HostSessionState } from '../../../contracts/transport';
 import type { BrowserShellRefs } from './browser-shell-template';
 import { BrowserController } from './browser-controller';
+import { controllerPrivates } from './browser-controller.test-helpers';
 import { BrowserPresenter } from './browser-presenter';
 import { defaultLocalDeckExample } from './local-examples';
 import { frame, renderStub, snapshot } from './navigation-state.test-helpers';
@@ -249,7 +250,7 @@ describe('BrowserController behavior coverage', () => {
     const controller = new BrowserController(hostClient as never, presenter, refs);
 
     await controller.init('<wml><card id="seed"/></wml>');
-    await (controller as any).setRunMode('network', { loadLocalOnEnter: false });
+    await controllerPrivates(controller).setRunMode('network', { loadLocalOnEnter: false });
     vi.mocked(hostClient.fetchDeck).mockClear();
 
     refs.fetchUrlInput.value = 'http://example.test/network.wml';
@@ -442,7 +443,7 @@ describe('BrowserController behavior coverage', () => {
     vi.mocked(hostClient.fetchDeck).mockResolvedValue(gatewayTimeoutResponse() as never);
     const controller = new BrowserController(hostClient as never, presenter, refs);
     await controller.init('<wml><card id="seed"/></wml>');
-    await (controller as any).setRunMode('network', { loadLocalOnEnter: false });
+    await controllerPrivates(controller).setRunMode('network', { loadLocalOnEnter: false });
 
     refs.fetchUrlInput.value = 'http://example.test/network.wml';
     document.querySelector<HTMLButtonElement>('#btn-fetch-url')?.click();
@@ -475,7 +476,7 @@ describe('BrowserController behavior coverage', () => {
     } as never);
     const controller = new BrowserController(hostClient as never, presenter, refs);
     await controller.init('<wml><card id="seed"/></wml>');
-    await (controller as any).setRunMode('network', { loadLocalOnEnter: false });
+    await controllerPrivates(controller).setRunMode('network', { loadLocalOnEnter: false });
 
     refs.fetchUrlInput.value = 'http://example.test/network.wml';
     document.querySelector<HTMLButtonElement>('#btn-fetch-url')?.click();
@@ -503,8 +504,8 @@ describe('BrowserController behavior coverage', () => {
       // mocked engineAdvanceTimeMs response would otherwise trigger an
       // unrelated re-render mid-delay, incidentally canceling the pending
       // indicator this test is trying to observe.
-      (controller as any).timerRuntime.stop();
-      await (controller as any).setRunMode('network', { loadLocalOnEnter: false });
+      controllerPrivates(controller).timerRuntime.stop();
+      await controllerPrivates(controller).setRunMode('network', { loadLocalOnEnter: false });
       // setRunMode kicks off the startup network probe, which also calls
       // hostClient.fetchDeck -- let that settle against the default (fast,
       // successful) mock before installing the pending mock below, so it
@@ -567,7 +568,7 @@ describe('BrowserController behavior coverage', () => {
     const controller = new BrowserController(hostClient as never, presenter, refs);
 
     await controller.init('<wml><card id="seed"/></wml>');
-    await (controller as any).setRunMode('network', { loadLocalOnEnter: false });
+    await controllerPrivates(controller).setRunMode('network', { loadLocalOnEnter: false });
     const backBtn = document.querySelector<HTMLButtonElement>('#btn-back');
     // No page has been fetched yet in this mode -- nothing to go back to.
     expect(backBtn?.disabled).toBe(false);

--- a/browser/frontend/src/app/browser-controller.probe.test.ts
+++ b/browser/frontend/src/app/browser-controller.probe.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 import type { HostSessionState } from '../../../contracts/transport';
 import type { BrowserShellRefs } from './browser-shell-template';
 import { BrowserController } from './browser-controller';
+import { controllerPrivates } from './browser-controller.test-helpers';
 import { BrowserPresenter } from './browser-presenter';
 import { frame, renderStub, snapshot } from './navigation-state.test-helpers';
 
@@ -125,7 +126,9 @@ describe('BrowserController startup probe behavior', () => {
 
     const controller = new BrowserController(hostClient as never, presenter, refs);
     let settled = false;
-    const modePromise = (controller as any).setRunMode('network', { loadLocalOnEnter: false });
+    const modePromise = controllerPrivates(controller).setRunMode('network', {
+      loadLocalOnEnter: false
+    });
     void modePromise.then(() => {
       settled = true;
     });
@@ -206,8 +209,8 @@ describe('BrowserController startup probe behavior', () => {
     };
 
     const controller = new BrowserController(hostClient as never, presenter, refs);
-    await (controller as any).setRunMode('network', { loadLocalOnEnter: false });
-    await (controller as any).setRunMode('local', { loadLocalOnEnter: false });
+    await controllerPrivates(controller).setRunMode('network', { loadLocalOnEnter: false });
+    await controllerPrivates(controller).setRunMode('local', { loadLocalOnEnter: false });
 
     resolveProbe?.({
       ok: false,

--- a/browser/frontend/src/app/browser-controller.select-edit.test.ts
+++ b/browser/frontend/src/app/browser-controller.select-edit.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 import type { HostSessionState } from '../../../contracts/transport';
 import type { BrowserShellRefs } from './browser-shell-template';
 import { BrowserController } from './browser-controller';
+import { controllerPrivates } from './browser-controller.test-helpers';
 import { BrowserPresenter } from './browser-presenter';
 import { frame, renderStub, snapshot } from './navigation-state.test-helpers';
 
@@ -147,10 +148,10 @@ describe('BrowserController select edit keyboard routing', () => {
     };
 
     const controller = new BrowserController(hostClient as never, presenter, refs);
-    (controller as any).keyboardIntentRouter.handleWindowKeydown(
+    controllerPrivates(controller).keyboardIntentRouter.handleWindowKeydown(
       new KeyboardEvent('keydown', { key: 'Enter' })
     );
-    await (controller as any).keyboardIntentRouter.actionQueue;
+    await controllerPrivates(controller).keyboardIntentRouter.actionQueue;
 
     expect(engineBeginFocusedSelectEditFrame).toHaveBeenCalledTimes(1);
     expect(engineCommitFocusedSelectEdit).not.toHaveBeenCalled();
@@ -231,10 +232,10 @@ describe('BrowserController select edit keyboard routing', () => {
     };
 
     const controller = new BrowserController(hostClient as never, presenter, refs);
-    (controller as any).keyboardIntentRouter.handleWindowKeydown(
+    controllerPrivates(controller).keyboardIntentRouter.handleWindowKeydown(
       new KeyboardEvent('keydown', { key: 'Enter' })
     );
-    await (controller as any).keyboardIntentRouter.actionQueue;
+    await controllerPrivates(controller).keyboardIntentRouter.actionQueue;
 
     expect(engineCommitFocusedSelectEditFrame).toHaveBeenCalledTimes(1);
     expect(engineHandleKey).not.toHaveBeenCalled();

--- a/browser/frontend/src/app/browser-controller.test-helpers.ts
+++ b/browser/frontend/src/app/browser-controller.test-helpers.ts
@@ -1,0 +1,21 @@
+import type { BrowserController, RunMode } from './browser-controller';
+import type { EngineTimerRuntime } from './engine-timer-runtime';
+import type { KeyboardIntentRouter } from './keyboard-intent-router';
+
+/**
+ * Typed access to `BrowserController`'s private test-only surface, so test
+ * files reach into implementation details through one narrow, reviewable
+ * cast instead of scattering `as any` at each call site.
+ */
+interface BrowserControllerPrivates {
+  setRunMode(mode: RunMode, options: { loadLocalOnEnter: boolean }): Promise<void>;
+  tickEngineTimerRuntime(): Promise<void>;
+  readonly timerRuntime: EngineTimerRuntime;
+  readonly keyboardIntentRouter: Omit<KeyboardIntentRouter, 'actionQueue'> & {
+    actionQueue: Promise<void>;
+  };
+}
+
+export function controllerPrivates(controller: BrowserController): BrowserControllerPrivates {
+  return controller as unknown as BrowserControllerPrivates;
+}

--- a/browser/frontend/src/app/browser-controller.timer.test.ts
+++ b/browser/frontend/src/app/browser-controller.timer.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 import type { HostSessionState } from '../../../contracts/transport';
 import type { BrowserShellRefs } from './browser-shell-template';
 import { BrowserController } from './browser-controller';
+import { controllerPrivates } from './browser-controller.test-helpers';
 import { BrowserPresenter } from './browser-presenter';
 import { frame, renderStub, snapshot } from './navigation-state.test-helpers';
 
@@ -151,7 +152,7 @@ describe('BrowserController local timer behavior', () => {
     const controller = new BrowserController(hostClient as never, presenter, refs);
     presenter.setSessionState(initialSession);
     presenter.setSnapshot(snapshot({ activeCardId: 'home', focusedLinkIndex: 0 }));
-    await (controller as any).tickEngineTimerRuntime();
+    await controllerPrivates(controller).tickEngineTimerRuntime();
 
     expect(engineRender).not.toHaveBeenCalled();
   });

--- a/browser/frontend/src/app/browser-controller.ts
+++ b/browser/frontend/src/app/browser-controller.ts
@@ -24,7 +24,7 @@ import {
 import { WAVES_CONFIG } from './waves-config';
 import { WAVES_COPY } from './waves-copy';
 
-type RunMode = 'local' | 'network';
+export type RunMode = 'local' | 'network';
 
 const WAP_ACCEPT_HEADER = 'text/vnd.wap.wml, application/vnd.wap.wmlc, application/vnd.wap.wml+xml';
 

--- a/eslint.shared.mjs
+++ b/eslint.shared.mjs
@@ -16,6 +16,7 @@ export const createTsLintConfig = ({
         : globals.browser;
 
   return [
+    ...tsPlugin.configs['flat/recommended'],
     {
       files,
       ignores,


### PR DESCRIPTION
## Summary

Found during a repo-wide clean-up/quality audit pass. `eslint.shared.mjs`
(consumed by `browser/frontend` and `engine-wasm/host-sample`) registered
the TypeScript parser/plugin but extended **no ruleset** — the only rule
doing real work was `no-unused-vars` (as a warning). `tsc --noEmit` and
`prettier` were catching real issues; ESLint itself was mostly inert.

- Probed both consumers against `typescript-eslint`'s `flat/recommended`:
  `host-sample` was already clean (0 violations). `browser/frontend` had
  exactly 14 violations, all `@typescript-eslint/no-explicit-any`, all in
  the 4 `browser-controller.*.test.ts` files reaching into
  `BrowserController`'s private members via `(controller as any).x`.
- Replaced those blunt `as any` casts with a single typed accessor
  (`browser-controller.test-helpers.ts`, matching this codebase's existing
  colocated `*.test-helpers.ts` convention) that exposes exactly the
  private surface tests need through one narrow, reviewable cast instead of
  scattering untyped ones at each call site. Exported `RunMode` from
  `browser-controller.ts` so the helper can reference the real type.
- Caught one real thing along the way: intersecting `KeyboardIntentRouter`
  with an object re-declaring its private `actionQueue` field collapses to
  `never` under strict typecheck (TS2339) — fixed with
  `Omit<KeyboardIntentRouter, 'actionQueue'>`.
- Extended `eslint.shared.mjs` with `typescript-eslint`'s `flat/recommended`
  for both consumers going forward, now that both are clean under it.

No behavior change.

## Test plan

- [x] `pnpm run typecheck` (`browser/frontend`) — clean
- [x] `pnpm run lint` (`browser/frontend`) — clean under the new
      `flat/recommended` ruleset
- [x] `npx eslint .` (`engine-wasm/host-sample`) — clean, unaffected
- [x] `pnpm run format:check` (`browser/frontend`) — clean
- [x] `pnpm run test` (`browser/frontend`) — 198 tests pass, 36 files
- [x] `pnpm run build` (`browser/frontend`) — production build succeeds
- [x] Full repo `pre-push` hook suite passed (fmt/clippy across engine-wasm,
      transport-rust, browser tauri; frontend typecheck)

🤖 Generated with [Claude Code](https://claude.com/claude-code)