### PR TITLE
fix(transport): disable implicit system proxy for PublicOnly HTTP/HTTPS fetches

### DIFF
--- a/transport-rust/src/fetch_policy.rs
+++ b/transport-rust/src/fetch_policy.rs
@@ -291,3 +291,42 @@ fn apply_ua_capability_headers(
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolve_fetch_destination_addresses_rejects_a_public_looking_host_that_resolves_private() {
+        // A DNS-rebinding-style resolved answer: the host is an IP literal
+        // here only to keep the test deterministic and offline (per
+        // docs/agents/RUST_TRANSPORT_STEERING.md's no-external-network-in-
+        // default-tests rule) -- `to_socket_addrs` on an IP literal doesn't
+        // touch the network. `resolve_fetch_destination_addresses` classifies
+        // whatever address the lookup actually returns, exactly as it would
+        // for a hostname a DNS answer rebound to a private address.
+        let error = resolve_fetch_destination_addresses(
+            "10.0.0.1",
+            80,
+            &FetchDestinationPolicy::PublicOnly,
+        )
+        .expect_err("a resolved private address must be rejected under PublicOnly");
+
+        assert!(error.is_policy_blocked());
+        assert_eq!(
+            error,
+            FetchDestinationError::blocked_resolved_address(DestinationHostClass::Private)
+        );
+    }
+
+    #[test]
+    fn resolve_fetch_destination_addresses_allows_private_answer_under_allow_private() {
+        let addresses = resolve_fetch_destination_addresses(
+            "10.0.0.1",
+            80,
+            &FetchDestinationPolicy::AllowPrivate,
+        )
+        .expect("AllowPrivate must retain its documented behavior");
+        assert_eq!(addresses, vec![SocketAddr::from(([10, 0, 0, 1], 80))]);
+    }
+}

--- a/transport-rust/src/fetch_runtime/execution.rs
+++ b/transport-rust/src/fetch_runtime/execution.rs
@@ -72,7 +72,16 @@ fn http_client_builder(
     destination_policy: FetchDestinationPolicy,
 ) -> ClientBuilder {
     let redirect_destination_policy = destination_policy.clone();
-    Client::builder()
+    // reqwest enables system-proxy discovery (HTTP_PROXY/HTTPS_PROXY/etc.) by
+    // default. When a proxy is in play, the proxy resolves the target host,
+    // not PolicyDnsResolver below -- so a PublicOnly request to a
+    // public-looking hostname can be silently routed to a private/loopback
+    // address via ambient proxy configuration, bypassing the destination
+    // check entirely. AllowPrivate (explicit dev/smoke opt-in, and the
+    // operator-configured gateway-bridged WAP upstream) has no destination
+    // check to bypass, so it's left alone.
+    let disable_implicit_proxy = matches!(destination_policy, FetchDestinationPolicy::PublicOnly);
+    let mut builder = Client::builder()
         .timeout(Duration::from_millis(timeout_ms))
         .dns_resolver(Arc::new(PolicyDnsResolver { destination_policy }))
         .redirect(Policy::custom(move |attempt| {
@@ -83,7 +92,11 @@ fn http_client_builder(
                 Ok(()) => attempt.follow(),
                 Err(error) => attempt.error(DestinationPolicyError(error)),
             }
-        }))
+        }));
+    if disable_implicit_proxy {
+        builder = builder.no_proxy();
+    }
+    builder
 }
 
 pub(super) fn execute_fetch(plan: FetchExecutionPlan) -> FetchDeckResponse {
@@ -286,6 +299,7 @@ fn destination_policy_error(error: &reqwest::Error) -> Option<FetchDestinationEr
 mod tests {
     use super::*;
     use crate::fetch_policy::DestinationHostClass;
+    use crate::test_support::with_env_var_locked;
     use std::io::{Read, Write};
     use std::net::TcpListener;
     use std::thread;
@@ -314,7 +328,6 @@ mod tests {
     #[test]
     fn http_client_rejects_private_dns_answer() {
         let client = http_client_builder(1_000, FetchDestinationPolicy::PublicOnly)
-            .no_proxy()
             .build()
             .expect("build DNS policy test client");
         let error = client
@@ -351,7 +364,6 @@ mod tests {
         });
 
         let client = http_client_builder(1_000, FetchDestinationPolicy::PublicOnly)
-            .no_proxy()
             .resolve("public.test", listener_address)
             .build()
             .expect("build redirect test client");
@@ -375,5 +387,89 @@ mod tests {
         let message = policy_error.to_string();
         assert!(message.contains("public-only"));
         assert!(message.contains("loopback"));
+    }
+
+    #[test]
+    fn public_only_client_ignores_ambient_system_proxy_env_vars() {
+        // reqwest enables system-proxy discovery by default: if HTTP_PROXY
+        // were honored here, the request below would be routed to
+        // `fake_proxy` (which resolves the destination itself, bypassing
+        // PolicyDnsResolver) instead of connecting directly to
+        // `direct_server`. Bound both sides so a regression fails fast
+        // instead of hanging: the client's own 1s timeout bounds the
+        // request, and `direct_server`'s accept loop is bounded to slightly
+        // longer than that.
+        let direct_listener = TcpListener::bind("127.0.0.1:0").expect("bind direct test server");
+        let direct_address = direct_listener
+            .local_addr()
+            .expect("read direct server address");
+        let direct_server = thread::spawn(move || -> bool {
+            direct_listener
+                .set_nonblocking(true)
+                .expect("direct listener should support nonblocking mode");
+            let deadline = Instant::now() + Duration::from_millis(1_500);
+            loop {
+                match direct_listener.accept() {
+                    Ok((mut stream, _)) => {
+                        stream
+                            .set_nonblocking(false)
+                            .expect("accepted stream should support blocking mode");
+                        read_http_request_headers(&mut stream);
+                        stream
+                            .write_all(
+                                b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok",
+                            )
+                            .expect("write direct response");
+                        return true;
+                    }
+                    Err(error) if error.kind() == io::ErrorKind::WouldBlock => {
+                        if Instant::now() >= deadline {
+                            return false;
+                        }
+                        thread::sleep(Duration::from_millis(10));
+                    }
+                    Err(error) => panic!("unexpected direct listener error: {error}"),
+                }
+            }
+        });
+
+        let fake_proxy = TcpListener::bind("127.0.0.1:0").expect("bind fake proxy listener");
+        let fake_proxy_address = fake_proxy.local_addr().expect("read fake proxy address");
+        fake_proxy
+            .set_nonblocking(true)
+            .expect("fake proxy listener should support nonblocking mode");
+
+        let response = with_env_var_locked(
+            "HTTP_PROXY",
+            &format!("http://{fake_proxy_address}"),
+            || {
+                let client = http_client_builder(1_000, FetchDestinationPolicy::PublicOnly)
+                    .resolve("public.test", direct_address)
+                    .build()
+                    .expect("build proxy-env test client");
+                client
+                    .get(format!("http://public.test:{}/", direct_address.port()))
+                    .send()
+            },
+        );
+
+        let reached_direct_server = direct_server
+            .join()
+            .expect("direct server thread should not panic");
+
+        match fake_proxy.accept() {
+            Err(error) if error.kind() == io::ErrorKind::WouldBlock => {}
+            Ok(_) => panic!(
+                "PublicOnly client must not route through the ambient HTTP_PROXY environment variable"
+            ),
+            Err(error) => panic!("unexpected fake proxy listener error: {error}"),
+        }
+
+        assert!(
+            reached_direct_server,
+            "PublicOnly client must reach the destination directly, not through the ambient proxy"
+        );
+        let response = response.expect("direct request should succeed");
+        assert_eq!(response.status(), 200);
     }
 }

--- a/transport-rust/src/native_fetch.rs
+++ b/transport-rust/src/native_fetch.rs
@@ -486,7 +486,7 @@ mod tests {
     use crate::fetch_policy::DestinationHostClass;
     use crate::network::wdp::transport_trait::WdpResult;
     use crate::network::wsp::connectionless::{decode_uintvar, encode_uintvar};
-    use std::sync::{Mutex, OnceLock};
+    use crate::test_support::{with_env_removed_locked, with_env_var_locked};
 
     #[test]
     fn unprotected_waps_warning_payload_flags_waps_scheme() {
@@ -516,35 +516,6 @@ mod tests {
         fn receive(&mut self) -> WdpResult<WdpDatagram> {
             self.next_receive.clone()
         }
-    }
-
-    fn env_lock() -> &'static Mutex<()> {
-        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-        LOCK.get_or_init(|| Mutex::new(()))
-    }
-
-    fn with_env_var_locked<T>(name: &str, value: &str, f: impl FnOnce() -> T) -> T {
-        let _guard = env_lock().lock().expect("env lock should succeed");
-        let previous = std::env::var(name).ok();
-        std::env::set_var(name, value);
-        let out = f();
-        if let Some(previous) = previous {
-            std::env::set_var(name, previous);
-        } else {
-            std::env::remove_var(name);
-        }
-        out
-    }
-
-    fn with_env_removed_locked<T>(name: &str, f: impl FnOnce() -> T) -> T {
-        let _guard = env_lock().lock().expect("env lock should succeed");
-        let previous = std::env::var(name).ok();
-        std::env::remove_var(name);
-        let out = f();
-        if let Some(previous) = previous {
-            std::env::set_var(name, previous);
-        }
-        out
     }
 
     fn detail_string(response: &FetchDeckResponse, key: &str) -> Option<String> {

--- a/transport-rust/src/test_support.rs
+++ b/transport-rust/src/test_support.rs
@@ -1,6 +1,7 @@
 use serde::de::DeserializeOwned;
 use std::fs;
 use std::path::PathBuf;
+use std::sync::{Mutex, OnceLock};
 
 pub(crate) fn load_json_fixture<T>(segments: &[&str]) -> T
 where
@@ -19,4 +20,36 @@ fn fixture_path(segments: &[&str]) -> PathBuf {
         path.push(segment);
     }
     path
+}
+
+/// Shared serialization lock for tests that mutate process environment
+/// variables, per `docs/agents/RUST_TRANSPORT_STEERING.md` §12: such tests
+/// must use a shared lock, restore prior values, and run serialized.
+fn env_lock() -> &'static Mutex<()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+}
+
+pub(crate) fn with_env_var_locked<T>(name: &str, value: &str, f: impl FnOnce() -> T) -> T {
+    let _guard = env_lock().lock().expect("env lock should succeed");
+    let previous = std::env::var(name).ok();
+    std::env::set_var(name, value);
+    let out = f();
+    if let Some(previous) = previous {
+        std::env::set_var(name, previous);
+    } else {
+        std::env::remove_var(name);
+    }
+    out
+}
+
+pub(crate) fn with_env_removed_locked<T>(name: &str, f: impl FnOnce() -> T) -> T {
+    let _guard = env_lock().lock().expect("env lock should succeed");
+    let previous = std::env::var(name).ok();
+    std::env::remove_var(name);
+    let out = f();
+    if let Some(previous) = previous {
+        std::env::set_var(name, previous);
+    }
+    out
 }


### PR DESCRIPTION
## Summary

- `reqwest` enables system-proxy discovery (`HTTP_PROXY`/`HTTPS_PROXY`/etc.) by default. When a proxy is configured, the proxy resolves the target host, not `PolicyDnsResolver` -- so a `PublicOnly` request to a public-looking hostname could be routed through ambient proxy configuration to a private/loopback address, bypassing the destination-address check entirely (SSRF-adjacent policy bypass). The existing tests in `execution.rs` already called `.no_proxy()` explicitly to work around this; production client construction did not.
- `http_client_builder` now calls `.no_proxy()` whenever `destination_policy` is `PublicOnly`, disabling automatic system-proxy usage for exactly the policy that has a destination check to bypass. `AllowPrivate` (explicit dev/smoke opt-in, and the operator-configured gateway-bridged WAP upstream per `fetch_runtime.rs`) has no destination check to bypass and is left untouched, per the issue's acceptance criteria.
- Removed the now-redundant explicit `.no_proxy()` calls from the two existing `execution.rs` tests (the builder now applies it for `PublicOnly` automatically).
- Added `public_only_client_ignores_ambient_system_proxy_env_vars`: a fake local "proxy" listener + a direct fixture server, with `HTTP_PROXY` pointed at the fake proxy via an environment-locked helper; proves the fake proxy is never contacted and the request reaches the direct server instead. Bounded on both sides (client's own timeout + a bounded accept loop) so a future regression fails fast instead of hanging.
- Added `resolve_fetch_destination_addresses_rejects_a_public_looking_host_that_resolves_private` / `..._allows_private_answer_under_allow_private` in `fetch_policy.rs` (previously untested in isolation): deterministic, offline coverage of a resolved-private-address rejection/allow-list, using an IP-literal host so `to_socket_addrs` doesn't touch the network.
- Deduplicated the env-var test-lock helpers (`env_lock`/`with_env_var_locked`/`with_env_removed_locked`), previously only in `native_fetch.rs`'s test module, into the shared `test_support.rs` and reused them from the new `execution.rs` test instead of copy-pasting a second copy.

Fixes #447

## Test plan

- [x] `cargo fmt --check` (transport-rust)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` (transport-rust)
- [x] `cargo test -- --test-threads=1` (transport-rust, the repo's actual serialized gate) — 263 passed, including all 3 new tests
- [x] Full repo pre-push hook suite (fmt/clippy across engine, transport, browser tauri; engine+go tests; opentofu validate)

Note: the new proxy test mutates the process-global `HTTP_PROXY` env var. It uses the shared `with_env_var_locked` lock like the rest of the suite, but that lock only serializes against other lock-using tests -- it doesn't stop unrelated concurrent tests from building their own `reqwest` clients while the var is set. Running under `cargo test`'s default parallelism can race and produce a false failure; running with `--test-threads=1` (the actual `make test-rust-transport` gate) is required and passes cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
