### PR TITLE
fix(transport): reject malformed Encoding-Version text

### DIFF
--- a/docs/waves/WSP_802_HEADER_ENCODING_EVIDENCE.md
+++ b/docs/waves/WSP_802_HEADER_ENCODING_EVIDENCE.md
@@ -34,6 +34,9 @@ connectionless Content-Type framing and does not claim WML-304 media/charset own
 - Binary Encoding-Version supports default and application-page identities, version defaults,
   sender/peer version caps, hop-local caching, hop-by-hop removal, per-extension-page
   advertisements, and compatible textual retry selection.
+- Corrective issue `#449` closes a residual in the completed WSP-802 text-form evidence:
+  malformed one- or two-token textual values are rejected instead of being normalized into a
+  different valid binary advertisement. This correction does not reopen WSP-802 or `T0-20`.
 - Expect uses SIN 001: `100-continue` is octet `0x80`; extension expressions require a
   Value-length wrapper. The superseded unwrapped expression is rejected.
 - HTTP comma-list values are expanded into ordered repeated WSP fields while quoted commas are
@@ -43,6 +46,8 @@ connectionless Content-Type framing and does not claim WML-304 media/charset own
 
 - `transport-rust/tests/wsp_header_grammar.rs`
 - `transport-rust/tests/fixtures/transport/wsp_header_grammar_mapped/header_fixture.json`
+- The mapped Encoding-Version table asserts exact bytes for `1.3`, `40`, and `40 1.3`, plus
+  exact `InvalidVersion` failures for malformed one- and two-token values.
 - Native WSP header, Encoding-Version, Expect, peer-cache, retry, list-expansion, and hop-boundary
   unit tests under `transport-rust/src/network/wsp/`
 - `cargo test --manifest-path transport-rust/Cargo.toml --test wsp_header_grammar`

--- a/transport-rust/src/network/wsp/header_block.rs
+++ b/transport-rust/src/network/wsp/header_block.rs
@@ -425,11 +425,10 @@ pub fn parse_encoding_version_header_value(input: &str) -> Option<WspEncodingVer
         return None;
     }
 
-    if let Some(version) = second.and_then(parse_version) {
-        let code_page = u8::from_str_radix(first, 16).ok()?;
+    if let Some(second) = second {
         return Some(WspEncodingVersionHeader {
-            code_page: Some(code_page),
-            version: Some(version),
+            code_page: Some(u8::from_str_radix(first, 16).ok()?),
+            version: Some(parse_version(second)?),
         });
     }
 
@@ -441,7 +440,7 @@ pub fn parse_encoding_version_header_value(input: &str) -> Option<WspEncodingVer
     }
 
     Some(WspEncodingVersionHeader {
-        code_page: u8::from_str_radix(first, 16).ok(),
+        code_page: Some(u8::from_str_radix(first, 16).ok()?),
         version: None,
     })
 }

--- a/transport-rust/tests/fixtures/transport/wsp_header_grammar_mapped/header_fixture.json
+++ b/transport-rust/tests/fixtures/transport/wsp_header_grammar_mapped/header_fixture.json
@@ -18,6 +18,39 @@
     { "code": 56, "name": "Expect", "major": 1, "minor": 3 },
     { "code": 67, "name": "Encoding-Version", "major": 1, "minor": 3 }
   ],
+  "encodingVersionTextCases": [
+    {
+      "name": "default-page-version",
+      "input": "1.3",
+      "expectedVersion": { "major": 1, "minor": 3 },
+      "expectedEncoded": [195, 147]
+    },
+    {
+      "name": "extension-page-only",
+      "input": "40",
+      "expectedCodePage": 64,
+      "expectedEncoded": [195, 1, 192]
+    },
+    {
+      "name": "extension-page-version",
+      "input": "40 1.3",
+      "expectedCodePage": 64,
+      "expectedVersion": { "major": 1, "minor": 3 },
+      "expectedEncoded": [195, 2, 192, 147]
+    },
+    {
+      "name": "page-with-invalid-version",
+      "input": "40 garbage"
+    },
+    {
+      "name": "version-with-invalid-trailing-token",
+      "input": "1.3 garbage"
+    },
+    {
+      "name": "invalid-single-token",
+      "input": "garbage"
+    }
+  ],
   "headerSections": [
     {
       "name": "assigned-special-values",

--- a/transport-rust/tests/fixtures/transport/wsp_header_grammar_mapped/meta.toml
+++ b/transport-rust/tests/fixtures/transport/wsp_header_grammar_mapped/meta.toml
@@ -32,6 +32,6 @@ spec_items = [
 testing_ac = [
   "Covers all 68 effective Table 39 default-page assignments from 0x00 through 0x43 and excludes successor-only tokens.",
   "Exercises short and uintvar value lengths, text and short-integer values, default/application/reserved page handling, and explicit error/preserve/skip behavior.",
-  "Uses the SIN 001 length-delimited Expect expression and compact Encoding-Version forms, including extension-page identity.",
+  "Uses the SIN 001 length-delimited Expect expression and compact Encoding-Version forms, including extension-page identity and strict rejection of malformed textual values.",
   "Keeps connectionless Content-Type framing on the existing WSP-801 seam and re-runs its byte-exact fixture independently.",
 ]

--- a/transport-rust/tests/wsp_header_grammar.rs
+++ b/transport-rust/tests/wsp_header_grammar.rs
@@ -3,8 +3,11 @@ use lowband_transport_rust::network::wsp::header_registry::{
     WspHeaderCodePageClass, WspHeaderValueGrammar,
 };
 use lowband_transport_rust::network::wsp::{
-    decode_header_section, decode_raw_value, encode_value_length, DecodedWspHeaderName,
-    UnknownHeaderBehavior, WspEncodingVersion, WspHeaderSectionDecodePolicy, WspHeaderValueForm,
+    decode_header_section, decode_raw_value, encode_header_block, encode_value_length,
+    parse_encoding_version_header_value, DecodedWspHeaderName, UnknownHeaderBehavior,
+    WspEncodingVersion, WspEncodingVersionHeader, WspHeaderBlock, WspHeaderBlockEncodeError,
+    WspHeaderBlockEncodePolicy, WspHeaderField, WspHeaderNameEncoding,
+    WspHeaderSectionDecodePolicy, WspHeaderValueEncodeError, WspHeaderValueForm,
 };
 use serde::Deserialize;
 use std::fs;
@@ -21,6 +24,7 @@ struct Fixture {
     default_header_last_code: u8,
     deprecated_codes: Vec<u8>,
     version_boundaries: Vec<VersionBoundary>,
+    encoding_version_text_cases: Vec<EncodingVersionTextCase>,
     header_sections: Vec<HeaderSectionCase>,
 }
 
@@ -28,6 +32,22 @@ struct Fixture {
 struct VersionBoundary {
     code: u8,
     name: String,
+    major: u8,
+    minor: u8,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct EncodingVersionTextCase {
+    name: String,
+    input: String,
+    expected_code_page: Option<u8>,
+    expected_version: Option<ExpectedVersion>,
+    expected_encoded: Option<Vec<u8>>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ExpectedVersion {
     major: u8,
     minor: u8,
 }
@@ -149,6 +169,62 @@ fn value_length_boundary_space_roundtrips_without_panics() {
         assert_eq!(decoded.form, WspHeaderValueForm::LengthDelimited);
         assert_eq!(decoded.encoded, encoded);
         assert_eq!(consumed, encoded.len());
+    }
+}
+
+#[test]
+fn encoding_version_text_parser_accepts_only_complete_defined_forms() {
+    for case in fixture().encoding_version_text_cases {
+        let expected = case
+            .expected_encoded
+            .as_ref()
+            .map(|_| WspEncodingVersionHeader {
+                code_page: case.expected_code_page,
+                version: case.expected_version.map(|version| WspEncodingVersion {
+                    major: version.major,
+                    minor: version.minor,
+                }),
+            });
+
+        assert_eq!(
+            parse_encoding_version_header_value(&case.input),
+            expected,
+            "case '{}' failed",
+            case.name
+        );
+    }
+}
+
+#[test]
+fn encoding_version_text_encoding_is_byte_exact_or_rejected() {
+    for case in fixture().encoding_version_text_cases {
+        let block = WspHeaderBlock {
+            headers: vec![WspHeaderField {
+                name: "Encoding-Version".to_string(),
+                value: case.input.clone(),
+                name_encoding: WspHeaderNameEncoding::Binary { page: 1 },
+            }],
+            encoding_version_headers: Vec::new(),
+        };
+        let result = encode_header_block(
+            &block,
+            WspHeaderBlockEncodePolicy {
+                recipient_version: Some(WspEncodingVersion::V1_4),
+                ..WspHeaderBlockEncodePolicy::STRICT
+            },
+        );
+
+        match case.expected_encoded {
+            Some(expected) => assert_eq!(result, Ok(expected), "case '{}' failed", case.name),
+            None => assert_eq!(
+                result,
+                Err(WspHeaderBlockEncodeError::HeaderValue(
+                    WspHeaderValueEncodeError::InvalidVersion,
+                )),
+                "case '{}' failed",
+                case.name
+            ),
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

- require textual `Encoding-Version` values to match one complete defined form
- reject malformed one- and two-token values with deterministic `InvalidVersion` errors
- add mapped, table-driven parser and header-block encoding coverage with exact bytes for `1.3`, `40`, and `40 1.3`
- record issue #449 as additive corrective WSP-802 evidence without reopening completed WSP-802/T0-20 history

## Root cause

The parser treated an invalid second token as if it were absent, then reinterpreted the first token alone. It also returned a populated header whose page and version were both absent for an invalid single token. The binary encoder trusted that normalized parser result.

## Verification

- `cargo test --manifest-path transport-rust/Cargo.toml --test wsp_header_grammar`
- `cargo test --manifest-path transport-rust/Cargo.toml --test wsp_connectionless_matrix`
- `make test-rust-transport`
- `make lint-rust-transport`
- `pnpm wap-graph:generate`
- `pnpm wap-compliance:check`
- `pnpm wap-graph:check`
- `cargo fmt --manifest-path transport-rust/Cargo.toml -- --check`
- `git diff --check`
- repository pre-push checks

No Rust public contract or generated TypeScript contract changed.

Fixes #449
