### PR TITLE
fix(engine): bound WML variable substitution and aggregate variable memory

### DIFF
--- a/engine-wasm/engine/src/engine_public_api.rs
+++ b/engine-wasm/engine/src/engine_public_api.rs
@@ -235,13 +235,13 @@ impl WmlEngine {
         self.vars.get(&name).cloned()
     }
 
-    /// Set a runtime variable if `name` passes deterministic validation.
+    /// Set a runtime variable if `name` passes deterministic validation and
+    /// the aggregate variable store stays within its byte budget.
     pub fn set_var(&mut self, name: String, value: String) -> bool {
         if !is_valid_var_name(&name) {
             return false;
         }
-        self.vars.insert(name, value);
-        true
+        crate::runtime::variable::checked_insert(&mut self.vars, name, value).is_ok()
     }
 
     /// Render active card into draw commands for the current viewport width.

--- a/engine-wasm/engine/src/engine_runtime_internal.rs
+++ b/engine-wasm/engine/src/engine_runtime_internal.rs
@@ -1,5 +1,7 @@
 use crate::runtime::node::{InlineNode, Node};
-use crate::runtime::variable::{evaluate as evaluate_variable, SubstitutionContext};
+use crate::runtime::variable::{
+    checked_insert as checked_insert_var, evaluate as evaluate_variable, SubstitutionContext,
+};
 use crate::*;
 
 mod navigation;
@@ -372,7 +374,7 @@ impl WmlEngine {
                     };
 
                     if let Some(initial_value) = initial_value {
-                        vars.insert(input.name.to_string(), initial_value.clone());
+                        checked_insert_var(vars, input.name.to_string(), initial_value.clone())?;
                         *input.value = initial_value;
                     } else {
                         vars.remove(input.name);
@@ -826,10 +828,11 @@ fn sync_select_variables(
         if values.is_empty() {
             vars.remove(name);
         } else {
-            vars.insert(
+            checked_insert_var(
+                vars,
                 name.to_string(),
                 values.join(if multiple { ";" } else { "" }),
-            );
+            )?;
         }
     }
     if let Some(iname) = iname {
@@ -842,7 +845,7 @@ fn sync_select_variables(
                 .collect::<Vec<_>>()
                 .join(if multiple { ";" } else { "" })
         };
-        vars.insert(iname.to_string(), serialized);
+        checked_insert_var(vars, iname.to_string(), serialized)?;
     }
     Ok(())
 }

--- a/engine-wasm/engine/src/engine_runtime_internal/navigation.rs
+++ b/engine-wasm/engine/src/engine_runtime_internal/navigation.rs
@@ -1,5 +1,5 @@
 use crate::runtime::card::{CardGoRequest, CardPostField, CardSetVar};
-use crate::runtime::variable::is_valid_name;
+use crate::runtime::variable::{checked_apply_assignments, is_valid_name};
 use crate::*;
 use url::Url;
 
@@ -195,7 +195,10 @@ impl WmlEngine {
         nav.engine.active_select_edit = None;
         nav.engine.active_card_idx = back_target_idx;
         nav.engine.focused_link_idx = 0;
-        nav.engine.apply_set_var_assignments(assignments);
+        if let Err(err) = nav.engine.apply_set_var_assignments(assignments) {
+            nav.engine.push_trace("SETVAR_BUDGET_ERROR", err);
+            return true;
+        }
         nav.engine.push_trace("ACTION_BACK", String::new());
         // Each fallible entry step traces first, then leaves the guard armed so
         // the drop restores the pre-navigation state before returning.
@@ -267,7 +270,7 @@ impl WmlEngine {
         match action {
             CardTaskAction::Go { href, request } => {
                 let href = evaluate_href(href, &self.vars)?;
-                self.apply_set_var_assignments(&assignments);
+                self.apply_set_var_assignments(&assignments)?;
                 self.execute_prepared_action_href(&href, request)
             }
             CardTaskAction::Prev => {
@@ -278,7 +281,7 @@ impl WmlEngine {
             CardTaskAction::Refresh => {
                 self.push_trace("ACTION_REFRESH", String::new());
                 self.stop_active_timer_for_exit();
-                self.apply_set_var_assignments(&assignments);
+                self.apply_set_var_assignments(&assignments)?;
                 self.initialize_controls_on_active_card()?;
                 self.start_timer_for_active_card()?;
                 Ok(())
@@ -365,12 +368,16 @@ impl WmlEngine {
             .collect()
     }
 
-    fn apply_set_var_assignments(&mut self, assignments: &[(String, String)]) {
-        for (name, value) in assignments {
-            if is_valid_name(name) {
-                self.vars.insert(name.clone(), value.clone());
-            }
-        }
+    fn apply_set_var_assignments(
+        &mut self,
+        assignments: &[(String, String)],
+    ) -> Result<(), String> {
+        let valid_assignments: Vec<(String, String)> = assignments
+            .iter()
+            .filter(|(name, _)| is_valid_name(name))
+            .cloned()
+            .collect();
+        checked_apply_assignments(&mut self.vars, &valid_assignments)
     }
 
     pub(crate) fn resolve_external_href(&self, href: &str) -> String {

--- a/engine-wasm/engine/src/engine_tests/wml_302_variables.rs
+++ b/engine-wasm/engine/src/engine_tests/wml_302_variables.rs
@@ -246,3 +246,88 @@ fn wml_302_newcontext_and_task_failure_preserve_existing_atomicity() {
         Some("original")
     );
 }
+
+#[test]
+fn wml_302_exponential_timer_refresh_doubling_fails_deterministically_without_partial_commit() {
+    // M1-46 / #446: a repeating ontimer refresh doubling a variable through
+    // itself ($(x)$(x)) must fail before it can grow into a large
+    // allocation, and a failed refresh must not partially apply.
+    let mut engine = WmlEngine::new();
+    let xml = r##"
+        <wml>
+          <card id="home"><a href="#loop">Start</a></card>
+          <card id="loop">
+            <onevent type="ontimer"><refresh><setvar name="x" value="$(x)$(x)"/></refresh></onevent>
+            <timer value="1"/>
+            <p>Doubling</p>
+          </card>
+        </wml>
+        "##;
+    engine.load_deck(xml).expect("deck should load");
+    assert!(engine.set_var("x".to_string(), "a".to_string()));
+    engine
+        .handle_key("enter".to_string())
+        .expect("loop card should open and start the timer");
+    assert!(engine.next_timer_wakeup_ms().is_some());
+
+    let mut failure = None;
+    let mut last_ok_len = 1usize;
+    for _ in 0..30 {
+        match engine.advance_time_ms(100) {
+            Ok(()) => {
+                last_ok_len = engine
+                    .get_var("x".to_string())
+                    .map(|value| value.len())
+                    .unwrap_or(last_ok_len);
+            }
+            Err(err) => {
+                failure = Some(err);
+                break;
+            }
+        }
+    }
+    let error = failure.expect(
+        "exponential doubling must fail deterministically before completing 30 refresh cycles",
+    );
+    assert!(
+        error.contains("byte"),
+        "error should be the stable substitution/aggregate budget message, got: {error}"
+    );
+    assert_eq!(
+        engine.get_var("x".to_string()).map(|value| value.len()),
+        Some(last_ok_len),
+        "a failed refresh must not partially commit the doubled value"
+    );
+    assert_eq!(engine.active_card_id().as_deref(), Ok("loop"));
+}
+
+#[test]
+fn wml_302_single_pass_amplification_below_input_limit_fails_deterministically() {
+    // Below any single deck/value-size limit individually, but many
+    // substitutions of a moderately-sized variable in one attribute can
+    // still amplify past the substitution-output bound in one evaluation.
+    let mut engine = WmlEngine::new();
+    let repeated_refs = "$(a)".repeat(2_000); // 2,000 * 40 bytes = 80,000 > 64 KiB bound
+    let xml = format!(
+        r##"<wml><card id="home">
+              <do type="accept"><refresh><setvar name="out" value="{repeated_refs}"/></refresh></do>
+              <p>Home</p>
+            </card></wml>"##
+    );
+    engine.load_deck(&xml).expect("deck should load");
+    assert!(engine.set_var("a".to_string(), "x".repeat(40)));
+
+    let error = engine.handle_key("enter".to_string()).expect_err(
+        "single-pass amplification must fail deterministically before large allocation",
+    );
+    assert!(
+        error.contains("byte"),
+        "error should be the stable substitution budget message, got: {error}"
+    );
+    assert_eq!(
+        engine.get_var("out".to_string()),
+        None,
+        "the failed setvar must not partially commit"
+    );
+    assert_eq!(engine.active_card_id().as_deref(), Ok("home"));
+}

--- a/engine-wasm/engine/src/engine_wasm_bindings_tests.rs
+++ b/engine-wasm/engine/src/engine_wasm_bindings_tests.rs
@@ -210,6 +210,60 @@ fn wasm_wml_305_named_timer_lifecycle_matches_native_boundary() {
     assert_eq!(zero.active_card_id_wasm().as_deref(), Ok("zero"));
 }
 
+#[wasm_bindgen_test]
+fn wasm_variable_substitution_amplification_bounds_match_native_boundary() {
+    // M1-46 / #446: an unbounded exponential $(x)$(x) doubling via a
+    // repeating ontimer refresh must fail deterministically on wasm32 the
+    // same way it does natively, since `catch_unwind` cannot recover an
+    // allocation-failure panic on wasm32-unknown-unknown at all (see #434).
+    let mut engine = WmlEngine::new();
+    let xml = r##"
+        <wml>
+          <card id="home"><a href="#loop">Start</a></card>
+          <card id="loop">
+            <onevent type="ontimer"><refresh><setvar name="x" value="$(x)$(x)"/></refresh></onevent>
+            <timer value="1"/>
+            <p>Doubling</p>
+          </card>
+        </wml>
+        "##;
+    engine.load_deck_wasm(xml).expect("deck should load");
+    assert!(engine.set_var_wasm("x".to_string(), "a".to_string()));
+    engine
+        .handle_key_wasm("enter".to_string())
+        .expect("loop card should open and start the timer");
+    assert!(engine.next_timer_wakeup_ms_wasm().is_some());
+
+    let mut failed = false;
+    let mut last_ok_len = 1usize;
+    for _ in 0..30 {
+        match engine.advance_time_ms_wasm(100) {
+            Ok(()) => {
+                last_ok_len = engine
+                    .get_var_wasm("x".to_string())
+                    .map(|value| value.len())
+                    .unwrap_or(last_ok_len);
+            }
+            Err(_) => {
+                failed = true;
+                break;
+            }
+        }
+    }
+    assert!(
+        failed,
+        "exponential doubling must fail deterministically before completing 30 refresh cycles"
+    );
+    assert_eq!(
+        engine
+            .get_var_wasm("x".to_string())
+            .map(|value| value.len()),
+        Some(last_ok_len),
+        "a failed refresh must not partially commit the doubled value"
+    );
+    assert_eq!(engine.active_card_id_wasm().as_deref(), Ok("loop"));
+}
+
 fn draw_text(render_value: &JsValue) -> Vec<String> {
     let draw = Reflect::get(render_value, &JsValue::from_str("draw")).expect("draw property");
     Array::from(&draw)

--- a/engine-wasm/engine/src/runtime/variable.rs
+++ b/engine-wasm/engine/src/runtime/variable.rs
@@ -13,6 +13,22 @@ const RFC2396_ESCAPE_SET: &AsciiSet = &NON_ALPHANUMERIC
     .remove(b'(')
     .remove(b')');
 
+/// Bounds a single `evaluate`/`scan` call's output. Without this, a deck can
+/// amplify a variable reference into an unbounded allocation in one
+/// evaluation -- either by chaining many substitutions in one attribute
+/// (single-pass amplification) or by repeatedly doubling a variable's own
+/// value through itself via a repeating timer/refresh (e.g.
+/// `<setvar name="X" value="$(X)$(X)"/>`), since each such evaluation only
+/// needs to stay under this bound to succeed, capping the growth rate.
+pub(crate) const MAX_SUBSTITUTION_OUTPUT_BYTES: usize = 64 * 1024;
+
+/// Bounds the aggregate size (all keys + all values) of the browser-context
+/// variable store, independent of any single substitution. Many separately
+/// under-`MAX_SUBSTITUTION_OUTPUT_BYTES` values (e.g. a `<select multiple>`
+/// with many deck-controlled option values) could otherwise still sum to an
+/// unbounded total.
+pub(crate) const MAX_AGGREGATE_VAR_STORE_BYTES: usize = 1024 * 1024;
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum SubstitutionContext {
     VData,
@@ -47,6 +63,40 @@ pub(crate) fn is_valid_name(name: &str) -> bool {
     variable_name_len(name).is_ok_and(|len| len == name.len())
 }
 
+/// Applies `assignments` to `vars` atomically: if the resulting aggregate
+/// store size would exceed [`MAX_AGGREGATE_VAR_STORE_BYTES`], none of them
+/// are applied and a stable error is returned instead. Used for every
+/// deck/script-controlled write into the variable store so many
+/// individually-bounded values can't still sum to an unbounded total.
+pub(crate) fn checked_apply_assignments(
+    vars: &mut HashMap<String, String>,
+    assignments: &[(String, String)],
+) -> Result<(), String> {
+    if assignments.is_empty() {
+        return Ok(());
+    }
+    let mut projected = vars.clone();
+    for (name, value) in assignments {
+        projected.insert(name.clone(), value.clone());
+    }
+    let total_bytes: usize = projected.iter().map(|(k, v)| k.len() + v.len()).sum();
+    if total_bytes > MAX_AGGREGATE_VAR_STORE_BYTES {
+        return Err(format!(
+            "variable store would exceed the {MAX_AGGREGATE_VAR_STORE_BYTES}-byte aggregate budget"
+        ));
+    }
+    *vars = projected;
+    Ok(())
+}
+
+pub(crate) fn checked_insert(
+    vars: &mut HashMap<String, String>,
+    name: String,
+    value: String,
+) -> Result<(), String> {
+    checked_apply_assignments(vars, &[(name, value)])
+}
+
 pub(crate) fn evaluate(
     raw: &str,
     vars: &HashMap<String, String>,
@@ -79,20 +129,20 @@ fn scan(
     raw: &str,
     mut resolve: impl FnMut(Reference<'_>) -> Result<String, String>,
 ) -> Result<String, String> {
-    let mut out = String::with_capacity(raw.len());
+    let mut out = String::with_capacity(raw.len().min(MAX_SUBSTITUTION_OUTPUT_BYTES));
     let mut cursor = 0usize;
     while cursor < raw.len() {
         let Some(relative_dollar) = raw[cursor..].find('$') else {
-            out.push_str(&raw[cursor..]);
+            push_bounded(&mut out, &raw[cursor..])?;
             break;
         };
         let dollar = cursor + relative_dollar;
-        out.push_str(&raw[cursor..dollar]);
+        push_bounded(&mut out, &raw[cursor..dollar])?;
         let after_dollar = dollar + 1;
         let remainder = &raw[after_dollar..];
 
         if remainder.starts_with('$') {
-            out.push('$');
+            push_bounded(&mut out, "$")?;
             cursor = after_dollar + 1;
             continue;
         }
@@ -103,20 +153,36 @@ fn scan(
                 .ok_or_else(|| "unterminated parenthesized variable reference".to_string())?;
             let body = &parenthesized[..close];
             let (name, conversion) = parse_parenthesized(body)?;
-            out.push_str(&resolve(Reference { name, conversion })?);
+            push_bounded(&mut out, &resolve(Reference { name, conversion })?)?;
             cursor = after_dollar + 1 + close + 1;
             continue;
         }
 
         let name_len = variable_name_len(remainder)?;
         let name = &remainder[..name_len];
-        out.push_str(&resolve(Reference {
-            name,
-            conversion: None,
-        })?);
+        push_bounded(
+            &mut out,
+            &resolve(Reference {
+                name,
+                conversion: None,
+            })?,
+        )?;
         cursor = after_dollar + name_len;
     }
     Ok(out)
+}
+
+/// Appends `piece` to `out`, failing before the append if doing so would
+/// cross [`MAX_SUBSTITUTION_OUTPUT_BYTES`] -- the check runs before the
+/// push, so the bound is enforced without ever allocating past it.
+fn push_bounded(out: &mut String, piece: &str) -> Result<(), String> {
+    if out.len().saturating_add(piece.len()) > MAX_SUBSTITUTION_OUTPUT_BYTES {
+        return Err(format!(
+            "variable substitution exceeds {MAX_SUBSTITUTION_OUTPUT_BYTES}-byte output limit"
+        ));
+    }
+    out.push_str(piece);
+    Ok(())
 }
 
 fn parse_parenthesized(body: &str) -> Result<(&str, Option<Conversion>), String> {
@@ -210,5 +276,70 @@ mod tests {
             decode_literal_dollars("literal $$ value").as_deref(),
             Ok("literal $ value")
         );
+    }
+
+    #[test]
+    fn evaluate_accepts_output_exactly_at_the_substitution_limit() {
+        let value = "x".repeat(MAX_SUBSTITUTION_OUTPUT_BYTES);
+        let vars = HashMap::from([("V".to_string(), value.clone())]);
+        let result =
+            evaluate("$(V)", &vars, SubstitutionContext::VData).expect("exact-limit output ok");
+        assert_eq!(result.len(), MAX_SUBSTITUTION_OUTPUT_BYTES);
+        assert_eq!(result, value);
+    }
+
+    #[test]
+    fn evaluate_rejects_output_one_byte_over_the_substitution_limit() {
+        let value = "x".repeat(MAX_SUBSTITUTION_OUTPUT_BYTES + 1);
+        let vars = HashMap::from([("V".to_string(), value)]);
+        let error = evaluate("$(V)", &vars, SubstitutionContext::VData)
+            .expect_err("over-limit output must fail deterministically");
+        assert!(error.contains(&MAX_SUBSTITUTION_OUTPUT_BYTES.to_string()));
+    }
+
+    #[test]
+    fn evaluate_rejects_single_pass_amplification_via_many_references() {
+        // Below any deck/value-size limit individually, but the fully
+        // resolved output (2,000 * 40 bytes = 80,000) crosses the 64 KiB
+        // substitution-output bound in one evaluation.
+        let vars = HashMap::from([("A".to_string(), "x".repeat(40))]);
+        let raw = "$(A)".repeat(2_000);
+        let error = evaluate(&raw, &vars, SubstitutionContext::VData)
+            .expect_err("single-pass amplification must fail deterministically");
+        assert!(error.contains(&MAX_SUBSTITUTION_OUTPUT_BYTES.to_string()));
+    }
+
+    #[test]
+    fn checked_apply_assignments_is_atomic_and_bounds_the_aggregate_store() {
+        let mut vars = HashMap::new();
+        checked_apply_assignments(
+            &mut vars,
+            &[
+                ("a".to_string(), "1".to_string()),
+                ("b".to_string(), "2".to_string()),
+            ],
+        )
+        .expect("small assignments stay under budget");
+        assert_eq!(vars.get("a").map(String::as_str), Some("1"));
+        assert_eq!(vars.get("b").map(String::as_str), Some("2"));
+
+        let oversized = "x".repeat(MAX_AGGREGATE_VAR_STORE_BYTES);
+        let error = checked_apply_assignments(
+            &mut vars,
+            &[
+                ("c".to_string(), oversized),
+                ("d".to_string(), "should not be applied either".to_string()),
+            ],
+        )
+        .expect_err("assignments exceeding the aggregate budget must be rejected");
+        assert!(error.contains(&MAX_AGGREGATE_VAR_STORE_BYTES.to_string()));
+
+        // Atomic: neither "c" nor "d" from the rejected batch was applied,
+        // and the pre-existing "a"/"b" entries are untouched.
+        assert_eq!(vars.len(), 2);
+        assert_eq!(vars.get("a").map(String::as_str), Some("1"));
+        assert_eq!(vars.get("b").map(String::as_str), Some("2"));
+        assert!(!vars.contains_key("c"));
+        assert!(!vars.contains_key("d"));
     }
 }

--- a/engine-wasm/engine/src/wavescript/stdlib/wmlbrowser.rs
+++ b/engine-wasm/engine/src/wavescript/stdlib/wmlbrowser.rs
@@ -81,7 +81,9 @@ impl<'a> WmlBrowserHost<'a> {
         if value.len() > MAX_VAR_VALUE_BYTES {
             return ScriptValue::Invalid;
         }
-        self.vars.insert(name, value);
+        if crate::runtime::variable::checked_insert(self.vars, name, value).is_err() {
+            return ScriptValue::Invalid;
+        }
         self.effects.mark_refresh_required();
         ScriptValue::Bool(true)
     }

--- a/engine-wasm/engine/src/wavescript/stdlib/wmlbrowser_tests.rs
+++ b/engine-wasm/engine/src/wavescript/stdlib/wmlbrowser_tests.rs
@@ -188,6 +188,31 @@ fn oversized_setvar_value_is_rejected_without_mutation() {
 }
 
 #[test]
+fn set_var_rejects_when_aggregate_store_budget_would_be_exceeded() {
+    // M1-46 / #446: a single WMLScript setVar() call is already bounded by
+    // MAX_VAR_VALUE_BYTES, but many separately-bounded values can still sum
+    // to an unbounded total across the whole variable store.
+    let mut vars = HashMap::new();
+    vars.insert("existing".to_string(), "x".repeat(1024 * 1024 - 100));
+    let mut effects = ScriptRuntimeEffects::default();
+    let mut host = WmlBrowserHost::new(&mut vars, &mut effects, WmlBrowserContext::default());
+
+    let result = host
+        .call(
+            WMLBROWSER_SET_VAR,
+            &[
+                ScriptValue::String("new".to_string()),
+                ScriptValue::String("y".repeat(200)),
+            ],
+        )
+        .expect("setVar should return invalid, not trap");
+
+    assert_eq!(result, ScriptValue::Invalid);
+    assert!(!vars.contains_key("new"));
+    assert!(!effects.requires_refresh());
+}
+
+#[test]
 fn dialog_calls_record_requests_with_deterministic_return_values() {
     let mut vars = HashMap::new();
     let mut effects = ScriptRuntimeEffects::default();


### PR DESCRIPTION
## Summary

A hostile deck could exhaust process/WASM memory with an unnamed repeating timer whose `ontimer` refresh doubles a variable through itself (`<setvar name="X" value="$(X)$(X)"/>`), or with many substitutions of a moderately-sized value packed into a single attribute. Neither path had any output bound, and allocation OOM is not recoverable via `catch_unwind`, including on `wasm32` (see #434).

- `runtime/variable.rs`: `scan()` now bounds a single `evaluate()` call's output to `MAX_SUBSTITUTION_OUTPUT_BYTES` (64 KiB), checked *before* each append so the bound is enforced without ever allocating past it. `evaluate()` is the single chokepoint for every vdata/href substitution site, so this covers all of them uniformly (render text, option labels, setvar values, href resolution, timer values, postfields, enctype, ...).
- `runtime/variable.rs`: added `checked_apply_assignments()` / `checked_insert()`, enforcing `MAX_AGGREGATE_VAR_STORE_BYTES` (1 MiB) across the whole variable store atomically. Many individually-bounded values (e.g. a `<select multiple>` with many deck-controlled option labels) could otherwise still sum to an unbounded total.
- Routed every deck/script-reachable `vars.insert()` through the checked helpers:
  - input control defaults and select-variable sync (`engine_runtime_internal.rs`)
  - deck-authored `<setvar>` task assignments (`engine_runtime_internal/navigation.rs` -- the exact PoC path from the issue; now atomic per the existing `TaskRollbackGuard`/`NavRollbackGuard` rollback pattern, so a rejected batch doesn't partially commit)
  - the public `set_var()` API (`engine_public_api.rs` -- signature unchanged, still returns `bool`, `false` now also covers budget rejection)
  - WMLScript's `WMLBrowser.setVar()` (`wavescript/stdlib/wmlbrowser.rs`)

Fixes #446

## Acceptance criteria (from the issue)

- [x] Exponential timer-refresh expansion fails deterministically before large allocation
- [x] Single-pass amplification below the input-size limit also fails deterministically
- [x] Exactly-at-limit and normal substitutions retain current behavior
- [x] Failure does not partially commit variable/task/navigation state
- [x] Native and WASM adapters expose equivalent results

## Test plan

- [x] `cargo fmt --check` (engine-wasm/engine)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` (engine-wasm/engine)
- [x] `cargo test` (engine-wasm/engine) -- 379 passed, including:
  - `runtime::variable::tests::evaluate_accepts_output_exactly_at_the_substitution_limit`
  - `runtime::variable::tests::evaluate_rejects_output_one_byte_over_the_substitution_limit`
  - `runtime::variable::tests::evaluate_rejects_single_pass_amplification_via_many_references`
  - `runtime::variable::tests::checked_apply_assignments_is_atomic_and_bounds_the_aggregate_store`
  - `wml_302_exponential_timer_refresh_doubling_fails_deterministically_without_partial_commit`
  - `wml_302_single_pass_amplification_below_input_limit_fails_deterministically`
  - `wavescript::stdlib::wmlbrowser::tests::set_var_rejects_when_aggregate_store_budget_would_be_exceeded`
- [x] `wasm-pack test --node` -- 28/28 passed, including `wasm_variable_substitution_amplification_bounds_match_native_boundary` (native/WASM parity)
- [x] `make coverage-rust-engine` -- 94.77% lines / 94.17% functions (thresholds: 90%/85%)
- [x] Full repo pre-push hook suite (fmt/clippy/test across engine, transport, browser tauri; go vet/test; opentofu validate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
