### PR TITLE
fix(engine): reject missing fragments on initial deck load

### DIFF
--- a/docs/wml-engine/architecture.md
+++ b/docs/wml-engine/architecture.md
@@ -86,6 +86,10 @@ Compatibility policy:
 - Deterministic rendering for snapshot tests.
 - Never panic across wasm boundary; convert to structured error.
 - Reject malformed/invalid loads atomically without replacing the last successfully loaded deck.
+- Reject an unresolved non-empty fragment on an independent/top-level load with the same stable
+  `Card id not found` error used by same-deck navigation. No fragment or an empty fragment still
+  selects the first card; host-fetched forward navigation retains the WML `<go>` first-card
+  fallback.
 
 ## 7. Future-Proofing Without Overengineering
 

--- a/docs/wml-engine/spec-derived-requirements.md
+++ b/docs/wml-engine/spec-derived-requirements.md
@@ -95,6 +95,8 @@ Minimum output guarantees:
 - Unsupported optional constructs and explicitly recoverable content are ignored with distinct
   diagnostics; recognized nested content remains available where the recovery policy permits it.
 - Invalid internal target (`#missing`) must emit a runtime error event.
+- Invalid independent/top-level target (`deck.wml#missing`) must reject the load atomically with
+  the same deterministic error, while absent and empty fragments select the first card.
 
 ## 10. Conformance Baseline (for this project)
 

--- a/engine-wasm/contracts/wml-engine.ts
+++ b/engine-wasm/contracts/wml-engine.ts
@@ -236,6 +236,8 @@ export interface WmlEngineCommon {
 // WASM target: `loadDeckContext` takes positional arguments because the
 // wasm-bindgen boundary does not carry a structured input object.
 export interface WmlEngineWasm extends WmlEngineCommon {
+  // A non-empty fragment in an independent/top-level URL must resolve; otherwise
+  // the load rejects with the same stable error as same-deck fragment navigation.
   loadDeckContext(
     wmlXml: string,
     baseUrl: string,
@@ -256,6 +258,8 @@ export interface WmlEngineWasm extends WmlEngineCommon {
 
 // Native target: `loadDeckContext` takes the structured `WmlDeckInput`.
 export interface WmlEngineNative extends WmlEngineCommon {
+  // Independent/top-level missing fragments reject atomically; absent and empty
+  // fragments select card 0.
   loadDeckContext(input: WmlDeckInput): void;
 }
 

--- a/engine-wasm/engine/src/engine_public_api.rs
+++ b/engine-wasm/engine/src/engine_public_api.rs
@@ -176,8 +176,12 @@ impl WmlEngine {
         next.content_type = content_type.to_string();
         next.raw_bytes_base64 = raw_bytes_base64;
         next.last_wml_load_diagnostics = parsed.diagnostics;
-        next.active_card_idx =
-            next.destination_card_index(navigation.navigation_url.unwrap_or(base_url));
+        next.active_card_idx = next
+            .destination_card_index(
+                navigation.navigation_url.unwrap_or(base_url),
+                navigation.kind,
+            )
+            .map_err(WmlLoadDiagnostic::recoverable_rejection)?;
         let reset_context = navigation.kind == DeckNavigationKind::Forward
             && next
                 .deck
@@ -211,14 +215,29 @@ impl WmlEngine {
         Ok(())
     }
 
-    fn destination_card_index(&self, navigation_url: &str) -> usize {
+    fn destination_card_index(
+        &self,
+        navigation_url: &str,
+        navigation_kind: DeckNavigationKind,
+    ) -> Result<usize, String> {
         let fragment = navigation_url
             .split_once('#')
             .map(|(_, fragment)| fragment)
             .filter(|fragment| !fragment.is_empty());
-        fragment
-            .and_then(|fragment| self.deck.as_ref()?.card_index(fragment))
-            .unwrap_or(0)
+        let Some(fragment) = fragment else {
+            return Ok(0);
+        };
+        match self
+            .deck
+            .as_ref()
+            .and_then(|deck| deck.card_index(fragment))
+        {
+            Some(index) => Ok(index),
+            None if navigation_kind == DeckNavigationKind::Independent => {
+                Err(CARD_ID_NOT_FOUND_ERROR.to_string())
+            }
+            None => Ok(0),
+        }
     }
 
     /// Diagnostics emitted by the most recent WML load attempt.

--- a/engine-wasm/engine/src/engine_runtime_internal/navigation.rs
+++ b/engine-wasm/engine/src/engine_runtime_internal/navigation.rs
@@ -101,7 +101,7 @@ impl WmlEngine {
 
         let next_idx = deck
             .card_index(id)
-            .ok_or_else(|| "Card id not found".to_string())?;
+            .ok_or_else(|| CARD_ID_NOT_FOUND_ERROR.to_string())?;
         let reset_context = apply_new_context && deck.cards[next_idx].new_context;
 
         // Every fallible entry step below rolls back all navigation state for

--- a/engine-wasm/engine/src/engine_tests/wml_301_context_history.rs
+++ b/engine-wasm/engine/src/engine_tests/wml_301_context_history.rs
@@ -1,5 +1,8 @@
 use super::*;
-use crate::{DeckNavigationContext, DeckNavigationKind};
+use crate::{
+    DeckNavigationContext, DeckNavigationKind, WmlLoadDiagnosticClassLiteral,
+    WmlLoadDiagnosticCodeLiteral, WmlLoadDiagnosticOutcomeLiteral,
+};
 
 const CONTENT_TYPE: &str = "text/vnd.wap.wml";
 
@@ -88,6 +91,77 @@ fn wml_301_forward_load_falls_back_to_first_card_for_unknown_fragment() {
     );
 
     assert_eq!(engine.active_card_id().as_deref(), Ok("first"));
+}
+
+#[test]
+fn wml_301_independent_load_rejects_unknown_fragment_and_preserves_state() {
+    let mut engine = WmlEngine::new();
+    engine
+        .load_deck_context(
+            r#"<wml><card id="source"><p>Source</p></card></wml>"#,
+            "http://example.test/source.wml",
+            CONTENT_TYPE,
+            None,
+        )
+        .expect("source deck should load");
+    assert!(engine.set_var("token".to_string(), "kept".to_string()));
+    let epoch = engine.browser_context_epoch();
+    let trace =
+        serde_json::to_value(engine.trace_entries()).expect("trace entries should serialize");
+
+    let error = engine
+        .load_deck_context(
+            r#"<wml><card id="first"><p>First</p></card></wml>"#,
+            "http://example.test/destination.wml#missing",
+            CONTENT_TYPE,
+            None,
+        )
+        .expect_err("an unknown top-level fragment should reject the load");
+
+    assert_eq!(error, "Card id not found");
+    let diagnostics = engine.last_wml_load_diagnostics();
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(
+        diagnostics[0].class,
+        WmlLoadDiagnosticClassLiteral::Recoverable
+    );
+    assert_eq!(
+        diagnostics[0].code,
+        WmlLoadDiagnosticCodeLiteral::RecoverableContent
+    );
+    assert_eq!(
+        diagnostics[0].outcome,
+        WmlLoadDiagnosticOutcomeLiteral::Rejected
+    );
+    assert_eq!(diagnostics[0].message, error);
+    assert_eq!(engine.active_card_id().as_deref(), Ok("source"));
+    assert_eq!(engine.base_url(), "http://example.test/source.wml");
+    assert_eq!(engine.get_var("token".to_string()).as_deref(), Some("kept"));
+    assert_eq!(engine.browser_context_epoch(), epoch);
+    assert_eq!(
+        serde_json::to_value(engine.trace_entries()).expect("trace entries should serialize"),
+        trace
+    );
+}
+
+#[test]
+fn wml_301_independent_load_without_nonempty_fragment_selects_first_card() {
+    for url in [
+        "http://example.test/destination.wml",
+        "http://example.test/destination.wml#",
+    ] {
+        let mut engine = WmlEngine::new();
+        engine
+            .load_deck_context(
+                r#"<wml><card id="first"><p>First</p></card><card id="second"><p>Second</p></card></wml>"#,
+                url,
+                CONTENT_TYPE,
+                None,
+            )
+            .expect("no fragment or an empty fragment should load the first card");
+
+        assert_eq!(engine.active_card_id().as_deref(), Ok("first"), "{url}");
+    }
 }
 
 #[test]

--- a/engine-wasm/engine/src/engine_wasm_bindings_tests.rs
+++ b/engine-wasm/engine/src/engine_wasm_bindings_tests.rs
@@ -407,6 +407,108 @@ fn wasm_wml_301_forward_deck_load_preserves_context_and_selects_fragment() {
 }
 
 #[wasm_bindgen_test]
+fn wasm_wml_301_independent_load_rejects_unknown_fragment_and_preserves_state() {
+    let mut engine = WmlEngine::wasm_new();
+    engine
+        .load_deck_context_wasm(
+            r#"<wml><card id="source"><p>Source</p></card></wml>"#,
+            "http://example.test/source.wml",
+            "text/vnd.wap.wml",
+            None,
+            None,
+        )
+        .expect("source deck should load through the wasm boundary");
+    assert!(engine.set_var_wasm("token".to_string(), "kept".to_string()));
+    let epoch = engine.browser_context_epoch_wasm();
+
+    let error = engine
+        .load_deck_context_wasm(
+            r#"<wml><card id="first"><p>First</p></card></wml>"#,
+            "http://example.test/destination.wml#missing",
+            "text/vnd.wap.wml",
+            None,
+            None,
+        )
+        .expect_err("an unknown top-level fragment should reject the wasm load");
+
+    assert_eq!(error.as_string().as_deref(), Some("Card id not found"));
+    let diagnostics = Array::from(
+        &engine
+            .last_wml_load_diagnostics_wasm()
+            .expect("load diagnostics should serialize"),
+    );
+    assert_eq!(diagnostics.length(), 1);
+    let diagnostic = diagnostics.get(0);
+    assert_eq!(
+        Reflect::get(&diagnostic, &JsValue::from_str("class"))
+            .expect("class field")
+            .as_string()
+            .as_deref(),
+        Some("recoverable")
+    );
+    assert_eq!(
+        Reflect::get(&diagnostic, &JsValue::from_str("code"))
+            .expect("code field")
+            .as_string()
+            .as_deref(),
+        Some("WML_RECOVERABLE_CONTENT")
+    );
+    assert_eq!(
+        Reflect::get(&diagnostic, &JsValue::from_str("outcome"))
+            .expect("outcome field")
+            .as_string()
+            .as_deref(),
+        Some("rejected")
+    );
+    assert_eq!(
+        Reflect::get(&diagnostic, &JsValue::from_str("message"))
+            .expect("message field")
+            .as_string()
+            .as_deref(),
+        Some("Card id not found")
+    );
+    assert_eq!(
+        engine
+            .active_card_id_wasm()
+            .expect("rejected load must preserve the active card"),
+        "source"
+    );
+    assert_eq!(engine.base_url_wasm(), "http://example.test/source.wml");
+    assert_eq!(
+        engine.get_var_wasm("token".to_string()).as_deref(),
+        Some("kept")
+    );
+    assert_eq!(engine.browser_context_epoch_wasm(), epoch);
+}
+
+#[wasm_bindgen_test]
+fn wasm_wml_301_independent_load_without_nonempty_fragment_selects_first_card() {
+    for url in [
+        "http://example.test/destination.wml",
+        "http://example.test/destination.wml#",
+    ] {
+        let mut engine = WmlEngine::wasm_new();
+        engine
+            .load_deck_context_wasm(
+                r#"<wml><card id="first"><p>First</p></card><card id="second"><p>Second</p></card></wml>"#,
+                url,
+                "text/vnd.wap.wml",
+                None,
+                None,
+            )
+            .expect("no fragment or an empty fragment should load the first card");
+
+        assert_eq!(
+            engine
+                .active_card_id_wasm()
+                .expect("the first card should be active"),
+            "first",
+            "{url}"
+        );
+    }
+}
+
+#[wasm_bindgen_test]
 fn wasm_wml_202_head_metadata_parser_matches_native_boundary_behavior() {
     let valid = r#"
         <wml>

--- a/engine-wasm/engine/src/lib.rs
+++ b/engine-wasm/engine/src/lib.rs
@@ -96,6 +96,7 @@ const MAX_TIMER_DISPATCH_DEPTH: u8 = 8;
 const MAX_NAV_DISPATCH_DEPTH: u8 = 8;
 const MAX_DECK_WML_XML_BYTES: usize = 512 * 1024;
 const MAX_DECK_RAW_BYTES_BASE64_BYTES: usize = 1024 * 1024;
+const CARD_ID_NOT_FOUND_ERROR: &str = "Card id not found";
 
 /// Panic-containment boundary for public engine entrypoints.
 ///


### PR DESCRIPTION
## Summary

- reject unresolved non-empty fragments on independent/top-level deck loads with the stable `Card id not found` error
- preserve the previous engine state while publishing a deterministic rejected load diagnostic
- retain card-0 selection for absent or empty fragments and preserve WML `<go>` cross-deck fallback behavior
- add native and wasm32 parity regressions and document the boundary contract

## Root cause

`destination_card_index` collapsed both absent fragments and failed non-empty fragment lookups to card index 0. Initial `loadDeckContext` calls therefore committed the parsed deck and silently selected its first card instead of surfacing the same error used by same-deck navigation.

## Verification

- `cargo test --manifest-path engine-wasm/engine/Cargo.toml wml_301_`
- `fnm exec --using=22.22.1 -- wasm-pack test --node engine-wasm/engine`
- `fnm exec --using=22.22.1 -- pnpm test:story WML-301`
- `fnm exec --using=22.22.1 -- pnpm verify:change`
- `fnm exec --using=22.22.1 -- pnpm verify:full`
- `fnm exec --using=22.22.1 -- pnpm wap-compliance:check`
- `cargo clippy --manifest-path engine-wasm/engine/Cargo.toml --all-targets --all-features -- -D warnings`
- `make coverage-rust-engine` (95.64% lines, 94.28% functions)

No new executable story was added because the current story action model requires a successfully loaded initial deck and cannot represent a rejected top-level load while retaining a prior engine instance; the existing WML-301 story suite remains green.

Fixes #461
