### PR TITLE
fix(engine): avoid bogus empty-select index

### DIFF
--- a/engine-wasm/engine/src/engine_runtime_internal.rs
+++ b/engine-wasm/engine/src/engine_runtime_internal.rs
@@ -530,8 +530,13 @@ impl WmlEngine {
 
     pub(crate) fn select_selected_index_on_active_card(&self, select_name: &str) -> Option<usize> {
         let card = self.active_card_internal().ok()?;
-        node_lookup::find_select(card, select_name)
-            .map(|select| select.selected_indices.first().copied().unwrap_or(0))
+        node_lookup::find_select(card, select_name).and_then(|select| {
+            select
+                .selected_indices
+                .first()
+                .copied()
+                .or_else(|| (!select.options.is_empty()).then_some(0))
+        })
     }
 
     pub(crate) fn select_option_count_on_active_card(&self, select_name: &str) -> Option<usize> {

--- a/engine-wasm/engine/src/engine_tests/mod.rs
+++ b/engine-wasm/engine/src/engine_tests/mod.rs
@@ -6,6 +6,9 @@ use super::{
     MAX_DECK_WML_XML_BYTES, MAX_TRACE_ENTRIES,
 };
 use crate::render::render_list::DrawCmd;
+use crate::runtime::card::Card;
+use crate::runtime::deck::Deck;
+use crate::runtime::node::{InlineNode, Node};
 use crate::wavescript::value::ScriptValue;
 use crate::wavescript::vm::VmTrap;
 
@@ -69,6 +72,36 @@ fn render_snapshot_lines(engine: &WmlEngine) -> Vec<String> {
             } => format!("link:{x}:{y}:focused={focused}:href={href}:text={text}"),
         })
         .collect()
+}
+
+pub(crate) fn engine_with_empty_select() -> WmlEngine {
+    let mut engine = WmlEngine::new();
+    engine.deck = Some(Deck::with_template(
+        vec![Card {
+            id: "home".to_string(),
+            language: None,
+            new_context: false,
+            ordered: false,
+            nodes: vec![Node::Paragraph(vec![InlineNode::Select {
+                control_id: "Empty".to_string(),
+                name: Some("Empty".to_string()),
+                iname: None,
+                title: None,
+                default_value: None,
+                default_index_value: None,
+                multiple: false,
+                options: Vec::new(),
+                selected_indices: Vec::new(),
+            }])],
+            event_bindings: Vec::new(),
+            timer: None,
+        }],
+        None,
+        Vec::new(),
+        None,
+        Vec::new(),
+    ));
+    engine
 }
 
 fn push_string(bytes: &mut Vec<u8>, value: &str) {

--- a/engine-wasm/engine/src/engine_tests/select_semantics.rs
+++ b/engine-wasm/engine/src/engine_tests/select_semantics.rs
@@ -280,6 +280,51 @@ fn wml_204_same_name_selects_keep_independent_control_state() {
 }
 
 #[test]
+fn empty_select_has_no_selected_index_or_edit_session() {
+    let mut engine = engine_with_empty_select();
+
+    assert_eq!(engine.select_selected_index_on_active_card("Empty"), None);
+    assert!(!engine
+        .begin_focused_select_edit()
+        .expect("empty select must be handled without panicking"));
+    assert_eq!(engine.focused_select_edit_name(), None);
+    assert_eq!(engine.focused_select_edit_value(), None);
+}
+
+#[test]
+fn non_empty_unselected_multi_select_still_edits_first_option() {
+    let mut engine = WmlEngine::new();
+    engine
+        .load_deck(
+            r#"
+            <wml><card id="home">
+              <select name="Choices" multiple="true">
+                <option value="alpha">Alpha</option>
+                <option value="beta">Beta</option>
+              </select>
+            </card></wml>
+            "#,
+        )
+        .expect("multi-select deck should load");
+
+    assert_eq!(
+        engine.select_selected_index_on_active_card("Choices"),
+        Some(0)
+    );
+    assert!(engine
+        .begin_focused_select_edit()
+        .expect("non-empty multi-select edit should begin"));
+    assert_eq!(engine.focused_select_edit_value().as_deref(), Some("alpha"));
+    assert!(engine
+        .commit_focused_select_edit()
+        .expect("first option should toggle on"));
+    assert_eq!(
+        engine.get_var("Choices".to_string()).as_deref(),
+        Some("alpha")
+    );
+}
+
+#[test]
 fn wml_fx_select_default_precedence_covers_every_source_and_fallback() {
     // WML-CL-SELECT-DEFAULT-PRECEDENCE and WML-CL-SELECT-INDEX-VALIDATION,
     // WAP-191_104-WML section 11.6.2.1 step 1.

--- a/engine-wasm/engine/src/engine_wasm_bindings_tests.rs
+++ b/engine-wasm/engine/src/engine_wasm_bindings_tests.rs
@@ -3,6 +3,7 @@ use js_sys::{Array, Object, Reflect};
 use wasm_bindgen::JsValue;
 use wasm_bindgen_test::*;
 
+use crate::engine_tests::engine_with_empty_select;
 use crate::wavescript::wap_decoder::{decode_wap_compilation_unit, WapDecodeError};
 
 const SAMPLE: &str = r##"
@@ -1150,6 +1151,57 @@ fn wasm_wml_204_select_initialization_and_commit_match_native_state() {
     assert_eq!(
         engine.get_var_wasm("ChoiceIndexes".to_string()),
         Some("1".to_string())
+    );
+}
+
+#[wasm_bindgen_test]
+fn wasm_empty_select_is_inert_and_non_empty_multi_select_still_edits() {
+    let mut engine = engine_with_empty_select();
+
+    assert!(!engine
+        .begin_focused_select_edit_wasm()
+        .expect("empty select must be handled without trapping"));
+    assert!(!engine.move_focused_select_edit_wasm(1));
+    assert!(!engine
+        .commit_focused_select_edit_wasm()
+        .expect("empty select commit must be a no-op"));
+    assert_eq!(engine.focused_select_edit_name_wasm(), None);
+    assert_eq!(engine.focused_select_edit_value_wasm(), None);
+    engine
+        .render_wasm()
+        .expect("empty select should still render");
+    engine
+        .handle_key_wasm("enter".to_string())
+        .expect("empty select activation must not trap");
+    assert_eq!(engine.focused_select_edit_name_wasm(), None);
+
+    engine
+        .load_deck_wasm(
+            r#"
+              <wml>
+                <card id="home">
+                  <select name="Choices" multiple="true">
+                    <option value="alpha">Alpha</option>
+                    <option value="beta">Beta</option>
+                  </select>
+                </card>
+              </wml>
+            "#,
+        )
+        .expect("non-empty multi-select deck should load");
+    assert!(engine
+        .begin_focused_select_edit_wasm()
+        .expect("non-empty multi-select edit should begin"));
+    assert_eq!(
+        engine.focused_select_edit_value_wasm().as_deref(),
+        Some("alpha")
+    );
+    assert!(engine
+        .commit_focused_select_edit_wasm()
+        .expect("first option should toggle on"));
+    assert_eq!(
+        engine.get_var_wasm("Choices".to_string()).as_deref(),
+        Some("alpha")
     );
 }
 


### PR DESCRIPTION
## Summary

- return no selected index when an internal select has neither options nor a selection
- retain option `0` as the edit cursor for non-empty, unselected multi-select controls
- cover empty-select edit, render, and key handling through native and WASM APIs

## Compliance and scope

- used the focused `WML-204` context pack and canonical select index/preselection evidence
- preserved the completed WML-204 work-item history and existing parser behavior
- did not add a new executable story because source-level empty selects are already rejected by the active WML grammar; the existing WML-204 stories cover stable valid-control behavior

## Verification

- `cargo test --manifest-path engine-wasm/engine/Cargo.toml empty_select`
- `cargo test --manifest-path engine-wasm/engine/Cargo.toml non_empty_unselected_multi_select_still_edits_first_option`
- `cargo test --manifest-path engine-wasm/engine/Cargo.toml --locked` (383 passed)
- `wasm-pack test --node engine-wasm/engine` under Node 22.22.1 (31 passed)
- `pnpm test:story WML-204` (2 passed)
- `cargo clippy --manifest-path engine-wasm/engine/Cargo.toml --all-targets --all-features -- -D warnings`
- engine and browser contract drift checks
- `pnpm wap-compliance:check`
- `pnpm wap-graph:check`
- Rust/Node formatting, Node lint/typecheck, ticket-link, worklist, source-corpus, networking-profile, and pre-push checks

Fixes #460
