### PR TITLE
fix(browser): re-arm blocked engine timer wakeups

### DIFF
--- a/browser/frontend/src/app/engine-timer-runtime.test.ts
+++ b/browser/frontend/src/app/engine-timer-runtime.test.ts
@@ -80,6 +80,153 @@ describe('EngineTimerRuntime', () => {
     expect(advanceLocal).toHaveBeenCalledWith(275);
   });
 
+  it('re-arms a native timer wakeup skipped while an action is in flight', async () => {
+    let actionInFlight = true;
+    const advanceLocal = vi.fn(async () => snapshot({ activeCardId: 'done', focusedLinkIndex: 0 }));
+    const deps = createDeps({
+      canTick: () => !actionInFlight,
+      advanceLocal
+    });
+    const runtime = new EngineTimerRuntime(deps);
+
+    runtime.start();
+    runtime.applySnapshot(
+      snapshot({ activeCardId: 'timed', focusedLinkIndex: 0, nextTimerWakeupMs: 100 })
+    );
+
+    await vi.advanceTimersByTimeAsync(100);
+    expect(advanceLocal).not.toHaveBeenCalled();
+    expect(vi.getTimerCount()).toBe(1);
+
+    actionInFlight = false;
+    await vi.advanceTimersByTimeAsync(100);
+    expect(advanceLocal).toHaveBeenCalledOnce();
+    expect(advanceLocal).toHaveBeenCalledWith(100);
+  });
+
+  it('stops a re-armed blocked wakeup without scheduling again', async () => {
+    let actionInFlight = true;
+    const advanceLocal = vi.fn(async () => snapshot({ activeCardId: 'done', focusedLinkIndex: 0 }));
+    const deps = createDeps({
+      canTick: () => !actionInFlight,
+      advanceLocal
+    });
+    const runtime = new EngineTimerRuntime(deps);
+
+    runtime.start();
+    runtime.applySnapshot(
+      snapshot({ activeCardId: 'timed', focusedLinkIndex: 0, nextTimerWakeupMs: 100 })
+    );
+    await vi.advanceTimersByTimeAsync(100);
+    expect(vi.getTimerCount()).toBe(1);
+
+    runtime.stop();
+    actionInFlight = false;
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    expect(advanceLocal).not.toHaveBeenCalled();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('preserves script timer cadence across a blocked wakeup', async () => {
+    let actionInFlight = true;
+    const advanceLocal = vi.fn(async () => snapshot({ activeCardId: 'home', focusedLinkIndex: 0 }));
+    const deps = createDeps({
+      canTick: () => !actionInFlight,
+      advanceLocal
+    });
+    const runtime = new EngineTimerRuntime(deps);
+
+    runtime.start();
+    runtime.applySnapshot(
+      snapshot({
+        activeCardId: 'home',
+        focusedLinkIndex: 0,
+        lastScriptTimerRequests: [{ type: 'schedule', token: 'blocked', delayMs: 80 }]
+      })
+    );
+
+    await vi.advanceTimersByTimeAsync(80);
+    expect(advanceLocal).not.toHaveBeenCalled();
+    expect(vi.getTimerCount()).toBe(1);
+
+    actionInFlight = false;
+    await vi.advanceTimersByTimeAsync(79);
+    expect(advanceLocal).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(1);
+
+    expect(advanceLocal).toHaveBeenCalledWith(80);
+    expect(deps.recordTimeline).toHaveBeenCalledWith(
+      'script-timer-expire',
+      'state',
+      expect.objectContaining({ token: 'blocked', dueMs: 80, nowMs: 80 })
+    );
+  });
+
+  it('backs off an already-due blocked timer to the engine cadence', async () => {
+    let actionInFlight = true;
+    const advanceLocal = vi.fn(async () => snapshot({ activeCardId: 'home', focusedLinkIndex: 0 }));
+    const deps = createDeps({
+      canTick: () => !actionInFlight,
+      advanceLocal
+    });
+    const runtime = new EngineTimerRuntime(deps);
+
+    runtime.start();
+    runtime.applySnapshot(
+      snapshot({ activeCardId: 'home', focusedLinkIndex: 0, nextTimerWakeupMs: 0 })
+    );
+    await vi.advanceTimersByTimeAsync(0);
+    expect(advanceLocal).not.toHaveBeenCalled();
+    expect(vi.getTimerCount()).toBe(1);
+
+    actionInFlight = false;
+    await vi.advanceTimersByTimeAsync(99);
+    expect(advanceLocal).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(1);
+
+    expect(advanceLocal).toHaveBeenCalledWith(100);
+  });
+
+  it('lets the active tick re-arm after re-entrant wakeups without duplicate timers', async () => {
+    let releaseTick: (() => void) | undefined;
+    const advanceLocal = vi
+      .fn()
+      .mockImplementationOnce(
+        async () =>
+          new Promise<ReturnType<typeof snapshot>>((resolve) => {
+            releaseTick = () =>
+              resolve(
+                snapshot({ activeCardId: 'home', focusedLinkIndex: 0, nextTimerWakeupMs: 100 })
+              );
+          })
+      )
+      .mockResolvedValue(snapshot({ activeCardId: 'done', focusedLinkIndex: 0 }));
+    const deps = createDeps({ advanceLocal });
+    const runtime = new EngineTimerRuntime(deps);
+
+    runtime.start();
+    runtime.applySnapshot(
+      snapshot({ activeCardId: 'home', focusedLinkIndex: 0, nextTimerWakeupMs: 100 })
+    );
+    const firstTick = runtime.tick();
+
+    await vi.advanceTimersByTimeAsync(100);
+    expect(advanceLocal).toHaveBeenCalledOnce();
+    expect(vi.getTimerCount()).toBe(0);
+
+    await runtime.tick();
+    expect(vi.getTimerCount()).toBe(0);
+
+    releaseTick?.();
+    await firstTick;
+    expect(vi.getTimerCount()).toBe(1);
+
+    await vi.advanceTimersByTimeAsync(100);
+    expect(advanceLocal).toHaveBeenCalledTimes(2);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
   it('renders local snapshots when timer advancement changes state', async () => {
     const deps = createDeps({
       advanceLocal: vi.fn(async () =>

--- a/browser/frontend/src/app/engine-timer-runtime.ts
+++ b/browser/frontend/src/app/engine-timer-runtime.ts
@@ -66,7 +66,13 @@ export class EngineTimerRuntime {
   }
 
   async tick(deltaMs: number = WAVES_CONFIG.engineTimerTickMs): Promise<void> {
-    if (this.timerTickInFlight || !this.deps.canTick()) {
+    if (this.timerTickInFlight) {
+      return;
+    }
+    if (!this.deps.canTick()) {
+      if (this.timerLoopHandle === null) {
+        this.scheduleNextWakeup(WAVES_CONFIG.engineTimerTickMs);
+      }
       return;
     }
     this.timerTickInFlight = true;
@@ -110,7 +116,7 @@ export class EngineTimerRuntime {
     }
   }
 
-  private scheduleNextWakeup(): void {
+  private scheduleNextWakeup(minimumDelayMs = 0): void {
     if (!this.running || this.timerTickInFlight) {
       return;
     }
@@ -124,7 +130,8 @@ export class EngineTimerRuntime {
     if (delays.length === 0) {
       return;
     }
-    const delayMs = Math.max(0, Math.min(...delays));
+    const requestedDelayMs = Math.max(0, Math.min(...delays));
+    const delayMs = requestedDelayMs === 0 ? minimumDelayMs : requestedDelayMs;
     this.timerLoopHandle = setTimeout(() => {
       this.timerLoopHandle = null;
       void this.tick(delayMs);


### PR DESCRIPTION
## Summary

- re-arm the engine timer timeout chain when a scheduled tick is blocked by an in-flight keyboard action
- preserve positive native/WMLScript wakeup delays while backing already-due retries off to the 100 ms engine cadence
- keep reentrant in-flight skips single-timer and ensure stop still cancels recovery

## Root cause

The scheduled timeout cleared its handle before calling `tick()`. When `canTick()` was false, `tick()` returned before the existing `finally` rescheduling path, leaving no timeout to advance native WML or WMLScript timers.

## Verification

- `pnpm --dir browser/frontend exec vitest run src/app/engine-timer-runtime.test.ts` — 11 passed
- `pnpm --dir browser/frontend test` — 216 passed
- `pnpm --dir browser/frontend run lint`
- `pnpm --dir browser/frontend run typecheck`
- `pnpm --dir browser/frontend run format:check`
- `pnpm --dir browser run contracts:check`
- `pnpm test:story WML-305` — 4 passed
- `pnpm run verify:change` — all selected lanes passed, including 51 executable stories, 30 WASM boundary tests, 64 Tauri host tests, and rendered accessibility
- pre-push repository checks — passed

Fixes #435
