### PR TITLE
Fix Kannel development process supervision

### DIFF
--- a/docker/kannel/start.sh
+++ b/docker/kannel/start.sh
@@ -1,6 +1,40 @@
 #!/usr/bin/env sh
 set -eu
 
+bearerbox_pid=
+wapbox_pid=
+
+# shellcheck disable=SC2317,SC2329 # Invoked through POSIX signal traps.
+stop_children() {
+  if [ -n "$wapbox_pid" ]; then
+    kill "$wapbox_pid" 2>/dev/null || true
+  fi
+  if [ -n "$bearerbox_pid" ]; then
+    kill "$bearerbox_pid" 2>/dev/null || true
+  fi
+
+  if [ -n "$wapbox_pid" ]; then
+    wait "$wapbox_pid" 2>/dev/null || true
+  fi
+  if [ -n "$bearerbox_pid" ]; then
+    wait "$bearerbox_pid" 2>/dev/null || true
+  fi
+}
+
+# shellcheck disable=SC2329 # Invoked through POSIX signal traps.
+handle_signal() {
+  signal_name="$1"
+  signal_status="$2"
+
+  trap - TERM INT
+  echo "Received $signal_name; stopping Kannel..." >&2
+  stop_children
+  exit "$signal_status"
+}
+
+trap 'handle_signal TERM 143' TERM
+trap 'handle_signal INT 130' INT
+
 echo "Starting Kannel bearerbox..."
 bearerbox /etc/kannel/kannel.conf &
 bearerbox_pid=$!
@@ -13,9 +47,47 @@ wapbox /etc/kannel/kannel.conf &
 wapbox_pid=$!
 
 # POSIX sh has no `wait -n` (wait for whichever background job exits first).
-# Poll instead so the container exits as soon as either process dies, rather
-# than staying up silently with a crashed peer.
-while kill -0 "$bearerbox_pid" 2>/dev/null && kill -0 "$wapbox_pid" 2>/dev/null; do
+# Poll instead, then explicitly reap the failed child and stop/reap its peer.
+exited_name=
+exited_pid=
+surviving_name=
+surviving_pid=
+while [ -z "$exited_pid" ]; do
+  if ! kill -0 "$bearerbox_pid" 2>/dev/null; then
+    exited_name=bearerbox
+    exited_pid="$bearerbox_pid"
+    surviving_name=wapbox
+    surviving_pid="$wapbox_pid"
+  elif ! kill -0 "$wapbox_pid" 2>/dev/null; then
+    exited_name=wapbox
+    exited_pid="$wapbox_pid"
+    surviving_name=bearerbox
+    surviving_pid="$bearerbox_pid"
+  else
     sleep 1
+  fi
 done
-wait
+
+if wait "$exited_pid"; then
+  child_status=0
+else
+  child_status=$?
+fi
+
+echo "Kannel $exited_name exited unexpectedly with status $child_status." >&2
+
+# An unexpected clean child exit still means the two-process service failed.
+if [ "$child_status" -eq 0 ]; then
+  supervisor_status=1
+  echo "Treating unexpected status 0 as supervisor failure status 1." >&2
+else
+  supervisor_status="$child_status"
+fi
+
+if kill -0 "$surviving_pid" 2>/dev/null; then
+  echo "Stopping Kannel $surviving_name..." >&2
+  kill "$surviving_pid" 2>/dev/null || true
+fi
+wait "$surviving_pid" 2>/dev/null || true
+
+exit "$supervisor_status"

--- a/docker/kannel/tests/fake-kannel-child.sh
+++ b/docker/kannel/tests/fake-kannel-child.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env sh
+set -eu
+
+process_name=${0##*/}
+state_dir=${KANNEL_TEST_STATE_DIR:?KANNEL_TEST_STATE_DIR is required}
+
+case "$process_name" in
+  bearerbox)
+    mode=${FAKE_BEARERBOX_MODE:-run}
+    exit_status=${FAKE_BEARERBOX_STATUS:-0}
+    peer_name=wapbox
+    ;;
+  wapbox)
+    mode=${FAKE_WAPBOX_MODE:-run}
+    exit_status=${FAKE_WAPBOX_STATUS:-0}
+    peer_name=bearerbox
+    ;;
+  *)
+    echo "Unexpected fake child name: $process_name" >&2
+    exit 64
+    ;;
+esac
+
+printf '%s\n' "$$" >"$state_dir/$process_name.pid"
+
+case "$mode" in
+  run)
+    exec tail -f /dev/null
+    ;;
+  exit)
+    exit "$exit_status"
+    ;;
+  exit-after-peer-starts)
+    while [ ! -f "$state_dir/$peer_name.pid" ]; do
+      sleep 1
+    done
+    exit "$exit_status"
+    ;;
+  *)
+    echo "Unexpected fake child mode for $process_name: $mode" >&2
+    exit 64
+    ;;
+esac

--- a/docker/kannel/tests/start.test.sh
+++ b/docker/kannel/tests/start.test.sh
@@ -1,0 +1,167 @@
+#!/usr/bin/env sh
+set -eu
+
+ROOT_DIR=$(cd "$(dirname "$0")/../../.." && pwd)
+START_SCRIPT="$ROOT_DIR/docker/kannel/start.sh"
+TEST_DIR=$(mktemp -d "${TMPDIR:-/tmp}/kannel-supervisor-test.XXXXXX")
+FAKE_BIN="$TEST_DIR/bin"
+supervisor_pid=
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+cleanup() {
+  if [ -n "$supervisor_pid" ]; then
+    kill "$supervisor_pid" 2>/dev/null || true
+    wait "$supervisor_pid" 2>/dev/null || true
+  fi
+
+  for pid_file in "$TEST_DIR"/*/*.pid; do
+    if [ -f "$pid_file" ]; then
+      child_pid=$(sed -n '1p' "$pid_file")
+      kill "$child_pid" 2>/dev/null || true
+    fi
+  done
+
+  rm -rf "$TEST_DIR"
+}
+trap cleanup EXIT HUP INT TERM
+
+mkdir -p "$FAKE_BIN"
+cp "$ROOT_DIR/docker/kannel/tests/fake-kannel-child.sh" "$FAKE_BIN/bearerbox"
+cp "$ROOT_DIR/docker/kannel/tests/fake-kannel-child.sh" "$FAKE_BIN/wapbox"
+
+wait_for_file() {
+  awaited_file="$1"
+  awaited_description="$2"
+  attempts=0
+
+  while [ ! -f "$awaited_file" ] && [ "$attempts" -lt 8 ]; do
+    sleep 1
+    attempts=$((attempts + 1))
+  done
+
+  [ -f "$awaited_file" ] || fail "timed out waiting for $awaited_description"
+}
+
+wait_for_exit() {
+  awaited_pid="$1"
+  awaited_description="$2"
+  attempts=0
+
+  while kill -0 "$awaited_pid" 2>/dev/null && [ "$attempts" -lt 6 ]; do
+    sleep 1
+    attempts=$((attempts + 1))
+  done
+
+  if kill -0 "$awaited_pid" 2>/dev/null; then
+    fail "$awaited_description did not exit promptly"
+  fi
+}
+
+assert_process_gone() {
+  pid_file="$1"
+  process_description="$2"
+  wait_for_file "$pid_file" "$process_description pid file"
+  process_pid=$(sed -n '1p' "$pid_file")
+  if kill -0 "$process_pid" 2>/dev/null; then
+    fail "$process_description process $process_pid is still running"
+  fi
+}
+
+run_child_exit_test() {
+  test_name="$1"
+  bearerbox_mode="$2"
+  bearerbox_status="$3"
+  wapbox_mode="$4"
+  wapbox_status="$5"
+  failed_child="$6"
+  raw_child_status="$7"
+  expected_supervisor_status="$8"
+
+  state_dir="$TEST_DIR/$test_name"
+  log_file="$state_dir/supervisor.log"
+  mkdir -p "$state_dir"
+
+  PATH="$FAKE_BIN:$PATH" \
+    KANNEL_TEST_STATE_DIR="$state_dir" \
+    FAKE_BEARERBOX_MODE="$bearerbox_mode" \
+    FAKE_BEARERBOX_STATUS="$bearerbox_status" \
+    FAKE_WAPBOX_MODE="$wapbox_mode" \
+    FAKE_WAPBOX_STATUS="$wapbox_status" \
+    sh "$START_SCRIPT" >"$log_file" 2>&1 &
+  supervisor_pid=$!
+
+  wait_for_file "$state_dir/bearerbox.pid" "bearerbox startup"
+  wait_for_file "$state_dir/wapbox.pid" "wapbox startup"
+  wait_for_exit "$supervisor_pid" "supervisor after $failed_child exit"
+
+  if wait "$supervisor_pid"; then
+    actual_status=0
+  else
+    actual_status=$?
+  fi
+  supervisor_pid=
+
+  if [ "$actual_status" -ne "$expected_supervisor_status" ]; then
+    fail "$test_name expected supervisor status $expected_supervisor_status, got $actual_status"
+  fi
+
+  grep -Fq \
+    "Kannel $failed_child exited unexpectedly with status $raw_child_status." \
+    "$log_file" || fail "$test_name did not identify the failed child and status"
+  if [ "$raw_child_status" -eq 0 ]; then
+    grep -Fq 'Treating unexpected status 0 as supervisor failure status 1.' \
+      "$log_file" || fail "$test_name did not document the status conversion"
+  fi
+
+  assert_process_gone "$state_dir/bearerbox.pid" "$test_name bearerbox"
+  assert_process_gone "$state_dir/wapbox.pid" "$test_name wapbox"
+  rm -f "$state_dir/bearerbox.pid" "$state_dir/wapbox.pid"
+  echo "PASS: $test_name"
+}
+
+run_signal_cleanup_test() {
+  state_dir="$TEST_DIR/signal-cleanup"
+  log_file="$state_dir/supervisor.log"
+  mkdir -p "$state_dir"
+
+  PATH="$FAKE_BIN:$PATH" \
+    KANNEL_TEST_STATE_DIR="$state_dir" \
+    FAKE_BEARERBOX_MODE=run \
+    FAKE_WAPBOX_MODE=run \
+    sh "$START_SCRIPT" >"$log_file" 2>&1 &
+  supervisor_pid=$!
+
+  wait_for_file "$state_dir/bearerbox.pid" "signal test bearerbox startup"
+  wait_for_file "$state_dir/wapbox.pid" "signal test wapbox startup"
+  kill -TERM "$supervisor_pid"
+  wait_for_exit "$supervisor_pid" "supervisor after TERM"
+
+  if wait "$supervisor_pid"; then
+    actual_status=0
+  else
+    actual_status=$?
+  fi
+  supervisor_pid=
+
+  [ "$actual_status" -eq 143 ] || fail "TERM expected status 143, got $actual_status"
+  grep -Fq 'Received TERM; stopping Kannel...' "$log_file" || \
+    fail "TERM cleanup was not logged"
+  assert_process_gone "$state_dir/bearerbox.pid" "TERM bearerbox"
+  assert_process_gone "$state_dir/wapbox.pid" "TERM wapbox"
+  rm -f "$state_dir/bearerbox.pid" "$state_dir/wapbox.pid"
+  echo 'PASS: signal cleanup'
+}
+
+run_child_exit_test \
+  bearerbox-failure exit-after-peer-starts 23 run 0 bearerbox 23 23
+run_child_exit_test \
+  wapbox-failure run 0 exit 37 wapbox 37 37
+run_child_exit_test \
+  clean-child-exit run 0 exit 0 wapbox 0 1
+run_signal_cleanup_test
+
+echo 'PASS: Kannel supervisor tests'


### PR DESCRIPTION
## Summary

- replace the development Kannel supervisor's bare `wait` with explicit failed-child status capture
- terminate and reap the surviving bearerbox/wapbox process before exiting
- handle TERM and INT by terminating and reaping both children
- add deterministic POSIX shell coverage for bearerbox failure, wapbox failure, unexpected clean child exit, prompt shutdown, status propagation, and signal cleanup

## Root cause

The polling loop detected a child exit correctly, but the trailing argument-free `wait` then blocked on the healthy peer and returned success after all jobs completed. That masked the failure and prevented prompt container restart.

## Exit semantics

- propagate an unexpected nonzero child status
- convert an unexpected child status 0 to supervisor status 1
- return 143 for TERM cleanup and 130 for INT cleanup

## Verification

- `sh -n docker/kannel/start.sh docker/kannel/tests/fake-kannel-child.sh docker/kannel/tests/start.test.sh`
- `shellcheck docker/kannel/start.sh docker/kannel/tests/fake-kannel-child.sh docker/kannel/tests/start.test.sh`
- `docker/kannel/tests/start.test.sh`
- focused suite under `alpine:3.22` / BusyBox
- `docker build --target development --tag wap-labs-kannel:issue-438 docker/kannel`
- packaged `/start.sh` syntax and SHA-256 match
- `node scripts/verify.mjs change --base origin/main` through Node 22.22.1
- repository pre-push hook suite

Fixes #438
