### PR TITLE
fix(wml-server): equalize login PIN comparison

### DIFF
--- a/wml-server/internal/origin/app.go
+++ b/wml-server/internal/origin/app.go
@@ -31,6 +31,7 @@ const (
 	defaultMaxSessions = 256
 	defaultMaxBody     = int64(8 << 10)
 	maxUsernameBytes   = 32
+	maxPINBytes        = 6
 	maxSessionIDBytes  = 64
 	pageSize           = 2
 )
@@ -310,7 +311,7 @@ func (a *App) login(w http.ResponseWriter, r *http.Request) {
 		a.sendWML(w, renderLoginDeck(username, "Username and PIN are required."), http.StatusOK)
 		return
 	}
-	if !validUsername(username) || len(pin) > 6 {
+	if !validUsername(username) || len(pin) > maxPINBytes {
 		a.counts.loginFailure.Add(1)
 		a.sendWML(w, renderLoginDeck(username, "Invalid username or PIN."), http.StatusOK)
 		return
@@ -319,7 +320,8 @@ func (a *App) login(w http.ResponseWriter, r *http.Request) {
 	a.mu.Lock()
 	account, found := a.users[username]
 	a.mu.Unlock()
-	if !found || subtle.ConstantTimeCompare([]byte(account.PIN), []byte(pin)) != 1 {
+	pinMatches := constantTimePINCompare(account.PIN, pin)
+	if pinMatches != 1 || !found {
 		a.counts.loginFailure.Add(1)
 		a.sendWML(w, renderLoginDeck(username, "Invalid username or PIN."), http.StatusOK)
 		return
@@ -333,6 +335,15 @@ func (a *App) login(w http.ResponseWriter, r *http.Request) {
 	}
 	a.counts.loginSuccess.Add(1)
 	a.sendWML(w, renderLoginSuccess(username, sid, createdAt), http.StatusOK)
+}
+
+func constantTimePINCompare(storedPIN, submittedPIN string) int {
+	var stored, submitted [maxPINBytes + 1]byte
+	copy(stored[:maxPINBytes], storedPIN)
+	copy(submitted[:maxPINBytes], submittedPIN)
+	stored[maxPINBytes] = byte(len(storedPIN))
+	submitted[maxPINBytes] = byte(len(submittedPIN))
+	return subtle.ConstantTimeCompare(stored[:], submitted[:])
 }
 
 func (a *App) registerForm(w http.ResponseWriter, _ *http.Request) {

--- a/wml-server/internal/origin/app_test.go
+++ b/wml-server/internal/origin/app_test.go
@@ -215,16 +215,62 @@ func TestLoginRejectsUnknownUserAndWrongPIN(t *testing.T) {
 		t.Fatalf("register = %d %s", register.Code, register.Body.String())
 	}
 
-	for name, body := range map[string]string{
-		"unknown user": "username=nobody&pin=1234",
-		"wrong pin":    "username=demo&pin=9999",
-		"shorter pin":  "username=demo&pin=123",
-		"longer pin":   "username=demo&pin=12345",
-	} {
-		t.Run(name, func(t *testing.T) {
-			response := perform(handler, http.MethodPost, "/login", body, "application/x-www-form-urlencoded")
+	tests := []struct {
+		name string
+		body string
+	}{
+		{"unknown user", "username=nobody&pin=1234"},
+		{"wrong pin", "username=demo&pin=9999"},
+		{"shorter pin", "username=demo&pin=123"},
+		{"longer pin", "username=demo&pin=12345"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			response := perform(handler, http.MethodPost, "/login", test.body, "application/x-www-form-urlencoded")
 			if response.Code != http.StatusOK || !strings.Contains(response.Body.String(), "Invalid username or PIN") {
-				t.Fatalf("login(%s) = %d %s", body, response.Code, response.Body.String())
+				t.Fatalf("login case %q = %d %s", test.name, response.Code, response.Body.String())
+			}
+		})
+	}
+
+	if got := app.counts.loginFailure.Load(); got != uint64(len(tests)) {
+		t.Fatalf("login failure count = %d, want %d", got, len(tests))
+	}
+	if got := app.counts.loginSuccess.Load(); got != 0 {
+		t.Fatalf("login success count after failures = %d, want 0", got)
+	}
+
+	response := perform(handler, http.MethodPost, "/login", "username=demo&pin=1234", "application/x-www-form-urlencoded")
+	if response.Code != http.StatusOK || !strings.Contains(response.Body.String(), `id="login-ok"`) {
+		t.Fatalf("valid login = %d %s", response.Code, response.Body.String())
+	}
+	if got := app.counts.loginFailure.Load(); got != uint64(len(tests)) {
+		t.Fatalf("login failure count after success = %d, want %d", got, len(tests))
+	}
+	if got := app.counts.loginSuccess.Load(); got != 1 {
+		t.Fatalf("login success count = %d, want 1", got)
+	}
+}
+
+func TestConstantTimePINCompare(t *testing.T) {
+	tests := []struct {
+		name      string
+		stored    string
+		submitted string
+		want      int
+	}{
+		{"four-byte match", "1234", "1234", 1},
+		{"six-byte match", "123456", "123456", 1},
+		{"different content", "1234", "4321", 0},
+		{"shorter submission", "1234", "123", 0},
+		{"longer submission", "1234", "12345", 0},
+		{"embedded padding byte", "1234", "1234\x00", 0},
+		{"unknown account value", "", "1234", 0},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := constantTimePINCompare(test.stored, test.submitted); got != test.want {
+				t.Fatalf("constantTimePINCompare() = %d, want %d", got, test.want)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

- run the login PIN comparison before the generic account-validity decision for both existing and nonexistent usernames
- compare fixed seven-byte buffers (six PIN bytes plus the original length) so differing PIN lengths do not trigger `ConstantTimeCompare`'s early return or collide through zero-padding
- preserve the existing generic response, HTTP status, session behavior, and login counters
- add deterministic helper and login control-path tests without wall-clock timing assertions or PIN-bearing diagnostics

## Root cause

The login failure condition checked `!found` first in a boolean OR. Go short-circuiting therefore skipped `crypto/subtle.ConstantTimeCompare` whenever the username was absent.

## Verification

- `go test ./internal/origin -run 'TestConstantTimePINCompare|TestLoginRejectsUnknownUserAndWrongPIN|TestRegistrationLoginAndProtectedRoutes' -count=1`
- `go test ./... -count=1`
- `go test -race ./... -count=1`
- Go format check and `go vet ./...`
- `pnpm verify:change`
- `go run golang.org/x/vuln/cmd/govulncheck@v1.1.4 ./...`
- `./scripts/tests/transport-wap-smoke-status.sh`
- `./scripts/transport-wap-smoke.sh` with the CI smoke prerequisites (`WML_DTD_VERSION=1.3` and built browser frontend)
- repository pre-push checks

This removes the branch that skipped the comparison primitive; it does not claim resistance to remote timing analysis.

Fixes #439
