### PR TITLE
fix(transport): enforce max_retries on NACK-driven retransmission when SAR disabled

### DIFF
--- a/transport-rust/src/network/wtp/retransmission.rs
+++ b/transport-rust/src/network/wtp/retransmission.rs
@@ -115,8 +115,12 @@ pub fn decide_retransmission(
         WtpRetransmissionEvent::NackObserved { elapsed_ms } => {
             if !policy.sar_enabled {
                 let next_attempt = next_state.attempts.saturating_add(1);
-                next_state.attempts = next_attempt;
-                WtpRetransmissionDecision::Send(next_attempt)
+                if next_attempt > policy.max_retries {
+                    WtpRetransmissionDecision::RetryExhausted
+                } else {
+                    next_state.attempts = next_attempt;
+                    WtpRetransmissionDecision::Send(next_attempt)
+                }
             } else if let Some(last_nack) = next_state.last_nack_elapsed_ms {
                 let next_send_allowed = last_nack.saturating_add(policy.nack_holdoff_ms);
                 if elapsed_ms < next_send_allowed {
@@ -248,6 +252,48 @@ mod tests {
             WtpRetransmissionEvent::NackObserved { elapsed_ms: 80 },
         );
         assert_eq!(third, WtpRetransmissionDecision::Send(1));
+    }
+
+    #[test]
+    fn nack_flood_respects_max_retries_when_sar_is_disabled() {
+        let policy = WtpRetransmissionPolicy {
+            max_retries: 2,
+            sar_enabled: false,
+            ..WtpRetransmissionPolicy::default()
+        };
+        let mut state = WtpRetransmissionState::default();
+
+        let (first, next, _) = decide_retransmission(
+            &policy,
+            &state,
+            WtpRetransmissionEvent::NackObserved { elapsed_ms: 0 },
+        );
+        assert_eq!(first, WtpRetransmissionDecision::Send(1));
+        state = next;
+
+        let (second, next, _) = decide_retransmission(
+            &policy,
+            &state,
+            WtpRetransmissionEvent::NackObserved { elapsed_ms: 10 },
+        );
+        assert_eq!(second, WtpRetransmissionDecision::Send(2));
+        state = next;
+
+        let (third, next, _) = decide_retransmission(
+            &policy,
+            &state,
+            WtpRetransmissionEvent::NackObserved { elapsed_ms: 20 },
+        );
+        assert_eq!(third, WtpRetransmissionDecision::RetryExhausted);
+        assert_eq!(next.attempts, 2);
+
+        let (fourth, next, _) = decide_retransmission(
+            &policy,
+            &next,
+            WtpRetransmissionEvent::NackObserved { elapsed_ms: 30 },
+        );
+        assert_eq!(fourth, WtpRetransmissionDecision::RetryExhausted);
+        assert_eq!(next.attempts, 2);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- The non-SAR branch of `NackObserved` in `decide_retransmission` always returned `Send(next_attempt)` without checking `policy.max_retries`, unlike the `TimerExpired` branch and the SAR-enabled `NackObserved` branch.
- A peer (or an attacker spoofing WTLS handshake NACKs, since this decision function is wired into `decide_handshake_retransmission`) could keep sending NACK events with SAR disabled and drive `attempts` past `max_retries` indefinitely — unbounded retransmission driven by untrusted input.
- Added the same `next_attempt > policy.max_retries` cap check to that branch, matching the other two.
- Added regression test `nack_flood_respects_max_retries_when_sar_is_disabled` covering a NACK flood exceeding `max_retries` under `sar_enabled: false`.

Fixes #462

## Test plan

- [x] `cargo fmt --check` (transport-rust)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` (transport-rust)
- [x] `cargo test` (transport-rust) — including new regression test
- [x] Full repo pre-push hook suite (fmt/clippy/test across engine, transport, browser tauri; go vet/test; opentofu validate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
