### PR TITLE
docs(infra): codify protected OpenTofu workflow

### DIFF
--- a/.codex/steering/infrastructure-opentofu-steering.md
+++ b/.codex/steering/infrastructure-opentofu-steering.md
@@ -1,0 +1,70 @@
+# Infrastructure and OpenTofu Steering
+
+Repository-specific steering for `infra/network-preview/` and its related GitHub workflows,
+verification scripts, and active documentation.
+
+## Authority and precedence
+
+Apply instructions in this order:
+
+1. system, developer, and explicit user instructions;
+2. the nearest applicable `AGENTS.md`, including repository security and contributor standards;
+3. this infrastructure steering for implementation details in its scope;
+4. active repository planning and runbook documentation;
+5. generic external guidance, including installed or AI Central infrastructure skills.
+
+Canonical repository code and active planning evidence decide current implementation and
+acceptance status. External guidance may inform a change but must not silently override this file,
+claim an access-backed gate, or broaden authority to mutate cloud or repository settings.
+
+## Toolchain and source control
+
+- Pin OpenTofu and every provider exactly. The current `INF-101` pins are OpenTofu `1.12.5` and
+  `digitalocean/digitalocean` `2.96.0`; change them only through an intentional dependency update.
+- Commit `.terraform.lock.hcl` with checksums for every supported CI/developer platform. Current
+  preview support is `linux_amd64`, `darwin_arm64`, and `darwin_amd64`.
+- Keep ordinary static validation secret-free and backend-disabled. It may run formatting,
+  `init -backend=false -lockfile=readonly`, validation, and provider-lock drift checks.
+- Supply partial backend bucket, key, endpoint, and credentials only at runtime. Never commit
+  generated state, plans, `.tfvars`/`.tfvars.json`, backend configuration, credentials, or
+  `.terraform/` data. Saved local plans belong only below the ignored environment `.plans/`
+  directory.
+- Do not introduce a shared OpenTofu module until a second real environment demonstrates actual
+  repetition.
+
+## Protected state and execution
+
+- Keep protected plan and apply jobs separate. Both must use the same shared-state concurrency
+  group with `cancel-in-progress: false`; secret-free static validation uses a distinct cancelable
+  group because it never contacts shared state.
+- A successful protected plan run records its commit SHA and plan SHA-256 in trusted workflow-run
+  provenance. Manual apply must verify the run and artifact IDs, repository, approved workflow and
+  ref, source commit, successful conclusion, and expected digest from that provenance rather than
+  operator input or the artifact itself. It executes the exact encrypted reviewed plan and must
+  not re-plan or substitute another artifact.
+- Publish only sanitized action, resource-address, and count summaries. Never log or retain raw
+  `tofu show -json`, plaintext state, or decrypted plan content.
+- State and plan encryption remain enforced. Before apply, copy the encrypted R2 state to a unique
+  recovery key containing commit, run ID, attempt, and a collision-resistant nonce. Refuse a
+  pre-existing destination; download and SHA-256 compare the encrypted source and copy, then
+  recheck the source digest before changing resources. Retain the five most recent verified
+  pre-apply copies; prune older copies only after a successful apply and current-state verification,
+  never deleting the last known-good copy.
+- For the first resource-creating apply only, a missing state object is permitted only when the
+  serialized protected job proves both state and lock keys are absent immediately before apply,
+  records that bootstrap fact in trusted run metadata, and verifies the resulting encrypted remote
+  state through a protected backend operation. Any unexpected object fails closed.
+- Never run `tofu apply`, `tofu destroy`, or `tofu force-unlock` without explicit authority for
+  that exact protected operation. Documentation or test scaffolding does not grant execution
+  authority.
+- R2 lock testing must use the dedicated test prefix and a new collision-resistant run ID, refuse
+  pre-existing objects, never target the preview state key, and verify remote cleanup before
+  reporting success.
+
+## INF-101 boundary
+
+The offline scaffold may define contracts and secret-free checks, but it must not create accounts,
+credentials, protected environments, DNS, provider resources, or deployment configuration. Live
+R2 locking, provider planning, serialized manual apply, and recovery-copy evidence remain
+unfinished until their prerequisite decisions, credentials, protected environments, and explicit
+execution authority exist. Never mark those gates complete from configuration or prose alone.

--- a/.github/workflows/opentofu.yml
+++ b/.github/workflows/opentofu.yml
@@ -29,6 +29,12 @@ on:
 permissions:
   contents: read
 
+# This workflow is secret-free and backend-disabled, so replacing an older static run is safe.
+# Future shared-state plan/apply workflows must use a different, non-cancelable concurrency group.
+concurrency:
+  group: opentofu-static-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   validate:
     name: OpenTofu Static Validation

--- a/.gitignore
+++ b/.gitignore
@@ -182,8 +182,13 @@ infra/network-preview/**/.terraform/
 infra/network-preview/**/*.tfstate
 infra/network-preview/**/*.tfstate.*
 infra/network-preview/**/*.tfplan
+infra/network-preview/**/tfplan
+infra/network-preview/**/.plans/
 infra/network-preview/**/backend.hcl
+infra/network-preview/**/*.backend.hcl
 infra/network-preview/**/*.tfvars
 infra/network-preview/**/*.auto.tfvars
+infra/network-preview/**/*.tfvars.json
+infra/network-preview/**/*.auto.tfvars.json
 infra/network-preview/**/crash.log
 infra/network-preview/**/crash.*.log

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -130,6 +130,10 @@ Prefer work that improves:
 ## Additional standards
 
 - Use `docs/agents/AGENT_STANDARDS.md` for repository-wide contributor and architecture standards.
+- For `infra/network-preview/` and its related workflows, scripts, and active documentation, use
+  `.codex/steering/infrastructure-opentofu-steering.md`. Root and nearer `AGENTS.md` instructions
+  take precedence; the infrastructure steering narrows them for this repository and overrides
+  generic external or installed infrastructure guidance when they conflict.
 - Use `docs/agents/RUST_ENGINE_STEERING.md` for WaveNav engine Rust rules.
 - Use `docs/agents/RUST_TRANSPORT_STEERING.md` for Lowband transport Rust rules.
 - Use `docs/agents/SHELL_STEERING.md` and `docs/agents/SCRIPTING_STEERING.md` for reusable shell/script guidance (POSIX-first, Alpine-compatible where possible, reuse existing tools before custom scripting).

--- a/infra/network-preview/README.md
+++ b/infra/network-preview/README.md
@@ -56,6 +56,9 @@ The same contract is available as `make lint-tofu` and is enforced by
 The `s3` backend is partial. Bucket, key, and endpoint values are supplied only at runtime; R2
 credentials use the standard `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment
 variables. Do not commit backend configuration files, credentials, `.tfvars`, state, or plans.
+Saved plans must live below the environment's ignored `.plans/` directory, for example
+`infra/network-preview/environments/preview/.plans/preview.tfplan`; do not use ad hoc tracked or
+workspace-root plan paths.
 
 The intended state key is `wap-labs/network-preview/preview.tfstate` without a leading slash.
 Native S3 lock-file mode is mandatory. State and plan encryption are enforced with PBKDF2 and
@@ -67,6 +70,43 @@ copy the already encrypted state object to a timestamped recovery prefix before 
 resources. That protected workflow remains unfinished `INF-101` acceptance scope; it is not
 implemented or executed by this offline checkpoint.
 
+## Protected plan and apply contract
+
+The access-backed `INF-101` automation must preserve one exact reviewed plan from planning through
+manual apply:
+
+- protected plan and apply jobs share one preview-state concurrency group with
+  `cancel-in-progress: false`; this is intentionally distinct from the cancelable, secret-free
+  static workflow;
+- the plan job saves the encrypted plan under `.plans/`, records the source commit SHA and the
+  plan file's SHA-256 digest, and publishes only that exact encrypted artifact for apply. Trusted
+  workflow-run metadata binds the repository, authorized ref, source commit, workflow identity,
+  artifact ID, and digest;
+- review output is limited to a sanitized summary of action, resource address, and count; raw
+  `tofu show -json`, plaintext state, and decrypted plan content must never be logged, uploaded, or
+  retained as review artifacts;
+- the manually approved apply job accepts a plan workflow-run and artifact ID, then verifies the
+  run belongs to this repository and approved workflow/ref, concluded successfully, and matches
+  the recorded source commit. It obtains the expected digest from trusted run provenance rather
+  than operator input or the downloaded artifact, verifies the plan SHA-256, and applies that
+  exact reviewed plan rather than generating a replacement;
+- immediately before apply, the job copies the already encrypted R2 state object to a timestamped
+  key containing the source commit, workflow run ID and attempt, and a collision-resistant nonce.
+  It refuses a pre-existing destination, downloads the encrypted source and recovery objects, and
+  requires their SHA-256 digests to match. It then rechecks the encrypted source digest before
+  continuing so the recovery copy cannot silently represent stale state;
+- retain the five most recent verified pre-apply recovery objects. Prune older objects only after
+  a successful apply and verification of the current encrypted state, and never remove the last
+  known-good recovery object;
+- for the first resource-creating apply only, when no state exists to copy, the serialized apply
+  job must prove both the configured state and lock keys are absent immediately before applying,
+  record that bootstrap condition in trusted run metadata, and verify the resulting encrypted
+  remote state through a protected backend operation. Any unexpected object fails closed.
+
+These controls are unfinished, access-backed `INF-101` acceptance. This checkpoint documents the
+contract but does not create protected environments, handle credentials, produce a remote plan,
+copy state, or run `tofu apply`.
+
 ## Access-backed gates
 
 `INF-101` remains incomplete until all of the following are true:
@@ -77,6 +117,8 @@ implemented or executed by this offline checkpoint.
 3. The protected R2 test proves acquisition, contention failure, normal release, stale-lock
    recovery, and cleanup against a unique non-production key.
 4. A protected DigitalOcean speculative plan succeeds without exposing a plaintext plan or state.
+5. The protected plan/apply path proves exact-plan review, non-cancelable shared-state
+   serialization, verified encrypted recovery copies, and manual apply approval.
 
 Executing a cloud apply remains explicitly out of scope for this offline checkpoint. Implementing
 the serialized, manually approved apply and state-recovery automation remains part of `INF-101`

--- a/infra/network-preview/environments/preview/variables.tf
+++ b/infra/network-preview/environments/preview/variables.tf
@@ -1,6 +1,11 @@
 variable "project_name" {
   description = "Accepted DigitalOcean project name from PRE-003."
   type        = string
+
+  validation {
+    condition     = length(trimspace(var.project_name)) > 0
+    error_message = "project_name must not be empty"
+  }
 }
 
 variable "region" {


### PR DESCRIPTION
## Summary

- add tracked repository-specific OpenTofu steering with explicit authority precedence and INF-101 safety boundaries
- harden the future protected plan/apply contract around trusted workflow provenance, exact encrypted plans, shared-state serialization, verified R2 recovery copies, bounded retention, and first-apply behavior
- add scoped plan/backend/JSON-variable ignores, validate non-empty project names, and give secret-free static validation a distinct cancelable concurrency group

## Why

This is the reference-audit and AI-central adoption follow-up to merged PR #432. It keeps generic infrastructure guidance subordinate to repository policy and makes the unfinished access-backed INF-101 gates precise without creating credentials, protected environments, cloud resources, or deployment automation.

The canonical steering source for downstream collection is:

`.codex/steering/infrastructure-opentofu-steering.md`

## Impact

- static validation remains backend-disabled, secret-free, and safe to cancel
- future protected plan/apply execution must use a separate non-cancelable shared-state group and an exact provenance-bound reviewed plan
- no live R2/provider plan, apply, destroy, force-unlock, cloud mutation, or AI-central skill installation was performed

## Verification

- `pnpm verify:change`
- exact OpenTofu 1.12.5 format, backend-disabled init/validate, and provider-lock drift checks
- YAML, Prettier, ShellCheck, ignore-pattern, and whitespace checks
- all repository pre-push hooks
- independent correctness and security reviews: no remaining actionable findings
