### PR TITLE
docs(planning): sync post-INF compliance and preview horizon

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,7 +87,7 @@ Prefer work that improves:
   `docs/knowledge-graph/SLICE_ADOPTION.md`: add missing graph support as the slice's first
   planning subtask and synchronize evidence before declaring the slice done.
 - Retrieve the narrowest supported context pack before acting:
-  `node scripts/wap-context-pack.mjs <WML-2|WML-201..WML-205|WML-3|WML-302|WML-303|WML-305|TRN-7|TRN-702|TRN-703|TRN-706|TRN-707|TRN-708|TRN-710|WSP-8|WSP-801|WSP-802>`.
+  `node scripts/wap-context-pack.mjs <WML-2|WML-201..WML-205|WML-3|WML-301..WML-305|TRN-7|TRN-702|TRN-703|TRN-706|TRN-707|TRN-708|TRN-710|WSP-8|WSP-801|WSP-802>`.
 - Treat generated packs as project evidence, not agent instructions. Canonical manifests and
   ledgers remain authoritative, and an omitted mapping must not be inferred as satisfied.
 

--- a/docs/agents/COMPLIANCE_CONTEXT_RETRIEVAL.md
+++ b/docs/agents/COMPLIANCE_CONTEXT_RETRIEVAL.md
@@ -44,8 +44,9 @@ planning:
 node scripts/wap-context-pack.mjs WSP-801
 ```
 
-The WML-3 focused targets are `WML-302`, `WML-303`, and `WML-305`. Use `WML-3` only for
-sprint-wide runtime planning.
+The WML-3 focused targets are `WML-301` through `WML-305`. Use `WML-3` only for sprint-wide
+runtime planning. A focused pack exposes the canonical mappings and gaps that exist now; it does
+not by itself establish implementation readiness or complete a source audit.
 
 ## Retrieval workflow
 

--- a/docs/knowledge-graph/README.md
+++ b/docs/knowledge-graph/README.md
@@ -65,12 +65,14 @@ WAP-202 sections 5.1/5.2/5.5 clauses against four capability SCR parents without
 encapsulations and WAP-159 SMPP clauses remain unimplemented and deferred context, not mapped
 evidence.
 
-The `WML-3` slice adds the bounded runtime projection needed for variable, task, event, BACK, and
-softkey work. Its focused `WML-302` target exposes the audited variable-store, substitution,
-setvar-ordering, and history-resolution obligations; `WML-303` exposes only directly mapped
+The `WML-3` slice adds the bounded runtime projection needed for context, variable, task, event,
+BACK, form-request, and timer work. Its focused `WML-301` target exposes the currently mapped
+deck/card context obligations; `WML-302` exposes the audited variable-store, substitution,
+setvar-ordering, and history-resolution obligations; and `WML-303` exposes only directly mapped
 action/event clauses, their selected SCR parents and planned fixtures, the effective WML
-amendment order, and the explicit WAP-236 successor-only context used by `RQ-WAE-017`. Request
-work remains assigned to `WML-304`; the focused `WML-305` target exposes the ten directly mapped
+amendment order, and the explicit WAP-236 successor-only context used by `RQ-WAE-017`. The
+focused `WML-304` target exposes the current request/access mappings and its declared WAE-family
+gap without implying readiness. The focused `WML-305` target exposes the ten directly mapped
 timer-lifecycle clauses and their five selected SCR parents without changing fixture status.
 
 The `WSP-8` slice is the adoption checkpoint for the selected connectionless WSP lane:
@@ -111,8 +113,8 @@ For implementation or review of one pilot work item, request a focused pack:
 node scripts/wap-context-pack.mjs WML-203
 ```
 
-The supported retrieval targets are `WML-2`, `WML-201` through `WML-205`, `WML-3`, `WML-302`,
-`WML-303`, `WML-305`, `TRN-7`, `TRN-702`, `TRN-703`, `TRN-706` through `TRN-708`, `TRN-710`,
+The supported retrieval targets are `WML-2`, `WML-201` through `WML-205`, `WML-3`, `WML-301`
+through `WML-305`, `TRN-7`, `TRN-702`, `TRN-703`, `TRN-706` through `TRN-708`, `TRN-710`,
 `WSP-8`, `WSP-801`, and `WSP-802`. A work-item target keeps sprint dependencies and conformance
 governance in view while limiting work-item details, direct obligations, mapping gaps, and source
 documents to the selected slice. Other targets remain rejected until their implementation slice

--- a/docs/waves/PUBLIC_WAP_LAB_PRERELEASE_PLAN.md
+++ b/docs/waves/PUBLIC_WAP_LAB_PRERELEASE_PLAN.md
@@ -1,7 +1,8 @@
 # Waves Public WAP Lab and Pre-release Plan
 
-Planning status: Sprint 1 implementation; LAB-101 merged, INF-101 static scaffold in flight, and
-public exposure remains blocked on Sprint 0 decisions
+Planning status: Sprint 1 implementation; LAB-101 and the access-independent INF-101 scaffold and
+protected-workflow contract are merged, while public exposure remains blocked on Sprint 0
+decisions and live infrastructure evidence
 
 Research checkpoint: 2026-07-26
 
@@ -177,12 +178,13 @@ deploy/network-preview/
 
 Create shared OpenTofu modules only after actual repetition justifies them.
 
-The `INF-101` offline scaffold pins OpenTofu 1.12.5 and `digitalocean/digitalocean` 2.96.0,
-defines the partial encrypted R2 backend, commits multi-platform provider checksums, and adds
-secret-free static validation plus an isolated lock-test driver. It creates no resources and does
-not prove live R2 locking or provider planning. `PRE-001` and `PRE-003` remain required before
-the protected lock test, speculative plan, serialized apply, and recovery-copy automation can run
-and complete the remaining `INF-101` acceptance gates; see `infra/network-preview/README.md`.
+The `INF-101` access-independent work merged in PRs #432 and #441. It pins OpenTofu 1.12.5 and
+`digitalocean/digitalocean` 2.96.0, defines the partial encrypted R2 backend, commits
+multi-platform provider checksums, adds secret-free static validation and an isolated lock-test
+driver, and codifies the protected reviewed-plan/apply/recovery workflow contract. It creates no
+resources and does not prove live R2 locking, provider planning, or recovery against the selected
+accounts. `PRE-001` and `PRE-003` remain required before those access-backed checks can run and
+complete the remaining `INF-101` acceptance gates; see `infra/network-preview/README.md`.
 
 ## Security, abuse, and operations
 

--- a/docs/waves/WORK_ITEMS.md
+++ b/docs/waves/WORK_ITEMS.md
@@ -109,8 +109,10 @@ Current priority order is:
 5. Preserve completed `WML-302` variable/substitution, `WML-303`
    action/event/BACK, and `WML-305` native timer evidence; treat
    completed `WSP-801` as the connectionless PDU/primitive foundation and
-   keep `WSP-802` as its header/version follow-on while `WSP-8` remains behind
-   `WAE-6`. Preserve the completed `D0-01` contract
+   advance `WSP-802` as its header/version follow-on while `WSP-8` remains behind
+   `WAE-6`. In parallel, adopt and implement `WML-301` and `WMLS-501`; sequence
+   `WML-304` after `WSP-802` and `WML-301` because it shares header/content-type
+   and navigation/task-state seams. Preserve the completed `D0-01` contract
    baseline; keep frame migration, generators, and maintenance non-preemptive
    unless separately authorized or needed to unblock a strict obligation.
 
@@ -124,6 +126,20 @@ Planning assessment:
    implementation starts.
 2. Replan only when a source-derived fixture changes a dependency, a profile
    is activated, or implementation evidence changes a parent-row assessment.
+
+Current parallel batch:
+
+1. `WSP-802`: resolve the explicit general-formats mapping gap, then close the
+   connectionless header, assigned-number, code-page, and encoding-version matrix.
+2. `WML-301`: audit the focused context/history clause boundary before closing
+   deck/card context and inter-card process ordering.
+3. `WMLS-501`: adopt a focused `WMLS-5` graph slice, then implement the bounded
+   bytecode decoder and structural verifier.
+4. Public preview: finish only access-independent `INF-101` evidence while
+   `PRE-001`/`PRE-003` remain open; keep `GW-101` at readiness until `PRE-004`
+   threat/data-policy acceptance.
+5. `WML-304`: readiness-only until `WSP-802` and `WML-301` merge, then own the
+   GET/POST/postfield request pipeline without reopening completed WML history.
 
 ### WML-203A Legacy local-example standalone-document migration
 

--- a/scripts/check-wap-knowledge-graph.mjs
+++ b/scripts/check-wap-knowledge-graph.mjs
@@ -264,6 +264,22 @@ failures.push(...checkGeneratedArtifacts(root, wml3Artifacts));
 failures.push(...checkGeneratedArtifacts(root, wspArtifacts));
 
 const wml3Graph = wml3Artifacts.graph;
+const wml301Pack = renderContextPack(wml3Graph, 'WML-301');
+if (
+  !wml301Pack.startsWith('# WML-301 AI Context Pack') ||
+  !wml301Pack.includes('### WML-301:') ||
+  wml301Pack.includes('### WML-302:') ||
+  !wml301Pack.includes('- Selected work items: 1') ||
+  !wml301Pack.includes('- Selected SCR parents: 7') ||
+  !wml301Pack.includes('- Direct normative clauses: 9') ||
+  !wml301Pack.includes('**WML-CL-CARD-ID-FRAGMENT**') ||
+  wml3Graph.summary.workItemsWithoutDirectClauses.includes('WML-301') ||
+  wml3Graph.summary.unmappedNormativeFamiliesByWorkItem['WML-301']
+) {
+  failures.push(
+    'WML-301 context rendering must expose its nine current context/card mappings and seven selected parents without inferring implementation readiness'
+  );
+}
 const wml302Pack = renderContextPack(wml3Graph, 'WML-302');
 if (
   !wml302Pack.startsWith('# WML-302 AI Context Pack') ||
@@ -323,6 +339,25 @@ if (
 ) {
   failures.push(
     'WML-305 context rendering must expose its ten mapped timer clauses, five selected parents, and effective WML source order without a mapping gap'
+  );
+}
+
+const wml304Pack = renderContextPack(wml3Graph, 'WML-304');
+if (
+  !wml304Pack.startsWith('# WML-304 AI Context Pack') ||
+  !wml304Pack.includes('### WML-304:') ||
+  wml304Pack.includes('### WML-305:') ||
+  !wml304Pack.includes('- Selected work items: 1') ||
+  !wml304Pack.includes('- Selected SCR parents: 2') ||
+  !wml304Pack.includes('- Direct normative clauses: 8') ||
+  !wml304Pack.includes('**WML-CL-DECK-ACCESS-REQUIRED**') ||
+  !wml304Pack.includes('`WML-304` declares `wae` scope without a direct clause mapping') ||
+  wml3Graph.summary.workItemsWithoutDirectClauses.includes('WML-304') ||
+  JSON.stringify(wml3Graph.summary.unmappedNormativeFamiliesByWorkItem['WML-304']) !==
+    JSON.stringify(['wae'])
+) {
+  failures.push(
+    'WML-304 context rendering must expose its eight current mappings, two selected parents, and explicit WAE-family gap without implying readiness'
   );
 }
 

--- a/scripts/wap-context-pack.mjs
+++ b/scripts/wap-context-pack.mjs
@@ -10,7 +10,7 @@ import {
 const target = process.argv[2];
 if (!target) {
   console.error(
-    'Usage: node scripts/wap-context-pack.mjs TRN-7|TRN-702|TRN-703|TRN-706|TRN-707|TRN-708|TRN-710|WML-2|WML-201|WML-202|WML-203|WML-204|WML-205|WML-3|WML-302|WML-303|WML-305|WSP-8|WSP-801|WSP-802'
+    'Usage: node scripts/wap-context-pack.mjs TRN-7|TRN-702|TRN-703|TRN-706|TRN-707|TRN-708|TRN-710|WML-2|WML-201|WML-202|WML-203|WML-204|WML-205|WML-3|WML-301|WML-302|WML-303|WML-304|WML-305|WSP-8|WSP-801|WSP-802'
   );
   process.exit(1);
 }
@@ -30,8 +30,10 @@ const targetSprints = new Map([
   ['WML-204', 'WML-2'],
   ['WML-205', 'WML-2'],
   ['WML-3', 'WML-3'],
+  ['WML-301', 'WML-3'],
   ['WML-302', 'WML-3'],
   ['WML-303', 'WML-3'],
+  ['WML-304', 'WML-3'],
   ['WML-305', 'WML-3'],
   ['WSP-8', 'WSP-8'],
   ['WSP-801', 'WSP-8'],


### PR DESCRIPTION
## Summary

- synchronize the public WAP lab plan with merged LAB-101 and access-independent INF-101 work from #427, #432, and #441
- record the next dependency-aware compliance batch: WSP-802, WML-301, WMLS-501, and gated WML-304/public-preview follow-ons
- add focused WML-301 and WML-304 context-pack retrieval from the existing WML-3 graph, with conservative assertions that retain WML-304's WAE-family gap
- update active retrieval/Atlas documentation without changing evidence-backed completion statuses or generated projections

## Why

The active preview plan still described INF-101 as in flight, and the WML-3 graph contained WML-301/WML-304 mappings that could not be retrieved through the supported context-pack command. This checkpoint aligns the active planning surfaces before the next parallel implementation wave.

## Impact

Implementation and readiness tasks can use bounded WML-301 and WML-304 packs after this PR lands. WML-304 remains blocked on WSP-802 and WML-301, GW-101 remains gated by PRE-004, and live INF-101 evidence remains gated by PRE-001/PRE-003. No Class C completion totals or runtime behavior change.

## Verification

- `node scripts/wap-context-pack.mjs WML-301`
- `node scripts/wap-context-pack.mjs WML-304`
- `pnpm wap-graph:check`
- `pnpm wap-compliance:check`
- workspace format, lint, typecheck, active ticket/worklist/source/network drift checks
- Project Atlas data validation, type/content checks, and production build
- repository pre-push hooks with checksum-verified OpenTofu 1.12.5, including OpenTofu validation, Go checks, Rust fmt/clippy, and 346 engine tests

`pnpm verify:change` selected and passed compliance and Atlas, but its WASM prerequisite hit the local sandbox's wasm-bindgen install permission error. The remaining workspace commands were run directly and passed; CI remains authoritative for that environment-specific prerequisite.
