### PR TITLE
fix(engine): make script-triggered WMLBrowser.newContext() reset fully

### DIFF
--- a/engine-wasm/engine/src/engine_runtime_internal/navigation.rs
+++ b/engine-wasm/engine/src/engine_runtime_internal/navigation.rs
@@ -134,6 +134,23 @@ impl WmlEngine {
     }
 
     pub(crate) fn reset_browser_context_for_newcontext(&mut self) {
+        self.reset_browser_context_state();
+        self.pending_script_effects = ScriptRuntimeEffects::default();
+        self.last_script_outcome = None;
+        self.last_script_dialog_requests.clear();
+        self.last_script_timer_requests.clear();
+    }
+
+    /// Resets the browser-context state shared by both newcontext triggers:
+    /// card-attribute `newcontext="true"` entry (via
+    /// [`Self::reset_browser_context_for_newcontext`]) and WMLScript
+    /// `WMLBrowser.newContext()` (`engine_runtime_internal/script_effects.rs`).
+    /// Deliberately excludes `pending_script_effects`/`last_script_outcome`/
+    /// `last_script_dialog_requests`/`last_script_timer_requests`: the script
+    /// path records the current call's dialog/timer requests into those
+    /// fields immediately before requesting a reset, and clearing them here
+    /// would drop that call's own outputs before the host reads them.
+    pub(crate) fn reset_browser_context_state(&mut self) {
         self.browser_context_epoch = self.browser_context_epoch.saturating_add(1);
         self.vars.clear();
         self.nav_stack.clear();
@@ -143,10 +160,6 @@ impl WmlEngine {
         self.active_timer = None;
         self.active_input_edit = None;
         self.active_select_edit = None;
-        self.pending_script_effects = ScriptRuntimeEffects::default();
-        self.last_script_outcome = None;
-        self.last_script_dialog_requests.clear();
-        self.last_script_timer_requests.clear();
     }
 
     /// Navigate back in history, guarded against unbounded recursion. See

--- a/engine-wasm/engine/src/engine_runtime_internal/script_effects.rs
+++ b/engine-wasm/engine/src/engine_runtime_internal/script_effects.rs
@@ -50,8 +50,8 @@ impl WmlEngine {
         let context_reset_requested = effects.context_reset_requested();
 
         if context_reset_requested {
-            self.vars.clear();
-            self.nav_stack.clear();
+            self.stop_active_timer_for_exit();
+            self.reset_browser_context_state();
             self.push_trace("ACTION_NEWCONTEXT", String::new());
         }
 

--- a/engine-wasm/engine/src/engine_tests/script_runtime.rs
+++ b/engine-wasm/engine/src/engine_tests/script_runtime.rs
@@ -720,6 +720,70 @@ fn wmlbrowser_new_context_clears_vars_and_history_and_prev_has_no_effect() {
 }
 
 #[test]
+fn wmlbrowser_new_context_stops_active_timer_and_bumps_epoch() {
+    let mut engine = WmlEngine::new();
+    let xml = r##"
+        <wml>
+          <card id="home">
+            <a href="#next">To next</a>
+          </card>
+          <card id="next" ontimer="#next">
+            <timer name="tvar" value="50"/>
+            <a href="script:ctx.wmlsc#main">Run context reset</a>
+          </card>
+        </wml>
+        "##;
+    engine
+        .load_deck_context(
+            xml,
+            "http://example.test/deck.wml",
+            "text/vnd.wap.wml",
+            None,
+        )
+        .expect("deck should load");
+
+    engine
+        .handle_key("enter".to_string())
+        .expect("home enter should navigate to next");
+    assert!(
+        engine.next_timer_wakeup_ms().is_some(),
+        "card timer should start on entry"
+    );
+    let epoch_before = engine.browser_context_epoch();
+
+    let unit = vec![0x20, 0x0A, 0x00, 0x00]; // newContext()
+    register_legacy_script_fixture(&mut engine, "ctx.wmlsc", unit);
+
+    engine.clear_trace_entries();
+    engine
+        .handle_key("enter".to_string())
+        .expect("script context reset should succeed");
+
+    assert_eq!(
+        engine.next_timer_wakeup_ms(),
+        None,
+        "newContext triggered from script should stop the active timer, \
+         not leave it running against the cleared context"
+    );
+    assert_eq!(
+        engine.browser_context_epoch(),
+        epoch_before + 1,
+        "script-triggered newContext should bump browser_context_epoch \
+         the same way card newcontext=\"true\" does"
+    );
+    let traces = engine.trace_entries();
+    assert!(
+        traces.iter().any(|entry| entry.kind == "TIMER_STOP"),
+        "active timer should be stopped (and traced) before the reset, not left ticking"
+    );
+    assert_eq!(
+        engine.get_var("tvar".to_string()),
+        None,
+        "the stopped timer's persisted value must not survive the context reset"
+    );
+}
+
+#[test]
 fn execute_script_ref_is_raw_and_does_not_apply_navigation_effects() {
     let mut engine = WmlEngine::new();
     let xml = r##"


### PR DESCRIPTION
## Summary

- Script-triggered `WMLBrowser.newContext()` only cleared `vars`/`nav_stack`, unlike card-attribute `newcontext="true"` (`reset_browser_context_for_newcontext`), which also stops the active timer, clears input/select edit state, resets focus, and bumps `browser_context_epoch`.
- A card with an active `<timer>` calling `WMLBrowser.newContext()` from a script left the timer running against the just-cleared vars — `stop_active_timer_for_exit`/`persist_timer_value` would re-insert a variable the reset was supposed to drop.
- Hosts relying on `browser_context_epoch` to invalidate cached session/history state on a newcontext reset had no signal when the reset was script-triggered.
- Split the shared reset into `reset_browser_context_state()` (epoch bump, vars/nav_stack/focus/external-nav-intent/timer/edit-state clearing), reused by both triggers. Kept the nav-only clearing of `pending_script_effects`/`last_script_outcome`/`last_script_dialog_requests`/`last_script_timer_requests` in `reset_browser_context_for_newcontext()` only — the script path populates those fields with the *current* call's own dialog/timer requests moments earlier in `apply_pending_script_effects`, and clearing them again would drop that call's outputs before the host reads them.
- Added `wmlbrowser_new_context_stops_active_timer_and_bumps_epoch` covering: active timer stopped + `TIMER_STOP` traced, `browser_context_epoch` incremented, persisted timer var not surviving the reset.

Fixes #457
Fixes #458

## Test plan

- [x] `cargo fmt --check` (engine-wasm/engine)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` (engine-wasm/engine)
- [x] `cargo test` (engine-wasm/engine) — 371 passed, including new regression test and existing `wmlbrowser_new_context_clears_vars_and_history_and_prev_has_no_effect`
- [x] Full repo pre-push hook suite (fmt/clippy/test across engine, transport, browser tauri; go vet/test; opentofu validate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
