### PR TITLE
fix(engine): reject WMLBrowser.setVar() names substitution can't resolve

### DIFF
--- a/engine-wasm/engine/src/wavescript/stdlib/wmlbrowser.rs
+++ b/engine-wasm/engine/src/wavescript/stdlib/wmlbrowser.rs
@@ -262,31 +262,19 @@ pub fn coerce_to_string(value: &ScriptValue) -> String {
     }
 }
 
+/// Accepts a name only if it matches the exact charset
+/// [`crate::runtime::variable::is_valid_name`] uses for `$name`/`$(name)`
+/// substitution. WMLBrowser.setVar()/getVar() must not accept a name that
+/// substitution can never resolve back -- a wider charset here would let
+/// script silently write a variable no `$name` reference in any card can
+/// ever read.
 fn normalize_var_name(value: &ScriptValue) -> Option<String> {
     let raw = coerce_to_string(value);
-    if raw.is_empty() {
-        return None;
+    if crate::runtime::variable::is_valid_name(&raw) {
+        Some(raw)
+    } else {
+        None
     }
-
-    let mut chars = raw.chars();
-    let first = chars.next()?;
-    if !is_valid_var_first_char(first) {
-        return None;
-    }
-
-    if !chars.all(is_valid_var_char) {
-        return None;
-    }
-
-    Some(raw)
-}
-
-fn is_valid_var_first_char(ch: char) -> bool {
-    ch.is_ascii_alphabetic() || ch == '_'
-}
-
-fn is_valid_var_char(ch: char) -> bool {
-    ch.is_ascii_alphanumeric() || ch == '_' || ch == '.' || ch == '-'
 }
 
 #[cfg(test)]

--- a/engine-wasm/engine/src/wavescript/stdlib/wmlbrowser_tests.rs
+++ b/engine-wasm/engine/src/wavescript/stdlib/wmlbrowser_tests.rs
@@ -67,6 +67,42 @@ fn invalid_var_name_does_not_mutate_store() {
 }
 
 #[test]
+fn set_var_rejects_names_wml_substitution_can_never_resolve() {
+    // A name with a dash (or dot) previously passed normalize_var_name's own
+    // charset check and stored a value, but `$name`/`$(name)` substitution
+    // (crate::runtime::variable) stops scanning a var name at the first
+    // non-alphanumeric/underscore byte, so no card text could ever read it
+    // back -- a silent dead write. normalize_var_name must reject exactly
+    // what substitution would reject, not a wider charset.
+    let mut vars = HashMap::new();
+    let mut effects = ScriptRuntimeEffects::default();
+    let mut host = WmlBrowserHost::new(&mut vars, &mut effects, WmlBrowserContext::default());
+
+    let set = host
+        .call(
+            WMLBROWSER_SET_VAR,
+            &[
+                ScriptValue::String("session-id".to_string()),
+                ScriptValue::String("abc".to_string()),
+            ],
+        )
+        .expect("setVar should not trap");
+    assert_eq!(
+        set,
+        ScriptValue::Invalid,
+        "setVar must reject a name substitution can never resolve back"
+    );
+
+    let value = host
+        .call(
+            WMLBROWSER_GET_VAR,
+            &[ScriptValue::String("session-id".to_string())],
+        )
+        .expect("getVar should not trap");
+    assert_eq!(value, ScriptValue::Invalid);
+}
+
+#[test]
 fn go_and_prev_update_deferred_navigation_intent() {
     let mut vars = HashMap::new();
     let mut effects = ScriptRuntimeEffects::default();


### PR DESCRIPTION
## Summary

- `normalize_var_name()` in `engine-wasm/engine/src/wavescript/stdlib/wmlbrowser.rs` allowed `.` and `-` in variable names in addition to alphanumerics/underscore, but `$name`/`$(name)` substitution (`runtime::variable::variable_name_len`) only accepts `[A-Za-z_][A-Za-z0-9_]*`.
- `WMLBrowser.setVar("session-id", "abc")` returned `true` and stored the value under a key no `$session-id` or `$(session-id)` reference could ever resolve — a silent dead write reachable directly from untrusted deck script content, with no error surfaced to the script.
- `normalize_var_name` now delegates to `runtime::variable::is_valid_name` — the same charset substitution uses — instead of hand-rolling a second, wider one (single source of truth, per the duplication policy in `docs/agents/AGENT_STANDARDS.md`).
- Added `set_var_rejects_names_wml_substitution_can_never_resolve`, plus verified all existing `wmlbrowser` tests still pass.

Fixes #459

## Test plan

- [x] `cargo fmt --check` (engine-wasm/engine)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` (engine-wasm/engine)
- [x] `cargo test` (engine-wasm/engine) — 371 passed, including new regression test
- [x] Full repo pre-push hook suite (fmt/clippy/test across engine, transport, browser tauri; go vet/test; opentofu validate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
