### PR TITLE
fix(ci): validate protected OpenTofu workflows

### DIFF
--- a/.github/workflows/opentofu-protected-apply.yml
+++ b/.github/workflows/opentofu-protected-apply.yml
@@ -30,7 +30,6 @@ jobs:
     env:
       TF_IN_AUTOMATION: '1'
       TF_INPUT: '0'
-      TF_DATA_DIR: ${{ runner.temp }}/network-preview-terraform
       TF_VAR_state_encryption_passphrase: ${{ secrets.TOFU_ENCRYPTION_PASSPHRASE }}
       TF_VAR_project_name: ${{ vars.NETWORK_PREVIEW_DO_PROJECT }}
       TF_VAR_region: ${{ vars.NETWORK_PREVIEW_DO_REGION }}
@@ -44,6 +43,10 @@ jobs:
       NETWORK_PREVIEW_R2_STATE_KEY: ${{ vars.NETWORK_PREVIEW_R2_STATE_KEY }}
       NETWORK_PREVIEW_R2_RECOVERY_PREFIX: ${{ vars.NETWORK_PREVIEW_R2_RECOVERY_PREFIX }}
     steps:
+      - name: Configure runner-local OpenTofu data directory
+        shell: sh
+        run: echo "TF_DATA_DIR=$RUNNER_TEMP/network-preview-terraform" >>"$GITHUB_ENV"
+
       - name: Refuse non-main workflow dispatches
         shell: sh
         run: |

--- a/.github/workflows/opentofu-protected-plan.yml
+++ b/.github/workflows/opentofu-protected-plan.yml
@@ -20,7 +20,6 @@ jobs:
     env:
       TF_IN_AUTOMATION: '1'
       TF_INPUT: '0'
-      TF_DATA_DIR: ${{ runner.temp }}/network-preview-terraform
       TF_VAR_state_encryption_passphrase: ${{ secrets.TOFU_ENCRYPTION_PASSPHRASE }}
       TF_VAR_project_name: ${{ vars.NETWORK_PREVIEW_DO_PROJECT }}
       TF_VAR_region: ${{ vars.NETWORK_PREVIEW_DO_REGION }}
@@ -34,6 +33,10 @@ jobs:
       NETWORK_PREVIEW_R2_STATE_KEY: ${{ vars.NETWORK_PREVIEW_R2_STATE_KEY }}
       NETWORK_PREVIEW_R2_RECOVERY_PREFIX: ${{ vars.NETWORK_PREVIEW_R2_RECOVERY_PREFIX }}
     steps:
+      - name: Configure runner-local OpenTofu data directory
+        shell: sh
+        run: echo "TF_DATA_DIR=$RUNNER_TEMP/network-preview-terraform" >>"$GITHUB_ENV"
+
       - name: Refuse non-main workflow dispatches
         shell: sh
         run: |

--- a/.github/workflows/opentofu.yml
+++ b/.github/workflows/opentofu.yml
@@ -56,6 +56,18 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Setup Go for pinned actionlint
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version: '1.25'
+          cache: false
+
+      - name: Install pinned actionlint
+        run: go install github.com/rhysd/actionlint/cmd/actionlint@v1.7.12
+
+      - name: Validate OpenTofu workflow semantics
+        run: scripts/ci/check-network-preview-workflows.sh
+
       - name: Setup pinned OpenTofu
         uses: opentofu/setup-opentofu@a1320f892987e89d278cc92dc5adc984fb93aca4 # v2
         with:

--- a/Makefile
+++ b/Makefile
@@ -116,6 +116,8 @@ lint-tofu:
 	fi
 	@echo "==> tofu fmt -check -recursive (network preview)"
 	@tofu fmt -check -recursive infra/network-preview
+	@echo "==> actionlint (network-preview workflows)"
+	@scripts/ci/check-network-preview-workflows.sh
 	@echo "==> tofu init -backend=false -lockfile=readonly (network preview)"
 	@TF_VAR_state_encryption_passphrase=offline-validation-only-not-for-state \
 		tofu -chdir=infra/network-preview/environments/preview init -backend=false -lockfile=readonly -no-color >/dev/null

--- a/docs/ci/CI_SETUP.md
+++ b/docs/ci/CI_SETUP.md
@@ -130,17 +130,21 @@ Behavior:
 - validates the root with a non-secret, validation-only encryption sentinel;
 - regenerates the `linux_amd64`, `darwin_arm64`, and `darwin_amd64` provider checksums and fails
   on lock-file drift;
+- installs pinned actionlint 1.7.12 through Go 1.25 and semantically validates the static,
+  protected-plan, and protected-apply workflow definitions, including expression-context
+  availability;
 - checks every network-preview CI helper's POSIX syntax, runs `shellcheck`, and exercises the
   protected workflow contracts without credentials;
 - has only `contents: read`, does not persist checkout credentials, and receives no repository or
   environment secrets.
 
 This workflow does not contact R2 or DigitalOcean, produce a speculative plan, create a GitHub
-environment, or run `tofu apply`. It also proves locally that enforced plan encryption produces an
-opaque saved plan and runs contract tests over the protected workflow definitions. Live R2
-locking and provider planning remain blocked by `PRE-001`/`PRE-003` and require separately
-protected environments before activation. Do not make this path-triggered job a global required
-context; ordinary PRs outside its paths do not create it.
+environment, or run `tofu apply`. It proves that the workflow definitions pass the pinned offline
+GitHub Actions validator, proves locally that enforced plan encryption produces an opaque saved
+plan, and runs contract tests over the protected workflow definitions. That validation is distinct
+from operational readiness: live R2 locking and provider planning remain blocked by
+`PRE-001`/`PRE-003` and require separately protected environments before activation. Do not make
+this path-triggered job a global required context; ordinary PRs outside its paths do not create it.
 
 ### OpenTofu Protected Plan and Apply
 

--- a/docs/ci/LOCAL_VERIFICATION.md
+++ b/docs/ci/LOCAL_VERIFICATION.md
@@ -30,9 +30,11 @@ There is no successful skip for a missing prerequisite in a selected required la
 `./scripts/init-refresh.sh` to refresh workspace dependencies. Install the repository Node/pnpm
 versions first when absent; use `AUTO_INSTALL_RUST_TOOLS=1 ./scripts/init-refresh.sh` when the
 pinned `wasm-pack` or Tauri CLI must be installed. Go 1.25 or newer is required when the selected
-lane includes `wml-server/`. OpenTofu 1.12.5 is required when the selected lane includes
-`infra/network-preview/`; its static lane never receives cloud credentials or enables the R2
-backend.
+lane includes `wml-server/`. OpenTofu 1.12.5 and actionlint 1.7.12 are required when the selected
+lane includes `infra/network-preview/`; install actionlint with
+`go install github.com/rhysd/actionlint/cmd/actionlint@v1.7.12`. Its static lane validates the three
+OpenTofu workflow definitions semantically, never receives cloud credentials, and never enables
+the R2 backend.
 
 ## Selection and evidence boundaries
 
@@ -51,6 +53,10 @@ The `full` profile is the ordinary pre-PR command. It deliberately excludes:
   jobs.
 - protected R2 locking and DigitalOcean speculative planning, which remain unavailable until
   `PRE-001` and `PRE-003` are completed.
+
+Passing actionlint proves that the checked expression contexts and workflow structure satisfy the
+pinned offline validator. It does not create the `PRE-003` protected environments or prove live
+R2 locking, provider planning, exact-plan apply, or state-recovery behavior.
 
 These exclusions are visible in command output and do not imply conformance or release readiness.
 The full compliance wrapper proves that canonical compliance inputs and generated projections are

--- a/docs/ci/REQUIRED_CHECKS.md
+++ b/docs/ci/REQUIRED_CHECKS.md
@@ -118,10 +118,12 @@ only after every required status check and any other ruleset requirement succeed
   `docs/waves/TRANSPORT_E2E_READINESS_SCORECARD.md` are satisfied and the follow-up widens its
   stable PR paths to relevant product changes.
 - `OpenTofu Static Validation` validates only network-preview infrastructure changes. It is
-  intentionally path-scoped and must not be a global required context. Manual OpenTofu protected
-  plan/apply workflow definitions exist, but remain access-backed operational gates rather than
-  merge-required checks and must not run until protected `PRE-003` access is configured and the
-  exact operation is authorized.
+  intentionally path-scoped and must not be a global required context. Its pinned actionlint gate
+  proves offline semantic validity for the static and protected workflow definitions; it does not
+  configure their protected environments or prove provider/R2 access. Manual OpenTofu protected
+  plan/apply workflows remain access-backed operational gates rather than merge-required checks
+  and must not run until protected `PRE-003` access is configured and the exact operation is
+  authorized.
 - `Build and Deploy to gh-pages` is deployment-focused and must not be required for code merges.
 - Scheduled/manual fuzzing, browser baseline, and release workflows must not be required
   pull-request checks.

--- a/docs/development-prerequisites.md
+++ b/docs/development-prerequisites.md
@@ -17,6 +17,7 @@ Optional but commonly required:
 - `cargo-tauri` / `tauri-cli` (desktop host dev/build)
 - Docker + Compose (legacy Kannel stack)
 - OpenTofu 1.12.5 (network-preview infrastructure validation)
+- actionlint 1.7.12 (semantic validation of network-preview GitHub Actions workflows)
 - `shellcheck` (network-preview reusable shell validation)
 
 ## One-shot Bootstrap / Refresh
@@ -72,8 +73,12 @@ Environment variables supported by `scripts/init-refresh.sh`:
 
 - Version: `infra/network-preview/.opentofu-version`
 - Static validation: `make lint-tofu`
+- Install the pinned workflow linter with
+  `go install github.com/rhysd/actionlint/cmd/actionlint@v1.7.12`.
 - Direct format check: `tofu fmt -check -recursive infra/network-preview`
 - Static checks disable the remote backend and use no cloud credentials.
+- Semantic workflow validity is offline evidence only; it does not configure the protected
+  `PRE-003` environments or prove live R2/DigitalOcean behavior.
 - The R2 lock driver is access-backed and must not run before the protected `PRE-003` environment
   exists; see `infra/network-preview/README.md`.
 

--- a/infra/network-preview/README.md
+++ b/infra/network-preview/README.md
@@ -43,6 +43,7 @@ a non-secret validation sentinel; it must never be used for remote state.
 
 ```sh
 tofu fmt -check -recursive infra/network-preview
+scripts/ci/check-network-preview-workflows.sh
 TF_VAR_state_encryption_passphrase=offline-validation-only-not-for-state \
   tofu -chdir=infra/network-preview/environments/preview \
   init -backend=false -lockfile=readonly
@@ -51,8 +52,11 @@ TF_VAR_state_encryption_passphrase=offline-validation-only-not-for-state \
 sh -n scripts/ci/check-network-preview-r2-lock.sh
 ```
 
-The same contract is available as `make lint-tofu` and is enforced by
-`.github/workflows/opentofu.yml` without repository secrets.
+Install the pinned semantic workflow linter with
+`go install github.com/rhysd/actionlint/cmd/actionlint@v1.7.12`. The same contract is available as
+`make lint-tofu` and is enforced by `.github/workflows/opentofu.yml` without repository secrets.
+Passing these checks proves offline workflow validity; it does not configure the `PRE-003`
+environments or prove live R2/provider behavior.
 
 ## Remote backend contract
 

--- a/scripts/ci/check-network-preview-workflows.sh
+++ b/scripts/ci/check-network-preview-workflows.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env sh
+set -eu
+
+if ! command -v actionlint >/dev/null 2>&1; then
+  echo "FAIL: actionlint not found; install v1.7.12 with 'go install github.com/rhysd/actionlint/cmd/actionlint@v1.7.12'" >&2
+  exit 1
+fi
+
+actionlint \
+  .github/workflows/opentofu.yml \
+  .github/workflows/opentofu-protected-plan.yml \
+  .github/workflows/opentofu-protected-apply.yml

--- a/scripts/tests/network-preview-protected.test.mjs
+++ b/scripts/tests/network-preview-protected.test.mjs
@@ -14,6 +14,7 @@ function read(relativePath) {
 
 const planWorkflowPath = '.github/workflows/opentofu-protected-plan.yml';
 const applyWorkflowPath = '.github/workflows/opentofu-protected-apply.yml';
+const staticWorkflow = read('.github/workflows/opentofu.yml');
 const planWorkflow = read(planWorkflowPath);
 const applyWorkflow = read(applyWorkflowPath);
 
@@ -24,6 +25,28 @@ test('protected plan and apply serialize the same shared state without cancellat
     assert.match(workflow, /workflow_dispatch:/);
     assert.doesNotMatch(workflow, /pull_request(?:_target)?:/);
   }
+});
+
+test('runner-dependent OpenTofu data paths are configured only after runner allocation', () => {
+  for (const workflow of [planWorkflow, applyWorkflow]) {
+    assert.doesNotMatch(workflow, /TF_DATA_DIR:\s*\$\{\{\s*runner\./);
+    assert.match(
+      workflow,
+      /echo "TF_DATA_DIR=\$RUNNER_TEMP\/network-preview-terraform" >>"\$GITHUB_ENV"/
+    );
+  }
+});
+
+test('static validation runs pinned semantic workflow lint', () => {
+  assert.match(
+    staticWorkflow,
+    /uses: actions\/setup-go@[0-9a-f]{40} # v7\.0\.0[\s\S]*?go-version: '1\.25'/
+  );
+  assert.match(
+    staticWorkflow,
+    /go install github\.com\/rhysd\/actionlint\/cmd\/actionlint@v1\.7\.12/
+  );
+  assert.match(staticWorkflow, /run: scripts\/ci\/check-network-preview-workflows\.sh/);
 });
 
 test('protected workflows pin every external action to a full commit SHA', () => {

--- a/scripts/tests/verify.test.mjs
+++ b/scripts/tests/verify.test.mjs
@@ -49,6 +49,7 @@ test('change selects backend-disabled OpenTofu checks for network preview infras
     lane.commands.map((command) => command.label),
     [
       'OpenTofu formatting',
+      'GitHub Actions semantic validation',
       'backend-disabled initialization',
       'OpenTofu validation',
       'network-preview script POSIX syntax',

--- a/scripts/verify-lib.mjs
+++ b/scripts/verify-lib.mjs
@@ -311,6 +311,7 @@ export const LANES = Object.freeze([
     profiles: ['change', 'full', 'extended'],
     paths: [
       'infra/network-preview/',
+      'scripts/ci/check-network-preview-workflows.sh',
       'scripts/ci/check-network-preview-r2-lock.sh',
       'scripts/ci/check-network-preview-encrypted-plan.sh',
       'scripts/ci/manage-network-preview-recovery.sh',
@@ -325,6 +326,10 @@ export const LANES = Object.freeze([
     ],
     prerequisites: [
       prerequisite('tofu', 'install OpenTofu 1.12.5'),
+      prerequisite(
+        'actionlint',
+        'run go install github.com/rhysd/actionlint/cmd/actionlint@v1.7.12'
+      ),
       prerequisite('sh', 'install a POSIX shell'),
       prerequisite('node', 'install the repository Node version')
     ],
@@ -335,6 +340,11 @@ export const LANES = Object.freeze([
         '-recursive',
         'infra/network-preview'
       ]),
+      command(
+        'GitHub Actions semantic validation',
+        'scripts/ci/check-network-preview-workflows.sh',
+        []
+      ),
       command(
         'backend-disabled initialization',
         'tofu',
@@ -358,6 +368,7 @@ export const LANES = Object.freeze([
       }),
       command('network-preview script POSIX syntax', 'sh', [
         '-n',
+        'scripts/ci/check-network-preview-workflows.sh',
         'scripts/ci/check-network-preview-r2-lock.sh',
         'scripts/ci/check-network-preview-encrypted-plan.sh',
         'scripts/ci/manage-network-preview-recovery.sh',


### PR DESCRIPTION
## Summary

- move the runner-derived OpenTofu data directory into a first runner step that exports through `GITHUB_ENV`, where `RUNNER_TEMP` is available
- add pinned actionlint semantic validation to the OpenTofu CI lane and local verification, with regression contracts for the protected workflows
- update only directly affected OpenTofu setup and required-check documentation, preserving the distinction between offline validation and remaining live prerequisites

## Root cause

The protected plan and apply workflows defined `TF_DATA_DIR` in job-level `env` using `${{ runner.temp }}`. GitHub evaluates that location before a runner exists, so the `runner` context is unavailable and both workflows were rejected before jobs could start:

- https://github.com/dills122/wap-labs/actions/runs/30264978216
- https://github.com/dills122/wap-labs/actions/runs/30264977551

The fix configures the same runner-local path after runner allocation. Protected environments, exact-plan provenance, encrypted artifact and state recovery, shared concurrency serialization, credential boundaries, and manual approvals are unchanged.

## Validation

- `actionlint` v1.7.12 over all three OpenTofu workflows
- `make lint-tofu` with OpenTofu 1.12.5
- protected-workflow contract tests (10 passing)
- backend-disabled init, validate, encrypted offline plan, and provider lock checksum verification
- POSIX syntax and shellcheck for network-preview CI scripts
- targeted Prettier and Markdown link validation for affected workflow/docs files
- `pnpm run wap-compliance:check`
- `pnpm run verify:test`
- `pnpm run verify:change` with the repository-pinned Node 22.22.1 and OpenTofu 1.12.5
- repository pre-push hooks

## Live gates and safety

This PR performs offline validation only. It does not configure PRE-001 provider/location/cost ownership decisions or PRE-003 protected environments, private R2 storage, credentials, billing alerts, or recovery access. Live R2 lock/recovery behavior and live DigitalOcean plan/apply behavior remain unproved and gated by those prerequisites.

No apply, destroy, force-unlock, cloud, DNS, credential, environment, or state mutation was performed.

## Rollback

Revert this PR. No cloud state changed.
