### PR TITLE
feat(infra): add protected OpenTofu execution lane

### DIFF
--- a/.github/workflows/opentofu-protected-apply.yml
+++ b/.github/workflows/opentofu-protected-apply.yml
@@ -1,0 +1,195 @@
+name: OpenTofu Protected Apply
+
+on:
+  workflow_dispatch:
+    inputs:
+      plan_run_id:
+        description: Successful OpenTofu Protected Plan workflow run ID
+        required: true
+        type: string
+      plan_artifact_id:
+        description: Exact encrypted-plan artifact ID from that run
+        required: true
+        type: string
+
+permissions:
+  actions: read
+  contents: read
+
+# This exact group is shared with protected plan; queued state operations are never cancelled.
+concurrency:
+  group: opentofu-network-preview-state
+  cancel-in-progress: false
+
+jobs:
+  apply:
+    name: Manually approved network-preview apply
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+    environment: network-preview-apply
+    env:
+      TF_IN_AUTOMATION: '1'
+      TF_INPUT: '0'
+      TF_DATA_DIR: ${{ runner.temp }}/network-preview-terraform
+      TF_VAR_state_encryption_passphrase: ${{ secrets.TOFU_ENCRYPTION_PASSPHRASE }}
+      TF_VAR_project_name: ${{ vars.NETWORK_PREVIEW_DO_PROJECT }}
+      TF_VAR_region: ${{ vars.NETWORK_PREVIEW_DO_REGION }}
+      DIGITALOCEAN_TOKEN: ${{ secrets.DIGITALOCEAN_TOKEN }}
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      AWS_REGION: auto
+      AWS_DEFAULT_REGION: auto
+      NETWORK_PREVIEW_R2_ACCOUNT_ID: ${{ vars.NETWORK_PREVIEW_R2_ACCOUNT_ID }}
+      NETWORK_PREVIEW_R2_BUCKET: ${{ vars.NETWORK_PREVIEW_R2_BUCKET }}
+      NETWORK_PREVIEW_R2_STATE_KEY: ${{ vars.NETWORK_PREVIEW_R2_STATE_KEY }}
+      NETWORK_PREVIEW_R2_RECOVERY_PREFIX: ${{ vars.NETWORK_PREVIEW_R2_RECOVERY_PREFIX }}
+    steps:
+      - name: Refuse non-main workflow dispatches
+        shell: sh
+        run: |
+          if [ "$GITHUB_REF" != "refs/heads/main" ]; then
+            echo "FAIL: protected applies may run only from refs/heads/main" >&2
+            exit 1
+          fi
+
+      - name: Checkout protected source commit
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+
+      - name: Setup pinned OpenTofu
+        uses: opentofu/setup-opentofu@a1320f892987e89d278cc92dc5adc984fb93aca4 # v2
+        with:
+          tofu_version_file: infra/network-preview/.opentofu-version
+          tofu_wrapper: false
+
+      - name: Verify trusted provenance and download exact artifact ID
+        id: provenance
+        shell: sh
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PLAN_RUN_ID: ${{ inputs.plan_run_id }}
+          PLAN_ARTIFACT_ID: ${{ inputs.plan_artifact_id }}
+          EXPECTED_SOURCE_COMMIT: ${{ github.sha }}
+          PLAN_DESTINATION: ${{ runner.temp }}/encrypted.tfplan
+        run: scripts/ci/verify-network-preview-plan-provenance.sh
+
+      - name: Write runtime-only partial backend configuration
+        shell: sh
+        run: scripts/ci/write-network-preview-backend-config.sh "$RUNNER_TEMP/backend.hcl"
+
+      - name: Initialize exact source against encrypted R2 backend
+        shell: sh
+        run: |
+          tofu -chdir=infra/network-preview/environments/preview init \
+            -reconfigure \
+            -backend-config="$RUNNER_TEMP/backend.hcl" \
+            -lockfile=readonly \
+            -no-color >/dev/null
+
+      - name: Re-publish sanitized exact-plan summary
+        shell: sh
+        run: |
+          scripts/ci/summarize-network-preview-plan.sh \
+            infra/network-preview/environments/preview \
+            "$RUNNER_TEMP/encrypted.tfplan"
+
+      - name: Prepare and verify encrypted pre-apply recovery copy
+        id: recovery
+        shell: sh
+        env:
+          SOURCE_COMMIT: ${{ steps.provenance.outputs.source_commit }}
+          APPLY_RUN_ID: ${{ github.run_id }}
+          APPLY_RUN_ATTEMPT: ${{ github.run_attempt }}
+          TOFU_ROOT: infra/network-preview/environments/preview
+        run: |
+          RECOVERY_NONCE=$(openssl rand -hex 16)
+          export RECOVERY_NONCE
+          scripts/ci/manage-network-preview-recovery.sh prepare
+
+      - name: Record pre-apply recovery provenance
+        shell: sh
+        env:
+          PLAN_RUN_ID: ${{ inputs.plan_run_id }}
+          PLAN_ARTIFACT_ID: ${{ inputs.plan_artifact_id }}
+          PLAN_DIGEST: ${{ steps.provenance.outputs.plan_digest }}
+          SOURCE_COMMIT: ${{ steps.provenance.outputs.source_commit }}
+          RECOVERY_MODE: ${{ steps.recovery.outputs.recovery_mode }}
+          RECOVERY_KEY: ${{ steps.recovery.outputs.recovery_key }}
+          RECOVERY_SHA256: ${{ steps.recovery.outputs.recovery_sha256 }}
+        run: |
+          {
+            echo
+            echo "## Verified pre-apply provenance"
+            echo
+            echo "- Source commit: \`$SOURCE_COMMIT\`"
+            echo "- Plan run / artifact ID: \`$PLAN_RUN_ID\` / \`$PLAN_ARTIFACT_ID\`"
+            echo "- Encrypted plan SHA-256: \`$PLAN_DIGEST\`"
+            echo "- Recovery mode: \`$RECOVERY_MODE\`"
+            echo "- Recovery key: \`$RECOVERY_KEY\`"
+            echo "- Recovery SHA-256: \`$RECOVERY_SHA256\`"
+            echo "- Apply run ID / attempt: \`$GITHUB_RUN_ID\` / \`$GITHUB_RUN_ATTEMPT\`"
+          } >>"$GITHUB_STEP_SUMMARY"
+
+      - name: Reconfirm state and recovery immediately before apply
+        shell: sh
+        env:
+          SOURCE_COMMIT: ${{ steps.provenance.outputs.source_commit }}
+          APPLY_RUN_ID: ${{ github.run_id }}
+          APPLY_RUN_ATTEMPT: ${{ github.run_attempt }}
+          TOFU_ROOT: infra/network-preview/environments/preview
+          RECOVERY_MODE: ${{ steps.recovery.outputs.recovery_mode }}
+          RECOVERY_KEY: ${{ steps.recovery.outputs.recovery_key }}
+          RECOVERY_SHA256: ${{ steps.recovery.outputs.recovery_sha256 }}
+        run: scripts/ci/manage-network-preview-recovery.sh assert
+
+      - name: Apply exact encrypted reviewed plan without re-planning
+        shell: sh
+        run: |
+          if ! tofu -chdir=infra/network-preview/environments/preview apply \
+            -input=false \
+            -no-color \
+            "$RUNNER_TEMP/encrypted.tfplan" >/dev/null 2>&1; then
+            echo "FAIL: exact reviewed-plan apply failed; decrypted output remains suppressed" >&2
+            exit 1
+          fi
+
+      - name: Verify current state and enforce recovery retention
+        id: finalize
+        shell: sh
+        env:
+          SOURCE_COMMIT: ${{ steps.provenance.outputs.source_commit }}
+          APPLY_RUN_ID: ${{ github.run_id }}
+          APPLY_RUN_ATTEMPT: ${{ github.run_attempt }}
+          TOFU_ROOT: infra/network-preview/environments/preview
+          RECOVERY_MODE: ${{ steps.recovery.outputs.recovery_mode }}
+          RECOVERY_KEY: ${{ steps.recovery.outputs.recovery_key }}
+          RECOVERY_SHA256: ${{ steps.recovery.outputs.recovery_sha256 }}
+        run: scripts/ci/manage-network-preview-recovery.sh finalize
+
+      - name: Record successful state verification
+        shell: sh
+        env:
+          CURRENT_STATE_SHA256: ${{ steps.finalize.outputs.current_state_sha256 }}
+          RECOVERY_RETAINED_COUNT: ${{ steps.finalize.outputs.recovery_retained_count }}
+        run: |
+          {
+            echo
+            echo "## Post-apply verification"
+            echo
+            echo "- Current encrypted state SHA-256: \`$CURRENT_STATE_SHA256\`"
+            echo "- Verified recovery objects retained: \`$RECOVERY_RETAINED_COUNT\`"
+          } >>"$GITHUB_STEP_SUMMARY"
+
+      - name: Remove local runtime material
+        if: always()
+        shell: sh
+        run: |
+          rm -f "$RUNNER_TEMP/backend.hcl" "$RUNNER_TEMP/encrypted.tfplan"
+          rm -f infra/network-preview/environments/preview/errored.tfstate
+          rm -f infra/network-preview/environments/preview/errored.tfstate.*
+          case "$TF_DATA_DIR" in
+            "$RUNNER_TEMP"/*) rm -rf "$TF_DATA_DIR" ;;
+            *) echo "WARN: refusing to remove unexpected TF_DATA_DIR: $TF_DATA_DIR" >&2 ;;
+          esac

--- a/.github/workflows/opentofu-protected-plan.yml
+++ b/.github/workflows/opentofu-protected-plan.yml
@@ -1,0 +1,137 @@
+name: OpenTofu Protected Plan
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+# Plan and apply both contact the same encrypted state and must never overlap or be cancelled.
+concurrency:
+  group: opentofu-network-preview-state
+  cancel-in-progress: false
+
+jobs:
+  plan:
+    name: Protected network-preview plan
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    environment: network-preview-plan
+    env:
+      TF_IN_AUTOMATION: '1'
+      TF_INPUT: '0'
+      TF_DATA_DIR: ${{ runner.temp }}/network-preview-terraform
+      TF_VAR_state_encryption_passphrase: ${{ secrets.TOFU_ENCRYPTION_PASSPHRASE }}
+      TF_VAR_project_name: ${{ vars.NETWORK_PREVIEW_DO_PROJECT }}
+      TF_VAR_region: ${{ vars.NETWORK_PREVIEW_DO_REGION }}
+      DIGITALOCEAN_TOKEN: ${{ secrets.DIGITALOCEAN_TOKEN }}
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      AWS_REGION: auto
+      AWS_DEFAULT_REGION: auto
+      NETWORK_PREVIEW_R2_ACCOUNT_ID: ${{ vars.NETWORK_PREVIEW_R2_ACCOUNT_ID }}
+      NETWORK_PREVIEW_R2_BUCKET: ${{ vars.NETWORK_PREVIEW_R2_BUCKET }}
+      NETWORK_PREVIEW_R2_STATE_KEY: ${{ vars.NETWORK_PREVIEW_R2_STATE_KEY }}
+      NETWORK_PREVIEW_R2_RECOVERY_PREFIX: ${{ vars.NETWORK_PREVIEW_R2_RECOVERY_PREFIX }}
+    steps:
+      - name: Refuse non-main workflow dispatches
+        shell: sh
+        run: |
+          if [ "$GITHUB_REF" != "refs/heads/main" ]; then
+            echo "FAIL: protected plans may run only from refs/heads/main" >&2
+            exit 1
+          fi
+
+      - name: Checkout protected source commit
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+
+      - name: Setup pinned OpenTofu
+        uses: opentofu/setup-opentofu@a1320f892987e89d278cc92dc5adc984fb93aca4 # v2
+        with:
+          tofu_version_file: infra/network-preview/.opentofu-version
+          tofu_wrapper: false
+
+      - name: Write runtime-only partial backend configuration
+        shell: sh
+        run: scripts/ci/write-network-preview-backend-config.sh "$RUNNER_TEMP/backend.hcl"
+
+      - name: Initialize encrypted R2 backend with native locking
+        shell: sh
+        run: |
+          tofu -chdir=infra/network-preview/environments/preview init \
+            -reconfigure \
+            -backend-config="$RUNNER_TEMP/backend.hcl" \
+            -lockfile=readonly \
+            -no-color >/dev/null
+
+      - name: Create encrypted speculative plan without logging decrypted content
+        shell: sh
+        run: |
+          if ! tofu -chdir=infra/network-preview/environments/preview plan \
+            -lock-timeout=5m \
+            -input=false \
+            -no-color \
+            -out="$RUNNER_TEMP/encrypted.tfplan" >/dev/null 2>&1; then
+            echo "FAIL: protected OpenTofu plan failed; decrypted plan output remains suppressed" >&2
+            exit 1
+          fi
+
+      - name: Publish sanitized reviewed-plan summary
+        shell: sh
+        run: |
+          scripts/ci/summarize-network-preview-plan.sh \
+            infra/network-preview/environments/preview \
+            "$RUNNER_TEMP/encrypted.tfplan"
+
+      - name: Bind plan digest to trusted artifact name
+        id: provenance
+        shell: sh
+        run: |
+          . scripts/ci/network-preview-lib.sh
+          plan_digest=$(network_preview_sha256_file "$RUNNER_TEMP/encrypted.tfplan")
+          artifact_name="network-preview-plan-v1-${GITHUB_SHA}-${GITHUB_RUN_ATTEMPT}-${plan_digest}"
+          network_preview_write_output plan_digest "$plan_digest"
+          network_preview_write_output artifact_name "$artifact_name"
+
+      - name: Upload exact encrypted reviewed plan
+        id: upload
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: ${{ steps.provenance.outputs.artifact_name }}
+          path: ${{ runner.temp }}/encrypted.tfplan
+          if-no-files-found: error
+          retention-days: 7
+          compression-level: 0
+
+      - name: Record trusted plan-run provenance
+        shell: sh
+        env:
+          PLAN_ARTIFACT_ID: ${{ steps.upload.outputs.artifact-id }}
+          PLAN_DIGEST: ${{ steps.provenance.outputs.plan_digest }}
+          PLAN_ARTIFACT_NAME: ${{ steps.provenance.outputs.artifact_name }}
+        run: |
+          {
+            echo
+            echo "## Trusted plan provenance"
+            echo
+            echo "- Repository: \`$GITHUB_REPOSITORY\`"
+            echo "- Workflow ref: \`$GITHUB_WORKFLOW_REF\`"
+            echo "- Source commit: \`$GITHUB_SHA\`"
+            echo "- Run ID / attempt: \`$GITHUB_RUN_ID\` / \`$GITHUB_RUN_ATTEMPT\`"
+            echo "- Artifact ID: \`$PLAN_ARTIFACT_ID\`"
+            echo "- Artifact name: \`$PLAN_ARTIFACT_NAME\`"
+            echo "- Encrypted plan SHA-256: \`$PLAN_DIGEST\`"
+          } >>"$GITHUB_STEP_SUMMARY"
+
+      - name: Remove local runtime material
+        if: always()
+        shell: sh
+        run: |
+          rm -f "$RUNNER_TEMP/backend.hcl" "$RUNNER_TEMP/encrypted.tfplan"
+          case "$TF_DATA_DIR" in
+            "$RUNNER_TEMP"/*) rm -rf "$TF_DATA_DIR" ;;
+            *) echo "WARN: refusing to remove unexpected TF_DATA_DIR: $TF_DATA_DIR" >&2 ;;
+          esac

--- a/.github/workflows/opentofu.yml
+++ b/.github/workflows/opentofu.yml
@@ -4,24 +4,30 @@ on:
   pull_request:
     paths:
       - '.github/workflows/opentofu.yml'
+      - '.github/workflows/opentofu-protected-apply.yml'
+      - '.github/workflows/opentofu-protected-plan.yml'
       - '.github/dependabot.yml'
       - '.pre-commit-config.yaml'
       - '.gitignore'
       - 'Makefile'
       - 'infra/network-preview/**'
-      - 'scripts/ci/check-network-preview-r2-lock.sh'
+      - 'scripts/ci/*network-preview*.sh'
+      - 'scripts/tests/network-preview-protected.test.mjs'
       - 'scripts/verify-lib.mjs'
       - 'scripts/tests/verify.test.mjs'
   push:
     branches: [main]
     paths:
       - '.github/workflows/opentofu.yml'
+      - '.github/workflows/opentofu-protected-apply.yml'
+      - '.github/workflows/opentofu-protected-plan.yml'
       - '.github/dependabot.yml'
       - '.pre-commit-config.yaml'
       - '.gitignore'
       - 'Makefile'
       - 'infra/network-preview/**'
-      - 'scripts/ci/check-network-preview-r2-lock.sh'
+      - 'scripts/ci/*network-preview*.sh'
+      - 'scripts/tests/network-preview-protected.test.mjs'
       - 'scripts/verify-lib.mjs'
       - 'scripts/tests/verify.test.mjs'
   workflow_dispatch:
@@ -76,7 +82,13 @@ jobs:
             -platform=darwin_amd64
           git diff --exit-code -- .terraform.lock.hcl
 
-      - name: Validate R2 lock driver syntax
+      - name: Validate network-preview CI scripts
         run: |
-          sh -n scripts/ci/check-network-preview-r2-lock.sh
-          shellcheck scripts/ci/check-network-preview-r2-lock.sh
+          sh -n scripts/ci/*network-preview*.sh
+          shellcheck -x scripts/ci/*network-preview*.sh
+
+      - name: Prove enforced offline plan encryption
+        run: scripts/ci/check-network-preview-encrypted-plan.sh
+
+      - name: Test protected workflow contracts
+        run: node --test scripts/tests/network-preview-protected.test.mjs

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,13 +33,20 @@ repos:
           TF_VAR_state_encryption_passphrase=offline-validation-only-not-for-state
           tofu -chdir=infra/network-preview/environments/preview validate -no-color'
 
-      - id: network-preview-r2-lock-script-syntax
-        name: R2 lock driver POSIX syntax
+      - id: network-preview-script-syntax
+        name: Network-preview CI script POSIX syntax
         language: system
         pass_filenames: false
-        files: ^scripts/ci/check-network-preview-r2-lock\.sh$
+        files: ^scripts/ci/.*network-preview.*\.sh$
         stages: [pre-push]
-        entry: sh -n scripts/ci/check-network-preview-r2-lock.sh
+        entry: >-
+          sh -n scripts/ci/check-network-preview-r2-lock.sh
+          scripts/ci/check-network-preview-encrypted-plan.sh
+          scripts/ci/manage-network-preview-recovery.sh
+          scripts/ci/network-preview-lib.sh
+          scripts/ci/summarize-network-preview-plan.sh
+          scripts/ci/verify-network-preview-plan-provenance.sh
+          scripts/ci/write-network-preview-backend-config.sh
 
       - id: rust-fmt-check
         name: rust fmt check (engine-wasm)

--- a/Makefile
+++ b/Makefile
@@ -122,14 +122,19 @@ lint-tofu:
 	@echo "==> tofu validate (network preview)"
 	@TF_VAR_state_encryption_passphrase=offline-validation-only-not-for-state \
 		tofu -chdir=infra/network-preview/environments/preview validate -no-color
-	@echo "==> POSIX syntax (R2 lock driver)"
-	@sh -n scripts/ci/check-network-preview-r2-lock.sh
+	@echo "==> POSIX syntax (network-preview CI scripts)"
+	@sh -n scripts/ci/*network-preview*.sh
 	@if command -v shellcheck >/dev/null 2>&1; then \
-		echo "==> shellcheck (R2 lock driver)"; \
-		shellcheck scripts/ci/check-network-preview-r2-lock.sh; \
+		echo "==> shellcheck (network-preview CI scripts)"; \
+		shellcheck -x scripts/ci/*network-preview*.sh; \
 	else \
-		echo "skip: shellcheck not found (R2 lock driver)"; \
+		echo "skip: shellcheck not found (network-preview CI scripts)"; \
 	fi
+	@echo "==> encrypted offline plan check (network preview)"
+	@TF_VAR_state_encryption_passphrase=offline-validation-only-not-for-state \
+		scripts/ci/check-network-preview-encrypted-plan.sh
+	@echo "==> protected workflow contract tests (network preview)"
+	@node --test scripts/tests/network-preview-protected.test.mjs
 
 test-rust:
 	@$(MAKE) test-rust-engine

--- a/docs/ci/CI_SETUP.md
+++ b/docs/ci/CI_SETUP.md
@@ -130,14 +130,41 @@ Behavior:
 - validates the root with a non-secret, validation-only encryption sentinel;
 - regenerates the `linux_amd64`, `darwin_arm64`, and `darwin_amd64` provider checksums and fails
   on lock-file drift;
-- checks the future R2 lock driver's POSIX syntax and runs `shellcheck`;
+- checks every network-preview CI helper's POSIX syntax, runs `shellcheck`, and exercises the
+  protected workflow contracts without credentials;
 - has only `contents: read`, does not persist checkout credentials, and receives no repository or
   environment secrets.
 
 This workflow does not contact R2 or DigitalOcean, produce a speculative plan, create a GitHub
-environment, or run `tofu apply`. Live R2 locking and provider planning remain blocked by
-`PRE-001`/`PRE-003` and require a separate protected environment before activation. Do not make
-this path-triggered job a global required context; ordinary PRs outside its paths do not create it.
+environment, or run `tofu apply`. It also proves locally that enforced plan encryption produces an
+opaque saved plan and runs contract tests over the protected workflow definitions. Live R2
+locking and provider planning remain blocked by `PRE-001`/`PRE-003` and require separately
+protected environments before activation. Do not make this path-triggered job a global required
+context; ordinary PRs outside its paths do not create it.
+
+### OpenTofu Protected Plan and Apply
+
+`.github/workflows/opentofu-protected-plan.yml` and
+`.github/workflows/opentofu-protected-apply.yml` are manual-only access-backed workflows. They:
+
+- run only from `main` through the `network-preview-plan` and `network-preview-apply`
+  environments;
+- share `opentofu-network-preview-state` concurrency with `cancel-in-progress: false`;
+- generate an encrypted plan whose SHA-256 is bound into its GitHub artifact name alongside the
+  source commit and run attempt;
+- let apply accept only the plan run ID and exact artifact ID, then verify the repository,
+  workflow identity/ref, successful conclusion, source commit, artifact ownership, and digest via
+  GitHub's read-only Actions API;
+- reject a reviewed plan when `main` advanced, and apply the downloaded encrypted plan without
+  generating a replacement;
+- create and verify an encrypted pre-apply R2 recovery object, reconfirm source/lock/copy state
+  immediately before apply, and retain at most the five newest verified recovery objects only
+  after successful apply and current-state verification.
+
+All external actions are full-SHA pinned. Decrypted plan/state content is neither logged nor
+retained; workflow summaries contain only sanitized action/address/count data and provenance
+digests. These workflow definitions must not be enabled or run until `PRE-001`/`PRE-003`, protected
+environment review, real credential scope, and exact operation authority are complete.
 
 Caching:
 

--- a/docs/ci/REQUIRED_CHECKS.md
+++ b/docs/ci/REQUIRED_CHECKS.md
@@ -118,8 +118,10 @@ only after every required status check and any other ruleset requirement succeed
   `docs/waves/TRANSPORT_E2E_READINESS_SCORECARD.md` are satisfied and the follow-up widens its
   stable PR paths to relevant product changes.
 - `OpenTofu Static Validation` validates only network-preview infrastructure changes. It is
-  intentionally path-scoped and must not be a global required context. Live R2 lock and
-  DigitalOcean plan jobs do not exist until protected `PRE-003` access is configured.
+  intentionally path-scoped and must not be a global required context. Manual OpenTofu protected
+  plan/apply workflow definitions exist, but remain access-backed operational gates rather than
+  merge-required checks and must not run until protected `PRE-003` access is configured and the
+  exact operation is authorized.
 - `Build and Deploy to gh-pages` is deployment-focused and must not be required for code merges.
 - Scheduled/manual fuzzing, browser baseline, and release workflows must not be required
   pull-request checks.

--- a/infra/network-preview/README.md
+++ b/infra/network-preview/README.md
@@ -5,8 +5,11 @@ This directory owns the OpenTofu configuration for the public WAP network previe
 
 The current `INF-101` checkpoint is intentionally resource-free. It pins the toolchain and
 DigitalOcean provider, defines the encrypted Cloudflare R2 backend contract, and supplies static
-validation plus an isolated future lock integration test. It does not create an account, bucket,
-GitHub environment, DNS record, Droplet, firewall, Reserved IP, deployment, or public endpoint.
+validation, protected plan/apply workflow definitions, recovery-copy automation, and an isolated
+future lock integration test. It does not create an account, bucket, GitHub environment, DNS
+record, Droplet, firewall, Reserved IP, deployment, or public endpoint. The protected workflows
+remain unusable until `PRE-001` and `PRE-003` establish and independently review their trust
+boundary.
 
 ## Layout
 
@@ -65,15 +68,18 @@ Native S3 lock-file mode is mandatory. State and plan encryption are enforced wi
 AES-GCM; the passphrase is provided through `TF_VAR_state_encryption_passphrase` in a protected
 environment.
 
-R2 does not provide ordinary S3 bucket versioning. A future manually approved apply workflow must
-copy the already encrypted state object to a timestamped recovery prefix before changing cloud
-resources. That protected workflow remains unfinished `INF-101` acceptance scope; it is not
-implemented or executed by this offline checkpoint.
+R2 does not provide ordinary S3 bucket versioning. The manually approved apply workflow copies
+the already encrypted state object to the fixed `wap-labs/network-preview/recovery` prefix before
+changing cloud resources. Its conditional write refuses an existing destination; object metadata
+records the source key and SHA-256, source commit, apply run ID/attempt, and creation time. The
+workflow downloads and compares the source and recovery digests, then rechecks them immediately
+before apply. This automation is implemented but intentionally has not been executed against R2.
 
-## Protected plan and apply contract
+## Protected plan and apply automation
 
-The access-backed `INF-101` automation must preserve one exact reviewed plan from planning through
-manual apply:
+`.github/workflows/opentofu-protected-plan.yml` and
+`.github/workflows/opentofu-protected-apply.yml` preserve one exact reviewed plan from planning
+through manual apply:
 
 - protected plan and apply jobs share one preview-state concurrency group with
   `cancel-in-progress: false`; this is intentionally distinct from the cancelable, secret-free
@@ -95,17 +101,49 @@ manual apply:
   It refuses a pre-existing destination, downloads the encrypted source and recovery objects, and
   requires their SHA-256 digests to match. It then rechecks the encrypted source digest before
   continuing so the recovery copy cannot silently represent stale state;
-- retain the five most recent verified pre-apply recovery objects. Prune older objects only after
-  a successful apply and verification of the current encrypted state, and never remove the last
-  known-good recovery object;
+- retain the five most recent verified pre-apply recovery objects. The finalizer decrypts current
+  state only through `tofu state pull` with output discarded, verifies every recovery object's
+  metadata and downloaded SHA-256, and prunes older objects only after successful apply. An apply
+  failure leaves every recovery object untouched;
 - for the first resource-creating apply only, when no state exists to copy, the serialized apply
   job must prove both the configured state and lock keys are absent immediately before applying,
   record that bootstrap condition in trusted run metadata, and verify the resulting encrypted
   remote state through a protected backend operation. Any unexpected object fails closed.
 
-These controls are unfinished, access-backed `INF-101` acceptance. This checkpoint documents the
-contract but does not create protected environments, handle credentials, produce a remote plan,
-copy state, or run `tofu apply`.
+The checked-in automation is access-independent readiness evidence, not access-backed acceptance.
+This checkpoint does not create protected environments, handle real credentials, produce a remote
+plan, copy remote state, or run `tofu apply`.
+
+## Manual protected flow
+
+After `PRE-001` and `PRE-003` are accepted and an exact operation is authorized:
+
+1. Dispatch **OpenTofu Protected Plan** from `main`. Review its sanitized action/address/count
+   summary and record the run ID and artifact ID from the trusted run summary.
+2. Dispatch **OpenTofu Protected Apply** from the same current `main` commit with only those two
+   IDs. The workflow obtains the commit, run attempt, and plan digest from GitHub's workflow and
+   artifact APIs; no digest or commit is accepted from the operator.
+3. The apply fails closed if `main` advanced after planning, the run/workflow/repository/ref or
+   artifact identity differs, the encrypted plan digest differs, or the seven-day artifact has
+   expired. Create and review a new plan instead of bypassing a stale-plan failure.
+4. Approve the `network-preview-apply` environment only after independently matching the plan run,
+   artifact ID, source commit, and sanitized review. The apply never re-plans.
+
+The plan and apply workflows use the exact shared `opentofu-network-preview-state` concurrency
+group with cancellation disabled. The secret-free static workflow remains separately cancelable.
+
+## Failure and recovery behavior
+
+- Before a non-bootstrap apply, the recovery object key contains the source commit, apply run ID,
+  run attempt, and a 128-bit nonce. A failed apply or failed post-apply verification performs no
+  retention deletion.
+- On the first resource-creating apply only, the workflow records a bootstrap mode after proving
+  both the state and native `.tflock` keys absent, and reconfirms absence immediately before apply.
+- After successful apply, the finalizer requires a decryptable current state, no remaining lock,
+  and a downloadable encrypted current-state object before it considers retention.
+- Recovery restoration, lock removal, destroy, and force-unlock are intentionally not automated by
+  these workflows. They are separate state mutations requiring exact authorization and a reviewed
+  runbook decision. The newest verified pre-apply copy remains the rollback source.
 
 ## Access-backed gates
 
@@ -117,9 +155,10 @@ copy state, or run `tofu apply`.
 3. The protected R2 test proves acquisition, contention failure, normal release, stale-lock
    recovery, and cleanup against a unique non-production key.
 4. A protected DigitalOcean speculative plan succeeds without exposing a plaintext plan or state.
-5. The protected plan/apply path proves exact-plan review, non-cancelable shared-state
+5. An authorized protected plan/apply run proves exact-plan review, non-cancelable shared-state
    serialization, verified encrypted recovery copies, and manual apply approval.
 
 Executing a cloud apply remains explicitly out of scope for this offline checkpoint. Implementing
-the serialized, manually approved apply and state-recovery automation remains part of `INF-101`
-after `PRE-003` supplies its protected trust boundary.
+the serialized, manually approved apply and state-recovery automation is complete at the
+access-independent configuration level; live proof remains part of `INF-101` after `PRE-003`
+supplies its protected trust boundary and explicit authority is granted.

--- a/infra/network-preview/bootstrap/README.md
+++ b/infra/network-preview/bootstrap/README.md
@@ -31,5 +31,16 @@ No values belong in this repository, workflow inputs, logs, plans, cloud-init, i
 text. Do not reference a secret-bearing environment from an enabled job until its protection rules
 and reviewers have been configured and independently checked.
 
+Both environments must restrict deployments to `main`. The apply environment must require a
+manual reviewer who did not author the reviewed infrastructure change; the plan environment must
+also require explicitly approved operators. Keep the two DigitalOcean credentials separately
+scoped so the plan credential cannot mutate resources, and restrict the R2 credential to object
+read/write/list operations for the one private bucket. GitHub's `GITHUB_TOKEN` remains read-only;
+only the apply job receives `actions: read` so it can verify the selected run and artifact IDs.
+
+The workflow definitions alone do not enforce repository environment settings. Record an
+independent screenshot/export review of deployment-branch restrictions, required reviewers,
+credential scope, and recovery access under `PRE-003` before enabling either workflow.
+
 The bucket, environment, credentials, and cloud resources do not exist merely because this
 directory exists. Keep `PRE-001` and `PRE-003` open until their acceptance evidence is recorded.

--- a/infra/network-preview/environments/preview/backend.tf
+++ b/infra/network-preview/environments/preview/backend.tf
@@ -1,10 +1,3 @@
-variable "state_encryption_passphrase" {
-  description = "Protected passphrase used to encrypt OpenTofu state and plan data."
-  type        = string
-  sensitive   = true
-  ephemeral   = true
-}
-
 terraform {
   backend "s3" {
     region                      = "auto"
@@ -15,28 +8,5 @@ terraform {
     skip_region_validation      = true
     skip_requesting_account_id  = true
     skip_s3_checksum            = true
-  }
-
-  encryption {
-    key_provider "pbkdf2" "network_preview" {
-      passphrase               = var.state_encryption_passphrase
-      key_length               = 32
-      iterations               = 600000
-      encrypted_metadata_alias = "network-preview-v1"
-    }
-
-    method "aes_gcm" "network_preview" {
-      keys = key_provider.pbkdf2.network_preview
-    }
-
-    state {
-      method   = method.aes_gcm.network_preview
-      enforced = true
-    }
-
-    plan {
-      method   = method.aes_gcm.network_preview
-      enforced = true
-    }
   }
 }

--- a/infra/network-preview/environments/preview/encryption.tf
+++ b/infra/network-preview/environments/preview/encryption.tf
@@ -1,0 +1,31 @@
+variable "state_encryption_passphrase" {
+  description = "Protected passphrase used to encrypt OpenTofu state and plan data."
+  type        = string
+  sensitive   = true
+  ephemeral   = true
+}
+
+terraform {
+  encryption {
+    key_provider "pbkdf2" "network_preview" {
+      passphrase               = var.state_encryption_passphrase
+      key_length               = 32
+      iterations               = 600000
+      encrypted_metadata_alias = "network-preview-v1"
+    }
+
+    method "aes_gcm" "network_preview" {
+      keys = key_provider.pbkdf2.network_preview
+    }
+
+    state {
+      method   = method.aes_gcm.network_preview
+      enforced = true
+    }
+
+    plan {
+      method   = method.aes_gcm.network_preview
+      enforced = true
+    }
+  }
+}

--- a/scripts/ci/check-network-preview-encrypted-plan.sh
+++ b/scripts/ci/check-network-preview-encrypted-plan.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env sh
+set -eu
+
+script_directory=$(CDPATH='' cd "$(dirname "$0")" && pwd)
+# shellcheck source=scripts/ci/network-preview-lib.sh
+. "$script_directory/network-preview-lib.sh"
+
+for command_name in tofu jq grep mktemp cp mkdir; do
+  network_preview_require_command "$command_name"
+done
+
+network_preview_require_value TF_VAR_state_encryption_passphrase
+
+repository_root=$(CDPATH='' cd "$script_directory/../.." && pwd)
+tofu_root="$repository_root/infra/network-preview/environments/preview"
+work_root=$(mktemp -d "${TMPDIR:-/tmp}/wap-labs-encrypted-plan.XXXXXX")
+offline_root="$work_root/config"
+plan_path="$work_root/offline.tfplan"
+summary_path="$work_root/summary.md"
+
+cleanup() {
+  case "$work_root" in
+    "${TMPDIR:-/tmp}"/wap-labs-encrypted-plan.*) rm -rf "$work_root" ;;
+    *) echo "WARN: refusing to remove unexpected temporary path: $work_root" >&2 ;;
+  esac
+}
+trap cleanup EXIT HUP INT TERM
+
+mkdir "$offline_root"
+for source_file in \
+  encryption.tf \
+  outputs.tf \
+  providers.tf \
+  variables.tf \
+  versions.tf \
+  .terraform.lock.hcl; do
+  cp "$tofu_root/$source_file" "$offline_root/$source_file"
+done
+
+tofu -chdir="$offline_root" init -backend=false -lockfile=readonly -no-color >/dev/null
+
+TF_VAR_project_name=offline-validation \
+  TF_VAR_region=tor1 \
+  tofu -chdir="$offline_root" plan \
+  -input=false \
+  -lock=false \
+  -no-color \
+  -out="$plan_path" >/dev/null
+
+# A known planned output value must not appear in the encrypted on-disk plan.
+if LC_ALL=C grep -a -F 'offline-scaffold-only' "$plan_path" >/dev/null 2>&1; then
+  network_preview_fail "saved plan exposes known plaintext despite enforced plan encryption"
+fi
+
+# OpenTofu must still decrypt and parse the plan with the configured passphrase.
+tofu -chdir="$offline_root" show -json "$plan_path" |
+  jq -e '.format_version | type == "string"' >/dev/null
+
+GITHUB_STEP_SUMMARY="$summary_path" \
+  "$script_directory/summarize-network-preview-plan.sh" "$offline_root" "$plan_path" >/dev/null
+if grep -F 'offline-scaffold-only' "$summary_path" >/dev/null 2>&1; then
+  network_preview_fail "sanitized plan summary exposed a planned output value"
+fi
+if ! grep -F 'Sanitized OpenTofu plan' "$summary_path" >/dev/null 2>&1; then
+  network_preview_fail "sanitized plan summary was not produced"
+fi
+
+echo "PASS: saved plan is encrypted at rest and only sanitized review data is published"

--- a/scripts/ci/check-network-preview-r2-lock.sh
+++ b/scripts/ci/check-network-preview-r2-lock.sh
@@ -1,24 +1,12 @@
 #!/usr/bin/env sh
 set -eu
 
-require_command() {
-  if ! command -v "$1" >/dev/null 2>&1; then
-    echo "FAIL: required command not found: $1" >&2
-    exit 1
-  fi
-}
-
-require_value() {
-  variable_name=$1
-  eval "variable_value=\${$variable_name:-}"
-  if [ -z "$variable_value" ]; then
-    echo "FAIL: required environment variable is unset: $variable_name" >&2
-    exit 1
-  fi
-}
+script_directory=$(CDPATH='' cd "$(dirname "$0")" && pwd)
+# shellcheck source=scripts/ci/network-preview-lib.sh
+. "$script_directory/network-preview-lib.sh"
 
 for command_name in tofu aws jq mktemp cp kill sleep grep; do
-  require_command "$command_name"
+  network_preview_require_command "$command_name"
 done
 
 for variable_name in \
@@ -30,7 +18,7 @@ for variable_name in \
   AWS_ACCESS_KEY_ID \
   AWS_SECRET_ACCESS_KEY \
   TOFU_ENCRYPTION_PASSPHRASE; do
-  require_value "$variable_name"
+  network_preview_require_value "$variable_name"
 done
 
 case "$NETWORK_PREVIEW_R2_TEST_PREFIX" in
@@ -41,17 +29,9 @@ case "$NETWORK_PREVIEW_R2_TEST_PREFIX" in
     ;;
 esac
 
-if [ "${#NETWORK_PREVIEW_R2_ACCOUNT_ID}" -ne 32 ] ||
-  ! printf '%s\n' "$NETWORK_PREVIEW_R2_ACCOUNT_ID" | grep -Eq '^[0-9a-f]{32}$'; then
-  echo "FAIL: NETWORK_PREVIEW_R2_ACCOUNT_ID must be a 32-character lowercase hexadecimal ID" >&2
-  exit 1
-fi
-
-if ! printf '%s\n' "$NETWORK_PREVIEW_R2_BUCKET" |
-  grep -Eq '^[a-z0-9][a-z0-9-]{1,61}[a-z0-9]$'; then
-  echo "FAIL: NETWORK_PREVIEW_R2_BUCKET must be a 3-63 character lowercase bucket name" >&2
-  exit 1
-fi
+network_preview_validate_account_id
+network_preview_validate_bucket
+network_preview_validate_state_key
 
 test_run_id=$NETWORK_PREVIEW_R2_TEST_RUN_ID
 if ! printf '%s\n' "$test_run_id" |

--- a/scripts/ci/manage-network-preview-recovery.sh
+++ b/scripts/ci/manage-network-preview-recovery.sh
@@ -1,0 +1,341 @@
+#!/usr/bin/env sh
+set -eu
+
+script_directory=$(CDPATH='' cd "$(dirname "$0")" && pwd)
+# shellcheck source=scripts/ci/network-preview-lib.sh
+. "$script_directory/network-preview-lib.sh"
+
+for command_name in aws jq grep mktemp sort sed wc date tofu; do
+  network_preview_require_command "$command_name"
+done
+
+for variable_name in \
+  NETWORK_PREVIEW_R2_ACCOUNT_ID \
+  NETWORK_PREVIEW_R2_BUCKET \
+  NETWORK_PREVIEW_R2_STATE_KEY \
+  NETWORK_PREVIEW_R2_RECOVERY_PREFIX \
+  AWS_ACCESS_KEY_ID \
+  AWS_SECRET_ACCESS_KEY \
+  SOURCE_COMMIT \
+  APPLY_RUN_ID \
+  APPLY_RUN_ATTEMPT \
+  TOFU_ROOT; do
+  network_preview_require_value "$variable_name"
+done
+
+network_preview_validate_r2_contract
+if ! printf '%s\n' "$SOURCE_COMMIT" | grep -Eq '^[0-9a-f]{40}$'; then
+  network_preview_fail "SOURCE_COMMIT must be a lowercase 40-character commit SHA"
+fi
+for numeric_value in "$APPLY_RUN_ID" "$APPLY_RUN_ATTEMPT"; do
+  if ! printf '%s\n' "$numeric_value" | grep -Eq '^[1-9][0-9]*$'; then
+    network_preview_fail "apply run ID and attempt must be positive integers"
+  fi
+done
+if [ ! -d "$TOFU_ROOT" ]; then
+  network_preview_fail "TOFU_ROOT is not a directory: $TOFU_ROOT"
+fi
+
+case "${1:-}" in
+  prepare | assert | finalize) recovery_phase=$1 ;;
+  *) network_preview_fail "usage: $0 prepare|assert|finalize" ;;
+esac
+
+if [ "$recovery_phase" = "prepare" ]; then
+  network_preview_require_value RECOVERY_NONCE
+  if ! printf '%s\n' "$RECOVERY_NONCE" | grep -Eq '^[0-9a-f]{32}$'; then
+    network_preview_fail "RECOVERY_NONCE must be 128 bits of lowercase hexadecimal data"
+  fi
+else
+  RECOVERY_KEY=${RECOVERY_KEY:-}
+  RECOVERY_SHA256=${RECOVERY_SHA256:-}
+  network_preview_require_value RECOVERY_MODE
+  case "$RECOVERY_MODE" in
+    copy)
+      network_preview_require_value RECOVERY_KEY
+      network_preview_require_value RECOVERY_SHA256
+      ;;
+    bootstrap) ;;
+    *) network_preview_fail "RECOVERY_MODE must be copy or bootstrap" ;;
+  esac
+fi
+
+work_root=$(mktemp -d "${TMPDIR:-/tmp}/wap-labs-r2-recovery.XXXXXX")
+endpoint="https://${NETWORK_PREVIEW_R2_ACCOUNT_ID}.r2.cloudflarestorage.com"
+state_key=$NETWORK_PREVIEW_R2_STATE_KEY
+lock_key="${state_key}.tflock"
+recovery_prefix="${NETWORK_PREVIEW_R2_RECOVERY_PREFIX%/}/"
+
+cleanup() {
+  case "$work_root" in
+    "${TMPDIR:-/tmp}"/wap-labs-r2-recovery.*) rm -rf "$work_root" ;;
+    *) echo "WARN: refusing to remove unexpected temporary path: $work_root" >&2 ;;
+  esac
+}
+trap cleanup EXIT HUP INT TERM
+
+export AWS_REGION=auto
+export AWS_DEFAULT_REGION=auto
+
+list_objects() {
+  object_prefix=$1
+  output_path=$2
+  aws s3api list-objects-v2 \
+    --bucket "$NETWORK_PREVIEW_R2_BUCKET" \
+    --prefix "$object_prefix" \
+    --endpoint-url "$endpoint" \
+    --no-cli-pager \
+    --output json >"$output_path"
+}
+
+object_count() {
+  object_key=$1
+  list_path="$work_root/object-list.json"
+  list_objects "$object_key" "$list_path"
+  jq -er --arg key "$object_key" \
+    '[.Contents[]? | select(.Key == $key)] | length' "$list_path"
+}
+
+download_object() {
+  object_key=$1
+  destination=$2
+  aws s3api get-object \
+    --bucket "$NETWORK_PREVIEW_R2_BUCKET" \
+    --key "$object_key" \
+    --endpoint-url "$endpoint" \
+    --no-cli-pager \
+    "$destination" >/dev/null
+}
+
+head_object() {
+  object_key=$1
+  destination=$2
+  aws s3api head-object \
+    --bucket "$NETWORK_PREVIEW_R2_BUCKET" \
+    --key "$object_key" \
+    --endpoint-url "$endpoint" \
+    --no-cli-pager \
+    --output json >"$destination"
+}
+
+require_exact_object_count() {
+  object_key=$1
+  expected_count=$2
+  actual_count=$(object_count "$object_key")
+  if [ "$actual_count" -ne "$expected_count" ]; then
+    network_preview_fail \
+      "expected $expected_count object(s) at $object_key, found $actual_count"
+  fi
+}
+
+verify_recovery_object() {
+  object_key=$1
+  file_stem=$2
+  head_path="$work_root/${file_stem}.head.json"
+  body_path="$work_root/${file_stem}.body"
+  head_object "$object_key" "$head_path"
+  expected_digest=$(jq -er '
+    .Metadata
+    | select(.["recovery-format"] == "v1")
+    | .["source-sha256"]
+    | select(type == "string" and test("^[0-9a-f]{64}$"))
+  ' "$head_path")
+  if ! jq -e \
+    --arg source_key "$state_key" \
+    '
+      .Metadata["source-key"] == $source_key
+      and (.Metadata["source-commit"] | type == "string" and test("^[0-9a-f]{40}$"))
+      and (.Metadata["apply-run-id"] | type == "string" and test("^[1-9][0-9]*$"))
+      and (.Metadata["apply-run-attempt"] | type == "string" and test("^[1-9][0-9]*$"))
+      and (.Metadata["created-at"] | type == "string" and test("^[0-9]{4}-[0-9]{2}-[0-9]{2}T"))
+    ' "$head_path" >/dev/null; then
+    network_preview_fail "recovery metadata is incomplete for $object_key"
+  fi
+  download_object "$object_key" "$body_path"
+  actual_digest=$(network_preview_sha256_file "$body_path")
+  if [ "$actual_digest" != "$expected_digest" ]; then
+    network_preview_fail "recovery object SHA-256 does not match metadata: $object_key"
+  fi
+  verified_recovery_digest=$actual_digest
+}
+
+verify_selected_recovery_object() {
+  if ! printf '%s\n' "$RECOVERY_KEY" | grep -Eq \
+    "^${recovery_prefix}${SOURCE_COMMIT}/${APPLY_RUN_ID}-${APPLY_RUN_ATTEMPT}-[0-9a-f]{32}\\.tfstate$"; then
+    network_preview_fail "selected recovery key does not match this apply run provenance"
+  fi
+  verify_recovery_object "$RECOVERY_KEY" selected-recovery
+  if ! jq -e \
+    --arg source_commit "$SOURCE_COMMIT" \
+    --arg apply_run_id "$APPLY_RUN_ID" \
+    --arg apply_run_attempt "$APPLY_RUN_ATTEMPT" '
+      .Metadata["source-commit"] == $source_commit
+      and .Metadata["apply-run-id"] == $apply_run_id
+      and .Metadata["apply-run-attempt"] == $apply_run_attempt
+    ' "$work_root/selected-recovery.head.json" >/dev/null; then
+    network_preview_fail "selected recovery metadata does not match this apply run provenance"
+  fi
+}
+
+prepare_recovery() {
+  require_exact_object_count "$lock_key" 0
+  state_count=$(object_count "$state_key")
+  case "$state_count" in
+    0)
+      # This is permitted only for the serialized first resource-creating apply.
+      require_exact_object_count "$lock_key" 0
+      network_preview_write_output recovery_mode bootstrap
+      network_preview_write_output recovery_key none
+      network_preview_write_output recovery_sha256 none
+      echo "PASS: bootstrap proven immediately before apply; state and lock keys are absent"
+      ;;
+    1)
+      source_path="$work_root/source.tfstate"
+      source_recheck_path="$work_root/source-recheck.tfstate"
+      recovery_path="$work_root/recovery.tfstate"
+      download_object "$state_key" "$source_path"
+      source_digest=$(network_preview_sha256_file "$source_path")
+      recovery_key="${recovery_prefix}${SOURCE_COMMIT}/${APPLY_RUN_ID}-${APPLY_RUN_ATTEMPT}-${RECOVERY_NONCE}.tfstate"
+      require_exact_object_count "$recovery_key" 0
+      created_at=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
+
+      aws s3api put-object \
+        --bucket "$NETWORK_PREVIEW_R2_BUCKET" \
+        --key "$recovery_key" \
+        --body "$source_path" \
+        --content-type application/octet-stream \
+        --if-none-match '*' \
+        --metadata \
+        "recovery-format=v1,source-key=${state_key},source-sha256=${source_digest},source-commit=${SOURCE_COMMIT},apply-run-id=${APPLY_RUN_ID},apply-run-attempt=${APPLY_RUN_ATTEMPT},created-at=${created_at}" \
+        --endpoint-url "$endpoint" \
+        --no-cli-pager >/dev/null
+
+      require_exact_object_count "$recovery_key" 1
+      download_object "$recovery_key" "$recovery_path"
+      recovery_digest=$(network_preview_sha256_file "$recovery_path")
+      if [ "$recovery_digest" != "$source_digest" ]; then
+        network_preview_fail "encrypted recovery copy does not match its source SHA-256"
+      fi
+
+      download_object "$state_key" "$source_recheck_path"
+      source_recheck_digest=$(network_preview_sha256_file "$source_recheck_path")
+      if [ "$source_recheck_digest" != "$source_digest" ]; then
+        network_preview_fail "encrypted source state changed during recovery-copy preparation"
+      fi
+
+      network_preview_write_output recovery_mode copy
+      network_preview_write_output recovery_key "$recovery_key"
+      network_preview_write_output recovery_sha256 "$recovery_digest"
+      echo "PASS: created and verified an immutable encrypted pre-apply recovery copy"
+      ;;
+    *) network_preview_fail "multiple exact state objects were reported unexpectedly" ;;
+  esac
+}
+
+assert_recovery() {
+  require_exact_object_count "$lock_key" 0
+  case "$RECOVERY_MODE" in
+    bootstrap)
+      require_exact_object_count "$state_key" 0
+      echo "PASS: bootstrap state and lock absence reconfirmed immediately before apply"
+      ;;
+    copy)
+      require_exact_object_count "$state_key" 1
+      require_exact_object_count "$RECOVERY_KEY" 1
+      verify_selected_recovery_object
+      if [ "$verified_recovery_digest" != "$RECOVERY_SHA256" ]; then
+        network_preview_fail "selected recovery object changed before apply"
+      fi
+      source_assert_path="$work_root/source-assert.tfstate"
+      download_object "$state_key" "$source_assert_path"
+      source_assert_digest=$(network_preview_sha256_file "$source_assert_path")
+      if [ "$source_assert_digest" != "$RECOVERY_SHA256" ]; then
+        network_preview_fail "encrypted source state changed after recovery preparation"
+      fi
+      echo "PASS: source, lock, and recovery digests reconfirmed immediately before apply"
+      ;;
+  esac
+}
+
+finalize_recovery() {
+  # This decrypts state only in memory and discards it; no plaintext state is retained or logged.
+  tofu -chdir="$TOFU_ROOT" state pull >/dev/null
+  require_exact_object_count "$lock_key" 0
+  require_exact_object_count "$state_key" 1
+
+  current_state_path="$work_root/current.tfstate"
+  download_object "$state_key" "$current_state_path"
+  current_state_digest=$(network_preview_sha256_file "$current_state_path")
+
+  if [ "$RECOVERY_MODE" = "copy" ]; then
+    require_exact_object_count "$RECOVERY_KEY" 1
+    verify_selected_recovery_object
+    if [ "$verified_recovery_digest" != "$RECOVERY_SHA256" ]; then
+      network_preview_fail "selected recovery object no longer matches its pre-apply SHA-256"
+    fi
+  fi
+
+  recovery_list_json="$work_root/recovery-list.json"
+  recovery_list_tsv="$work_root/recovery-list.tsv"
+  verified_list_tsv="$work_root/verified-list.tsv"
+  sorted_list_tsv="$work_root/sorted-list.tsv"
+  prune_list_tsv="$work_root/prune-list.tsv"
+  list_objects "$recovery_prefix" "$recovery_list_json"
+  jq -r --arg prefix "$recovery_prefix" '
+    .Contents[]?
+    | select(.Key | startswith($prefix))
+    | [.LastModified, .Key]
+    | @tsv
+  ' "$recovery_list_json" >"$recovery_list_tsv"
+
+  : >"$verified_list_tsv"
+  verification_index=0
+  tab=$(printf '\t')
+  while IFS="$tab" read -r last_modified object_key; do
+    if [ -z "$object_key" ]; then
+      continue
+    fi
+    if ! printf '%s\n' "$object_key" | grep -Eq \
+      "^${recovery_prefix}[0-9a-f]{40}/[1-9][0-9]*-[1-9][0-9]*-[0-9a-f]{32}\\.tfstate$"; then
+      network_preview_fail "unexpected object under the recovery prefix: $object_key"
+    fi
+    verification_index=$((verification_index + 1))
+    verify_recovery_object "$object_key" "recovery-${verification_index}"
+    printf '%s\t%s\n' "$last_modified" "$object_key" >>"$verified_list_tsv"
+  done <"$recovery_list_tsv"
+
+  sort -r "$verified_list_tsv" >"$sorted_list_tsv"
+  verified_count=$(wc -l <"$sorted_list_tsv" | tr -d ' ')
+  : >"$prune_list_tsv"
+  if [ "$verified_count" -gt 5 ]; then
+    sed -n '6,$p' "$sorted_list_tsv" >"$prune_list_tsv"
+  fi
+
+  while IFS="$tab" read -r last_modified object_key; do
+    if [ -z "$object_key" ]; then
+      continue
+    fi
+    verification_index=$((verification_index + 1))
+    verify_recovery_object "$object_key" "prune-${verification_index}"
+    aws s3api delete-object \
+      --bucket "$NETWORK_PREVIEW_R2_BUCKET" \
+      --key "$object_key" \
+      --endpoint-url "$endpoint" \
+      --no-cli-pager >/dev/null
+    require_exact_object_count "$object_key" 0
+  done <"$prune_list_tsv"
+
+  retained_count=$verified_count
+  if [ "$retained_count" -gt 5 ]; then
+    retained_count=5
+  fi
+  network_preview_write_output current_state_sha256 "$current_state_digest"
+  network_preview_write_output recovery_retained_count "$retained_count"
+  echo "PASS: verified current encrypted state and retained up to five newest recovery copies"
+}
+
+case "$recovery_phase" in
+  prepare) prepare_recovery ;;
+  assert) assert_recovery ;;
+  finalize) finalize_recovery ;;
+esac

--- a/scripts/ci/network-preview-lib.sh
+++ b/scripts/ci/network-preview-lib.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env sh
+
+network_preview_fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+network_preview_require_command() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    network_preview_fail "required command not found: $1"
+  fi
+}
+
+network_preview_require_value() {
+  variable_name=$1
+  eval "variable_value=\${$variable_name:-}"
+  if [ -z "$variable_value" ]; then
+    network_preview_fail "required environment variable is unset: $variable_name"
+  fi
+}
+
+network_preview_validate_account_id() {
+  if [ "${#NETWORK_PREVIEW_R2_ACCOUNT_ID}" -ne 32 ] ||
+    ! printf '%s\n' "$NETWORK_PREVIEW_R2_ACCOUNT_ID" | grep -Eq '^[0-9a-f]{32}$'; then
+    network_preview_fail \
+      "NETWORK_PREVIEW_R2_ACCOUNT_ID must be a 32-character lowercase hexadecimal ID"
+  fi
+}
+
+network_preview_validate_bucket() {
+  if ! printf '%s\n' "$NETWORK_PREVIEW_R2_BUCKET" |
+    grep -Eq '^[a-z0-9][a-z0-9-]{1,61}[a-z0-9]$'; then
+    network_preview_fail \
+      "NETWORK_PREVIEW_R2_BUCKET must be a 3-63 character lowercase bucket name"
+  fi
+}
+
+network_preview_validate_state_key() {
+  if [ "$NETWORK_PREVIEW_R2_STATE_KEY" != "wap-labs/network-preview/preview.tfstate" ]; then
+    network_preview_fail \
+      "NETWORK_PREVIEW_R2_STATE_KEY must equal wap-labs/network-preview/preview.tfstate"
+  fi
+}
+
+network_preview_validate_recovery_prefix() {
+  if [ "${NETWORK_PREVIEW_R2_RECOVERY_PREFIX:-}" != "wap-labs/network-preview/recovery" ]; then
+    network_preview_fail \
+      "NETWORK_PREVIEW_R2_RECOVERY_PREFIX must equal wap-labs/network-preview/recovery"
+  fi
+}
+
+network_preview_validate_r2_contract() {
+  network_preview_validate_account_id
+  network_preview_validate_bucket
+  network_preview_validate_state_key
+  network_preview_validate_recovery_prefix
+}
+
+network_preview_sha256_file() {
+  file_path=$1
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$file_path" | awk '{ print $1 }'
+    return
+  fi
+  if command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "$file_path" | awk '{ print $1 }'
+    return
+  fi
+  network_preview_fail "sha256sum or shasum is required"
+}
+
+network_preview_write_output() {
+  output_name=$1
+  output_value=$2
+  if [ -n "${GITHUB_OUTPUT:-}" ]; then
+    printf '%s=%s\n' "$output_name" "$output_value" >>"$GITHUB_OUTPUT"
+  else
+    printf '%s=%s\n' "$output_name" "$output_value"
+  fi
+}

--- a/scripts/ci/summarize-network-preview-plan.sh
+++ b/scripts/ci/summarize-network-preview-plan.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env sh
+set -eu
+
+script_directory=$(CDPATH='' cd "$(dirname "$0")" && pwd)
+# shellcheck source=scripts/ci/network-preview-lib.sh
+. "$script_directory/network-preview-lib.sh"
+
+for command_name in tofu jq mktemp mkfifo; do
+  network_preview_require_command "$command_name"
+done
+
+if [ "$#" -ne 2 ]; then
+  network_preview_fail "usage: $0 TOFU_ROOT PLAN_PATH"
+fi
+
+tofu_root=$1
+plan_path=$2
+summary_destination=${GITHUB_STEP_SUMMARY:-}
+if [ -z "$summary_destination" ]; then
+  network_preview_fail "GITHUB_STEP_SUMMARY must name the trusted workflow-run summary"
+fi
+
+work_root=$(mktemp -d "${TMPDIR:-/tmp}/wap-labs-plan-summary.XXXXXX")
+show_fifo="$work_root/tofu-show.json"
+sanitized_summary="$work_root/sanitized.json"
+show_pid=
+
+cleanup() {
+  if [ -n "$show_pid" ]; then
+    kill "$show_pid" >/dev/null 2>&1 || true
+    wait "$show_pid" >/dev/null 2>&1 || true
+  fi
+  case "$work_root" in
+    "${TMPDIR:-/tmp}"/wap-labs-plan-summary.*) rm -rf "$work_root" ;;
+    *) echo "WARN: refusing to remove unexpected temporary path: $work_root" >&2 ;;
+  esac
+}
+trap cleanup EXIT HUP INT TERM
+
+mkfifo "$show_fifo"
+tofu -chdir="$tofu_root" show -json "$plan_path" >"$show_fifo" &
+show_pid=$!
+
+if ! jq -e '
+  [
+    .resource_changes[]?
+    | select(.change.actions != ["no-op"])
+    | {
+        address,
+        actions: (.change.actions | join(" -> "))
+      }
+  ] as $changes
+  | {
+      change_count: ($changes | length),
+      action_counts: (
+        $changes
+        | group_by(.actions)
+        | map({action: .[0].actions, count: length})
+      ),
+      resources: $changes
+    }
+' <"$show_fifo" >"$sanitized_summary"; then
+  wait "$show_pid" >/dev/null 2>&1 || true
+  show_pid=
+  network_preview_fail "could not sanitize the reviewed plan"
+fi
+
+if ! wait "$show_pid"; then
+  show_pid=
+  network_preview_fail "OpenTofu could not read the encrypted reviewed plan"
+fi
+show_pid=
+
+{
+  echo "## Sanitized OpenTofu plan"
+  echo
+  printf 'Changed resource addresses: **%s**\n\n' \
+    "$(jq -r '.change_count' "$sanitized_summary")"
+  echo "| Action | Count |"
+  echo "| --- | ---: |"
+  jq -r '.action_counts[] | "| \(.action | gsub("[|\\r\\n]"; " ")) | \(.count) |"' \
+    "$sanitized_summary"
+  echo
+  echo "| Resource address | Action |"
+  echo "| --- | --- |"
+  jq -r '
+    .resources[]
+    | "| `\(.address | gsub("[`|\\r\\n]"; " "))` | \(.actions | gsub("[|\\r\\n]"; " ")) |"
+  ' "$sanitized_summary"
+} >>"$summary_destination"
+
+echo "PASS: published only action, resource-address, and count plan data"

--- a/scripts/ci/verify-network-preview-plan-provenance.sh
+++ b/scripts/ci/verify-network-preview-plan-provenance.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env sh
+set -eu
+
+script_directory=$(CDPATH='' cd "$(dirname "$0")" && pwd)
+# shellcheck source=scripts/ci/network-preview-lib.sh
+. "$script_directory/network-preview-lib.sh"
+
+for command_name in gh jq grep mktemp unzip; do
+  network_preview_require_command "$command_name"
+done
+
+for variable_name in \
+  GITHUB_REPOSITORY \
+  GITHUB_REPOSITORY_ID \
+  PLAN_RUN_ID \
+  PLAN_ARTIFACT_ID \
+  EXPECTED_SOURCE_COMMIT \
+  PLAN_DESTINATION; do
+  network_preview_require_value "$variable_name"
+done
+
+if ! printf '%s\n' "$GITHUB_REPOSITORY" | grep -Eq '^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$'; then
+  network_preview_fail "GITHUB_REPOSITORY is invalid"
+fi
+for numeric_value in "$GITHUB_REPOSITORY_ID" "$PLAN_RUN_ID" "$PLAN_ARTIFACT_ID"; do
+  if ! printf '%s\n' "$numeric_value" | grep -Eq '^[1-9][0-9]*$'; then
+    network_preview_fail "repository, run, and artifact IDs must be positive integers"
+  fi
+done
+if ! printf '%s\n' "$EXPECTED_SOURCE_COMMIT" | grep -Eq '^[0-9a-f]{40}$'; then
+  network_preview_fail "EXPECTED_SOURCE_COMMIT must be a lowercase 40-character commit SHA"
+fi
+if [ -e "$PLAN_DESTINATION" ]; then
+  network_preview_fail "refusing to overwrite plan destination: $PLAN_DESTINATION"
+fi
+
+destination_parent=$(dirname "$PLAN_DESTINATION")
+if [ ! -d "$destination_parent" ]; then
+  network_preview_fail "plan destination parent does not exist: $destination_parent"
+fi
+
+work_root=$(mktemp -d "${TMPDIR:-/tmp}/wap-labs-plan-provenance.XXXXXX")
+workflow_json="$work_root/workflow.json"
+run_json="$work_root/run.json"
+artifact_json="$work_root/artifact.json"
+artifact_zip="$work_root/artifact.zip"
+
+cleanup() {
+  case "$work_root" in
+    "${TMPDIR:-/tmp}"/wap-labs-plan-provenance.*) rm -rf "$work_root" ;;
+    *) echo "WARN: refusing to remove unexpected temporary path: $work_root" >&2 ;;
+  esac
+}
+trap cleanup EXIT HUP INT TERM
+
+api_header="X-GitHub-Api-Version: 2022-11-28"
+workflow_path=".github/workflows/opentofu-protected-plan.yml"
+
+gh api -H "$api_header" \
+  "/repos/${GITHUB_REPOSITORY}/actions/workflows/opentofu-protected-plan.yml" >"$workflow_json"
+gh api -H "$api_header" \
+  "/repos/${GITHUB_REPOSITORY}/actions/runs/${PLAN_RUN_ID}" >"$run_json"
+gh api -H "$api_header" \
+  "/repos/${GITHUB_REPOSITORY}/actions/artifacts/${PLAN_ARTIFACT_ID}" >"$artifact_json"
+
+workflow_id=$(jq -er \
+  --arg path "$workflow_path" \
+  '.id | select(type == "number")' "$workflow_json")
+if ! jq -e --arg path "$workflow_path" \
+  '.path == $path and .state == "active"' "$workflow_json" >/dev/null; then
+  network_preview_fail "approved protected-plan workflow identity is not active"
+fi
+
+if ! jq -e \
+  --arg repository "$GITHUB_REPOSITORY" \
+  --argjson repository_id "$GITHUB_REPOSITORY_ID" \
+  --argjson run_id "$PLAN_RUN_ID" \
+  --argjson workflow_id "$workflow_id" \
+  --arg workflow_path "$workflow_path" '
+    .id == $run_id
+    and .repository.id == $repository_id
+    and .repository.full_name == $repository
+    and .head_repository.id == $repository_id
+    and .workflow_id == $workflow_id
+    and (.path == $workflow_path or .path == ($workflow_path + "@main"))
+    and .head_branch == "main"
+    and .event == "workflow_dispatch"
+    and .status == "completed"
+    and .conclusion == "success"
+    and (.run_attempt | type == "number" and . >= 1)
+    and (.head_sha | type == "string" and test("^[0-9a-f]{40}$"))
+  ' "$run_json" >/dev/null; then
+  network_preview_fail "plan run does not match the approved repository/workflow/ref/conclusion"
+fi
+
+source_commit=$(jq -er '.head_sha' "$run_json")
+plan_run_attempt=$(jq -er '.run_attempt' "$run_json")
+if [ "$source_commit" != "$EXPECTED_SOURCE_COMMIT" ]; then
+  network_preview_fail \
+    "reviewed plan is stale: its source commit is not the current protected main commit"
+fi
+
+if ! jq -e \
+  --argjson artifact_id "$PLAN_ARTIFACT_ID" \
+  --argjson run_id "$PLAN_RUN_ID" \
+  --argjson repository_id "$GITHUB_REPOSITORY_ID" \
+  --arg source_commit "$source_commit" '
+    .id == $artifact_id
+    and .expired == false
+    and .workflow_run.id == $run_id
+    and .workflow_run.repository_id == $repository_id
+    and .workflow_run.head_repository_id == $repository_id
+    and .workflow_run.head_branch == "main"
+    and .workflow_run.head_sha == $source_commit
+  ' "$artifact_json" >/dev/null; then
+  network_preview_fail "artifact does not belong to the verified protected plan run"
+fi
+
+artifact_name=$(jq -er '.name | select(type == "string")' "$artifact_json")
+artifact_prefix="network-preview-plan-v1-${source_commit}-${plan_run_attempt}-"
+case "$artifact_name" in
+  "$artifact_prefix"*) plan_digest=${artifact_name#"$artifact_prefix"} ;;
+  *) network_preview_fail "artifact name is not trusted protected-plan provenance" ;;
+esac
+if ! printf '%s\n' "$plan_digest" | grep -Eq '^[0-9a-f]{64}$'; then
+  network_preview_fail "artifact provenance does not contain a valid plan SHA-256"
+fi
+
+gh api -H "$api_header" -H "Accept: application/vnd.github+json" \
+  "/repos/${GITHUB_REPOSITORY}/actions/artifacts/${PLAN_ARTIFACT_ID}/zip" >"$artifact_zip"
+
+archive_entries=$(unzip -Z1 "$artifact_zip")
+if [ "$archive_entries" != "encrypted.tfplan" ]; then
+  network_preview_fail "plan artifact must contain exactly encrypted.tfplan"
+fi
+umask 077
+unzip -p "$artifact_zip" encrypted.tfplan >"$PLAN_DESTINATION"
+downloaded_digest=$(network_preview_sha256_file "$PLAN_DESTINATION")
+if [ "$downloaded_digest" != "$plan_digest" ]; then
+  rm -f "$PLAN_DESTINATION"
+  network_preview_fail "downloaded encrypted plan does not match trusted run provenance"
+fi
+
+network_preview_write_output source_commit "$source_commit"
+network_preview_write_output plan_run_attempt "$plan_run_attempt"
+network_preview_write_output artifact_name "$artifact_name"
+network_preview_write_output plan_digest "$plan_digest"
+network_preview_write_output plan_path "$PLAN_DESTINATION"
+
+echo "PASS: verified and downloaded the exact encrypted reviewed plan artifact"

--- a/scripts/ci/write-network-preview-backend-config.sh
+++ b/scripts/ci/write-network-preview-backend-config.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env sh
+set -eu
+
+script_directory=$(CDPATH='' cd "$(dirname "$0")" && pwd)
+# shellcheck source=scripts/ci/network-preview-lib.sh
+. "$script_directory/network-preview-lib.sh"
+
+network_preview_require_value NETWORK_PREVIEW_R2_ACCOUNT_ID
+network_preview_require_value NETWORK_PREVIEW_R2_BUCKET
+network_preview_require_value NETWORK_PREVIEW_R2_STATE_KEY
+network_preview_require_value NETWORK_PREVIEW_R2_RECOVERY_PREFIX
+network_preview_validate_r2_contract
+
+if [ "$#" -ne 1 ]; then
+  network_preview_fail "usage: $0 BACKEND_CONFIG_PATH"
+fi
+
+backend_config_path=$1
+if [ -e "$backend_config_path" ]; then
+  network_preview_fail "refusing to overwrite backend configuration: $backend_config_path"
+fi
+
+backend_parent=$(dirname "$backend_config_path")
+if [ ! -d "$backend_parent" ]; then
+  network_preview_fail "backend configuration parent does not exist: $backend_parent"
+fi
+
+endpoint="https://${NETWORK_PREVIEW_R2_ACCOUNT_ID}.r2.cloudflarestorage.com"
+umask 077
+{
+  printf 'bucket = "%s"\n' "$NETWORK_PREVIEW_R2_BUCKET"
+  printf 'key = "%s"\n' "$NETWORK_PREVIEW_R2_STATE_KEY"
+  printf 'endpoints = { s3 = "%s" }\n' "$endpoint"
+} >"$backend_config_path"
+
+echo "PASS: wrote partial R2 backend configuration"

--- a/scripts/tests/network-preview-protected.test.mjs
+++ b/scripts/tests/network-preview-protected.test.mjs
@@ -1,0 +1,321 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const repositoryRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+
+function read(relativePath) {
+  return fs.readFileSync(path.join(repositoryRoot, relativePath), 'utf8');
+}
+
+const planWorkflowPath = '.github/workflows/opentofu-protected-plan.yml';
+const applyWorkflowPath = '.github/workflows/opentofu-protected-apply.yml';
+const planWorkflow = read(planWorkflowPath);
+const applyWorkflow = read(applyWorkflowPath);
+
+test('protected plan and apply serialize the same shared state without cancellation', () => {
+  for (const workflow of [planWorkflow, applyWorkflow]) {
+    assert.match(workflow, /group: opentofu-network-preview-state/);
+    assert.match(workflow, /cancel-in-progress: false/);
+    assert.match(workflow, /workflow_dispatch:/);
+    assert.doesNotMatch(workflow, /pull_request(?:_target)?:/);
+  }
+});
+
+test('protected workflows pin every external action to a full commit SHA', () => {
+  for (const [workflowPath, workflow] of [
+    [planWorkflowPath, planWorkflow],
+    [applyWorkflowPath, applyWorkflow]
+  ]) {
+    const usesLines = workflow.split('\n').filter((line) => line.includes('uses:'));
+    assert.ok(usesLines.length > 0, `${workflowPath} should use pinned setup actions`);
+    for (const line of usesLines) {
+      assert.match(line, /uses:\s+[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+@[0-9a-f]{40}(?:\s|$)/);
+    }
+  }
+});
+
+test('shell run blocks do not interpolate GitHub expressions', () => {
+  for (const [workflowPath, workflow] of [
+    [planWorkflowPath, planWorkflow],
+    [applyWorkflowPath, applyWorkflow]
+  ]) {
+    const lines = workflow.split('\n');
+    for (let index = 0; index < lines.length; index += 1) {
+      const match = lines[index].match(/^(\s*)run:\s*\|\s*$/);
+      if (!match) continue;
+      const indentation = match[1].length;
+      const block = [];
+      for (let cursor = index + 1; cursor < lines.length; cursor += 1) {
+        const next = lines[cursor];
+        if (next.trim() && next.search(/\S/) <= indentation) break;
+        block.push(next);
+      }
+      assert.doesNotMatch(block.join('\n'), /\$\{\{/u, `${workflowPath} has run-time expression injection`);
+    }
+  }
+});
+
+test('apply verifies exact trusted provenance and never creates a replacement plan', () => {
+  assert.match(applyWorkflow, /permissions:\n\s+actions: read\n\s+contents: read/);
+  assert.match(applyWorkflow, /environment: network-preview-apply/);
+  assert.match(applyWorkflow, /verify-network-preview-plan-provenance\.sh/);
+  assert.match(applyWorkflow, /manage-network-preview-recovery\.sh prepare/);
+  assert.match(applyWorkflow, /manage-network-preview-recovery\.sh assert/);
+  assert.match(applyWorkflow, /manage-network-preview-recovery\.sh finalize/);
+  assert.match(applyWorkflow, /tofu -chdir=.* apply/);
+  assert.doesNotMatch(applyWorkflow, /tofu -chdir=.* plan/);
+
+  const verifier = read('scripts/ci/verify-network-preview-plan-provenance.sh');
+  for (const invariant of [
+    '.repository.id == $repository_id',
+    '.head_repository.id == $repository_id',
+    '.workflow_id == $workflow_id',
+    '.head_branch == "main"',
+    '.event == "workflow_dispatch"',
+    '.conclusion == "success"',
+    '.workflow_run.id == $run_id',
+    'downloaded_digest" != "$plan_digest'
+  ]) {
+    assert.ok(verifier.includes(invariant), `missing provenance invariant: ${invariant}`);
+  }
+});
+
+test('backend and recovery contracts enforce encryption, native locking, and retention five', () => {
+  const backend = read('infra/network-preview/environments/preview/backend.tf');
+  const encryption = read('infra/network-preview/environments/preview/encryption.tf');
+  const recovery = read('scripts/ci/manage-network-preview-recovery.sh');
+  assert.match(backend, /use_lockfile\s+=\s+true/);
+  assert.match(encryption, /state\s*\{[\s\S]*?enforced\s+=\s+true/);
+  assert.match(encryption, /plan\s*\{[\s\S]*?enforced\s+=\s+true/);
+  assert.match(recovery, /--if-none-match '\*'/);
+  assert.match(recovery, /source-sha256=/);
+  assert.match(recovery, /tofu -chdir="\$TOFU_ROOT" state pull >\/dev\/null/);
+  assert.match(recovery, /if \[ "\$verified_count" -gt 5 \]/);
+  assert.match(recovery, /sed -n '6,\$p'/);
+});
+
+test('partial backend writer accepts only the fixed preview state and recovery keys', () => {
+  const temporaryRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'wap-labs-backend-test-'));
+  const outputPath = path.join(temporaryRoot, 'backend.hcl');
+  const scriptPath = path.join(repositoryRoot, 'scripts/ci/write-network-preview-backend-config.sh');
+  const baseEnvironment = {
+    ...process.env,
+    NETWORK_PREVIEW_R2_ACCOUNT_ID: '0123456789abcdef0123456789abcdef',
+    NETWORK_PREVIEW_R2_BUCKET: 'wap-labs-preview',
+    NETWORK_PREVIEW_R2_STATE_KEY: 'wap-labs/network-preview/preview.tfstate',
+    NETWORK_PREVIEW_R2_RECOVERY_PREFIX: 'wap-labs/network-preview/recovery'
+  };
+
+  try {
+    const accepted = spawnSync(scriptPath, [outputPath], {
+      cwd: repositoryRoot,
+      env: baseEnvironment,
+      encoding: 'utf8'
+    });
+    assert.equal(accepted.status, 0, accepted.stderr);
+    const backendConfig = fs.readFileSync(outputPath, 'utf8');
+    assert.match(backendConfig, /key = "wap-labs\/network-preview\/preview\.tfstate"/);
+    assert.doesNotMatch(backendConfig, /AWS_|credential|secret/i);
+
+    const rejected = spawnSync(scriptPath, [path.join(temporaryRoot, 'bad.hcl')], {
+      cwd: repositoryRoot,
+      env: { ...baseEnvironment, NETWORK_PREVIEW_R2_STATE_KEY: 'wrong/state.tfstate' },
+      encoding: 'utf8'
+    });
+    assert.notEqual(rejected.status, 0);
+    assert.match(rejected.stderr, /must equal wap-labs\/network-preview\/preview\.tfstate/);
+  } finally {
+    fs.rmSync(temporaryRoot, { recursive: true, force: true });
+  }
+});
+
+function writeExecutable(filePath, contents) {
+  fs.writeFileSync(filePath, contents, { mode: 0o755 });
+}
+
+function parseOutputs(outputPath) {
+  return Object.fromEntries(
+    fs
+      .readFileSync(outputPath, 'utf8')
+      .trim()
+      .split('\n')
+      .filter(Boolean)
+      .map((line) => {
+        const separator = line.indexOf('=');
+        return [line.slice(0, separator), line.slice(separator + 1)];
+      })
+  );
+}
+
+test('recovery helper verifies copies and retains only the newest five after state verification', () => {
+  const temporaryRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'wap-labs-recovery-test-'));
+  const fakeBin = path.join(temporaryRoot, 'bin');
+  const objectRoot = path.join(temporaryRoot, 'objects');
+  const tofuRoot = path.join(temporaryRoot, 'tofu-root');
+  fs.mkdirSync(fakeBin, { recursive: true });
+  fs.mkdirSync(objectRoot, { recursive: true });
+  fs.mkdirSync(tofuRoot, { recursive: true });
+
+  writeExecutable(
+    path.join(fakeBin, 'tofu'),
+    `#!/usr/bin/env node
+if (process.argv.includes('state') && process.argv.includes('pull')) {
+  process.stdout.write('{"version":4}\\n');
+  process.exit(0);
+}
+process.exit(2);
+`
+  );
+  writeExecutable(
+    path.join(fakeBin, 'aws'),
+    `#!/usr/bin/env node
+const fs = require('node:fs');
+const path = require('node:path');
+const args = process.argv.slice(2);
+const root = process.env.FAKE_R2_ROOT;
+const option = (name) => {
+  const index = args.indexOf(name);
+  if (index < 0 || index + 1 >= args.length) throw new Error('missing ' + name);
+  return args[index + 1];
+};
+const keyPath = (key) => path.join(root, ...key.split('/'));
+const metadataPath = (key) => keyPath(key) + '.metadata.json';
+const walk = (directory) => {
+  if (!fs.existsSync(directory)) return [];
+  return fs.readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const full = path.join(directory, entry.name);
+    return entry.isDirectory() ? walk(full) : [full];
+  });
+};
+const operation = args[1];
+if (operation === 'list-objects-v2') {
+  const prefix = option('--prefix');
+  const contents = walk(root)
+    .filter((file) => !file.endsWith('.metadata.json'))
+    .map((file) => path.relative(root, file).split(path.sep).join('/'))
+    .filter((key) => key.startsWith(prefix))
+    .map((key) => {
+      const runMatch = key.match(/\\/(\\d+)-\\d+-[0-9a-f]{32}\\.tfstate$/);
+      const seconds = runMatch ? Number(runMatch[1]) : 0;
+      return { Key: key, LastModified: new Date(seconds * 1000).toISOString() };
+    });
+  process.stdout.write(JSON.stringify({ Contents: contents }));
+} else if (operation === 'get-object') {
+  fs.copyFileSync(keyPath(option('--key')), args.at(-1));
+  process.stdout.write('{}');
+} else if (operation === 'head-object') {
+  process.stdout.write(fs.readFileSync(metadataPath(option('--key')), 'utf8'));
+} else if (operation === 'put-object') {
+  const key = option('--key');
+  const destination = keyPath(key);
+  if (args.includes('--if-none-match') && fs.existsSync(destination)) process.exit(12);
+  fs.mkdirSync(path.dirname(destination), { recursive: true });
+  fs.copyFileSync(option('--body'), destination);
+  const metadata = Object.fromEntries(
+    option('--metadata').split(',').map((entry) => {
+      const separator = entry.indexOf('=');
+      return [entry.slice(0, separator), entry.slice(separator + 1)];
+    })
+  );
+  fs.writeFileSync(metadataPath(key), JSON.stringify({ Metadata: metadata }));
+  process.stdout.write('{}');
+} else if (operation === 'delete-object') {
+  const key = option('--key');
+  fs.rmSync(keyPath(key));
+  fs.rmSync(metadataPath(key), { force: true });
+  process.stdout.write('{}');
+} else {
+  process.stderr.write('unsupported fake aws operation: ' + operation + '\\n');
+  process.exit(2);
+}
+`
+  );
+
+  const stateKey = 'wap-labs/network-preview/preview.tfstate';
+  const statePath = path.join(objectRoot, ...stateKey.split('/'));
+  fs.mkdirSync(path.dirname(statePath), { recursive: true });
+  fs.writeFileSync(statePath, 'encrypted-state-fixture-v1');
+
+  const scriptPath = path.join(repositoryRoot, 'scripts/ci/manage-network-preview-recovery.sh');
+  const baseEnvironment = {
+    ...process.env,
+    PATH: `${fakeBin}:${process.env.PATH}`,
+    FAKE_R2_ROOT: objectRoot,
+    NETWORK_PREVIEW_R2_ACCOUNT_ID: '0123456789abcdef0123456789abcdef',
+    NETWORK_PREVIEW_R2_BUCKET: 'wap-labs-preview',
+    NETWORK_PREVIEW_R2_STATE_KEY: stateKey,
+    NETWORK_PREVIEW_R2_RECOVERY_PREFIX: 'wap-labs/network-preview/recovery',
+    AWS_ACCESS_KEY_ID: 'fixture-access',
+    AWS_SECRET_ACCESS_KEY: 'fixture-secret',
+    SOURCE_COMMIT: 'a'.repeat(40),
+    APPLY_RUN_ATTEMPT: '1',
+    TOFU_ROOT: tofuRoot
+  };
+
+  const runRecovery = (phase, runId, extraEnvironment = {}) => {
+    const outputPath = path.join(temporaryRoot, `outputs-${phase}-${runId}.txt`);
+    const result = spawnSync(scriptPath, [phase], {
+      cwd: repositoryRoot,
+      env: {
+        ...baseEnvironment,
+        APPLY_RUN_ID: String(runId),
+        RECOVERY_NONCE: String(runId).padStart(32, '0'),
+        GITHUB_OUTPUT: outputPath,
+        ...extraEnvironment
+      },
+      encoding: 'utf8'
+    });
+    assert.equal(result.status, 0, `${result.stdout}\n${result.stderr}`);
+    return fs.existsSync(outputPath) ? parseOutputs(outputPath) : {};
+  };
+
+  try {
+    let selectedRecovery;
+    for (let runId = 101; runId <= 106; runId += 1) {
+      selectedRecovery = runRecovery('prepare', runId);
+    }
+    assert.equal(selectedRecovery.recovery_mode, 'copy');
+    runRecovery('assert', 106, {
+      RECOVERY_MODE: selectedRecovery.recovery_mode,
+      RECOVERY_KEY: selectedRecovery.recovery_key,
+      RECOVERY_SHA256: selectedRecovery.recovery_sha256
+    });
+    const finalized = runRecovery('finalize', 106, {
+      RECOVERY_MODE: selectedRecovery.recovery_mode,
+      RECOVERY_KEY: selectedRecovery.recovery_key,
+      RECOVERY_SHA256: selectedRecovery.recovery_sha256
+    });
+    assert.equal(finalized.recovery_retained_count, '5');
+    assert.equal(finalized.current_state_sha256, selectedRecovery.recovery_sha256);
+
+    const retained = [];
+    const walk = (directory) => {
+      for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+        const fullPath = path.join(directory, entry.name);
+        if (entry.isDirectory()) walk(fullPath);
+        else if (entry.name.endsWith('.tfstate')) retained.push(fullPath);
+      }
+    };
+    walk(path.join(objectRoot, 'wap-labs/network-preview/recovery'));
+    assert.equal(retained.length, 5);
+    assert.ok(fs.existsSync(path.join(objectRoot, ...selectedRecovery.recovery_key.split('/'))));
+  } finally {
+    fs.rmSync(temporaryRoot, { recursive: true, force: true });
+  }
+});
+
+test('bootstrap recovery mode fails closed unless both state and native lock are absent', () => {
+  const recovery = read('scripts/ci/manage-network-preview-recovery.sh');
+  const bootstrapBlock = recovery.slice(
+    recovery.indexOf('0)\n      # This is permitted only'),
+    recovery.indexOf('1)\n      source_path=')
+  );
+  assert.match(bootstrapBlock, /require_exact_object_count "\$lock_key" 0/);
+  assert.match(recovery, /bootstrap\)\n\s+require_exact_object_count "\$state_key" 0/);
+  assert.match(recovery, /bootstrap state and lock absence reconfirmed immediately before apply/);
+});

--- a/scripts/tests/verify.test.mjs
+++ b/scripts/tests/verify.test.mjs
@@ -51,7 +51,9 @@ test('change selects backend-disabled OpenTofu checks for network preview infras
       'OpenTofu formatting',
       'backend-disabled initialization',
       'OpenTofu validation',
-      'R2 lock driver POSIX syntax'
+      'network-preview script POSIX syntax',
+      'encrypted offline plan check',
+      'protected workflow contract tests'
     ]
   );
   assert.equal(

--- a/scripts/verify-lib.mjs
+++ b/scripts/verify-lib.mjs
@@ -312,11 +312,21 @@ export const LANES = Object.freeze([
     paths: [
       'infra/network-preview/',
       'scripts/ci/check-network-preview-r2-lock.sh',
-      '.github/workflows/opentofu.yml'
+      'scripts/ci/check-network-preview-encrypted-plan.sh',
+      'scripts/ci/manage-network-preview-recovery.sh',
+      'scripts/ci/network-preview-lib.sh',
+      'scripts/ci/summarize-network-preview-plan.sh',
+      'scripts/ci/verify-network-preview-plan-provenance.sh',
+      'scripts/ci/write-network-preview-backend-config.sh',
+      'scripts/tests/network-preview-protected.test.mjs',
+      '.github/workflows/opentofu.yml',
+      '.github/workflows/opentofu-protected-apply.yml',
+      '.github/workflows/opentofu-protected-plan.yml'
     ],
     prerequisites: [
       prerequisite('tofu', 'install OpenTofu 1.12.5'),
-      prerequisite('sh', 'install a POSIX shell')
+      prerequisite('sh', 'install a POSIX shell'),
+      prerequisite('node', 'install the repository Node version')
     ],
     commands: [
       command('OpenTofu formatting', 'tofu', [
@@ -346,9 +356,29 @@ export const LANES = Object.freeze([
           TF_VAR_state_encryption_passphrase: 'offline-validation-only-not-for-state'
         }
       }),
-      command('R2 lock driver POSIX syntax', 'sh', [
+      command('network-preview script POSIX syntax', 'sh', [
         '-n',
-        'scripts/ci/check-network-preview-r2-lock.sh'
+        'scripts/ci/check-network-preview-r2-lock.sh',
+        'scripts/ci/check-network-preview-encrypted-plan.sh',
+        'scripts/ci/manage-network-preview-recovery.sh',
+        'scripts/ci/network-preview-lib.sh',
+        'scripts/ci/summarize-network-preview-plan.sh',
+        'scripts/ci/verify-network-preview-plan-provenance.sh',
+        'scripts/ci/write-network-preview-backend-config.sh'
+      ]),
+      command(
+        'encrypted offline plan check',
+        'scripts/ci/check-network-preview-encrypted-plan.sh',
+        [],
+        {
+          env: {
+            TF_VAR_state_encryption_passphrase: 'offline-validation-only-not-for-state'
+          }
+        }
+      ),
+      command('protected workflow contract tests', 'node', [
+        '--test',
+        'scripts/tests/network-preview-protected.test.mjs'
       ])
     ]
   },


### PR DESCRIPTION
## Summary

- add separate manual `OpenTofu Protected Plan` and `OpenTofu Protected Apply` workflows using the same non-cancelling shared-state concurrency group
- bind the encrypted reviewed plan to trusted GitHub run/artifact provenance and require apply to verify repository, workflow/ref, source commit, successful conclusion, run attempt, artifact ID, and SHA-256 before consuming the exact artifact
- add runtime-only partial R2 backend configuration, native `.tflock` handling, sanitized plan summaries, and explicit local-material cleanup
- add conditional encrypted pre-apply recovery writes with metadata and SHA-256 verification, immediate source/lock rechecks, bootstrap absence proof, current-state verification, and retention of the five newest verified copies
- add backend-disabled encrypted-plan proof, workflow contract tests, simulated R2 retention tests, ShellCheck coverage, local verification wiring, and operator documentation

This is only access-independent INF-101 readiness after #432, #441, and #442. It creates no accounts, credentials, environments, DNS, buckets, or cloud resources and does not execute `tofu apply`, `destroy`, `force-unlock`, or any remote-state mutation.

## Risk review and tradeoffs

- **Identity churn:** apply rejects the reviewed plan if `main` advanced after planning. This shortens plan usability but prevents stale source/workflow identity from being applied.
- **Secrets:** environment-scoped R2, encryption, and provider secrets are never accepted as inputs or retained in artifacts. Correct environment branch restrictions, reviewer rules, separate plan/apply provider scopes, and two-maintainer recovery access remain PRE-003 setup/evidence.
- **Concurrency and locking:** protected plan/apply share `opentofu-network-preview-state` with cancellation disabled, and the backend retains native S3 lock-file mode. Live R2 contention/recovery remains unproven until the dedicated test is explicitly authorized.
- **Blast radius:** the helper accepts only the fixed preview state and recovery prefixes, refuses pre-existing recovery destinations with a conditional write, and never automates recovery restoration, destroy, or force-unlock.
- **Reproducibility:** OpenTofu 1.12.5, DigitalOcean 2.96.0, provider checksums, source commit, run attempt, artifact ID, and plan digest are pinned/verified. Apply intentionally requires re-planning after any `main` change.
- **Supply chain:** every workflow action is full-SHA pinned and contract tests reject mutable action references or GitHub-expression interpolation in shell blocks. GitHub-hosted runner tools (`gh`, AWS CLI, OpenSSL) remain runner-image dependencies and are validated/fail-closed at runtime rather than vendored.

## Validation

- `make lint-tofu` with checksum-verified OpenTofu 1.12.5
  - `tofu fmt -check -recursive`
  - backend-disabled `init -lockfile=readonly` and `validate`
  - POSIX syntax and ShellCheck for all network-preview helpers
  - encrypted saved-plan and sanitized-summary proof
  - 8 protected workflow/backend/recovery contract tests, including simulated retention-five behavior
- `node --test scripts/tests/verify.test.mjs` (14 passed)
- provider lock drift for `linux_amd64`, `darwin_arm64`, and `darwin_amd64` (no changes)
- YAML parsing for all three OpenTofu workflows and pre-commit configuration
- full repository pre-push hook: all checks passed, including 346 engine tests, engine/browser/transport Clippy, and Go tests

## Rollback and recovery

- Revert this commit to remove the unexecuted workflow definitions and helpers; no cloud rollback is needed because this PR performs no cloud/state mutation.
- After a future authorized apply, failures leave recovery objects unpruned. Restoration from the newest verified encrypted pre-apply copy remains a separately authorized state mutation and is intentionally not automated here.
- PRE-001/PRE-003, live R2 lock testing, protected provider planning, and an authorized plan/apply/recovery run remain required before INF-101 can be called complete.
