### PR TITLE
fix(wml-server): compare login PINs in constant time

### DIFF
--- a/wml-server/internal/origin/app.go
+++ b/wml-server/internal/origin/app.go
@@ -3,6 +3,7 @@ package origin
 import (
 	"context"
 	"crypto/rand"
+	"crypto/subtle"
 	"embed"
 	"encoding/hex"
 	"errors"
@@ -318,7 +319,7 @@ func (a *App) login(w http.ResponseWriter, r *http.Request) {
 	a.mu.Lock()
 	account, found := a.users[username]
 	a.mu.Unlock()
-	if !found || account.PIN != pin {
+	if !found || subtle.ConstantTimeCompare([]byte(account.PIN), []byte(pin)) != 1 {
 		a.counts.loginFailure.Add(1)
 		a.sendWML(w, renderLoginDeck(username, "Invalid username or PIN."), http.StatusOK)
 		return

--- a/wml-server/internal/origin/app_test.go
+++ b/wml-server/internal/origin/app_test.go
@@ -191,6 +191,30 @@ func TestRegistrationLoginAndProtectedRoutes(t *testing.T) {
 	}
 }
 
+func TestLoginRejectsUnknownUserAndWrongPIN(t *testing.T) {
+	app, _ := newTestApp(t, nil)
+	handler := app.Handler()
+
+	register := perform(handler, http.MethodPost, "/register", "username=demo&pin=1234", "application/x-www-form-urlencoded")
+	if register.Code != http.StatusOK || !strings.Contains(register.Body.String(), `id="register-ok"`) {
+		t.Fatalf("register = %d %s", register.Code, register.Body.String())
+	}
+
+	for name, body := range map[string]string{
+		"unknown user": "username=nobody&pin=1234",
+		"wrong pin":    "username=demo&pin=9999",
+		"shorter pin":  "username=demo&pin=123",
+		"longer pin":   "username=demo&pin=12345",
+	} {
+		t.Run(name, func(t *testing.T) {
+			response := perform(handler, http.MethodPost, "/login", body, "application/x-www-form-urlencoded")
+			if response.Code != http.StatusOK || !strings.Contains(response.Body.String(), "Invalid username or PIN") {
+				t.Fatalf("login(%s) = %d %s", body, response.Code, response.Body.String())
+			}
+		})
+	}
+}
+
 func TestValidationAndEscaping(t *testing.T) {
 	app, _ := newTestApp(t, nil)
 	handler := app.Handler()


### PR DESCRIPTION
## Summary

Last round of a repo-wide clean-up/quality audit pass. Reviewed the new
Go `wml-server` rewrite (#427) since it's fresh, previously unreviewed
code — and genuinely well-written: bounded user/session maps with
oldest-eviction, atomic counters, host allowlisting, `MaxBytesReader`
request-size limits, session-ID regex validation before every map
lookup, control-character username rejection, separate public/internal
listeners (health/metrics not exposed on the public port), consistent
`html.EscapeString` on every user-controlled value rendered into WML.

One real gap in an otherwise careful file: `login()` compared the
stored and submitted PIN with a plain string `!=`, a non-constant-time
comparison that leaks timing information about how many leading digits
matched. `crypto/subtle.ConstantTimeCompare` is the standard fix for
exactly this class of check, and costs nothing here (PINs are already
length-bounded to 4-6 digits).

Also added `TestLoginRejectsUnknownUserAndWrongPIN`: the wrong-username/
wrong-PIN rejection path (the "Invalid username or PIN" branch) had
**zero test coverage** before this, for any PIN length relative to the
stored one. `internal/origin` coverage: 84.1% → 86.0%.

Also swept the rest of the repo's CI action pins for the same
Dependabot-ref-drift class of bug fixed in #425 — confirmed the
`taiki-e/install-action` fix already covers all 5 uses, and all 13
`dtolnay/rust-toolchain` pins resolve correctly except the one already
fixed. Nothing further needed there.

## Test plan

- [x] `go build ./...` / `go vet ./...` / `gofmt -l .` — clean
- [x] `go test ./... -cover` — all pass, `internal/origin` coverage
      84.1% → 86.0%
- [x] `go run golang.org/x/vuln/cmd/govulncheck@v1.1.4 ./...` — no
      vulnerabilities
- [x] Full repo `pre-push` hook suite passed (fmt/clippy across
      engine-wasm, transport-rust, browser tauri)

🤖 Generated with [Claude Code](https://claude.com/claude-code)