### PR TITLE
fix(wml-origin): conceal login and registration PINs

### DIFF
--- a/browser/src-tauri/tests/kannel_smoke.rs
+++ b/browser/src-tauri/tests/kannel_smoke.rs
@@ -89,6 +89,61 @@ fn unique_smoke_username(prefix: &str) -> String {
     format!("{prefix}{nonce}")
 }
 
+fn edit_auth_form_and_build_payload(url: &str, username: &str, pin: &str) -> String {
+    let transport =
+        fetch_deck_in_process_with_profile(request(url), FetchTransportProfile::WapNetCore);
+    assert!(
+        transport.ok,
+        "expected public auth form fetch to succeed: {:?}",
+        transport.error
+    );
+
+    let mut engine = WmlEngine::new();
+    load_transport_response_into_engine(&mut engine, transport);
+    assert!(engine
+        .begin_focused_input_edit()
+        .expect("username edit should begin"));
+    assert!(engine.set_focused_input_edit_draft(username.to_string()));
+    engine
+        .handle_key("down".to_string())
+        .expect("username should commit and focus should move to PIN");
+    assert!(engine
+        .begin_focused_input_edit()
+        .expect("PIN edit should begin"));
+    assert!(engine.set_focused_input_edit_draft(pin.to_string()));
+    assert!(
+        render_contains(&engine, "****"),
+        "password render should conceal the PIN during editing"
+    );
+    assert!(
+        !render_contains(&engine, pin),
+        "password render exposed the edited PIN"
+    );
+    assert!(engine
+        .commit_focused_input_edit()
+        .expect("PIN edit should commit"));
+    assert!(
+        render_contains(&engine, "****"),
+        "password render should conceal the committed PIN"
+    );
+    assert!(
+        !render_contains(&engine, pin),
+        "password render exposed the committed PIN"
+    );
+    if engine.get_var("pin".to_string()).as_deref() != Some(pin) {
+        panic!("engine did not preserve the actual PIN variable");
+    }
+
+    engine
+        .handle_key("enter".to_string())
+        .expect("accept action should submit the auth form");
+    engine
+        .external_navigation_request_policy()
+        .and_then(|policy| policy.post_context)
+        .and_then(|post_context| post_context.payload)
+        .expect("auth form should produce a POST payload")
+}
+
 #[test]
 #[ignore = "runs against external Kannel dev stack (make up)"]
 fn kannel_fetch_deck_smoke_loads_into_engine() {
@@ -116,16 +171,21 @@ fn kannel_fetch_deck_smoke_navigates_into_menu_card() {
 
 #[test]
 #[ignore = "runs against external Kannel dev stack (make up)"]
-fn kannel_native_post_smoke_loads_login_success_deck_into_engine() {
+fn kannel_public_auth_forms_conceal_pin_and_submit_actual_value() {
     let register_url = std::env::var("WAP_SMOKE_REGISTER_URL")
         .unwrap_or_else(|_| "wap://localhost/register".to_string());
     let login_url = std::env::var("WAP_SMOKE_LOGIN_URL")
         .unwrap_or_else(|_| "wap://localhost/login".to_string());
     let username = unique_smoke_username("enginesmoke");
-    let payload = format!("username={username}&pin=1234");
+    let pin = "1274";
+
+    let register_payload = edit_auth_form_and_build_payload(&register_url, &username, pin);
+    if register_payload != format!("username={username}&pin={pin}") {
+        panic!("registration form POST did not retain the actual PIN");
+    }
 
     let register = fetch_deck_in_process_with_profile(
-        post_request(&register_url, &payload),
+        post_request(&register_url, &register_payload),
         FetchTransportProfile::WapNetCore,
     );
     assert!(
@@ -134,8 +194,13 @@ fn kannel_native_post_smoke_loads_login_success_deck_into_engine() {
         register.error
     );
 
+    let login_payload = edit_auth_form_and_build_payload(&login_url, &username, pin);
+    if login_payload != register_payload {
+        panic!("login form POST did not retain the actual PIN");
+    }
+
     let login = fetch_deck_in_process_with_profile(
-        post_request(&login_url, &payload),
+        post_request(&login_url, &login_payload),
         FetchTransportProfile::WapNetCore,
     );
     assert!(

--- a/scripts/transport-wap-smoke.sh
+++ b/scripts/transport-wap-smoke.sh
@@ -13,6 +13,7 @@ WAP_SMOKE_DENIED_URL="${WAP_SMOKE_DENIED_URL:-wap://127.0.0.1:9200/}"
 TRANSPORT_WAP_TIMEOUT_MS="${TRANSPORT_WAP_TIMEOUT_MS:-15000}"
 TRANSPORT_WAP_RETRIES="${TRANSPORT_WAP_RETRIES:-1}"
 TRANSPORT_WAP_SKIP_INTERNAL_HEALTH="${TRANSPORT_WAP_SKIP_INTERNAL_HEALTH:-0}"
+AUTH_FORM_SMOKE_RAN=0
 case "${TRANSPORT_WAP_SKIP_INTERNAL_HEALTH}" in
   0 | 1) ;;
   *) echo 'TRANSPORT_WAP_SKIP_INTERNAL_HEALTH must be 0 or 1' >&2; exit 2 ;;
@@ -47,11 +48,19 @@ print_failure_diagnostics() {
   fi
 
   if [ "${TRANSPORT_WAP_SKIP_INTERNAL_HEALTH}" = 0 ] && command -v docker >/dev/null 2>&1; then
-    echo "-- docker compose logs (kannel, wml-server) --" >&2
-    (
-      cd "${ROOT_DIR}" &&
-      docker compose logs --tail=120 kannel wml-server
-    ) | tee "${SMOKE_ARTIFACT_DIR}/docker-compose.log" >&2 || true
+    if [ "${AUTH_FORM_SMOKE_RAN}" = 1 ]; then
+      echo "-- docker compose logs (wml-server; Kannel omitted after auth submission) --" >&2
+      (
+        cd "${ROOT_DIR}" &&
+        docker compose logs --tail=120 wml-server
+      ) | tee "${SMOKE_ARTIFACT_DIR}/docker-compose.log" >&2 || true
+    else
+      echo "-- docker compose logs (kannel, wml-server) --" >&2
+      (
+        cd "${ROOT_DIR}" &&
+        docker compose logs --tail=120 kannel wml-server
+      ) | tee "${SMOKE_ARTIFACT_DIR}/docker-compose.log" >&2 || true
+    fi
   fi
 
   return "${exit_code}"
@@ -109,9 +118,18 @@ echo "==> Running browser host native Kannel smoke unit test"
 echo "==> Running browser engine/render native Kannel smoke integration test"
 (
   cd "${ROOT_DIR}/browser/src-tauri"
-  export WAP_SMOKE_URL TRANSPORT_WAP_TIMEOUT_MS TRANSPORT_WAP_RETRIES
+  export WAP_SMOKE_URL WAP_SMOKE_LOGIN_URL WAP_SMOKE_REGISTER_URL TRANSPORT_WAP_TIMEOUT_MS TRANSPORT_WAP_RETRIES
   run_and_tee "${SMOKE_ARTIFACT_DIR}/browser-render-native-smoke.log" \
     cargo test kannel_fetch_deck_smoke_navigates_into_menu_card -- --ignored --test-threads=1
+)
+
+echo "==> Running browser auth-form privacy native Kannel smoke integration test"
+AUTH_FORM_SMOKE_RAN=1
+(
+  cd "${ROOT_DIR}/browser/src-tauri"
+  export WAP_SMOKE_LOGIN_URL WAP_SMOKE_REGISTER_URL TRANSPORT_WAP_TIMEOUT_MS TRANSPORT_WAP_RETRIES
+  run_and_tee "${SMOKE_ARTIFACT_DIR}/browser-auth-forms-smoke.log" \
+    cargo test kannel_public_auth_forms_conceal_pin_and_submit_actual_value -- --ignored --test-threads=1
 )
 
 echo "transport-wap-smoke: PASS (artifacts: ${SMOKE_ARTIFACT_DIR})"

--- a/wml-server/internal/origin/app_test.go
+++ b/wml-server/internal/origin/app_test.go
@@ -159,6 +159,21 @@ func TestHostProfilesAndAllowlist(t *testing.T) {
 	}
 }
 
+func TestAuthFormsRenderPINAsPasswordInput(t *testing.T) {
+	app, _ := newTestApp(t, nil)
+	for _, path := range []string{"/login", "/register"} {
+		t.Run(path, func(t *testing.T) {
+			response := perform(app.Handler(), http.MethodGet, path, "", "")
+			if response.Code != http.StatusOK {
+				t.Fatalf("GET %s status = %d", path, response.Code)
+			}
+			if !strings.Contains(response.Body.String(), `<input name="pin" type="password"`) {
+				t.Fatalf("GET %s PIN input is not a password control", path)
+			}
+		})
+	}
+}
+
 func TestRegistrationLoginAndProtectedRoutes(t *testing.T) {
 	app, _ := newTestApp(t, nil)
 	sid := registerAndLogin(t, app, "demo")

--- a/wml-server/internal/origin/render.go
+++ b/wml-server/internal/origin/render.go
@@ -60,7 +60,7 @@ func renderLoginDeck(prefillUser, errorMessage string) string {
 	return `<card id="login" title="Login">` +
 		message +
 		`<p>User: <input name="username" value="` + xmlEscape(prefillUser) + `" title="User" format="*M" emptyok="false"/></p>` +
-		`<p>PIN: <input name="pin" title="PIN" format="*N" maxlength="6" emptyok="false"/></p>` +
+		`<p>PIN: <input name="pin" type="password" title="PIN" format="*N" maxlength="6" emptyok="false"/></p>` +
 		`<do type="accept" label="Submit"><go method="post" href="/login">` +
 		`<postfield name="username" value="$(username)"/>` +
 		`<postfield name="pin" value="$(pin)"/>` +
@@ -78,7 +78,7 @@ func renderRegisterDeck(prefillUser, errorMessage string) string {
 	return `<card id="register" title="Register">` +
 		message +
 		`<p>User: <input name="username" value="` + xmlEscape(prefillUser) + `" title="User" format="*M" emptyok="false"/></p>` +
-		`<p>PIN: <input name="pin" title="PIN" format="*N" maxlength="6" emptyok="false"/></p>` +
+		`<p>PIN: <input name="pin" type="password" title="PIN" format="*N" maxlength="6" emptyok="false"/></p>` +
 		`<do type="accept" label="Create"><go method="post" href="/register">` +
 		`<postfield name="username" value="$(username)"/>` +
 		`<postfield name="pin" value="$(pin)"/>` +


### PR DESCRIPTION
## Summary

- declare the public login and registration PIN controls as WML `type="password"`
- cover both origin-rendered decks with a focused Go regression
- extend the existing Kannel/browser-engine smoke to verify masked rendering during and after editing while preserving the real variable and POST payload
- suppress Kannel debug-log diagnostics after auth submission so PIN values are not exposed on regression failures

## Root cause

Both dynamic origin renderers omitted the WML input type, so WML correctly defaulted each PIN control to plaintext. The engine's existing WML-204 password behavior was already correct.

## Verification

- `go test ./...`, `go vet ./...`, and Go format check
- `cargo test --manifest-path engine-wasm/engine/Cargo.toml` (381 passed)
- `fnm exec --using=22.22.1 -- wasm-pack test --node engine-wasm/engine` (30 passed)
- `cargo test --manifest-path browser/src-tauri/Cargo.toml` (64 passed; live tests intentionally ignored)
- `pnpm test:story WML-204` (2 passed)
- `pnpm --dir browser run contracts:check`
- `pnpm wap-compliance:check` and `pnpm wap-graph:check`
- worklist, ticket-reference, and source-corpus drift checks
- `pnpm run verify:change`
- `WML_DTD_VERSION=1.3` live stack plus `./scripts/transport-wap-smoke.sh`
- `shellcheck` and Rust/Node formatting checks
- repository pre-push hooks

Fixes #480
