### PR TITLE
fix(browser): consume Backspace on focused inputs

### DIFF
--- a/browser/frontend/src/app/browser-controller.behavior.test.ts
+++ b/browser/frontend/src/app/browser-controller.behavior.test.ts
@@ -458,6 +458,82 @@ describe('BrowserController behavior coverage', () => {
     expect(presenter.getSessionState().lastError).toBe('gateway timed out');
   });
 
+  it('consumes Backspace on a refocused PIN after a failed POST', async () => {
+    const refs = createRefs();
+    const presenter = new BrowserPresenter(refs, initialSession, 20);
+    const hostClient = createHostClient();
+    const controller = new BrowserController(hostClient as never, presenter, refs);
+
+    await controller.init('<wml><card id="seed"/></wml>');
+    controllerPrivates(controller).timerRuntime.stop();
+    await controllerPrivates(controller).setRunMode('network', { loadLocalOnEnter: false });
+    await flushAsyncWork();
+
+    vi.mocked(hostClient.fetchDeck).mockClear();
+    vi.mocked(hostClient.engineNavigateBackFrame).mockClear();
+    vi.mocked(hostClient.engineHandleKeyFrame).mockResolvedValueOnce(
+      frame(
+        {
+          activeCardId: 'login',
+          focusedLinkIndex: 1,
+          externalNavigationIntent: 'http://example.test/login',
+          externalNavigationRequestPolicy: {
+            postContext: {
+              sameDeck: false,
+              contentType: 'application/x-www-form-urlencoded',
+              payload: 'pin='
+            }
+          }
+        },
+        { draw: [{ type: 'text', x: 0, y: 0, text: 'PIN: ••••' }] }
+      )
+    );
+    vi.mocked(hostClient.fetchDeck).mockResolvedValueOnce(gatewayTimeoutResponse() as never);
+
+    controllerPrivates(controller).keyboardIntentRouter.handleWindowKeydown(
+      new KeyboardEvent('keydown', { key: 'Enter' })
+    );
+    await controllerPrivates(controller).keyboardIntentRouter.actionQueue;
+
+    expect(hostClient.fetchDeck).toHaveBeenCalledWith(
+      expect.objectContaining({ method: 'POST', url: 'http://example.test/login' })
+    );
+    expect(presenter.getSessionState().navigationStatus).toBe('error');
+
+    vi.mocked(hostClient.engineBeginFocusedInputEditFrame).mockResolvedValueOnce(
+      frame(
+        {
+          activeCardId: 'login',
+          focusedLinkIndex: 1,
+          focusedInputEditName: 'pin',
+          focusedInputEditValue: '••••'
+        },
+        { draw: [{ type: 'text', x: 0, y: 0, text: 'PIN: ••••' }] }
+      )
+    );
+    vi.mocked(hostClient.engineSetFocusedInputEditDraftFrame).mockResolvedValueOnce(
+      frame(
+        {
+          activeCardId: 'login',
+          focusedLinkIndex: 1,
+          focusedInputEditName: 'pin',
+          focusedInputEditValue: '•••'
+        },
+        { draw: [{ type: 'text', x: 0, y: 0, text: 'PIN: •••' }] }
+      )
+    );
+
+    const backspace = new KeyboardEvent('keydown', { key: 'Backspace', cancelable: true });
+    controllerPrivates(controller).keyboardIntentRouter.handleWindowKeydown(backspace);
+    await controllerPrivates(controller).keyboardIntentRouter.actionQueue;
+
+    expect(backspace.defaultPrevented).toBe(true);
+    expect(hostClient.engineBeginFocusedInputEditFrame).toHaveBeenCalledTimes(1);
+    expect(hostClient.engineSetFocusedInputEditDraftFrame).toHaveBeenCalledWith({ value: '•••' });
+    expect(hostClient.engineNavigateBackFrame).not.toHaveBeenCalled();
+    expect(refs.viewportEl.textContent).toBe('PIN: •••');
+  });
+
   it('words a malformed-deck-payload failure distinctly from a network failure', async () => {
     // U2: a fetch that succeeded but returned no usable WML must not read
     // like a network-layer "fetch failed" -- both toast and status text

--- a/browser/frontend/src/app/focused-control-edit.test.ts
+++ b/browser/frontend/src/app/focused-control-edit.test.ts
@@ -99,6 +99,36 @@ describe('FocusedControlEditController', () => {
     );
   });
 
+  it('begins input edit for Backspace and removes the final draft character', async () => {
+    const { host, applyFrame, syncSnapshot, recordTimeline } = createHost();
+    const controller = new FocusedControlEditController(host);
+
+    const result = await controller.applyKey('Backspace');
+
+    expect(result).toBe('handled');
+    expect(host.beginFocusedInputEdit).toHaveBeenCalledTimes(1);
+    expect(host.setFocusedInputEditDraft).toHaveBeenCalledWith('');
+    expect(applyFrame).toHaveBeenCalledTimes(1);
+    expect(syncSnapshot).toHaveBeenCalledTimes(1);
+    expect(recordTimeline).toHaveBeenLastCalledWith(
+      'keyboard-input-edit-state',
+      expect.not.objectContaining({ focusedInputEditValue: expect.anything() })
+    );
+  });
+
+  it('returns Backspace unhandled when the engine reports a non-input focus target', async () => {
+    const { host } = createHost({
+      beginFocusedInputEdit: vi.fn(async () => frame({ activeCardId: 'home', focusedLinkIndex: 1 }))
+    });
+    const controller = new FocusedControlEditController(host);
+
+    const result = await controller.applyKey('Backspace');
+
+    expect(result).toBe('unhandled');
+    expect(host.beginFocusedInputEdit).toHaveBeenCalledTimes(1);
+    expect(host.setFocusedInputEditDraft).not.toHaveBeenCalled();
+  });
+
   it('supports backspace and escape while deferring input commit to the engine', async () => {
     const { host } = createHost({
       getSnapshot: vi.fn(() =>

--- a/browser/frontend/src/app/focused-control-edit.ts
+++ b/browser/frontend/src/app/focused-control-edit.ts
@@ -50,7 +50,7 @@ export class FocusedControlEditController {
     key: string
   ): Promise<ControlEditDisposition> {
     let snapshot = initialSnapshot;
-    if (!snapshot.focusedInputEditName && key.length === 1) {
+    if (!snapshot.focusedInputEditName && (key.length === 1 || key === 'Backspace')) {
       snapshot = (await this.host.beginFocusedInputEdit()).snapshot;
     }
     if (!snapshot.focusedInputEditName) {
@@ -69,7 +69,6 @@ export class FocusedControlEditController {
         key,
         handled: false,
         focusedInputEditName: snapshot.focusedInputEditName ?? null,
-        focusedInputEditValue: snapshot.focusedInputEditValue ?? null,
         focusedLinkIndex: snapshot.focusedLinkIndex,
         phase: 'defer-to-engine'
       });
@@ -92,7 +91,6 @@ export class FocusedControlEditController {
         key,
         handled: false,
         focusedInputEditName: snapshot.focusedInputEditName ?? null,
-        focusedInputEditValue: snapshot.focusedInputEditValue ?? null,
         focusedLinkIndex: snapshot.focusedLinkIndex
       });
       return 'unhandled';
@@ -104,7 +102,6 @@ export class FocusedControlEditController {
       key,
       handled: true,
       focusedInputEditName: snapshot.focusedInputEditName ?? null,
-      focusedInputEditValue: snapshot.focusedInputEditValue ?? null,
       focusedLinkIndex: snapshot.focusedLinkIndex
     });
     return 'handled';

--- a/browser/frontend/src/app/keyboard-intent-router.test.ts
+++ b/browser/frontend/src/app/keyboard-intent-router.test.ts
@@ -124,7 +124,7 @@ describe('KeyboardIntentRouter', () => {
     expect(deps.setStatus).toHaveBeenCalledTimes(1);
   });
 
-  it('falls through to back navigation when the control-edit check does not handle Backspace', async () => {
+  it('retains back navigation when the focused WML target is not an input', async () => {
     const deps = createDeps();
     const router = new KeyboardIntentRouter(deps);
 


### PR DESCRIPTION
## Summary

- begin the engine-owned focused input edit session when an unmodified Backspace reaches an inactive WML input
- consume the key after deleting the final draft character, while preserving Back/history fallback for non-input focus targets
- omit focused input draft values from frontend keyboard timeline diagnostics
- add controller/router regressions and a masked failed-POST/refocused-PIN integration regression

## Root cause

The frontend only called `beginFocusedInputEdit()` for printable one-character keys. Backspace therefore returned `unhandled` when the input remained focused but its edit session was inactive, allowing the keyboard router to invoke engine/host history navigation.

## Impact

Focused WML inputs now handle Backspace consistently before and after failed form submissions without changing engine-owned input, softkey/action, or history semantics. Non-input Backspace behavior is unchanged.

## Verification

- `pnpm verify:change` — all selected lanes passed
- browser frontend: 36 files / 211 tests passed
- targeted controller/router/integration: 3 files / 29 tests passed
- WASM boundary: 28 tests passed
- executable stories: 51 passed
- Tauri host: 64 tests passed; external Kannel tests remain intentionally ignored
- generated contract/schema/icon drift, workspace format/lint/typecheck, production frontend build, and rendered accessibility passed
- pre-push repository checks passed, including 379 native engine tests

Fixes #481
