### PR TITLE
fix(transport): validate connectionless content-type bounds

### DIFF
--- a/transport-rust/src/network/wsp/connectionless.rs
+++ b/transport-rust/src/network/wsp/connectionless.rs
@@ -499,7 +499,8 @@ pub fn decode_connectionless_pdu(
             let uri = decode_uri(&body[..uri_len])?;
             let header_section = &body[uri_len..total_prefix];
             let content_type = decode_content_type_value(header_section)?;
-            let headers = header_section[content_type.consumed_bytes()..].to_vec();
+            let headers =
+                headers_after_content_type(header_section, content_type.consumed_bytes())?.to_vec();
             Ok(WspConnectionlessPdu::Post {
                 transaction_id,
                 uri,
@@ -518,7 +519,8 @@ pub fn decode_connectionless_pdu(
             }
             let (header_section, data) = body.split_at(headers_len);
             let content_type = decode_content_type_value(header_section)?;
-            let headers = header_section[content_type.consumed_bytes()..].to_vec();
+            let headers =
+                headers_after_content_type(header_section, content_type.consumed_bytes())?.to_vec();
             Ok(WspConnectionlessPdu::Reply {
                 transaction_id,
                 status_code: decode_wsp_status_code(status)?,
@@ -529,6 +531,15 @@ pub fn decode_connectionless_pdu(
         }
         _ => Err(WspConnectionlessDecodeError::UnexpectedPduType(pdu_type)),
     }
+}
+
+fn headers_after_content_type(
+    header_section: &[u8],
+    content_type_bytes: usize,
+) -> Result<&[u8], WspConnectionlessDecodeError> {
+    header_section
+        .get(content_type_bytes..)
+        .ok_or(WspConnectionlessDecodeError::ContentTypeOverrunsHeaderSection)
 }
 
 fn decode_request_uri(input: &[u8]) -> Result<(String, &[u8]), WspConnectionlessDecodeError> {
@@ -1111,6 +1122,60 @@ mod tests {
         assert_eq!(decoded.media_type(), "application/vnd.wap.wmlc");
         assert_eq!(decoded.charset(), Some("iso-8859-1"));
         assert_eq!(decoded.consumed_bytes(), 4);
+    }
+
+    #[test]
+    fn content_type_header_boundary_rejects_an_overrun() {
+        let header_section = [0x94, 0x80];
+
+        assert_eq!(
+            headers_after_content_type(&header_section, header_section.len()),
+            Ok(&[][..])
+        );
+        assert_eq!(
+            headers_after_content_type(&header_section, header_section.len() + 1),
+            Err(WspConnectionlessDecodeError::ContentTypeOverrunsHeaderSection)
+        );
+    }
+
+    #[test]
+    fn post_and_reply_reject_content_type_beyond_declared_header_section() {
+        // The short-length Content-Type declares two value octets, but the
+        // carrying Post/Reply header section declares room for only the length
+        // octet. Bytes after that boundary are body data and must not be used to
+        // complete Content-Type or reached by unchecked slicing.
+        let post = [TRANSACTION_ID, 0x60, 0x01, 0x01, b'/', 0x02, b'x', b'y'];
+        let reply = [TRANSACTION_ID, 0x04, 0x20, 0x01, 0x02, b'x', b'y'];
+
+        for wire in [&post[..], &reply[..]] {
+            assert_eq!(
+                decode_connectionless_pdu(wire),
+                Err(WspConnectionlessDecodeError::TruncatedContentType)
+            );
+        }
+    }
+
+    #[test]
+    fn post_and_reply_header_length_inputs_never_panic() {
+        for declared_length in 0u8..=8 {
+            for actual_length in 0u8..=8 {
+                for first_content_type_byte in 0u8..=u8::MAX {
+                    let mut post = vec![TRANSACTION_ID, 0x60, 0x00, declared_length];
+                    post.extend(std::iter::repeat_n(
+                        first_content_type_byte,
+                        usize::from(actual_length),
+                    ));
+                    let _ = decode_connectionless_pdu(&post);
+
+                    let mut reply = vec![TRANSACTION_ID, 0x04, 0x20, declared_length];
+                    reply.extend(std::iter::repeat_n(
+                        first_content_type_byte,
+                        usize::from(actual_length),
+                    ));
+                    let _ = decode_connectionless_pdu(&reply);
+                }
+            }
+        }
     }
 
     #[test]

--- a/transport-rust/tests/fuzz_lite_decoders.rs
+++ b/transport-rust/tests/fuzz_lite_decoders.rs
@@ -11,7 +11,7 @@
 //! deeper decoder logic.
 //!
 //! `#[ignore]`d (manual-only, like the other exploratory/slow tests in this
-//! crate) because ~9.5M decode calls take a couple of seconds even in
+//! crate) because ~11M decode calls take a couple of seconds even in
 //! release mode and add no value to the default `cargo test` loop. Run
 //! explicitly with:
 //! `cargo test --release --test fuzz_lite_decoders -- --ignored`
@@ -20,6 +20,7 @@ use lowband_transport_rust::network::wcmp::{
     decode_wcmp, decode_wdp_control_message, WdpControlProfile,
 };
 use lowband_transport_rust::network::wdp::decode_cdpd_ipv4_udp;
+use lowband_transport_rust::network::wsp::connectionless::decode_connectionless_pdu;
 use lowband_transport_rust::network::wsp::{decode_wsp_pdu, WspHeaderBlockDecodePolicy};
 
 struct Xorshift64(u64);
@@ -110,17 +111,20 @@ fn load_seeds(fixture_relative_path: &str, cases_key: &str) -> Vec<Vec<u8>> {
 }
 
 #[test]
-#[ignore = "slow fuzz-lite pass (~9.5M decode calls); run manually with --release"]
+#[ignore = "slow fuzz-lite pass (~11M decode calls); run manually with --release"]
 fn decoders_never_panic_on_mutated_valid_packets() {
     let wcmp_seeds = load_seeds("wcmp_core_mapped/wcmp_fixture.json", "cases");
     let icmp_seeds = load_seeds("wcmp_cdpd_icmp_profile/icmp_fixture.json", "cases");
     let wdp_seeds = load_seeds("wdp_cdpd_ipv4_mapped/wdp_fixture.json", "cases");
     let wsp_pdu_seeds = load_seeds("wsp_pdu_baseline_mapped/pdu_fixture.json", "successCases");
+    let wsp_connectionless_seeds =
+        load_seeds("wsp_connectionless_matrix/matrix_fixture.json", "pduCases");
 
     assert!(!wcmp_seeds.is_empty());
     assert!(!icmp_seeds.is_empty());
     assert!(!wdp_seeds.is_empty());
     assert!(!wsp_pdu_seeds.is_empty());
+    assert!(!wsp_connectionless_seeds.is_empty());
 
     let mut rng = Xorshift64(0x9E3779B97F4A7C15);
     let mut panics: Vec<String> = Vec::new();
@@ -171,6 +175,13 @@ fn decoders_never_panic_on_mutated_valid_packets() {
     fuzz!("decode_wsp_pdu", wsp_pdu_seeds, |b: &[u8]| {
         let _ = decode_wsp_pdu(b, WspHeaderBlockDecodePolicy::STRICT);
     });
+    fuzz!(
+        "decode_connectionless_pdu",
+        wsp_connectionless_seeds,
+        |b: &[u8]| {
+            let _ = decode_connectionless_pdu(b);
+        }
+    );
 
     assert!(
         panics.is_empty(),


### PR DESCRIPTION
## Summary

- validate decoded Content-Type byte consumption with a shared checked-slice boundary for connectionless POST and Reply PDUs
- preserve the existing decoder API and make `ContentTypeOverrunsHeaderSection` reachable through an explicitly tested boundary
- add malformed header-length regression/property coverage and connectionless seeds to the deterministic fuzz-lite decoder probe

## Verification

- `cargo test --manifest-path transport-rust/Cargo.toml network::wsp::connectionless::tests`
- `cargo test --manifest-path transport-rust/Cargo.toml --test wsp_connectionless_matrix`
- `cargo test --release --manifest-path transport-rust/Cargo.toml --test fuzz_lite_decoders -- --ignored`
- `make lint-rust-transport`
- `make test-rust-transport`
- `pnpm --dir browser run contracts:check`
- `pnpm run wap-compliance:check`
- `pnpm run wap-graph:check`
- worklist, ticket-reference, source-corpus, Rust, Node, and whitespace drift/format checks

Fixes #463
