### PR TITLE
feat(infra): deploy hardened WAP network preview

### DIFF
--- a/.github/workflows/opentofu.yml
+++ b/.github/workflows/opentofu.yml
@@ -10,11 +10,17 @@ on:
       - '.pre-commit-config.yaml'
       - '.gitignore'
       - 'Makefile'
+      - 'deploy/network-preview/**'
+      - 'docker/kannel/Dockerfile'
+      - 'docker/kannel/production/**'
       - 'infra/network-preview/**'
+      - 'scripts/build-network-preview-release.sh'
+      - 'scripts/deploy-network-preview-private.sh'
       - 'scripts/ci/*network-preview*.sh'
       - 'scripts/tests/network-preview-protected.test.mjs'
       - 'scripts/verify-lib.mjs'
       - 'scripts/tests/verify.test.mjs'
+      - 'wml-server/Dockerfile'
   push:
     branches: [main]
     paths:
@@ -25,11 +31,17 @@ on:
       - '.pre-commit-config.yaml'
       - '.gitignore'
       - 'Makefile'
+      - 'deploy/network-preview/**'
+      - 'docker/kannel/Dockerfile'
+      - 'docker/kannel/production/**'
       - 'infra/network-preview/**'
+      - 'scripts/build-network-preview-release.sh'
+      - 'scripts/deploy-network-preview-private.sh'
       - 'scripts/ci/*network-preview*.sh'
       - 'scripts/tests/network-preview-protected.test.mjs'
       - 'scripts/verify-lib.mjs'
       - 'scripts/tests/verify.test.mjs'
+      - 'wml-server/Dockerfile'
   workflow_dispatch:
 
 permissions:
@@ -117,3 +129,6 @@ jobs:
 
       - name: Test protected workflow contracts
         run: node --test scripts/tests/network-preview-protected.test.mjs
+
+      - name: Validate production deployment contracts
+        run: scripts/ci/check-network-preview-deploy.sh

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -110,3 +110,48 @@ jobs:
       - name: Audit WML origin and Go standard library
         working-directory: wml-server
         run: go run golang.org/x/vuln/cmd/govulncheck@v1.1.4 ./...
+
+  network-preview-images:
+    name: Network Preview Image Audit
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      - name: Setup Go for pinned image tools
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version: '1.25'
+          cache: false
+
+      - name: Install pinned Syft and Grype
+        run: |
+          go install github.com/anchore/syft/cmd/syft@v1.44.0
+          go install github.com/anchore/grype/cmd/grype@v0.112.0
+
+      - name: Build production images
+        run: |
+          docker build --tag wap-labs/wml-origin:security wml-server
+          docker build --target production --tag wap-labs/wap-gateway:security docker/kannel
+
+      - name: Scan high and critical vulnerabilities
+        run: |
+          grype wap-labs/wml-origin:security --fail-on high
+          grype wap-labs/wap-gateway:security --fail-on high
+
+      - name: Generate CycloneDX SBOMs
+        run: |
+          install -d artifacts/network-preview
+          syft wap-labs/wml-origin:security -o cyclonedx-json=artifacts/network-preview/wml-origin.sbom.cdx.json
+          syft wap-labs/wap-gateway:security -o cyclonedx-json=artifacts/network-preview/wap-gateway.sbom.cdx.json
+
+      - name: Upload image SBOMs
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: network-preview-sboms-${{ github.run_attempt }}
+          path: artifacts/network-preview
+          if-no-files-found: error
+          retention-days: 14

--- a/.github/workflows/transport-wap-smoke.yml
+++ b/.github/workflows/transport-wap-smoke.yml
@@ -10,6 +10,7 @@ on:
       - 'browser/src-tauri/**'
       - 'docker-compose.yml'
       - 'docker/kannel/**'
+      - 'deploy/network-preview/**'
       - 'engine-wasm/contracts/**'
       - 'engine-wasm/engine/**'
       - 'gateway-kannel/**'
@@ -83,10 +84,49 @@ jobs:
           ./scripts/tests/transport-wap-smoke-status.sh
           make smoke-transport-wap
 
+      - name: Stop development stack before production validation
+        run: docker compose down
+
+      - name: Build and start sealed production topology
+        env:
+          WAVES_SECRETS_DIR: ${{ runner.temp }}/waves-production-secrets
+          WML_ORIGIN_IMAGE: wap-labs/wml-origin:production-ci
+          WAP_GATEWAY_IMAGE: wap-labs/wap-gateway:production-ci
+        run: |
+          install -d -m 0700 "${WAVES_SECRETS_DIR}"
+          printf '%064d\n' 0 >"${WAVES_SECRETS_DIR}/kannel-admin-password"
+          printf '%064d\n' 1 >"${WAVES_SECRETS_DIR}/kannel-status-password"
+          docker build --tag "${WML_ORIGIN_IMAGE}" wml-server
+          docker build --target production --tag "${WAP_GATEWAY_IMAGE}" docker/kannel
+          docker compose -f deploy/network-preview/compose.yaml up --detach --wait
+
+      - name: Verify production WAP path and port publication
+        env:
+          WAVES_SECRETS_DIR: ${{ runner.temp }}/waves-production-secrets
+          WML_ORIGIN_IMAGE: wap-labs/wml-origin:production-ci
+          WAP_GATEWAY_IMAGE: wap-labs/wap-gateway:production-ci
+          WAP_SMOKE_URL: wap://127.0.0.1/
+          WAP_SMOKE_LOGIN_URL: wap://127.0.0.1/login
+          WAP_SMOKE_REGISTER_URL: wap://127.0.0.1/register
+          WAP_SMOKE_DENIED_URL: wap://127.0.0.1:9200/
+        run: |
+          test "$(docker compose -f deploy/network-preview/compose.yaml port --protocol udp wap-gateway 9200 | wc -l)" -eq 1
+          ! docker compose -f deploy/network-preview/compose.yaml port wap-gateway 13000
+          ! docker compose -f deploy/network-preview/compose.yaml port wap-gateway 13002
+          cd transport-rust
+          cargo test --test kannel_smoke -- --ignored --test-threads=1
+          cd ..
+          docker compose -f deploy/network-preview/compose.yaml logs --no-color >"${RUNNER_TEMP}/waves-production.log"
+          ! grep -Eq '[0-9a-f]{64}' "${RUNNER_TEMP}/waves-production.log"
+
       - name: Dump service logs on failure
         if: failure()
         run: |
           docker compose logs --tail=200 kannel wml-server || true
+          WAVES_SECRETS_DIR="${RUNNER_TEMP}/waves-production-secrets" \
+          WML_ORIGIN_IMAGE=wap-labs/wml-origin:production-ci \
+          WAP_GATEWAY_IMAGE=wap-labs/wap-gateway:production-ci \
+            docker compose -f deploy/network-preview/compose.yaml logs --tail=200 || true
 
       - name: Upload smoke diagnostics
         if: always()
@@ -99,4 +139,9 @@ jobs:
 
       - name: Stop stack
         if: always()
-        run: docker compose down
+        run: |
+          docker compose down
+          WAVES_SECRETS_DIR="${RUNNER_TEMP}/waves-production-secrets" \
+          WML_ORIGIN_IMAGE=wap-labs/wml-origin:production-ci \
+          WAP_GATEWAY_IMAGE=wap-labs/wap-gateway:production-ci \
+            docker compose -f deploy/network-preview/compose.yaml down || true

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ RUST_FUNCTION_COVERAGE_MIN ?= 85
 	fmt lint test test-fast verify-fast verify-change verify-full verify-extended ci-local \
 	coverage-rust coverage-rust-engine coverage-rust-transport \
 	lint-rust lint-rust-engine lint-rust-transport lint-node lint-go lint-tofu \
+	lint-network-preview-deploy \
 	test-rust test-rust-engine test-rust-transport test-transport-fixtures test-node test-go \
 	hooks-install hooks-update hooks-run \
 	dev-wavenav-host \
@@ -155,6 +156,11 @@ lint-tofu:
 		scripts/ci/check-network-preview-encrypted-plan.sh
 	@echo "==> protected workflow contract tests (network preview)"
 	@node --test scripts/tests/network-preview-protected.test.mjs
+	@$(MAKE) lint-network-preview-deploy
+
+lint-network-preview-deploy:
+	@echo "==> production deployment contracts (network preview)"
+	@scripts/ci/check-network-preview-deploy.sh
 
 test-rust:
 	@$(MAKE) test-rust-engine

--- a/deploy/network-preview/README.md
+++ b/deploy/network-preview/README.md
@@ -12,8 +12,8 @@ development fixture:
 
 - only UDP 9200 is published by Docker;
 - Kannel administration and wapbox ports stay inside its container and accept loopback only;
-- Kannel passwords are random host files mounted as Compose secrets, never image layers or
-  environment variables;
+- Kannel passwords are random host files owned by the fixed Kannel UID with mode `0400`, mounted
+  as Compose secrets, and never placed in image layers or environment variables;
 - both containers run as fixed non-root users with read-only root filesystems, all Linux
   capabilities dropped, `no-new-privileges`, PID/memory/CPU ceilings, bounded logs, and health
   checks;
@@ -61,7 +61,8 @@ The installer then generates host-local 256-bit Kannel secrets when absent, inst
 firewall and systemd units,
 forces firewall mode to `sealed`, starts the containers, and waits for their health checks. A
 failed start restores the prior release when one exists. The archive is removed from `/tmp` after
-success.
+success. With no prior release, a failed start explicitly removes the failed stateless containers
+and networks while leaving ingress sealed.
 
 Private validation can use the Tailnet-only hostname with the test client's private-destination
 policy:

--- a/deploy/network-preview/README.md
+++ b/deploy/network-preview/README.md
@@ -35,7 +35,7 @@ and UFW remain independent outer layers; passing one layer never substitutes for
 
 Release builds require a clean committed worktree plus Docker Buildx, Grype, and Syft. They build
 Linux AMD64 images off-host, fail on high or critical image vulnerabilities, generate CycloneDX
-SBOMs, and package the exact image IDs into a checksummed archive:
+SBOMs, and package the exact image config digests into a checksummed archive:
 
 ```sh
 scripts/build-network-preview-release.sh <release-id>
@@ -54,8 +54,11 @@ scripts/deploy-network-preview-private.sh \
   waves@waves-network-preview
 ```
 
-The remote installer verifies the archive checksum and both loaded Docker image IDs, generates
-host-local 256-bit Kannel secrets when absent, installs the persistent firewall and systemd units,
+The remote installer verifies the archive checksum, Linux AMD64 platform, and canonical config
+digest of both loaded images. The config digest check works with both Docker's classic image store
+and its containerd image store and binds each image's runtime configuration and root filesystem.
+The installer then generates host-local 256-bit Kannel secrets when absent, installs the persistent
+firewall and systemd units,
 forces firewall mode to `sealed`, starts the containers, and waits for their health checks. A
 failed start restores the prior release when one exists. The archive is removed from `/tmp` after
 success.

--- a/deploy/network-preview/README.md
+++ b/deploy/network-preview/README.md
@@ -1,0 +1,113 @@
+# Network Preview Service Deployment
+
+This directory packages the production WAP gateway and private WML origin for the existing
+DigitalOcean network-preview host. It does not create infrastructure, change OpenTofu state, or
+publish DNS. Every service deployment forces Docker ingress back to `sealed`; public UDP 9200 is
+a separate, explicit operation after the infrastructure publication plan is approved.
+
+## Security boundary
+
+The production stack differs intentionally from root `docker-compose.yml`, which remains a local
+development fixture:
+
+- only UDP 9200 is published by Docker;
+- Kannel administration and wapbox ports stay inside its container and accept loopback only;
+- Kannel passwords are random host files mounted as Compose secrets, never image layers or
+  environment variables;
+- both containers run as fixed non-root users with read-only root filesystems, all Linux
+  capabilities dropped, `no-new-privileges`, PID/memory/CPU ceilings, bounded logs, and health
+  checks;
+- the origin is reachable only over an `internal: true` bridge. Kannel also joins a dedicated
+  ingress bridge for UDP publication, while `DOCKER-USER` denies container-initiated traffic to
+  the host's public interface;
+- the origin accepts only its Compose service host, and Kannel maps only the three approved public
+  names plus the explicit local/Tailnet smoke aliases;
+- `/usr/local/sbin/waves-docker-firewall` owns a dedicated chain reached first from
+  `DOCKER-USER`. Its persisted default is `sealed`, which drops every packet entering Docker from
+  the host's public interface. Tailnet traffic may reach only UDP 9200, all other host interfaces
+  are denied access to Docker bridges, and container traffic may not leave through a host uplink.
+
+In `public` mode, that chain permits only UDP 9200 through both a per-source and global packet-rate
+limit before dropping all other public-interface container traffic. DigitalOcean Cloud Firewall
+and UFW remain independent outer layers; passing one layer never substitutes for another.
+
+## Build a release locally
+
+Release builds require a clean committed worktree plus Docker Buildx, Grype, and Syft. They build
+Linux AMD64 images off-host, fail on high or critical image vulnerabilities, generate CycloneDX
+SBOMs, and package the exact image IDs into a checksummed archive:
+
+```sh
+scripts/build-network-preview-release.sh <release-id>
+```
+
+Generated archives live below ignored `dist/network-preview/` by default and contain no
+credentials. Do not commit them.
+
+## Deploy privately
+
+The target must be named explicitly and be reachable through the existing Tailscale SSH path:
+
+```sh
+scripts/deploy-network-preview-private.sh \
+  dist/network-preview/waves-network-preview-<release-id>.tar.gz \
+  waves@waves-network-preview
+```
+
+The remote installer verifies the archive checksum and both loaded Docker image IDs, generates
+host-local 256-bit Kannel secrets when absent, installs the persistent firewall and systemd units,
+forces firewall mode to `sealed`, starts the containers, and waits for their health checks. A
+failed start restores the prior release when one exists. The archive is removed from `/tmp` after
+success.
+
+Private validation can use the Tailnet-only hostname with the test client's private-destination
+policy:
+
+```sh
+WAP_SMOKE_URL=wap://waves-network-preview/ \
+WAP_SMOKE_LOGIN_URL=wap://waves-network-preview/login \
+WAP_SMOKE_REGISTER_URL=wap://waves-network-preview/register \
+WAP_SMOKE_DENIED_URL=wap://waves-network-preview:9200/ \
+TRANSPORT_WAP_SKIP_INTERNAL_HEALTH=1 \
+  make smoke-transport-wap
+```
+
+The smoke suite also requests an intentionally unmapped origin and requires an explicit failure.
+Kannel's final catch-all maps both HTTP and HTTPS origins to a local 404 route, while the host
+firewall independently prevents container egress.
+
+The generic smoke wrapper's local HTTP diagnostics are unavailable remotely because the
+production stack correctly does not publish Kannel admin or WML health ports. Use `systemctl
+status waves-network-preview` and `docker compose` through Tailscale SSH for host-side diagnostics.
+
+## Rollback and emergency disable
+
+Seal Docker ingress immediately without stopping the private service:
+
+```sh
+sudo waves-docker-firewall set sealed
+```
+
+Roll back to the previously healthy release:
+
+```sh
+sudo waves-network-preview-rollback
+```
+
+Rollback always leaves ingress sealed. It never changes DNS, DigitalOcean Cloud Firewall, or
+OpenTofu state.
+
+## Public publication boundary
+
+Do not switch the host firewall to `public` from this deployment procedure. Publication requires:
+
+1. a reviewed OpenTofu plan that changes only the expected DNS records and UDP 9200 firewall
+   rule;
+2. explicit approval for that exact plan;
+3. successful application and verification of the external cloud firewall and DNS state;
+4. `sudo waves-docker-firewall set public` on the host;
+5. external positive UDP 9200 and negative internal-port probes;
+6. a tested `set sealed` kill switch.
+
+The emergency order is the reverse: set the host firewall to `sealed` first, then remove DNS and
+cloud ingress through a separately approved OpenTofu plan.

--- a/deploy/network-preview/bin/install-release
+++ b/deploy/network-preview/bin/install-release
@@ -18,6 +18,14 @@ sha256_file() {
   fi
 }
 
+sha256_stream() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum | awk '{print $1}'
+  else
+    shasum -a 256 | awk '{print $1}'
+  fi
+}
+
 manifest_value() {
   key=$1
   file=$2
@@ -29,6 +37,38 @@ validate_release_value() {
   label=$2
   printf '%s' "$value" | grep -Eq '^[0-9A-Za-z][0-9A-Za-z._/:-]{0,127}$' \
     || fail "$label contains unsupported characters"
+}
+
+verify_loaded_image() {
+  image=$1
+  expected_id=$2
+  label=$3
+  expected_config_digest=${expected_id#sha256:}
+  verification_archive=$stage_dir/${label}.loaded.tar
+
+  [ "$(docker image inspect --format '{{.Os}}/{{.Architecture}}' "$image")" = 'linux/amd64' ] \
+    || fail "loaded $label image is not Linux AMD64"
+
+  # Docker's classic image store reports the config digest as .Id, while the containerd image
+  # store reports the OCI manifest digest. Re-exporting the named image gives both stores the
+  # same canonical config blob, whose digest binds the runtime configuration and rootfs diff IDs.
+  docker image save --output "$verification_archive" "$image"
+  saved_manifest=$(tar -xOf "$verification_archive" manifest.json)
+  printf '%s' "$saved_manifest" | grep -F "\"$image\"" >/dev/null \
+    || fail "saved $label image manifest does not contain the expected tag"
+  config_paths=$(printf '%s' "$saved_manifest" \
+    | sed -n 's/.*"Config":[[:space:]]*"\([^"]*\)".*/\1/p')
+  [ "$(printf '%s\n' "$config_paths" | grep -c .)" -eq 1 ] \
+    || fail "saved $label image manifest has an unexpected config set"
+  case "$config_paths" in
+    "blobs/sha256/$expected_config_digest" | "$expected_config_digest.json") ;;
+    *) fail "saved $label image does not reference the release config digest" ;;
+  esac
+  tar -tf "$verification_archive" | grep -Fx "$config_paths" >/dev/null \
+    || fail "saved $label image is missing its release config blob"
+  actual_config_digest=$(tar -xOf "$verification_archive" "$config_paths" | sha256_stream)
+  [ "$actual_config_digest" = "$expected_config_digest" ] \
+    || fail "saved $label image config does not match the release digest"
 }
 
 [ "$(id -u)" -eq 0 ] || fail 'install-release must run as root'
@@ -89,10 +129,8 @@ done
 
 echo '==> Loading verified release images'
 docker image load --input "$stage_dir/images.tar" >/dev/null
-[ "$(docker image inspect --format '{{.Id}}' "$wml_image")" = "$wml_image_id" ] \
-  || fail 'loaded WML image ID does not match the release manifest'
-[ "$(docker image inspect --format '{{.Id}}' "$gateway_image")" = "$gateway_image_id" ] \
-  || fail 'loaded gateway image ID does not match the release manifest'
+verify_loaded_image "$wml_image" "$wml_image_id" WML
+verify_loaded_image "$gateway_image" "$gateway_image_id" gateway
 
 install -d -m 0755 "$release_dir"
 cp "$stage_dir/compose.yaml" "$stage_dir/manifest.env" "$release_dir/"

--- a/deploy/network-preview/bin/install-release
+++ b/deploy/network-preview/bin/install-release
@@ -72,7 +72,9 @@ verify_loaded_image() {
 }
 
 [ "$(id -u)" -eq 0 ] || fail 'install-release must run as root'
-[ -n "$archive_path" ] && [ -f "$archive_path" ] || fail 'release archive is required'
+if [ -z "$archive_path" ] || [ ! -f "$archive_path" ]; then
+  fail 'release archive is required'
+fi
 printf '%s' "$expected_sha256" | grep -Eq '^[0-9a-f]{64}$' || fail 'expected SHA-256 is invalid'
 [ "$(sha256_file "$archive_path")" = "$expected_sha256" ] || fail 'release archive SHA-256 mismatch'
 
@@ -122,8 +124,9 @@ for secret_name in kannel-admin-password kannel-status-password; do
     umask 077
     od -An -N32 -tx1 /dev/urandom | tr -d ' \n' >"$secret_path"
   fi
-  [ -f "$secret_path" ] && [ ! -L "$secret_path" ] \
-    || fail "secret path is not a regular file: $secret_path"
+  if [ ! -f "$secret_path" ] || [ -L "$secret_path" ]; then
+    fail "secret path is not a regular file: $secret_path"
+  fi
   chown 10001:10001 "$secret_path"
   chmod 0400 "$secret_path"
   printf '%s' "$(tr -d '\r\n' <"$secret_path")" | grep -Eq '^[0-9a-f]{64}$' \

--- a/deploy/network-preview/bin/install-release
+++ b/deploy/network-preview/bin/install-release
@@ -76,7 +76,7 @@ verify_loaded_image() {
 printf '%s' "$expected_sha256" | grep -Eq '^[0-9a-f]{64}$' || fail 'expected SHA-256 is invalid'
 [ "$(sha256_file "$archive_path")" = "$expected_sha256" ] || fail 'release archive SHA-256 mismatch'
 
-for command_name in docker grep install sed systemctl tar; do
+for command_name in chown docker grep install sed systemctl tar; do
   command -v "$command_name" >/dev/null 2>&1 || fail "missing required command: $command_name"
 done
 
@@ -122,7 +122,10 @@ for secret_name in kannel-admin-password kannel-status-password; do
     umask 077
     od -An -N32 -tx1 /dev/urandom | tr -d ' \n' >"$secret_path"
   fi
-  chmod 0600 "$secret_path"
+  [ -f "$secret_path" ] && [ ! -L "$secret_path" ] \
+    || fail "secret path is not a regular file: $secret_path"
+  chown 10001:10001 "$secret_path"
+  chmod 0400 "$secret_path"
   printf '%s' "$(tr -d '\r\n' <"$secret_path")" | grep -Eq '^[0-9a-f]{64}$' \
     || fail "invalid secret file: $secret_path"
 done
@@ -163,6 +166,11 @@ if ! systemctl restart waves-network-preview.service; then
     systemctl restart waves-network-preview.service || true
   else
     systemctl disable --now waves-network-preview.service || true
+    (
+      cd "$release_dir"
+      docker compose --project-name waves-network-preview --env-file manifest.env \
+        -f compose.yaml down
+    ) || true
     rm -f "$install_root/current"
   fi
   exit 1

--- a/deploy/network-preview/bin/install-release
+++ b/deploy/network-preview/bin/install-release
@@ -1,0 +1,137 @@
+#!/usr/bin/env sh
+set -eu
+
+archive_path=${1:-}
+expected_sha256=${2:-}
+install_root=${WAVES_INSTALL_ROOT:-/opt/waves}
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+sha256_file() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | awk '{print $1}'
+  else
+    shasum -a 256 "$1" | awk '{print $1}'
+  fi
+}
+
+manifest_value() {
+  key=$1
+  file=$2
+  sed -n "s/^${key}=//p" "$file"
+}
+
+validate_release_value() {
+  value=$1
+  label=$2
+  printf '%s' "$value" | grep -Eq '^[0-9A-Za-z][0-9A-Za-z._/:-]{0,127}$' \
+    || fail "$label contains unsupported characters"
+}
+
+[ "$(id -u)" -eq 0 ] || fail 'install-release must run as root'
+[ -n "$archive_path" ] && [ -f "$archive_path" ] || fail 'release archive is required'
+printf '%s' "$expected_sha256" | grep -Eq '^[0-9a-f]{64}$' || fail 'expected SHA-256 is invalid'
+[ "$(sha256_file "$archive_path")" = "$expected_sha256" ] || fail 'release archive SHA-256 mismatch'
+
+for command_name in docker grep install sed systemctl tar; do
+  command -v "$command_name" >/dev/null 2>&1 || fail "missing required command: $command_name"
+done
+
+stage_dir=$(mktemp -d "${TMPDIR:-/tmp}/waves-install-release.XXXXXX")
+cleanup() {
+  rm -rf "$stage_dir"
+}
+trap cleanup EXIT HUP INT TERM
+
+tar -tzf "$archive_path" >"$stage_dir/archive.list"
+while IFS= read -r entry; do
+  case "$entry" in
+    /* | ../* | */../* | */..) fail "unsafe archive path: $entry" ;;
+  esac
+done <"$stage_dir/archive.list"
+tar --no-same-owner -xzf "$archive_path" -C "$stage_dir"
+
+for required_file in compose.yaml images.tar manifest.env wml-origin.sbom.cdx.json wap-gateway.sbom.cdx.json bin/waves-docker-firewall bin/rollback-release systemd/waves-docker-firewall.service systemd/waves-network-preview.service; do
+  [ -f "$stage_dir/$required_file" ] || fail "release archive is missing $required_file"
+done
+
+release_id=$(manifest_value WAVES_RELEASE_ID "$stage_dir/manifest.env")
+source_commit=$(manifest_value WAVES_SOURCE_COMMIT "$stage_dir/manifest.env")
+wml_image=$(manifest_value WML_ORIGIN_IMAGE "$stage_dir/manifest.env")
+wml_image_id=$(manifest_value WML_ORIGIN_IMAGE_ID "$stage_dir/manifest.env")
+gateway_image=$(manifest_value WAP_GATEWAY_IMAGE "$stage_dir/manifest.env")
+gateway_image_id=$(manifest_value WAP_GATEWAY_IMAGE_ID "$stage_dir/manifest.env")
+validate_release_value "$release_id" WAVES_RELEASE_ID
+printf '%s' "$source_commit" | grep -Eq '^[0-9a-f]{40}$' || fail 'source commit is invalid'
+validate_release_value "$wml_image" WML_ORIGIN_IMAGE
+validate_release_value "$gateway_image" WAP_GATEWAY_IMAGE
+printf '%s' "$wml_image_id" | grep -Eq '^sha256:[0-9a-f]{64}$' || fail 'WML image ID is invalid'
+printf '%s' "$gateway_image_id" | grep -Eq '^sha256:[0-9a-f]{64}$' || fail 'gateway image ID is invalid'
+
+release_dir=$install_root/releases/$release_id
+[ ! -e "$release_dir" ] || fail "release is already installed: $release_id"
+install -d -m 0755 "$install_root/releases" "$install_root/shared" "$install_root/shared/secrets"
+chmod 0700 "$install_root/shared/secrets"
+
+for secret_name in kannel-admin-password kannel-status-password; do
+  secret_path=$install_root/shared/secrets/$secret_name
+  if [ ! -e "$secret_path" ]; then
+    umask 077
+    od -An -N32 -tx1 /dev/urandom | tr -d ' \n' >"$secret_path"
+  fi
+  chmod 0600 "$secret_path"
+  printf '%s' "$(tr -d '\r\n' <"$secret_path")" | grep -Eq '^[0-9a-f]{64}$' \
+    || fail "invalid secret file: $secret_path"
+done
+
+echo '==> Loading verified release images'
+docker image load --input "$stage_dir/images.tar" >/dev/null
+[ "$(docker image inspect --format '{{.Id}}' "$wml_image")" = "$wml_image_id" ] \
+  || fail 'loaded WML image ID does not match the release manifest'
+[ "$(docker image inspect --format '{{.Id}}' "$gateway_image")" = "$gateway_image_id" ] \
+  || fail 'loaded gateway image ID does not match the release manifest'
+
+install -d -m 0755 "$release_dir"
+cp "$stage_dir/compose.yaml" "$stage_dir/manifest.env" "$release_dir/"
+cp "$stage_dir/"*.sbom.cdx.json "$release_dir/"
+chmod 0644 "$release_dir/compose.yaml" "$release_dir/manifest.env" "$release_dir/"*.sbom.cdx.json
+
+install -m 0755 "$stage_dir/bin/waves-docker-firewall" /usr/local/sbin/waves-docker-firewall
+install -m 0755 "$stage_dir/bin/rollback-release" /usr/local/sbin/waves-network-preview-rollback
+install -m 0644 "$stage_dir/systemd/waves-docker-firewall.service" /etc/systemd/system/waves-docker-firewall.service
+install -m 0644 "$stage_dir/systemd/waves-network-preview.service" /etc/systemd/system/waves-network-preview.service
+systemctl daemon-reload
+/usr/local/sbin/waves-docker-firewall set sealed
+systemctl enable waves-docker-firewall.service >/dev/null
+
+if [ -e "$install_root/current" ] && [ ! -L "$install_root/current" ]; then
+  fail "$install_root/current exists but is not a managed symlink"
+fi
+old_release=
+if [ -L "$install_root/current" ]; then
+  old_release=$(readlink "$install_root/current")
+fi
+ln -sfn "$release_dir" "$install_root/current"
+
+systemctl enable waves-network-preview.service >/dev/null
+if ! systemctl restart waves-network-preview.service; then
+  echo 'Deployment failed; sealing Docker ingress and restoring the prior release.' >&2
+  /usr/local/sbin/waves-docker-firewall set sealed || true
+  if [ -n "$old_release" ] && [ -d "$old_release" ]; then
+    ln -sfn "$old_release" "$install_root/current"
+    systemctl restart waves-network-preview.service || true
+  else
+    systemctl disable --now waves-network-preview.service || true
+    rm -f "$install_root/current"
+  fi
+  exit 1
+fi
+
+if [ -n "$old_release" ] && [ -d "$old_release" ]; then
+  ln -sfn "$old_release" "$install_root/previous"
+fi
+/usr/local/sbin/waves-docker-firewall check
+echo "PASS: installed sealed network preview release $release_id from $source_commit"

--- a/deploy/network-preview/bin/rollback-release
+++ b/deploy/network-preview/bin/rollback-release
@@ -1,0 +1,31 @@
+#!/usr/bin/env sh
+set -eu
+
+install_root=${WAVES_INSTALL_ROOT:-/opt/waves}
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+[ "$(id -u)" -eq 0 ] || fail 'rollback-release must run as root'
+[ -L "$install_root/current" ] || fail 'current release symlink is missing'
+[ -L "$install_root/previous" ] || fail 'previous release symlink is missing'
+current_release=$(readlink "$install_root/current")
+previous_release=$(readlink "$install_root/previous")
+[ -d "$current_release" ] || fail 'current release directory is missing'
+[ -d "$previous_release" ] || fail 'previous release directory is missing'
+
+/usr/local/sbin/waves-docker-firewall set sealed
+systemctl stop waves-network-preview.service
+ln -sfn "$previous_release" "$install_root/current"
+if systemctl start waves-network-preview.service; then
+  ln -sfn "$current_release" "$install_root/previous"
+  echo "PASS: rolled back to $(basename "$previous_release"); Docker ingress remains sealed"
+  exit 0
+fi
+
+echo 'Rollback start failed; restoring the release that was active before rollback.' >&2
+ln -sfn "$current_release" "$install_root/current"
+systemctl start waves-network-preview.service || true
+exit 1

--- a/deploy/network-preview/bin/waves-docker-firewall
+++ b/deploy/network-preview/bin/waves-docker-firewall
@@ -1,0 +1,185 @@
+#!/usr/bin/env sh
+set -eu
+
+chain_name=WAVES-DOCKER
+state_file=${WAVES_FIREWALL_STATE_FILE:-/etc/default/waves-docker-firewall}
+public_rate=${WAVES_WAP_GLOBAL_RATE:-200/second}
+public_burst=${WAVES_WAP_GLOBAL_BURST:-400}
+source_rate=${WAVES_WAP_SOURCE_RATE:-20/second}
+source_burst=${WAVES_WAP_SOURCE_BURST:-40}
+tailnet_interface=${WAVES_TAILNET_INTERFACE:-tailscale0}
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+require_root() {
+  [ "$(id -u)" -eq 0 ] || fail 'waves-docker-firewall must run as root'
+}
+
+public_interface() {
+  if [ -n "${WAVES_PUBLIC_INTERFACE:-}" ]; then
+    printf '%s\n' "$WAVES_PUBLIC_INTERFACE"
+    return
+  fi
+  ip -4 route show default | awk 'NR == 1 { for (i = 1; i <= NF; i++) if ($i == "dev") { print $(i + 1); exit } }'
+}
+
+load_mode() {
+  mode=sealed
+  if [ -r "$state_file" ]; then
+    # shellcheck disable=SC1090 # Root-owned file accepts only the validated variable below.
+    . "$state_file"
+    mode=${WAVES_FIREWALL_MODE:-sealed}
+  fi
+  case "$mode" in
+    sealed | public) printf '%s\n' "$mode" ;;
+    *) fail "unsupported firewall mode in $state_file" ;;
+  esac
+}
+
+validate_rate() {
+  value=$1
+  label=$2
+  case "$value" in
+    *[!0-9/second]*) fail "$label contains unsupported characters" ;;
+  esac
+  printf '%s' "$value" | grep -Eq '^[1-9][0-9]*/second$' || fail "$label must use N/second"
+}
+
+validate_positive_integer() {
+  value=$1
+  label=$2
+  case "$value" in
+    '' | *[!0-9]*) fail "$label must be a positive integer" ;;
+  esac
+  [ "$value" -gt 0 ] || fail "$label must be greater than zero"
+}
+
+ensure_prerequisites() {
+  for command_name in ip iptables iptables-restore awk grep; do
+    command -v "$command_name" >/dev/null 2>&1 || fail "missing required command: $command_name"
+  done
+  iptables -n -L DOCKER-USER >/dev/null 2>&1 || fail 'Docker DOCKER-USER chain is unavailable'
+}
+
+ensure_jump() {
+  first_rule=$(iptables -S DOCKER-USER | sed -n '/^-A / { p; q; }')
+  if [ "$first_rule" = "-A DOCKER-USER -j $chain_name" ]; then
+    return
+  fi
+  if iptables -C DOCKER-USER -j "$chain_name" >/dev/null 2>&1; then
+    fail "$chain_name jump exists but is not first in DOCKER-USER"
+  fi
+  iptables -I DOCKER-USER 1 -j "$chain_name"
+}
+
+apply_rules() {
+  mode=$1
+  interface=$2
+  iptables -N "$chain_name" 2>/dev/null || true
+  ensure_jump
+
+  rules_file=$(mktemp "${TMPDIR:-/tmp}/waves-docker-firewall.XXXXXX")
+  trap 'rm -f "$rules_file"' EXIT HUP INT TERM
+  {
+    printf '%s\n' '*filter'
+    printf ':%s - [0:0]\n' "$chain_name"
+    printf -- '-F %s\n' "$chain_name"
+    printf -- '-A %s -m conntrack --ctstate RELATED,ESTABLISHED -j RETURN\n' "$chain_name"
+    printf -- '-A %s -i docker0 -o docker0 -j RETURN\n' "$chain_name"
+    printf -- '-A %s -i br+ -o br+ -j RETURN\n' "$chain_name"
+    printf -- '-A %s -i %s -p udp --dport 9200 -j RETURN\n' "$chain_name" "$tailnet_interface"
+    printf -- '-A %s -i %s -j DROP\n' "$chain_name" "$tailnet_interface"
+    if [ "$mode" = public ]; then
+      printf -- '-A %s -i %s -p udp --dport 9200 -m hashlimit --hashlimit-upto %s --hashlimit-burst %s --hashlimit-mode srcip --hashlimit-name waves_wap_source -m limit --limit %s --limit-burst %s -j RETURN\n' \
+        "$chain_name" "$interface" "$source_rate" "$source_burst" "$public_rate" "$public_burst"
+    fi
+    printf -- '-A %s -i %s -j DROP\n' "$chain_name" "$interface"
+    printf -- '-A %s -o docker0 -j DROP\n' "$chain_name"
+    printf -- '-A %s -o br+ -j DROP\n' "$chain_name"
+    printf -- '-A %s -i docker0 -j DROP\n' "$chain_name"
+    printf -- '-A %s -i br+ -j DROP\n' "$chain_name"
+    printf -- '-A %s -j RETURN\n' "$chain_name"
+    printf '%s\n' 'COMMIT'
+  } >"$rules_file"
+  iptables-restore --noflush <"$rules_file"
+  rm -f "$rules_file"
+  trap - EXIT HUP INT TERM
+}
+
+check_rules() {
+  mode=$1
+  interface=$2
+  first_rule=$(iptables -S DOCKER-USER | sed -n '/^-A / { p; q; }')
+  [ "$first_rule" = "-A DOCKER-USER -j $chain_name" ] || fail "$chain_name is not first in DOCKER-USER"
+  iptables -C "$chain_name" -m conntrack --ctstate RELATED,ESTABLISHED -j RETURN >/dev/null
+  iptables -C "$chain_name" -i "$tailnet_interface" -p udp --dport 9200 -j RETURN >/dev/null
+  iptables -C "$chain_name" -i "$tailnet_interface" -j DROP >/dev/null
+  iptables -C "$chain_name" -i "$interface" -j DROP >/dev/null
+  iptables -C "$chain_name" -o docker0 -j DROP >/dev/null
+  iptables -C "$chain_name" -o br+ -j DROP >/dev/null
+  iptables -C "$chain_name" -i docker0 -j DROP >/dev/null
+  iptables -C "$chain_name" -i br+ -j DROP >/dev/null
+  if [ "$mode" = public ]; then
+    iptables -S "$chain_name" | grep -Eq -- "^-A $chain_name -i $interface -p udp .*--dport 9200 .* -j RETURN$" \
+      || fail 'public UDP 9200 rate-limit rule is missing'
+  elif iptables -S "$chain_name" | grep -Eq -- "^-A $chain_name -i $interface -p udp .*--dport 9200 .* -j RETURN$"; then
+    fail 'sealed mode unexpectedly allows public UDP 9200'
+  fi
+  echo "PASS: Docker forwarding policy is $mode on $interface"
+}
+
+write_mode() {
+  mode=$1
+  install -d -m 0755 "$(dirname "$state_file")"
+  temporary_state=$(mktemp "${TMPDIR:-/tmp}/waves-firewall-state.XXXXXX")
+  trap 'rm -f "$temporary_state"' EXIT HUP INT TERM
+  printf 'WAVES_FIREWALL_MODE=%s\n' "$mode" >"$temporary_state"
+  chmod 0644 "$temporary_state"
+  install -m 0644 "$temporary_state" "$state_file"
+  rm -f "$temporary_state"
+  trap - EXIT HUP INT TERM
+}
+
+usage() {
+  echo 'usage: waves-docker-firewall apply [sealed|public] | check [sealed|public] | set sealed|public' >&2
+  exit 2
+}
+
+require_root
+ensure_prerequisites
+validate_rate "$public_rate" WAVES_WAP_GLOBAL_RATE
+validate_rate "$source_rate" WAVES_WAP_SOURCE_RATE
+validate_positive_integer "$public_burst" WAVES_WAP_GLOBAL_BURST
+validate_positive_integer "$source_burst" WAVES_WAP_SOURCE_BURST
+interface=$(public_interface)
+[ -n "$interface" ] || fail 'could not determine the public interface'
+printf '%s' "$interface" | grep -Eq '^[A-Za-z0-9_.:-]{1,15}$' \
+  || fail 'public interface name contains unsupported characters'
+printf '%s' "$tailnet_interface" | grep -Eq '^[A-Za-z0-9_.:-]{1,15}$' \
+  || fail 'tailnet interface name contains unsupported characters'
+ip link show "$interface" >/dev/null 2>&1 || fail "public interface does not exist: $interface"
+
+command_name=${1:-}
+requested_mode=${2:-}
+case "$command_name" in
+  apply | check)
+    if [ -z "$requested_mode" ]; then
+      requested_mode=$(load_mode)
+    fi
+    case "$requested_mode" in sealed | public) ;; *) usage ;; esac
+    if [ "$command_name" = apply ]; then
+      apply_rules "$requested_mode" "$interface"
+    fi
+    check_rules "$requested_mode" "$interface"
+    ;;
+  set)
+    case "$requested_mode" in sealed | public) ;; *) usage ;; esac
+    write_mode "$requested_mode"
+    apply_rules "$requested_mode" "$interface"
+    check_rules "$requested_mode" "$interface"
+    ;;
+  *) usage ;;
+esac

--- a/deploy/network-preview/compose.yaml
+++ b/deploy/network-preview/compose.yaml
@@ -1,0 +1,105 @@
+name: waves-network-preview
+
+services:
+  wml-origin:
+    image: ${WML_ORIGIN_IMAGE:?set WML_ORIGIN_IMAGE to the verified release image tag}
+    pull_policy: never
+    restart: unless-stopped
+    init: true
+    user: '65532:65532'
+    read_only: true
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+    environment:
+      WML_ALLOWED_HOSTS: wml-origin
+      WML_DTD_VERSION: '1.3'
+      WML_FORMS_HOSTS: forms.wap.shrimpworks.dev
+      WML_HOME_HOSTS: home.wap.shrimpworks.dev
+      WML_INTEROP_HOSTS: interop.wap.shrimpworks.dev
+    expose:
+      - '3000'
+      - '3001'
+    networks:
+      - origin
+    tmpfs:
+      - /tmp:size=4m,mode=1777
+    pids_limit: 64
+    mem_limit: 64m
+    mem_reservation: 24m
+    cpus: 0.25
+    stop_grace_period: 15s
+    healthcheck:
+      test: ['CMD', '/wml-server', 'healthcheck']
+      interval: 15s
+      timeout: 5s
+      retries: 4
+      start_period: 5s
+    logging:
+      driver: json-file
+      options:
+        max-file: '3'
+        max-size: 10m
+
+  wap-gateway:
+    image: ${WAP_GATEWAY_IMAGE:?set WAP_GATEWAY_IMAGE to the verified release image tag}
+    pull_policy: never
+    restart: unless-stopped
+    init: true
+    user: '10001:10001'
+    read_only: true
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+    depends_on:
+      wml-origin:
+        condition: service_healthy
+        restart: true
+    secrets:
+      - kannel_admin_password
+      - kannel_status_password
+    ports:
+      - name: wap-connectionless
+        target: 9200
+        published: '9200'
+        host_ip: 0.0.0.0
+        protocol: udp
+        app_protocol: wap-wsp
+    networks:
+      - edge
+      - origin
+    tmpfs:
+      - /run/kannel:size=4m,mode=0700,uid=10001,gid=10001
+      - /tmp:size=8m,mode=1777
+      - /var/log/kannel:size=8m,mode=0750,uid=10001,gid=10001
+    pids_limit: 64
+    mem_limit: 192m
+    mem_reservation: 64m
+    cpus: 0.50
+    stop_grace_period: 20s
+    healthcheck:
+      test: ['CMD', '/usr/local/bin/waves-kannel-healthcheck']
+      interval: 15s
+      timeout: 5s
+      retries: 4
+      start_period: 15s
+    logging:
+      driver: json-file
+      options:
+        max-file: '3'
+        max-size: 10m
+
+networks:
+  edge:
+    driver: bridge
+  origin:
+    internal: true
+    driver: bridge
+
+secrets:
+  kannel_admin_password:
+    file: ${WAVES_SECRETS_DIR:-/opt/waves/shared/secrets}/kannel-admin-password
+  kannel_status_password:
+    file: ${WAVES_SECRETS_DIR:-/opt/waves/shared/secrets}/kannel-status-password

--- a/deploy/network-preview/systemd/waves-docker-firewall.service
+++ b/deploy/network-preview/systemd/waves-docker-firewall.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Waves Docker forwarding firewall
+Requires=docker.service
+After=docker.service network-online.target
+Before=waves-network-preview.service
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+EnvironmentFile=-/etc/default/waves-docker-firewall
+ExecStart=/usr/local/sbin/waves-docker-firewall apply
+ExecReload=/usr/local/sbin/waves-docker-firewall apply
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/network-preview/systemd/waves-network-preview.service
+++ b/deploy/network-preview/systemd/waves-network-preview.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=Waves public WAP network preview
+Requires=docker.service waves-docker-firewall.service
+After=docker.service waves-docker-firewall.service network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+WorkingDirectory=/opt/waves/current
+ExecStartPre=/usr/local/sbin/waves-docker-firewall check
+ExecStart=/usr/bin/docker compose --project-name waves-network-preview --env-file manifest.env -f compose.yaml up --detach --wait
+ExecReload=/usr/bin/docker compose --project-name waves-network-preview --env-file manifest.env -f compose.yaml up --detach --wait
+ExecStop=/usr/bin/docker compose --project-name waves-network-preview --env-file manifest.env -f compose.yaml down
+TimeoutStartSec=180
+TimeoutStopSec=60
+
+[Install]
+WantedBy=multi-user.target

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,7 @@ services:
     build:
       context: ./docker/kannel
       dockerfile: Dockerfile
+      target: development
     container_name: wap-gateway
     depends_on:
       - wml-server

--- a/docker/kannel/Dockerfile
+++ b/docker/kannel/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04 AS kannel-build
+FROM ubuntu:22.04@sha256:0e0a0fc6d18feda9db1590da249ac93e8d5abfea8f4c3c0c849ce512b5ef8982 AS kannel-build
 
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -20,7 +20,7 @@ RUN kannel_source_dir="$(find /usr/src/kannel-build -mindepth 1 -maxdepth 1 -typ
     && patch -p1 < /tmp/connectionless-wbxml-version.patch \
     && dpkg-buildpackage -b -uc -us
 
-FROM ubuntu:22.04
+FROM ubuntu:22.04@sha256:0e0a0fc6d18feda9db1590da249ac93e8d5abfea8f4c3c0c849ce512b5ef8982 AS runtime-base
 
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -29,9 +29,12 @@ COPY --from=kannel-build /usr/src/kannel-build/kannel_*.deb /tmp/kannel-patched.
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
        ca-certificates \
+       curl \
        /tmp/kannel-patched.deb \
     && rm -f /tmp/kannel-patched.deb \
     && rm -rf /var/lib/apt/lists/*
+
+FROM runtime-base AS development
 
 COPY kannel.conf /etc/kannel/kannel.conf
 COPY start.sh /start.sh
@@ -40,3 +43,21 @@ RUN chmod +x /start.sh
 EXPOSE 13000 13002 9200/udp 9201/udp
 
 CMD ["/start.sh"]
+
+FROM runtime-base AS production
+
+RUN groupadd --gid 10001 waves-kannel \
+    && useradd --uid 10001 --gid 10001 --no-create-home --home-dir /nonexistent \
+       --shell /usr/sbin/nologin waves-kannel \
+    && install -d -m 0750 -o 10001 -g 10001 /run/kannel /var/log/kannel
+
+COPY --chown=10001:10001 production/kannel.conf.tmpl /etc/kannel/kannel.conf.tmpl
+COPY --chown=10001:10001 production/entrypoint.sh /usr/local/bin/waves-kannel-entrypoint
+COPY --chown=10001:10001 production/healthcheck.sh /usr/local/bin/waves-kannel-healthcheck
+
+RUN chmod 0555 /usr/local/bin/waves-kannel-entrypoint /usr/local/bin/waves-kannel-healthcheck \
+    && chmod 0444 /etc/kannel/kannel.conf.tmpl
+
+USER 10001:10001
+EXPOSE 9200/udp
+ENTRYPOINT ["/usr/local/bin/waves-kannel-entrypoint"]

--- a/docker/kannel/production/entrypoint.sh
+++ b/docker/kannel/production/entrypoint.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env sh
+set -eu
+
+admin_secret_file=${KANNEL_ADMIN_PASSWORD_FILE:-/run/secrets/kannel_admin_password}
+status_secret_file=${KANNEL_STATUS_PASSWORD_FILE:-/run/secrets/kannel_status_password}
+template_file=/etc/kannel/kannel.conf.tmpl
+runtime_dir=/run/kannel
+runtime_config=${runtime_dir}/kannel.conf
+
+read_secret() {
+  secret_file=$1
+  secret_name=$2
+  if [ ! -r "$secret_file" ]; then
+    echo "FAIL: $secret_name secret file is not readable" >&2
+    exit 1
+  fi
+  secret_value=$(tr -d '\r\n' <"$secret_file")
+  if ! printf '%s' "$secret_value" | grep -Eq '^[0-9a-f]{64}$'; then
+    echo "FAIL: $secret_name must contain exactly 64 lowercase hexadecimal characters" >&2
+    exit 1
+  fi
+  printf '%s' "$secret_value"
+}
+
+admin_password=$(read_secret "$admin_secret_file" KANNEL_ADMIN_PASSWORD)
+status_password=$(read_secret "$status_secret_file" KANNEL_STATUS_PASSWORD)
+
+umask 077
+mkdir -p "$runtime_dir"
+sed \
+  -e "s/__KANNEL_ADMIN_PASSWORD__/$admin_password/g" \
+  -e "s/__KANNEL_STATUS_PASSWORD__/$status_password/g" \
+  "$template_file" >"$runtime_config"
+unset admin_password status_password
+
+bearerbox_pid=
+wapbox_pid=
+# shellcheck disable=SC2329 # Invoked through POSIX signal/exit traps.
+terminate() {
+  trap - EXIT HUP INT TERM
+  if [ -n "$wapbox_pid" ]; then
+    kill "$wapbox_pid" 2>/dev/null || true
+  fi
+  if [ -n "$bearerbox_pid" ]; then
+    kill "$bearerbox_pid" 2>/dev/null || true
+  fi
+  wait 2>/dev/null || true
+}
+trap terminate EXIT HUP INT TERM
+
+echo 'Starting production Kannel bearerbox...'
+bearerbox -v 1 "$runtime_config" &
+bearerbox_pid=$!
+printf '%s\n' "$bearerbox_pid" >"$runtime_dir/bearerbox.pid"
+
+i=0
+while [ "$i" -lt 20 ]; do
+  if curl -sS --output /dev/null --connect-timeout 1 --max-time 2 \
+    'http://127.0.0.1:13000/status' \
+    >/dev/null 2>&1; then
+    break
+  fi
+  if ! kill -0 "$bearerbox_pid" 2>/dev/null; then
+    echo 'FAIL: bearerbox exited during startup' >&2
+    exit 1
+  fi
+  i=$((i + 1))
+  sleep 1
+done
+if [ "$i" -ge 20 ]; then
+  echo 'FAIL: bearerbox did not become healthy' >&2
+  exit 1
+fi
+
+echo 'Starting production Kannel wapbox...'
+wapbox -v 1 "$runtime_config" &
+wapbox_pid=$!
+printf '%s\n' "$wapbox_pid" >"$runtime_dir/wapbox.pid"
+
+while kill -0 "$bearerbox_pid" 2>/dev/null && kill -0 "$wapbox_pid" 2>/dev/null; do
+  sleep 1
+done
+
+echo 'FAIL: a Kannel process exited unexpectedly' >&2
+exit 1

--- a/docker/kannel/production/entrypoint.sh
+++ b/docker/kannel/production/entrypoint.sh
@@ -35,7 +35,7 @@ unset admin_password status_password
 
 bearerbox_pid=
 wapbox_pid=
-# shellcheck disable=SC2329 # Invoked through POSIX signal/exit traps.
+# shellcheck disable=SC2317,SC2329 # Invoked through POSIX signal/exit traps.
 terminate() {
   trap - EXIT HUP INT TERM
   if [ -n "$wapbox_pid" ]; then

--- a/docker/kannel/production/healthcheck.sh
+++ b/docker/kannel/production/healthcheck.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env sh
+set -eu
+
+runtime_dir=/run/kannel
+for process_name in bearerbox wapbox; do
+  pid_file=${runtime_dir}/${process_name}.pid
+  test -r "$pid_file"
+  pid=$(sed -n '1p' "$pid_file")
+  case "$pid" in
+    '' | *[!0-9]*) exit 1 ;;
+  esac
+  kill -0 "$pid" 2>/dev/null
+done
+
+curl -sS --output /dev/null --connect-timeout 1 --max-time 3 \
+  'http://127.0.0.1:13000/status'

--- a/docker/kannel/production/kannel.conf.tmpl
+++ b/docker/kannel/production/kannel.conf.tmpl
@@ -1,0 +1,58 @@
+group = core
+admin-port = 13000
+admin-password = __KANNEL_ADMIN_PASSWORD__
+status-password = __KANNEL_STATUS_PASSWORD__
+admin-deny-ip = "*.*.*.*"
+admin-allow-ip = "127.0.0.1"
+wapbox-port = 13002
+box-deny-ip = "*.*.*.*"
+box-allow-ip = "127.0.0.1"
+wdp-interface-name = "*"
+log-level = 1
+
+group = wapbox
+bearerbox-host = 127.0.0.1
+device-home = "http://wml-origin:3000/__lab/home/"
+
+# Private smoke aliases. Neither name is published in public DNS.
+group = wap-url-map
+name = private_localhost
+url = "http://localhost:13002/*"
+map-url = "http://wml-origin:3000/__lab/home/*"
+
+group = wap-url-map
+name = private_loopback
+url = "http://127.0.0.1:13002/*"
+map-url = "http://wml-origin:3000/__lab/home/*"
+
+group = wap-url-map
+name = private_tailnet
+url = "http://waves-network-preview/*"
+map-url = "http://wml-origin:3000/__lab/home/*"
+
+group = wap-url-map
+name = lab_home
+url = "http://home.wap.shrimpworks.dev/*"
+map-url = "http://wml-origin:3000/__lab/home/*"
+
+group = wap-url-map
+name = lab_forms
+url = "http://forms.wap.shrimpworks.dev/*"
+map-url = "http://wml-origin:3000/__lab/forms/*"
+
+group = wap-url-map
+name = lab_interop
+url = "http://interop.wap.shrimpworks.dev/*"
+map-url = "http://wml-origin:3000/__lab/interop/*"
+
+# Keep these final: Kannel uses the first matching URL map. Unapproved origins
+# are converted to an origin-local 404 instead of becoming an open HTTP proxy.
+group = wap-url-map
+name = deny_unmapped_http
+url = "http://*"
+map-url = "http://wml-origin:3000/__lab/denied"
+
+group = wap-url-map
+name = deny_unmapped_https
+url = "https://*"
+map-url = "http://wml-origin:3000/__lab/denied"

--- a/docs/waves/PUBLIC_WAP_LAB_PRERELEASE_PLAN.md
+++ b/docs/waves/PUBLIC_WAP_LAB_PRERELEASE_PLAN.md
@@ -130,9 +130,8 @@ state-lifecycle, concurrency, host-profile, route-denial, and internal-observabi
 exposure gate. The owner selected the Cloudflare-managed `shrimpworks.dev` zone for `PRE-002`:
 `home.wap.shrimpworks.dev`, `forms.wap.shrimpworks.dev`, and
 `interop.wap.shrimpworks.dev`. Use exact DNS-only records rather than a wildcard record, and defer
-a second apex until a cross-registrable-domain test proves subdomains insufficient. The existing
-staged OpenTofu DNS names must be updated and reviewed before public publication; the sealed
-default does not create any of them.
+a second apex until a cross-registrable-domain test proves subdomains insufficient. The staged
+OpenTofu root defines these exact names, but its sealed default does not create any of them.
 
 ## Public topology
 
@@ -236,10 +235,13 @@ Tailscale-only administration, and no
 application deployment. Enabling public UDP/DNS still depends on the production gateway,
 `PRE-003`, `PRE-004`, and a separately reviewed plan.
 
-The merged base-host bootstrap hardens the Docker daemon but does not yet install the production
-Compose stack or its `DOCKER-USER`/UFW forwarding policy. Treat that policy and its external
-negative tests as unfinished `INF-102`/`GW-101` work, not as a control already present on the
-restricted host.
+The host created from PR #456 does not itself contain the production Compose stack or persistent
+`DOCKER-USER` policy. The current service-deployment implementation packages that policy, a
+sealed-by-default systemd service, immutable local release artifacts, and rollback tooling; its
+private installer is also the upgrade path for the existing host. Cloud-init changes apply only to
+future replacement hosts because Droplet user data is lifecycle-ignored. Treat the forwarding
+control and its external negative tests as unfinished `INF-102`/`GW-101` evidence until the private
+installer and reboot behavior are verified on the restricted host.
 
 ## Security, abuse, and operations
 

--- a/docs/waves/PUBLIC_WAP_LAB_PRERELEASE_PLAN.md
+++ b/docs/waves/PUBLIC_WAP_LAB_PRERELEASE_PLAN.md
@@ -52,7 +52,16 @@ and size availability through its authenticated `/v2/regions` and `/v2/sizes` AP
 evidence, not this planning assumption, decides the exact region. Hetzner is the leading
 alternative for a Europe-hosted lab: its EU CX23 offers materially more memory for roughly EUR
 5.49/month plus IPv4 and tax, but its low-cost CX line is not available in North America.
-Lightsail, IONOS, and OVHcloud remain account or regional fallbacks rather than the default.
+IONOS and OVHcloud remain account or regional fallbacks rather than the default. AWS services are
+excluded by owner decision.
+
+DigitalOcean also provides free, always-on network and transport-layer DDoS protection for
+Droplets and assigned Reserved IPs, including UDP floods and reflection attacks. Keep Cloudflare
+records DNS-only: Cloudflare Spectrum is not required for the initial preview. This protection is
+baseline volumetric mitigation, not application-level WAP abuse protection or an availability
+guarantee; DigitalOcean may blackhole the target IP if an attack exceeds mitigation capacity.
+The response-size, amplification, rate-limit, monitoring, and kill-switch controls below therefore
+remain mandatory.
 
 Keep the first Kannel image on x86_64. Multi-architecture images should be a deliberate later
 slice backed by image and end-to-end tests, not a launch-time variable.
@@ -72,7 +81,9 @@ The current local assets prove the topology but are not production configuration
 - `scripts/transport-wap-smoke.sh` and native Kannel tests exercise the transport path.
 
 Production work must remove public Kannel administration/internal ports, placeholder secrets,
-source bind mounts, and package installation at container startup.
+source bind mounts, and package installation at container startup. It must also account for
+Docker's published-port rules, which can bypass ordinary UFW input policy unless forwarding is
+filtered through `DOCKER-USER` or an equivalent supported firewall integration.
 
 ## WML origin decision: Go
 
@@ -117,9 +128,11 @@ state-lifecycle, concurrency, host-profile, route-denial, and internal-observabi
 
 `LAB-101` merged in PR #427. This does not complete `GW-101`, `INF-101`, `INF-102`, or any public
 exposure gate. The owner selected the Cloudflare-managed `shrimpworks.dev` zone for `PRE-002`:
-`home.shrimpworks.dev`, `forms.shrimpworks.dev`, and `interop.shrimpworks.dev`. Use exact DNS-only
-records rather than a wildcard record, and defer a second apex until a cross-registrable-domain
-test proves subdomains insufficient.
+`home.wap.shrimpworks.dev`, `forms.wap.shrimpworks.dev`, and
+`interop.wap.shrimpworks.dev`. Use exact DNS-only records rather than a wildcard record, and defer
+a second apex until a cross-registrable-domain test proves subdomains insufficient. The existing
+staged OpenTofu DNS names must be updated and reviewed before public publication; the sealed
+default does not create any of them.
 
 ## Public topology
 
@@ -140,6 +153,14 @@ test proves subdomains insufficient.
 - A private Compose network connects gateway and origin.
 - Root filesystems are read-only and processes non-root where Kannel permits; any exception is
   documented and capability-constrained.
+- Host bootstrap installs idempotent, source-controlled Docker/UFW forwarding policy in the
+  `DOCKER-USER` path before application containers start. The policy permits only the reviewed
+  public UDP 9200 mapping, preserves required private container traffic, and denies every other
+  externally initiated published-port flow.
+- Do not download and execute an unpinned `ufw-docker` default-branch script as root. If the
+  `ufw-docker` utility is selected, pin an immutable release or commit, verify its checksum, and
+  test its generated rules across UFW reload, Docker restart, and host reboot. A small
+  repository-owned rules installer is acceptable when it is easier to audit and verify.
 - Images are pinned by digest and recorded in a rollbackable release manifest.
 
 ### First-party test hosts
@@ -215,10 +236,16 @@ Tailscale-only administration, and no
 application deployment. Enabling public UDP/DNS still depends on the production gateway,
 `PRE-003`, `PRE-004`, and a separately reviewed plan.
 
+The merged base-host bootstrap hardens the Docker daemon but does not yet install the production
+Compose stack or its `DOCKER-USER`/UFW forwarding policy. Treat that policy and its external
+negative tests as unfinished `INF-102`/`GW-101` work, not as a control already present on the
+restricted host.
+
 ## Security, abuse, and operations
 
-Public UDP is spoofable and can become an amplification surface. A cloud firewall controls reach,
-not protocol safety. Public exposure requires all of the following:
+Public UDP is spoofable and can become an amplification surface. DigitalOcean's included
+network-layer DDoS protection and Cloud Firewall reduce volumetric and reachability risk, but do
+not provide WAP-aware protocol safety. Public exposure requires all of the following:
 
 - exact-host allowlisting and no arbitrary URL fetch;
 - strict request/response byte ceilings and a measured amplification ratio;
@@ -228,6 +255,8 @@ not protocol safety. Public exposure requires all of the following:
 - redaction of form bodies, session values, and sensitive query values;
 - random Kannel administration/status credentials stored outside images;
 - administration bound to loopback/private networking;
+- enforced `DOCKER-USER`/UFW forwarding policy so a Compose port publication cannot bypass the
+  host deny-by-default policy;
 - SSH keys only, non-root administration, and automatic security updates;
 - CI image/dependency scanning and an SBOM;
 - a tested firewall kill switch, disable runbook, abuse contact, and acceptable-use notice.
@@ -277,14 +306,14 @@ be destroyed and rebuilt from OpenTofu.
 Capacity assumption: three parallel implementation lanes, 36 points gross, 29 committed, and a
 7-point (about 19 percent) buffer for Kannel/cloud/network unknowns.
 
-| Priority | ID         | Work item                                      | Points | Dependencies                   | Acceptance                                                                                                                                                                                  |
-| -------: | ---------- | ---------------------------------------------- | -----: | ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-|        1 | `INF-101`  | OpenTofu bootstrap and CI                      |      5 | `PRE-001`, `PRE-003`           | Pinned provider; encrypted R2 state; tested lock contention/recovery; serialized apply and state copies; fmt/init/validate/speculative-plan CI; no committed secrets                        |
-|        2 | `GW-101`   | Production Kannel/container baseline           |      5 | `PRE-004`                      | Immutable image; generated config; non-default secrets; private admin/box ports; exact-host maps; health checks; local GET/POST smoke                                                       |
-|        3 | `LAB-101`  | Go WML origin and deterministic multi-host lab |      8 | `PRE-002`                      | Standard-library service; current route/session/example golden parity; three-host matrix; public binary excludes gateway/viewer/emulator; `gofmt`, `go vet ./...`, and `go test ./...` pass |
-|        4 | `INF-102`  | Compute, IP, firewall, DNS, bootstrap          |      5 | `INF-101`, `GW-101` interface  | Rebuildable 512 MiB x86 host with bounded swap/limits; only UDP 9200 plus restricted administration public; idempotent cloud-init without long-lived secrets                                |
-|        5 | `PERF-101` | 512 MiB memory soak and resize gate            |      2 | `INF-102`, `GW-101`, `LAB-101` | Record RSS, swap, restarts, latency; allow 1 GiB only if the published threshold fails                                                                                                      |
-|        6 | `OPS-101`  | External WSP probe and disable runbook         |      4 | `INF-102`, `LAB-101`           | Exact external WSP/WBXML fixture; failure alert; tested rate-limit/firewall kill; redacted logs                                                                                             |
+| Priority | ID         | Work item                                      | Points | Dependencies                   | Acceptance                                                                                                                                                                                    |
+| -------: | ---------- | ---------------------------------------------- | -----: | ------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|        1 | `INF-101`  | OpenTofu bootstrap and CI                      |      5 | `PRE-001`, `PRE-003`           | Pinned provider; encrypted R2 state; tested lock contention/recovery; serialized apply and state copies; fmt/init/validate/speculative-plan CI; no committed secrets                          |
+|        2 | `GW-101`   | Production Kannel/container baseline           |      5 | `PRE-004`                      | Immutable image; generated config; non-default secrets; private admin/box ports; exact-host maps; health checks; local GET/POST smoke                                                         |
+|        3 | `LAB-101`  | Go WML origin and deterministic multi-host lab |      8 | `PRE-002`                      | Standard-library service; current route/session/example golden parity; three-host matrix; public binary excludes gateway/viewer/emulator; `gofmt`, `go vet ./...`, and `go test ./...` pass   |
+|        4 | `INF-102`  | Compute, IP, firewall, DNS, bootstrap          |      5 | `INF-101`, `GW-101` interface  | Rebuildable 512 MiB x86 host with bounded swap/limits; only UDP 9200 plus restricted administration public; idempotent cloud-init and Docker/UFW forwarding policy without long-lived secrets |
+|        5 | `PERF-101` | 512 MiB memory soak and resize gate            |      2 | `INF-102`, `GW-101`, `LAB-101` | Record RSS, swap, restarts, latency; allow 1 GiB only if the published threshold fails                                                                                                        |
+|        6 | `OPS-101`  | External WSP probe and disable runbook         |      4 | `INF-102`, `LAB-101`           | Exact external WSP/WBXML fixture; failure alert; tested rate-limit/firewall kill; redacted logs                                                                                               |
 
 Stretch only after committed acceptance:
 
@@ -332,14 +361,16 @@ The first public pre-release is allowed only when:
 
 1. The lab is exact-host allowlisted, not an open WAP-to-web proxy.
 2. Only UDP 9200 is public for WAP; Kannel administration/internal ports are unreachable.
-3. Repeated external synthetic GET and packaged-desktop supported POST both pass.
-4. Size, timeout, concurrency, amplification, and rate-limit behavior are tested.
-5. Someone other than the author tests the emergency firewall disable action.
-6. Infrastructure rebuild and Reserved IP reassignment are demonstrated.
-7. Remote state is private, encrypted, lock-tested, serialized, and recoverable.
-8. UI/release notes say the transport is unencrypted and WTLS is unsupported.
-9. Claims do not exceed current executable Class C evidence.
-10. Repository fast/change/full verification and public network E2E checks pass from current main.
+3. An external scan against the Reserved IP proves Docker-published ports cannot bypass the host
+   firewall before and after UFW reload, Docker restart, and host reboot.
+4. Repeated external synthetic GET and packaged-desktop supported POST both pass.
+5. Size, timeout, concurrency, amplification, and rate-limit behavior are tested.
+6. Someone other than the author tests the emergency firewall disable action.
+7. Infrastructure rebuild and Reserved IP reassignment are demonstrated.
+8. Remote state is private, encrypted, lock-tested, serialized, and recoverable.
+9. UI/release notes say the transport is unencrypted and WTLS is unsupported.
+10. Claims do not exceed current executable Class C evidence.
+11. Repository fast/change/full verification and public network E2E checks pass from current main.
 
 ## Verification to add or standardize
 
@@ -350,13 +381,17 @@ The first public pre-release is allowed only when:
 - provider-backed speculative plan in a protected CI environment (pending `PRE-001`/`PRE-003`)
 - image build, vulnerability scan, and SBOM
 - production Compose configuration validation
+- Docker/UFW forwarding-policy lint plus idempotent install/check tests against the rendered
+  cloud-init configuration
 - `gofmt -l`, `go vet ./...`, and `go test ./...`
 - HTTP/WML golden tests for content type, cache, status, escaping, forms, session expiry,
   examples, health, and metrics
 - local and external `scripts/transport-wap-smoke.sh` equivalents
 - browser/Tauri Kannel tests and generated-contract drift checks
 - link, format, and documentation validation
-- negative port scan for 13000, 13002, and UDP 9201-9208
+- external negative port scan for TCP 80/443/13000/13002 and UDP 9201-9208, repeated after UFW
+  reload, Docker restart, and host reboot
+- positive external UDP 9200 probe only after the publication gate is approved
 - negative proxy test proving an unknown resource host is rejected
 
 ## Key risks
@@ -365,6 +400,7 @@ The first public pre-release is allowed only when:
 | ----------------------------------- | ---------- | ----------------------------------------------------------------------------------------------- |
 | UDP spoofing/reflection             | high       | allowlist, response cap, rate limit, traffic alert, firewall kill switch                        |
 | Old Kannel exposure                 | high       | distro-patched/pinned build, isolation, minimal ports, scanning, no admin exposure              |
+| Docker bypasses host UFW policy     | high       | verified `DOCKER-USER` forwarding policy plus external negative scans across reload/restart     |
 | Client networks block UDP 9200      | medium     | stage-specific diagnostics and explicit supported-network guidance; no silent protocol fallback |
 | R2 backend lock mismatch            | high       | lock integration test, serialized apply, encrypted state copies, forced-unlock runbook          |
 | Desktop seam changes                | high       | start from refreshed main; audit WSP evidence; contract-first native/Tauri tests                |
@@ -391,16 +427,19 @@ OpenTofu and state:
 - [Cloudflare R2 pricing](https://developers.cloudflare.com/r2/pricing/)
 - [Cloudflare R2 S3 API](https://developers.cloudflare.com/r2/api/s3/api/)
 - [Cloudflare R2 consistency](https://developers.cloudflare.com/r2/reference/consistency/)
+- [Cloudflare Spectrum protocols by plan](https://developers.cloudflare.com/spectrum/protocols-per-plan/)
 
 Provider comparison:
 
 - [DigitalOcean Droplet pricing](https://www.digitalocean.com/pricing/droplets)
+- [DigitalOcean DDoS protection](https://docs.digitalocean.com/platform/ddos-protection/)
 - [DigitalOcean cloud-init](https://docs.digitalocean.com/products/droplets/how-to/provide-user-data/)
 - [DigitalOcean Cloud Firewall rules](https://docs.digitalocean.com/products/networking/firewalls/how-to/configure-rules/)
 - [DigitalOcean Reserved IP pricing](https://docs.digitalocean.com/products/networking/reserved-ips/details/pricing/)
+- [Docker packet filtering and firewalls](https://docs.docker.com/engine/network/packet-filtering-firewalls/)
+- [`ufw-docker` reference implementation](https://github.com/chaifeng/ufw-docker)
 - [Hetzner Cloud OpenTofu provider](https://github.com/hetznercloud/terraform-provider-hcloud)
 - [Hetzner locations](https://docs.hetzner.com/cloud/general/locations/)
 - [Hetzner price adjustment](https://docs.hetzner.com/general/infrastructure-and-availability/price-adjustment/)
-- [Amazon Lightsail bundles](https://docs.aws.amazon.com/lightsail/latest/userguide/amazon-lightsail-bundles.html)
 - [IONOS VPS pricing](https://www.ionos.com/servers/vps)
 - [OVHcloud Canada VPS pricing](https://www.ovhcloud.com/en-ca/vps/vps-canada/)

--- a/infra/network-preview/LOCAL_DEPLOYMENT.md
+++ b/infra/network-preview/LOCAL_DEPLOYMENT.md
@@ -17,6 +17,12 @@ The first stage is intentionally not public:
 Public UDP and DNS require a later reviewed plan with `NETWORK_PREVIEW_PUBLISH_PREVIEW=true`,
 after the gateway image/configuration and disable path have passed their own checks.
 
+Application deployment is a distinct, state-free checkpoint. After the sealed host exists, follow
+[`deploy/network-preview/README.md`](../../deploy/network-preview/README.md) to build a scanned,
+checksummed release locally and install it over Tailscale. The installer deploys only the service
+bundle and persistent Docker forwarding policy, forces that policy to `sealed`, and leaves the
+Cloud Firewall, DNS, Reserved IP, and OpenTofu state unchanged.
+
 ## Local configuration
 
 Keep the environment file outside version control with mode `0600`. In addition to the existing
@@ -102,3 +108,7 @@ and force-unlock are never implied by generating a plan.
 
 Rollback for the initial host is an explicitly approved `tofu destroy` of the same state after
 capturing required diagnostics. No application data belongs on the disposable host.
+
+Service rollback is separate and does not use OpenTofu: `sudo waves-network-preview-rollback`
+selects the preceding verified release and keeps Docker ingress sealed. The emergency service
+kill switch is `sudo waves-docker-firewall set sealed`.

--- a/infra/network-preview/README.md
+++ b/infra/network-preview/README.md
@@ -6,8 +6,9 @@ This directory owns the OpenTofu configuration for the public WAP network previe
 The configuration defines a staged single-host preview while keeping execution separate from
 authored infrastructure. Its default local deployment creates a hardened Droplet, Reserved IP,
 sealed inbound firewall, default-project verification, and free provider monitoring. Public UDP and
-the three Cloudflare DNS records remain disabled until `publish_preview` is explicitly enabled. No resource
-exists merely because the configuration is checked in, and no apply is authorized by this file.
+the three Cloudflare DNS records remain disabled until `publish_preview` is explicitly enabled. No
+resource exists merely because the configuration is checked in, and no apply is authorized by this
+file.
 
 The initial gate uses the [owner-local deployment path](LOCAL_DEPLOYMENT.md). Protected GitHub
 plan/apply automation remains available for a later shared/public operating model and stays
@@ -23,6 +24,11 @@ blocked until `PRE-003` has an independent reviewer and recovery maintainer.
 - `tests/r2-lock/`: an isolated lock holder used only by the access-backed R2 integration test.
 
 Do not introduce shared modules until a second real environment creates demonstrated repetition.
+
+The production application bundle is separate from OpenTofu and documented in
+[`deploy/network-preview/README.md`](../../deploy/network-preview/README.md). Its private installer
+keeps Docker forwarding sealed, verifies the transferred release and image IDs, and does not mutate
+cloud resources, DNS, or OpenTofu state.
 
 ## Pinned toolchain
 

--- a/infra/network-preview/bootstrap/OWNER_SETUP.md
+++ b/infra/network-preview/bootstrap/OWNER_SETUP.md
@@ -35,7 +35,8 @@ Current owner selections:
 - send the DigitalOcean billing alert to the owner's primary account email, which is also used for
   Git and GitHub;
 - use the Cloudflare-managed `shrimpworks.dev` zone with exact DNS-only records for
-  `home.shrimpworks.dev`, `forms.shrimpworks.dev`, and `interop.shrimpworks.dev`;
+  `home.wap.shrimpworks.dev`, `forms.wap.shrimpworks.dev`, and
+  `interop.wap.shrimpworks.dev`;
 - use `wap-labs-opentofu-state-shrimpworks` for the private R2 bucket, subject to availability in
   the account;
 - use an owner-local deployment for the initial restricted test host. Keep the shared/public

--- a/infra/network-preview/cloud-init/bootstrap.sh.tftpl
+++ b/infra/network-preview/cloud-init/bootstrap.sh.tftpl
@@ -46,6 +46,13 @@ ufw --force enable >/dev/null
 
 sysctl --system >/dev/null
 systemctl enable --now docker
+systemctl daemon-reload
+if [ ! -e /etc/default/waves-docker-firewall ]; then
+  /usr/local/sbin/waves-docker-firewall set sealed
+else
+  /usr/local/sbin/waves-docker-firewall apply
+fi
+systemctl enable waves-docker-firewall.service >/dev/null
 systemctl enable --now fail2ban
 systemctl enable --now unattended-upgrades
 systemctl restart ssh

--- a/infra/network-preview/cloud-init/user-data.yaml.tftpl
+++ b/infra/network-preview/cloud-init/user-data.yaml.tftpl
@@ -7,6 +7,8 @@ packages:
   - docker.io
   - docker-compose-v2
   - fail2ban
+  - iproute2
+  - iptables
   - unattended-upgrades
   - ufw
 
@@ -78,6 +80,16 @@ write_files:
     permissions: "0750"
     content: |
       ${bootstrap_script}
+  - path: /usr/local/sbin/waves-docker-firewall
+    owner: root:root
+    permissions: "0750"
+    content: |
+      ${docker_firewall_script}
+  - path: /etc/systemd/system/waves-docker-firewall.service
+    owner: root:root
+    permissions: "0644"
+    content: |
+      ${docker_firewall_unit}
 
 runcmd:
   - /usr/local/sbin/waves-bootstrap

--- a/infra/network-preview/environments/preview/dns.tf
+++ b/infra/network-preview/environments/preview/dns.tf
@@ -1,8 +1,8 @@
 locals {
   preview_hostnames = toset([
-    "forms.shrimpworks.dev",
-    "home.shrimpworks.dev",
-    "interop.shrimpworks.dev",
+    "forms.wap.shrimpworks.dev",
+    "home.wap.shrimpworks.dev",
+    "interop.wap.shrimpworks.dev",
   ])
 }
 

--- a/infra/network-preview/environments/preview/main.tf
+++ b/infra/network-preview/environments/preview/main.tf
@@ -24,10 +24,15 @@ locals {
     wap_ufw_rules   = local.wap_ufw_rules
   })
 
+  docker_firewall_script = file("${path.module}/../../../../deploy/network-preview/bin/waves-docker-firewall")
+  docker_firewall_unit   = file("${path.module}/../../../../deploy/network-preview/systemd/waves-docker-firewall.service")
+
   user_data = templatefile("${path.module}/../../cloud-init/user-data.yaml.tftpl", {
-    admin_public_key   = jsonencode(data.digitalocean_ssh_key.admin.public_key)
-    bootstrap_script   = indent(6, local.bootstrap_script)
-    tailscale_auth_key = jsonencode(var.tailscale_auth_key)
+    admin_public_key       = jsonencode(data.digitalocean_ssh_key.admin.public_key)
+    bootstrap_script       = indent(6, local.bootstrap_script)
+    docker_firewall_script = indent(6, local.docker_firewall_script)
+    docker_firewall_unit   = indent(6, local.docker_firewall_unit)
+    tailscale_auth_key     = jsonencode(var.tailscale_auth_key)
   })
 }
 

--- a/infra/network-preview/tests/cloud-init-render/main.tf
+++ b/infra/network-preview/tests/cloud-init-render/main.tf
@@ -4,15 +4,22 @@ locals {
     wap_ufw_rules   = ""
   })
 
+  docker_firewall_script = file("${path.module}/../../../../deploy/network-preview/bin/waves-docker-firewall")
+  docker_firewall_unit   = file("${path.module}/../../../../deploy/network-preview/systemd/waves-docker-firewall.service")
+
   user_data = templatefile("${path.module}/../../cloud-init/user-data.yaml.tftpl", {
-    admin_public_key   = jsonencode("ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOfflineValidationOnly")
-    bootstrap_script   = indent(6, local.bootstrap_script)
-    tailscale_auth_key = jsonencode("tskey-auth-offline-validation")
+    admin_public_key       = jsonencode("ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOfflineValidationOnly")
+    bootstrap_script       = indent(6, local.bootstrap_script)
+    docker_firewall_script = indent(6, local.docker_firewall_script)
+    docker_firewall_unit   = indent(6, local.docker_firewall_unit)
+    tailscale_auth_key     = jsonencode("tskey-auth-offline-validation")
   })
 
   cloud_config   = yamldecode(local.user_data)
   bootstrap_file = one([for file in local.cloud_config.write_files : file if file.path == "/usr/local/sbin/waves-bootstrap"])
   auth_key_file  = one([for file in local.cloud_config.write_files : file if file.path == "/run/waves-tailscale-auth-key"])
+  firewall_file  = one([for file in local.cloud_config.write_files : file if file.path == "/usr/local/sbin/waves-docker-firewall"])
+  firewall_unit  = one([for file in local.cloud_config.write_files : file if file.path == "/etc/systemd/system/waves-docker-firewall.service"])
 }
 
 check "rendered_cloud_init_contract" {
@@ -21,8 +28,11 @@ check "rendered_cloud_init_contract" {
       startswith(local.bootstrap_file.content, "#!/usr/bin/env sh\n") &&
       strcontains(local.bootstrap_file.content, "tailscale up") &&
       strcontains(local.bootstrap_file.content, "tag:waves-preview") &&
-      local.auth_key_file.permissions == "0600"
+      local.auth_key_file.permissions == "0600" &&
+      startswith(local.firewall_file.content, "#!/usr/bin/env sh\n") &&
+      local.firewall_file.permissions == "0750" &&
+      strcontains(local.firewall_unit.content, "ExecStart=/usr/local/sbin/waves-docker-firewall apply")
     )
-    error_message = "rendered cloud-init must contain a valid bootstrap script and protected one-off Tailscale key"
+    error_message = "rendered cloud-init must contain valid bootstrap/firewall scripts, systemd policy, and a protected one-off Tailscale key"
   }
 }

--- a/scripts/build-network-preview-release.sh
+++ b/scripts/build-network-preview-release.sh
@@ -83,7 +83,7 @@ WAP_GATEWAY_IMAGE_ID=$gateway_image_id
 EOF
 
 mkdir -p "$output_dir"
-tar -C "$stage_dir" -czf "$archive_path" .
+COPYFILE_DISABLE=1 tar -C "$stage_dir" -czf "$archive_path" .
 archive_sha256=$(sha256_file "$archive_path")
 printf '%s  %s\n' "$archive_sha256" "$(basename "$archive_path")" >"$checksum_path"
 

--- a/scripts/build-network-preview-release.sh
+++ b/scripts/build-network-preview-release.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env sh
+set -eu
+
+root_dir=$(CDPATH='' cd -- "$(dirname "$0")/.." && pwd)
+release_id=${1:-}
+output_dir=${2:-${root_dir}/dist/network-preview}
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+sha256_file() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | awk '{print $1}'
+  else
+    shasum -a 256 "$1" | awk '{print $1}'
+  fi
+}
+
+if [ -z "$release_id" ]; then
+  release_id=$(git -C "$root_dir" rev-parse --short=12 HEAD)
+fi
+printf '%s' "$release_id" | grep -Eq '^[0-9A-Za-z][0-9A-Za-z._-]{0,63}$' \
+  || fail 'release ID must contain only letters, digits, dots, underscores, and hyphens'
+
+for command_name in docker git grype syft tar; do
+  command -v "$command_name" >/dev/null 2>&1 || fail "missing required command: $command_name"
+done
+if [ -n "$(git -C "$root_dir" status --porcelain)" ]; then
+  fail 'release builds require a clean worktree'
+fi
+
+source_commit=$(git -C "$root_dir" rev-parse HEAD)
+wml_image="wap-labs/wml-origin:$release_id"
+gateway_image="wap-labs/wap-gateway:$release_id"
+archive_path=${output_dir}/waves-network-preview-${release_id}.tar.gz
+checksum_path=${archive_path}.sha256
+[ ! -e "$archive_path" ] || fail "release archive already exists: $archive_path"
+[ ! -e "$checksum_path" ] || fail "release checksum already exists: $checksum_path"
+
+stage_dir=$(mktemp -d "${TMPDIR:-/tmp}/waves-network-preview-release.XXXXXX")
+cleanup() {
+  rm -rf "$stage_dir"
+}
+trap cleanup EXIT HUP INT TERM
+
+echo '==> Building production WML origin image'
+docker buildx build --platform linux/amd64 --load \
+  --tag "$wml_image" "$root_dir/wml-server"
+
+echo '==> Building production Kannel image'
+docker buildx build --platform linux/amd64 --load --target production \
+  --tag "$gateway_image" "$root_dir/docker/kannel"
+
+echo '==> Scanning production images for high and critical vulnerabilities'
+grype "$wml_image" --fail-on high
+grype "$gateway_image" --fail-on high
+
+echo '==> Generating CycloneDX SBOMs'
+syft "$wml_image" -o "cyclonedx-json=$stage_dir/wml-origin.sbom.cdx.json"
+syft "$gateway_image" -o "cyclonedx-json=$stage_dir/wap-gateway.sbom.cdx.json"
+
+wml_image_id=$(docker image inspect --format '{{.Id}}' "$wml_image")
+gateway_image_id=$(docker image inspect --format '{{.Id}}' "$gateway_image")
+printf '%s' "$wml_image_id" | grep -Eq '^sha256:[0-9a-f]{64}$' || fail 'unexpected WML image ID'
+printf '%s' "$gateway_image_id" | grep -Eq '^sha256:[0-9a-f]{64}$' || fail 'unexpected gateway image ID'
+
+echo '==> Saving immutable image payload'
+docker image save --output "$stage_dir/images.tar" "$wml_image" "$gateway_image"
+cp "$root_dir/deploy/network-preview/compose.yaml" "$stage_dir/compose.yaml"
+cp -R "$root_dir/deploy/network-preview/bin" "$stage_dir/bin"
+cp -R "$root_dir/deploy/network-preview/systemd" "$stage_dir/systemd"
+cp "$root_dir/deploy/network-preview/README.md" "$stage_dir/README.md"
+
+cat >"$stage_dir/manifest.env" <<EOF
+WAVES_RELEASE_ID=$release_id
+WAVES_SOURCE_COMMIT=$source_commit
+WML_ORIGIN_IMAGE=$wml_image
+WML_ORIGIN_IMAGE_ID=$wml_image_id
+WAP_GATEWAY_IMAGE=$gateway_image
+WAP_GATEWAY_IMAGE_ID=$gateway_image_id
+EOF
+
+mkdir -p "$output_dir"
+tar -C "$stage_dir" -czf "$archive_path" .
+archive_sha256=$(sha256_file "$archive_path")
+printf '%s  %s\n' "$archive_sha256" "$(basename "$archive_path")" >"$checksum_path"
+
+echo "PASS: release archive $archive_path"
+echo "PASS: SHA-256 $archive_sha256"

--- a/scripts/build-network-preview-release.sh
+++ b/scripts/build-network-preview-release.sh
@@ -83,7 +83,7 @@ WAP_GATEWAY_IMAGE_ID=$gateway_image_id
 EOF
 
 mkdir -p "$output_dir"
-COPYFILE_DISABLE=1 tar -C "$stage_dir" -czf "$archive_path" .
+COPYFILE_DISABLE=1 tar --no-xattrs -C "$stage_dir" -czf "$archive_path" .
 archive_sha256=$(sha256_file "$archive_path")
 printf '%s  %s\n' "$archive_sha256" "$(basename "$archive_path")" >"$checksum_path"
 

--- a/scripts/ci/check-network-preview-deploy.sh
+++ b/scripts/ci/check-network-preview-deploy.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env sh
+set -eu
+
+script_directory=$(CDPATH='' cd -- "$(dirname "$0")" && pwd)
+repository_root=$(CDPATH='' cd -- "$script_directory/../.." && pwd)
+temporary_root=$(mktemp -d "${TMPDIR:-/tmp}/waves-network-preview-deploy-check.XXXXXX")
+
+cleanup() {
+  case "$temporary_root" in
+    "${TMPDIR:-/tmp}"/waves-network-preview-deploy-check.*) rm -rf "$temporary_root" ;;
+    *) echo "WARN: refusing to remove unexpected temporary path: $temporary_root" >&2 ;;
+  esac
+}
+trap cleanup EXIT HUP INT TERM
+
+scripts='docker/kannel/production/entrypoint.sh
+docker/kannel/production/healthcheck.sh
+deploy/network-preview/bin/install-release
+deploy/network-preview/bin/rollback-release
+deploy/network-preview/bin/waves-docker-firewall
+scripts/build-network-preview-release.sh
+scripts/deploy-network-preview-private.sh
+scripts/transport-wap-smoke.sh'
+
+cd "$repository_root"
+printf '%s\n' "$scripts" | while IFS= read -r script_path; do
+  sh -n "$script_path"
+done
+if command -v shellcheck >/dev/null 2>&1; then
+  # shellcheck disable=SC2086 # The newline-separated repository-owned list is intentional.
+  shellcheck -x $scripts
+else
+  echo 'FAIL: shellcheck is required for network-preview deployment validation' >&2
+  exit 1
+fi
+
+node --test scripts/tests/network-preview-deploy.test.mjs
+
+if command -v docker >/dev/null 2>&1 && docker compose version >/dev/null 2>&1; then
+  secrets_dir=$temporary_root/secrets
+  mkdir -p "$secrets_dir"
+  printf '%064d\n' 0 >"$secrets_dir/kannel-admin-password"
+  printf '%064d\n' 1 >"$secrets_dir/kannel-status-password"
+  WAVES_SECRETS_DIR=$secrets_dir \
+  WML_ORIGIN_IMAGE=wap-labs/wml-origin:offline-validation \
+  WAP_GATEWAY_IMAGE=wap-labs/wap-gateway:offline-validation \
+    docker compose -f deploy/network-preview/compose.yaml config --quiet
+else
+  echo 'FAIL: Docker Compose is required for network-preview deployment validation' >&2
+  exit 1
+fi
+
+echo 'PASS: production network-preview deployment contracts are valid'

--- a/scripts/deploy-network-preview-private.sh
+++ b/scripts/deploy-network-preview-private.sh
@@ -18,7 +18,9 @@ sha256_file() {
   fi
 }
 
-[ -n "$archive_path" ] && [ -f "$archive_path" ] || fail 'release archive path is required'
+if [ -z "$archive_path" ] || [ ! -f "$archive_path" ]; then
+  fail 'release archive path is required'
+fi
 [ -n "$ssh_target" ] || fail 'explicit Tailscale SSH target is required, for example waves@waves-network-preview'
 case "$ssh_target" in
   *[!0-9A-Za-z@._:-]*) fail 'SSH target contains unsupported characters' ;;

--- a/scripts/deploy-network-preview-private.sh
+++ b/scripts/deploy-network-preview-private.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env sh
+set -eu
+
+root_dir=$(CDPATH='' cd -- "$(dirname "$0")/.." && pwd)
+archive_path=${1:-}
+ssh_target=${2:-}
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+sha256_file() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | awk '{print $1}'
+  else
+    shasum -a 256 "$1" | awk '{print $1}'
+  fi
+}
+
+[ -n "$archive_path" ] && [ -f "$archive_path" ] || fail 'release archive path is required'
+[ -n "$ssh_target" ] || fail 'explicit Tailscale SSH target is required, for example waves@waves-network-preview'
+case "$ssh_target" in
+  *[!0-9A-Za-z@._:-]*) fail 'SSH target contains unsupported characters' ;;
+esac
+for command_name in scp ssh; do
+  command -v "$command_name" >/dev/null 2>&1 || fail "missing required command: $command_name"
+done
+
+expected_sha256=$(sha256_file "$archive_path")
+remote_archive=/tmp/waves-network-preview-release-${expected_sha256}.tar.gz
+remote_uploaded=0
+cleanup_remote_archive() {
+  if [ "$remote_uploaded" -eq 1 ]; then
+    ssh -- "$ssh_target" "rm -f '$remote_archive'" >/dev/null 2>&1 || true
+  fi
+}
+trap cleanup_remote_archive EXIT HUP INT TERM
+
+echo "==> Uploading verified release archive over Tailscale SSH to $ssh_target"
+scp -- "$archive_path" "$ssh_target:$remote_archive"
+remote_uploaded=1
+echo '==> Installing release with Docker ingress sealed'
+ssh -- "$ssh_target" "sudo /bin/sh -s -- '$remote_archive' '$expected_sha256'" \
+  <"$root_dir/deploy/network-preview/bin/install-release"
+cleanup_remote_archive
+remote_uploaded=0
+trap - EXIT HUP INT TERM
+echo 'PASS: private deployment completed; public Docker ingress remains sealed'

--- a/scripts/tests/network-preview-deploy.test.mjs
+++ b/scripts/tests/network-preview-deploy.test.mjs
@@ -108,6 +108,9 @@ test('release installation verifies provenance and reseals before restarting ser
   assert.match(installer, /docker image save --output "\$verification_archive" "\$image"/);
   assert.match(installer, /saved \$label image does not reference the release config digest/);
   assert.match(installer, /loaded \$label image is not Linux AMD64/);
+  assert.match(installer, /chown 10001:10001 "\$secret_path"/);
+  assert.match(installer, /chmod 0400 "\$secret_path"/);
+  assert.match(installer, /docker compose --project-name waves-network-preview --env-file manifest.env/);
   const sealIndex = installer.indexOf('waves-docker-firewall set sealed');
   const restartIndex = installer.indexOf('systemctl restart waves-network-preview.service');
   assert.ok(sealIndex >= 0 && restartIndex > sealIndex);

--- a/scripts/tests/network-preview-deploy.test.mjs
+++ b/scripts/tests/network-preview-deploy.test.mjs
@@ -105,8 +105,9 @@ test('Docker forwarding remains sealed by default and public mode is rate limite
 
 test('release installation verifies provenance and reseals before restarting services', () => {
   assert.match(installer, /release archive SHA-256 mismatch/);
-  assert.match(installer, /loaded WML image ID does not match/);
-  assert.match(installer, /loaded gateway image ID does not match/);
+  assert.match(installer, /docker image save --output "\$verification_archive" "\$image"/);
+  assert.match(installer, /saved \$label image does not reference the release config digest/);
+  assert.match(installer, /loaded \$label image is not Linux AMD64/);
   const sealIndex = installer.indexOf('waves-docker-firewall set sealed');
   const restartIndex = installer.indexOf('systemctl restart waves-network-preview.service');
   assert.ok(sealIndex >= 0 && restartIndex > sealIndex);

--- a/scripts/tests/network-preview-deploy.test.mjs
+++ b/scripts/tests/network-preview-deploy.test.mjs
@@ -1,0 +1,133 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const repositoryRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+
+function read(relativePath) {
+  return fs.readFileSync(path.join(repositoryRoot, relativePath), 'utf8');
+}
+
+const compose = read('deploy/network-preview/compose.yaml');
+const firewall = read('deploy/network-preview/bin/waves-docker-firewall');
+const installer = read('deploy/network-preview/bin/install-release');
+const kannel = read('docker/kannel/production/kannel.conf.tmpl');
+const kannelDockerfile = read('docker/kannel/Dockerfile');
+const wmlDockerfile = read('wml-server/Dockerfile');
+const buildRelease = read('scripts/build-network-preview-release.sh');
+const dns = read('infra/network-preview/environments/preview/dns.tf');
+
+test('production Compose exposes only connectionless WAP and isolates the origin network', () => {
+  assert.match(compose, /published: ['"]9200['"][\s\S]*?protocol: udp/);
+  for (const forbiddenPort of ['13000', '13002', '9201', '3000:3000', '3001:3001']) {
+    assert.doesNotMatch(compose, new RegExp(`published: "${forbiddenPort}"|-${forbiddenPort}:`));
+  }
+  assert.match(compose, /networks:[\s\S]*?edge:[\s\S]*?origin:[\s\S]*?internal: true/);
+  assert.doesNotMatch(compose, /^\s*build:/m);
+  assert.match(compose, /pull_policy: never/g);
+});
+
+test('both production containers have the expected confinement and resource controls', () => {
+  assert.equal((compose.match(/read_only: true/g) ?? []).length, 2);
+  assert.equal((compose.match(/no-new-privileges:true/g) ?? []).length, 2);
+  assert.equal((compose.match(/cap_drop:\n\s+- ALL/g) ?? []).length, 2);
+  assert.equal((compose.match(/pids_limit:/g) ?? []).length, 2);
+  assert.equal((compose.match(/mem_limit:/g) ?? []).length, 2);
+  assert.equal((compose.match(/healthcheck:/g) ?? []).length, 2);
+});
+
+test('production image inputs and runtime identities are immutable and non-root', () => {
+  assert.equal(
+    (
+      kannelDockerfile.match(
+        /FROM ubuntu:22\.04@sha256:0e0a0fc6d18feda9db1590da249ac93e8d5abfea8f4c3c0c849ce512b5ef8982/g
+      ) ?? []
+    ).length,
+    2
+  );
+  assert.match(kannelDockerfile, /FROM runtime-base AS production[\s\S]*USER 10001:10001/);
+  assert.match(wmlDockerfile, /FROM golang:1\.25-alpine@sha256:[0-9a-f]{64} AS build/);
+  assert.match(wmlDockerfile, /FROM scratch[\s\S]*USER 65532:65532/);
+});
+
+test('production Kannel maps only approved public hosts and explicit private smoke aliases', () => {
+  for (const hostname of [
+    'home.wap.shrimpworks.dev',
+    'forms.wap.shrimpworks.dev',
+    'interop.wap.shrimpworks.dev'
+  ]) {
+    assert.match(kannel, new RegExp(`http://${hostname.replaceAll('.', '\\.')}/\\*`));
+  }
+  assert.match(kannel, /http:\/\/localhost:13002\/\*/);
+  assert.match(kannel, /http:\/\/127\.0\.0\.1:13002\/\*/);
+  assert.match(kannel, /http:\/\/waves-network-preview\/\*/);
+  const publicInteropIndex = kannel.indexOf('name = lab_interop');
+  const denyHTTPIndex = kannel.indexOf('name = deny_unmapped_http');
+  const denyHTTPSIndex = kannel.indexOf('name = deny_unmapped_https');
+  assert.ok(publicInteropIndex >= 0 && denyHTTPIndex > publicInteropIndex);
+  assert.ok(denyHTTPSIndex > denyHTTPIndex);
+  assert.match(
+    kannel,
+    /url = "http:\/\/\*"[\s\S]*map-url = "http:\/\/wml-origin:3000\/__lab\/denied"/
+  );
+  assert.match(
+    kannel,
+    /url = "https:\/\/\*"[\s\S]*map-url = "http:\/\/wml-origin:3000\/__lab\/denied"/
+  );
+  assert.doesNotMatch(kannel, /changeme|http:\/\/wap\/\*|http:\/\/10\.0\.2\.2/);
+  assert.match(kannel, /admin-deny-ip = "\*\.\*\.\*\.\*"/);
+  assert.match(kannel, /admin-allow-ip = "127\.0\.0\.1"/);
+  const entrypoint = read('docker/kannel/production/entrypoint.sh');
+  const healthcheck = read('docker/kannel/production/healthcheck.sh');
+  assert.match(entrypoint, /bearerbox -v 1/);
+  assert.match(entrypoint, /wapbox -v 1/);
+  assert.doesNotMatch(healthcheck, /password|secret/);
+});
+
+test('Docker forwarding remains sealed by default and public mode is rate limited to UDP 9200', () => {
+  assert.match(firewall, /mode=sealed/);
+  assert.match(firewall, /sealed \| public/);
+  assert.equal((firewall.match(/sed -n '\/\^\-A \/ \{ p; q; \}'/g) ?? []).length, 2);
+  assert.match(
+    firewall,
+    /if \[ "\$mode" = public \]; then[\s\S]*--dport 9200[\s\S]*--hashlimit-upto/
+  );
+  assert.match(firewall, /-m limit --limit/);
+  assert.match(firewall, /tailnet_interface=\$\{WAVES_TAILNET_INTERFACE:-tailscale0\}/);
+  assert.match(firewall, /-i %s -p udp --dport 9200 -j RETURN/);
+  assert.ok((firewall.match(/-i %s -j DROP/g) ?? []).length >= 2);
+  assert.match(firewall, /-o br\+ -j DROP/);
+  assert.match(firewall, /-i br\+ -j DROP/);
+  assert.doesNotMatch(firewall, /curl|wget|github\.com/);
+});
+
+test('release installation verifies provenance and reseals before restarting services', () => {
+  assert.match(installer, /release archive SHA-256 mismatch/);
+  assert.match(installer, /loaded WML image ID does not match/);
+  assert.match(installer, /loaded gateway image ID does not match/);
+  const sealIndex = installer.indexOf('waves-docker-firewall set sealed');
+  const restartIndex = installer.indexOf('systemctl restart waves-network-preview.service');
+  assert.ok(sealIndex >= 0 && restartIndex > sealIndex);
+});
+
+test('release builds require scanning, SBOMs, exact images, and a clean commit', () => {
+  assert.match(buildRelease, /status --porcelain/);
+  assert.equal((buildRelease.match(/grype "\$/g) ?? []).length, 2);
+  assert.equal((buildRelease.match(/syft "\$/g) ?? []).length, 2);
+  assert.match(buildRelease, /docker image inspect --format '\{\{\.Id\}\}'/);
+  assert.doesNotMatch(buildRelease, /--push|docker login/);
+});
+
+test('staged DNS contains only the approved exact DNS-only WAP hostnames', () => {
+  for (const hostname of [
+    'home.wap.shrimpworks.dev',
+    'forms.wap.shrimpworks.dev',
+    'interop.wap.shrimpworks.dev'
+  ]) {
+    assert.match(dns, new RegExp(`"${hostname.replaceAll('.', '\\.')}"`));
+  }
+  assert.doesNotMatch(dns, /"(?:home|forms|interop)\.shrimpworks\.dev"/);
+  assert.match(dns, /proxied\s+=\s+false/);
+});

--- a/scripts/tests/verify.test.mjs
+++ b/scripts/tests/verify.test.mjs
@@ -76,7 +76,8 @@ test('change selects backend-disabled OpenTofu checks for network preview infras
       'network-preview script POSIX syntax',
       'network-preview local plan helper syntax',
       'encrypted offline plan check',
-      'protected workflow contract tests'
+      'protected workflow contract tests',
+      'production deployment contracts'
     ]
   );
   assert.equal(
@@ -84,6 +85,24 @@ test('change selects backend-disabled OpenTofu checks for network preview infras
       .TF_VAR_state_encryption_passphrase,
     'offline-validation-only-not-for-state'
   );
+});
+
+test('change selects production deployment checks for network preview service files', () => {
+  const lane = byId(
+    buildPlan('change', ['deploy/network-preview/compose.yaml']),
+    'opentofu-static'
+  );
+  assert.equal(lane.selected, true);
+  assert.equal(
+    lane.commands.some((command) => command.label === 'production deployment contracts'),
+    true
+  );
+});
+
+test('change selects production deployment checks for production image definitions', () => {
+  for (const path of ['docker/kannel/Dockerfile', 'wml-server/Dockerfile']) {
+    assert.equal(byId(buildPlan('change', [path]), 'opentofu-static').selected, true);
+  }
 });
 
 test('root verification surfaces select every ordinary change lane', () => {

--- a/scripts/transport-wap-smoke.sh
+++ b/scripts/transport-wap-smoke.sh
@@ -2,13 +2,21 @@
 set -eu
 
 ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+# shellcheck source=scripts/lib/run-and-tee.sh
 . "${ROOT_DIR}/scripts/lib/run-and-tee.sh"
 KANNEL_ADMIN_URL="${KANNEL_ADMIN_URL:-http://localhost:13000/status?password=changeme}"
 WML_HEALTH_URL="${WML_HEALTH_URL:-http://localhost:3001/health}"
 WAP_SMOKE_URL="${WAP_SMOKE_URL:-wap://localhost/}"
 WAP_SMOKE_LOGIN_URL="${WAP_SMOKE_LOGIN_URL:-wap://localhost/login}"
+WAP_SMOKE_REGISTER_URL="${WAP_SMOKE_REGISTER_URL:-wap://localhost/register}"
+WAP_SMOKE_DENIED_URL="${WAP_SMOKE_DENIED_URL:-wap://127.0.0.1:9200/}"
 TRANSPORT_WAP_TIMEOUT_MS="${TRANSPORT_WAP_TIMEOUT_MS:-15000}"
 TRANSPORT_WAP_RETRIES="${TRANSPORT_WAP_RETRIES:-1}"
+TRANSPORT_WAP_SKIP_INTERNAL_HEALTH="${TRANSPORT_WAP_SKIP_INTERNAL_HEALTH:-0}"
+case "${TRANSPORT_WAP_SKIP_INTERNAL_HEALTH}" in
+  0 | 1) ;;
+  *) echo 'TRANSPORT_WAP_SKIP_INTERNAL_HEALTH must be 0 or 1' >&2; exit 2 ;;
+esac
 if [ -n "${TRANSPORT_WAP_SMOKE_ARTIFACT_DIR:-}" ]; then
   SMOKE_ARTIFACT_DIR="${TRANSPORT_WAP_SMOKE_ARTIFACT_DIR}"
   mkdir -p "${SMOKE_ARTIFACT_DIR}"
@@ -26,17 +34,19 @@ print_failure_diagnostics() {
   echo
   echo "==> transport-wap-smoke diagnostics (exit ${exit_code})" >&2
   echo "Artifacts: ${SMOKE_ARTIFACT_DIR}" >&2
-  echo "-- Kannel admin status snapshot --" >&2
-  curl -fsS --connect-timeout 2 --max-time 5 "${KANNEL_ADMIN_URL}" \
-    | tee "${SMOKE_ARTIFACT_DIR}/kannel-status.txt" >&2 || true
-  echo >&2
+  if [ "${TRANSPORT_WAP_SKIP_INTERNAL_HEALTH}" = 0 ]; then
+    echo "-- Kannel admin status snapshot --" >&2
+    curl -fsS --connect-timeout 2 --max-time 5 "${KANNEL_ADMIN_URL}" \
+      | tee "${SMOKE_ARTIFACT_DIR}/kannel-status.txt" >&2 || true
+    echo >&2
 
-  echo "-- WML server health snapshot --" >&2
-  curl -fsS --connect-timeout 2 --max-time 5 "${WML_HEALTH_URL}" \
-    | tee "${SMOKE_ARTIFACT_DIR}/wml-health.txt" >&2 || true
-  echo >&2
+    echo "-- WML server health snapshot --" >&2
+    curl -fsS --connect-timeout 2 --max-time 5 "${WML_HEALTH_URL}" \
+      | tee "${SMOKE_ARTIFACT_DIR}/wml-health.txt" >&2 || true
+    echo >&2
+  fi
 
-  if command -v docker >/dev/null 2>&1; then
+  if [ "${TRANSPORT_WAP_SKIP_INTERNAL_HEALTH}" = 0 ] && command -v docker >/dev/null 2>&1; then
     echo "-- docker compose logs (kannel, wml-server) --" >&2
     (
       cd "${ROOT_DIR}" &&
@@ -69,17 +79,21 @@ wait_for_http() {
   return 1
 }
 
-echo "==> Checking Kannel admin status"
-wait_for_http "${KANNEL_ADMIN_URL}"
-curl -fsS --connect-timeout 2 --max-time 5 "${KANNEL_ADMIN_URL}" | grep -q 'Status: running'
+if [ "${TRANSPORT_WAP_SKIP_INTERNAL_HEALTH}" = 0 ]; then
+  echo "==> Checking Kannel admin status"
+  wait_for_http "${KANNEL_ADMIN_URL}"
+  curl -fsS --connect-timeout 2 --max-time 5 "${KANNEL_ADMIN_URL}" | grep -q 'Status: running'
 
-echo "==> Checking WML server health"
-wait_for_http "${WML_HEALTH_URL}"
+  echo "==> Checking WML server health"
+  wait_for_http "${WML_HEALTH_URL}"
+else
+  echo '==> Skipping local-only health URLs for remote sealed-stack smoke'
+fi
 
 echo "==> Running transport-rust WAP smoke integration test"
 (
   cd "${ROOT_DIR}/transport-rust"
-  export WAP_SMOKE_URL WAP_SMOKE_LOGIN_URL TRANSPORT_WAP_TIMEOUT_MS TRANSPORT_WAP_RETRIES
+  export WAP_SMOKE_URL WAP_SMOKE_LOGIN_URL WAP_SMOKE_REGISTER_URL WAP_SMOKE_DENIED_URL TRANSPORT_WAP_TIMEOUT_MS TRANSPORT_WAP_RETRIES
   run_and_tee "${SMOKE_ARTIFACT_DIR}/transport-kannel-smoke.log" \
     cargo test --test kannel_smoke -- --ignored --test-threads=1
 )

--- a/scripts/verify-lib.mjs
+++ b/scripts/verify-lib.mjs
@@ -323,7 +323,13 @@ export const LANES = Object.freeze([
     label: 'network preview OpenTofu static checks',
     profiles: ['change', 'full', 'extended'],
     paths: [
+      'deploy/network-preview/',
+      'docker/kannel/Dockerfile',
+      'docker/kannel/production/',
       'infra/network-preview/',
+      'scripts/build-network-preview-release.sh',
+      'scripts/deploy-network-preview-private.sh',
+      'scripts/ci/check-network-preview-deploy.sh',
       'scripts/ci/check-network-preview-workflows.sh',
       'scripts/ci/check-network-preview-r2-lock.sh',
       'scripts/ci/check-network-preview-encrypted-plan.sh',
@@ -334,6 +340,7 @@ export const LANES = Object.freeze([
       'scripts/ci/write-network-preview-backend-config.sh',
       'scripts/network-preview-local-plan.mjs',
       'scripts/tests/network-preview-protected.test.mjs',
+      'wml-server/Dockerfile',
       '.github/workflows/opentofu.yml',
       '.github/workflows/opentofu-protected-apply.yml',
       '.github/workflows/opentofu-protected-plan.yml'
@@ -345,6 +352,8 @@ export const LANES = Object.freeze([
         'run go install github.com/rhysd/actionlint/cmd/actionlint@v1.7.12'
       ),
       prerequisite('sh', 'install a POSIX shell'),
+      prerequisite('shellcheck', 'install shellcheck'),
+      prerequisite('docker', 'install Docker with Compose v2'),
       prerequisite('node', 'install the repository Node version')
     ],
     commands: [
@@ -400,7 +409,8 @@ export const LANES = Object.freeze([
       command('protected workflow contract tests', 'node', [
         '--test',
         'scripts/tests/network-preview-protected.test.mjs'
-      ])
+      ]),
+      command('production deployment contracts', 'scripts/ci/check-network-preview-deploy.sh', [])
     ]
   },
   {

--- a/transport-rust/tests/kannel_smoke.rs
+++ b/transport-rust/tests/kannel_smoke.rs
@@ -160,3 +160,21 @@ fn kannel_wap_post_smoke_registers_and_logs_in_user() {
         "expected login confirmation to mention authenticated username"
     );
 }
+
+#[test]
+#[ignore = "runs against external Kannel dev stack (make up)"]
+fn kannel_wap_unapproved_origin_is_not_proxied() {
+    let denied_url = std::env::var("WAP_SMOKE_DENIED_URL")
+        .unwrap_or_else(|_| "wap://127.0.0.1:9200/".to_string());
+    let response =
+        fetch_deck_in_process_with_profile(request(&denied_url), FetchTransportProfile::WapNetCore);
+    assert!(
+        !response.ok,
+        "unapproved WAP origin unexpectedly succeeded: target={denied_url} status={} contentType={}",
+        response.status, response.content_type
+    );
+    assert!(
+        response.status >= 400 || response.error.is_some(),
+        "unapproved WAP origin did not return an explicit failure: target={denied_url}"
+    );
+}

--- a/wml-server/cmd/wml-server/main.go
+++ b/wml-server/cmd/wml-server/main.go
@@ -3,6 +3,8 @@ package main
 import (
 	"context"
 	"errors"
+	"fmt"
+	"io"
 	"log/slog"
 	"net/http"
 	"os"
@@ -17,10 +19,25 @@ import (
 const (
 	defaultPublicAddress   = ":3000"
 	defaultInternalAddress = ":3001"
+	defaultHealthcheckURL  = "http://127.0.0.1:3001/health"
 	shutdownTimeout        = 10 * time.Second
+	healthcheckTimeout     = 3 * time.Second
+	healthcheckBodyLimit   = 4 << 10
 )
 
 func main() {
+	if len(os.Args) == 2 && os.Args[1] == "healthcheck" {
+		if err := runHealthcheck(envOrDefault("WML_HEALTHCHECK_URL", defaultHealthcheckURL)); err != nil {
+			fmt.Fprintln(os.Stderr, "healthcheck failed:", err)
+			os.Exit(1)
+		}
+		return
+	}
+	if len(os.Args) != 1 {
+		fmt.Fprintln(os.Stderr, "usage: wml-server [healthcheck]")
+		os.Exit(2)
+	}
+
 	logger := slog.New(slog.NewJSONHandler(os.Stdout, nil))
 	app, err := origin.New(origin.Config{
 		DTDVersion:   strings.TrimSpace(envOrDefault("WML_DTD_VERSION", "1.1")),
@@ -62,6 +79,29 @@ func main() {
 			logger.Error("graceful shutdown failed", "address", server.Addr, "error", err)
 		}
 	}
+}
+
+func runHealthcheck(url string) error {
+	client := &http.Client{Timeout: healthcheckTimeout}
+	response, err := client.Get(url)
+	if err != nil {
+		return err
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusOK {
+		return fmt.Errorf("unexpected status %s", response.Status)
+	}
+	body, err := io.ReadAll(io.LimitReader(response.Body, healthcheckBodyLimit+1))
+	if err != nil {
+		return err
+	}
+	if len(body) > healthcheckBodyLimit {
+		return errors.New("response body exceeded healthcheck limit")
+	}
+	if !strings.Contains(string(body), `"status":"ok"`) {
+		return errors.New("response did not report status ok")
+	}
+	return nil
 }
 
 func splitCSV(raw string) []string {

--- a/wml-server/cmd/wml-server/main_test.go
+++ b/wml-server/cmd/wml-server/main_test.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestRunHealthcheck(t *testing.T) {
+	tests := []struct {
+		name       string
+		status     int
+		body       string
+		wantErrSub string
+	}{
+		{name: "healthy", status: http.StatusOK, body: `{"status":"ok"}`},
+		{name: "bad status", status: http.StatusServiceUnavailable, body: `{"status":"down"}`, wantErrSub: "unexpected status"},
+		{name: "bad body", status: http.StatusOK, body: `{"status":"unknown"}`, wantErrSub: "did not report status ok"},
+		{name: "oversized", status: http.StatusOK, body: strings.Repeat("x", healthcheckBodyLimit+1), wantErrSub: "exceeded healthcheck limit"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(test.status)
+				fmt.Fprint(w, test.body)
+			}))
+			defer server.Close()
+
+			err := runHealthcheck(server.URL)
+			if test.wantErrSub == "" {
+				if err != nil {
+					t.Fatalf("runHealthcheck() error = %v", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), test.wantErrSub) {
+				t.Fatalf("runHealthcheck() error = %v, want substring %q", err, test.wantErrSub)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- add a production-only, non-root WML/Kannel Compose stack with read-only filesystems, dropped capabilities, resource ceilings, bounded logs, health checks, and an internal origin network
- add a persistent `DOCKER-USER` firewall that defaults to sealed, permits Tailnet-only UDP 9200 testing, blocks container uplink egress, and rate-limits the separately gated public mode
- add checksummed Linux AMD64 release packaging, vulnerability scans, CycloneDX SBOMs, cross-Docker provenance verification, host-local read-only secrets, systemd recovery, rollback, and private Tailscale deployment tooling
- restrict Kannel to the approved WAP hostnames and explicit private smoke aliases, with a final local 404 catch-all instead of an open proxy
- stage exact DNS-only names for `home.wap.shrimpworks.dev`, `forms.wap.shrimpworks.dev`, and `interop.wap.shrimpworks.dev` while leaving public publication disabled
- add semantic GitHub Actions lint, protected-workflow/deployment contracts, image scanning, and remote WAP negative-origin coverage

## Why

The existing host and local development stack did not form a production deployment boundary. This change adds a reproducible, fail-closed service release path without weakening the protected OpenTofu plan/apply boundary or exposing administrative/origin ports.

Two live fail-closed checks also found and fixed portability issues before publication: Docker's containerd image store reports an OCI manifest digest where the classic store reports a config digest, and bind-mounted Compose secrets retain host ownership. The installer now verifies the canonical config blob across both stores and owns mode-`0400` secret files by the fixed Kannel UID.

## Live checkpoint

- exact source release `63c8197d59afcadf4c70a39193fd772bd308f8c8` is healthy on the existing DigitalOcean preview host
- systemd and sealed-firewall persistence passed a host reboot
- the prior healthy release is retained for rollback
- access remains Tailnet-only; public Docker ingress is sealed
- no DNS, cloud firewall, OpenTofu state, or provider resources were changed by this service deployment

## Verification

- `make lint-tofu` with OpenTofu fmt/init (`-backend=false`)/validate, actionlint 1.7.12, cloud-init semantics, shellcheck, encrypted offline plan, 14 protected-workflow contracts, and 8 deployment contracts
- `pnpm run verify:change` under Node 22.22.1: workspace quality, docs/links/drift, compliance/knowledge graph, native/WASM engine, 51 executable stories, transport, browser/accessibility, Atlas, marketing, Go origin, and OpenTofu/deployment lanes
- Linux AMD64 image builds, Grype high/critical gates, CycloneDX SBOM generation, checksummed archive, and canonical image provenance verification
- live Tailnet WAP smoke: root/login/register, POST, browser fetch/render, and unmapped-origin denial
- post-reboot systemd/container health, sealed firewall, non-root/read-only/cap-drop inspection, listener audit, secret metadata audit, and secret-shaped log scan
- pre-push hooks, including OpenTofu, Go, Rust fmt/clippy/tests, all passed
- PR diff scan found no tracked env/state/archive artifacts or supported credential shapes

## Public publication remains gated

Do not switch the host firewall to `public` from this PR. Publication still requires a separately reviewed exact OpenTofu plan/apply for the DNS-only records and DigitalOcean UDP 9200 rule, verification of the external firewall/DNS state, then the explicit host public-mode switch and positive/negative external probes.

## Rollback

Run `sudo waves-network-preview-rollback` over Tailscale; it restores the prior healthy service release and leaves ingress sealed. Revert this PR for repository rollback. No cloud state was changed by the private deployment.
