### PR TITLE
fix(ci): repair the broken engine-fuzz.yml workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -237,6 +237,8 @@ jobs:
 
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@ed87afb44e1aa5ecc737d1d8cad72f2eeb3d3fec # cargo-llvm-cov
+        with:
+          tool: cargo-llvm-cov
 
       - name: Cache Rust build artifacts
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
@@ -286,6 +288,8 @@ jobs:
 
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@ed87afb44e1aa5ecc737d1d8cad72f2eeb3d3fec # cargo-llvm-cov
+        with:
+          tool: cargo-llvm-cov
 
       - name: Cache Rust build artifacts
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
@@ -521,6 +525,8 @@ jobs:
 
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@ed87afb44e1aa5ecc737d1d8cad72f2eeb3d3fec # cargo-llvm-cov
+        with:
+          tool: cargo-llvm-cov
 
       - name: Cache Browser Rust build artifacts
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2

--- a/.github/workflows/engine-fuzz.yml
+++ b/.github/workflows/engine-fuzz.yml
@@ -44,12 +44,6 @@ jobs:
           # what the trailing `# nightly` comment documents), so pin it
           # explicitly instead of relying on the ref alone.
           toolchain: nightly
-          # cargo-fuzz defaults to this target on Linux (for sanitizer-friendly
-          # static binaries); it is not part of the toolchain's default target
-          # set and must be installed explicitly. It must be installed on the
-          # nightly toolchain specifically, since that's what `cargo +nightly
-          # fuzz run` below actually uses.
-          targets: x86_64-unknown-linux-musl
 
       - name: Install cargo-fuzz
         uses: taiki-e/install-action@82fc405565b9cf90abfe700ba43b4751ce2fe422 # cargo-fuzz
@@ -61,7 +55,14 @@ jobs:
 
       - name: Run engine WML fuzz target
         working-directory: engine-wasm/engine
-        run: cargo +nightly fuzz run engine_wml_fuzzer -- -runs=${{ github.event_name == 'workflow_dispatch' && github.event.inputs.runs || '20000' }} -max_len=${{ github.event_name == 'workflow_dispatch' && github.event.inputs.max_len || '600000' }} -timeout=${{ github.event_name == 'workflow_dispatch' && github.event.inputs.timeout || '20' }}
+        # cargo-fuzz defaults to the musl target on Linux for fully static
+        # binaries, but musl's static libc conflicts with the sanitizer
+        # cargo-fuzz also enables by default ("sanitizer is incompatible
+        # with statically linked libc"). Target gnu explicitly instead of
+        # threading a matching `-C target-feature=-crt-static` override
+        # through; it needs no extra toolchain target install and is the
+        # standard fix for this well-known cargo-fuzz/musl interaction.
+        run: cargo +nightly fuzz run engine_wml_fuzzer --target x86_64-unknown-linux-gnu -- -runs=${{ github.event_name == 'workflow_dispatch' && github.event.inputs.runs || '20000' }} -max_len=${{ github.event_name == 'workflow_dispatch' && github.event.inputs.max_len || '600000' }} -timeout=${{ github.event_name == 'workflow_dispatch' && github.event.inputs.timeout || '20' }}
 
       - name: Upload fuzz artifacts
         if: always()

--- a/.github/workflows/engine-fuzz.yml
+++ b/.github/workflows/engine-fuzz.yml
@@ -37,6 +37,11 @@ jobs:
 
       - name: Setup Rust (nightly)
         uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # nightly
+        with:
+          # cargo-fuzz defaults to this target on Linux (for sanitizer-friendly
+          # static binaries); it is not part of the toolchain's default target
+          # set and must be installed explicitly.
+          targets: x86_64-unknown-linux-musl
 
       - name: Install cargo-fuzz
         uses: taiki-e/install-action@82fc405565b9cf90abfe700ba43b4751ce2fe422 # cargo-fuzz

--- a/.github/workflows/engine-fuzz.yml
+++ b/.github/workflows/engine-fuzz.yml
@@ -38,9 +38,17 @@ jobs:
       - name: Setup Rust (nightly)
         uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # nightly
         with:
+          # The pinned ref's default `toolchain` input silently resolved to
+          # `stable` (same class of Dependabot ref-drift bug fixed for
+          # taiki-e/install-action below: the SHA no longer corresponds to
+          # what the trailing `# nightly` comment documents), so pin it
+          # explicitly instead of relying on the ref alone.
+          toolchain: nightly
           # cargo-fuzz defaults to this target on Linux (for sanitizer-friendly
           # static binaries); it is not part of the toolchain's default target
-          # set and must be installed explicitly.
+          # set and must be installed explicitly. It must be installed on the
+          # nightly toolchain specifically, since that's what `cargo +nightly
+          # fuzz run` below actually uses.
           targets: x86_64-unknown-linux-musl
 
       - name: Install cargo-fuzz

--- a/.github/workflows/engine-fuzz.yml
+++ b/.github/workflows/engine-fuzz.yml
@@ -40,6 +40,8 @@ jobs:
 
       - name: Install cargo-fuzz
         uses: taiki-e/install-action@82fc405565b9cf90abfe700ba43b4751ce2fe422 # cargo-fuzz
+        with:
+          tool: cargo-fuzz
 
       - name: Install Ubuntu build dependencies
         run: sudo apt-get update && sudo apt-get install -y clang llvm

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -50,6 +50,8 @@ jobs:
 
       - name: Install cargo-audit
         uses: taiki-e/install-action@3a26e1142857d4ed43aacfecf39df466de8a685d # cargo-audit
+        with:
+          tool: cargo-audit
 
       - name: Audit engine runtime dependencies
         working-directory: engine-wasm/engine


### PR DESCRIPTION
## Summary

Found while looking at parts of the repo not yet audited this session
(CI workflows). `engine-fuzz.yml` — a real, well-designed `cargo-fuzz`
target for the WML parser (weekly cron + manual dispatch) — has **failed
every single scheduled run for at least 10 weeks straight** (every run
since 2026-05-18, the oldest retained in history). Completely silent,
since it's not a required check nobody watches.

Chased this to ground against the **real GitHub Actions runner** (not just
static diagnosis) via `workflow_dispatch` on this branch, fixing one layer
at a time as each fix exposed the next failure underneath it:

1. **`taiki-e/install-action` installed nothing.** Its own runner warning
   said it exactly: `no tool specified; this could be caused by a
   dependabot bug where @<tool_name> tags on this action are replaced by
   @<version> tags`. The action supports selecting the tool either via an
   explicit `with: tool:` input or by pinning to that tool's dedicated tag
   in its own repo (which the trailing `# cargo-fuzz` comment was
   documenting — the SHA itself used to be the tip of that tag).
   Dependabot bumped the SHA without preserving that correspondence, so it
   silently no-opped instead of installing `cargo-fuzz`.
   - Also applied the same defensive fix to the other 4
     `taiki-e/install-action` uses in this repo (`ci.yml` ×3 for
     `cargo-llvm-cov`, `security.yml` ×1 for `cargo-audit`) — not
     currently broken, but exposed to the exact same failure mode on the
     next Dependabot SHA bump, and this repo auto-merges Dependabot PRs.
2. **`dtolnay/rust-toolchain`'s pinned SHA (commented `# nightly`)
   actually resolved to `toolchain: stable`.** Same drift class, a
   different action. Confirmed directly in the runner log
   (`with: toolchain: stable`). The workflow only worked at all because
   the later `cargo +nightly fuzz run` auto-fetches a bare nightly
   toolchain via rustup's `+toolchain` override — but that toolchain never
   got the extra target install that mattered for the next problem, since
   `targets:` only applies to whatever toolchain the action itself set up
   (stable, wrongly).
3. **musl vs. sanitizer conflict.** With toolchain resolution fixed,
   cargo-fuzz's default Linux target (`x86_64-unknown-linux-musl`, for
   fully static binaries) hit `sanitizer is incompatible with statically
   linked libc`. Targeted `gnu` explicitly instead
   (`cargo fuzz run --target x86_64-unknown-linux-gnu`) — the standard fix
   for this well-known cargo-fuzz/musl interaction, needing no extra
   toolchain target install.

All three fixes are pinned explicitly (`with: tool:`, `with: toolchain:`,
`--target`) rather than relying on the SHA-implies-behavior conventions
that silently broke this workflow in the first place.

**Verified against the real runner**, not just locally: 4 scoped
`workflow_dispatch` runs on this branch, one per fix layer, ending in a
fully green end-to-end run
([30223005320](https://github.com/dills122/wap-labs/actions/runs/30223005320)).

No fuzz crash was found — every failure was CI plumbing, not an engine
bug.

## Test plan

- [x] YAML syntax validated for all 3 edited workflow files
- [x] 4 scoped `workflow_dispatch` verification runs on this branch, via
      `gh workflow run` + `gh run watch`, culminating in a clean pass
      (Checkout → Setup Rust → Install cargo-fuzz → apt deps → fuzz run →
      upload artifacts, all green)
- [x] `ci.yml`/`security.yml`'s pre-existing green history plus their
      identical `with: tool:` fix gives confidence they're unaffected
      (those workflows only trigger on `pull_request`, so they'll run
      against this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)