### PR TITLE
fix(infra): authenticate Kannel health probes

### DIFF
--- a/docker/kannel/production/entrypoint.sh
+++ b/docker/kannel/production/entrypoint.sh
@@ -56,6 +56,7 @@ printf '%s\n' "$bearerbox_pid" >"$runtime_dir/bearerbox.pid"
 i=0
 while [ "$i" -lt 20 ]; do
   if curl -sS --output /dev/null --connect-timeout 1 --max-time 2 \
+    --get --data-urlencode "password@$status_secret_file" \
     'http://127.0.0.1:13000/status' \
     >/dev/null 2>&1; then
     break

--- a/docker/kannel/production/healthcheck.sh
+++ b/docker/kannel/production/healthcheck.sh
@@ -2,6 +2,7 @@
 set -eu
 
 runtime_dir=/run/kannel
+status_secret_file=${KANNEL_STATUS_PASSWORD_FILE:-/run/secrets/kannel_status_password}
 for process_name in bearerbox wapbox; do
   pid_file=${runtime_dir}/${process_name}.pid
   test -r "$pid_file"
@@ -12,5 +13,7 @@ for process_name in bearerbox wapbox; do
   kill -0 "$pid" 2>/dev/null
 done
 
+test -r "$status_secret_file"
 curl -sS --output /dev/null --connect-timeout 1 --max-time 3 \
+  --get --data-urlencode "password@$status_secret_file" \
   'http://127.0.0.1:13000/status'

--- a/scripts/tests/network-preview-deploy.test.mjs
+++ b/scripts/tests/network-preview-deploy.test.mjs
@@ -83,7 +83,11 @@ test('production Kannel maps only approved public hosts and explicit private smo
   const healthcheck = read('docker/kannel/production/healthcheck.sh');
   assert.match(entrypoint, /bearerbox -v 1/);
   assert.match(entrypoint, /wapbox -v 1/);
-  assert.doesNotMatch(healthcheck, /password|secret/);
+  for (const probe of [entrypoint, healthcheck]) {
+    assert.match(probe, /--data-urlencode "password@\$status_secret_file"/);
+    assert.doesNotMatch(probe, /\?password=|--data-urlencode "password=\$/);
+  }
+  assert.doesNotMatch(healthcheck, /secret_value|tr -d|cat /);
 });
 
 test('Docker forwarding remains sealed by default and public mode is rate limited to UDP 9200', () => {


### PR DESCRIPTION
## Summary

- authenticate Kannel startup and container health probes with the existing mounted status-secret file
- pass the secret to curl through its file-backed `password@<path>` form so the value is not present in source, logs, or command arguments
- add a deployment contract that requires the file-backed form and rejects inline/interpolated password query forms

## Root cause

After the merged production deployment had run for several minutes, repeated unauthenticated requests to Kannel's password-protected `/status` endpoint wedged its admin listener. Both Kannel processes and the WAP path remained alive, but Docker correctly marked the gateway unhealthy after the probe began timing out. Restarting alone would only reset the timer; authenticating every startup/runtime probe removes the trigger.

## Verification

- POSIX syntax and ShellCheck
- production deployment contracts: 8/8
- full `pnpm run verify:change` under Node 22.22.1, including actionlint, OpenTofu backend-disabled init/validate/offline-plan checks, 14 protected-workflow contracts, docs/links/compliance drift, engine/WASM/stories, transport, browser/accessibility, Atlas, marketing, and Go
- pre-push OpenTofu, Go, Rust fmt/clippy/tests hooks
- exact source release `8b1e0db930a951defe09f029a0be149d223a195d` passed both Grype high/critical gates, produced both CycloneDX SBOMs, and was packaged with SHA-256 `340c22c7bdc354b34a99fc6d87ed9baacac28ad243281808931fed3004650c0f`
- exact release is installed healthy on the private host with both systemd units active and Docker ingress sealed; the content-equivalent pre-cherry-pick release passed Tailnet transport/browser/render smoke

## Safety and rollback

- public Docker ingress remains sealed; no DNS, cloud firewall, OpenTofu state, credentials, or provider resources are changed
- the fix reads the already-mounted status secret without printing it
- service rollback is `sudo waves-network-preview-rollback` over Tailscale and remains sealed; repository rollback is a revert of this PR
