### PR TITLE
fix(browser): coordinate navigation concurrency

### DIFF
--- a/browser/frontend/src/app/browser-controller.behavior.test.ts
+++ b/browser/frontend/src/app/browser-controller.behavior.test.ts
@@ -415,6 +415,95 @@ describe('BrowserController behavior coverage', () => {
     expect(hostClient.engineAdvanceTimeMs).toHaveBeenCalledTimes(1);
   });
 
+  it('does not tick the network engine while a transport navigation is in flight', async () => {
+    const refs = createRefs();
+    const presenter = new BrowserPresenter(refs, initialSession, 20);
+    const hostClient = createHostClient();
+    const controller = new BrowserController(hostClient as never, presenter, refs);
+
+    await controller.init('<wml><card id="seed"/></wml>');
+    controllerPrivates(controller).timerRuntime.stop();
+    await controllerPrivates(controller).setRunMode('network', { loadLocalOnEnter: false });
+    await flushAsyncWork();
+    vi.mocked(hostClient.engineAdvanceTimeMs).mockClear();
+
+    let resolveFetch: ((response: FetchResponse) => void) | undefined;
+    vi.mocked(hostClient.fetchDeck).mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveFetch = resolve;
+        })
+    );
+    refs.fetchUrlInput.value = 'http://example.test/pending.wml';
+    document.querySelector<HTMLButtonElement>('#btn-fetch-url')?.click();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    await controllerPrivates(controller).tickEngineTimerRuntime();
+    expect(hostClient.engineAdvanceTimeMs).not.toHaveBeenCalled();
+
+    resolveFetch?.({
+      ok: true,
+      status: 200,
+      finalUrl: 'http://example.test/pending.wml',
+      contentType: 'text/vnd.wap.wml',
+      wml: '<wml><card id="pending"><p>ok</p></card></wml>',
+      timingMs: { encode: 0, udpRtt: 0, decode: 0 },
+      engineDeckInput: {
+        wmlXml: '<wml><card id="pending"><p>ok</p></card></wml>',
+        baseUrl: 'http://example.test/pending.wml',
+        contentType: 'text/vnd.wap.wml'
+      }
+    });
+    await flushAsyncWork();
+  });
+
+  it('discards an engine key result after its starting run mode changes', async () => {
+    const refs = createRefs();
+    const presenter = new BrowserPresenter(refs, initialSession, 20);
+    const hostClient = createHostClient();
+    const controller = new BrowserController(hostClient as never, presenter, refs);
+
+    await controller.init('<wml><card id="seed"/></wml>');
+    controllerPrivates(controller).timerRuntime.stop();
+    await controllerPrivates(controller).setRunMode('network', { loadLocalOnEnter: false });
+    await flushAsyncWork();
+
+    let resolveKey: ((value: ReturnType<typeof frame>) => void) | undefined;
+    vi.mocked(hostClient.engineHandleKeyFrame).mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveKey = resolve;
+        })
+    );
+    const applyTimerSnapshot = vi.spyOn(
+      controllerPrivates(controller).timerRuntime,
+      'applySnapshot'
+    );
+    const pendingKey = controllerPrivates(controller).applyEngineKey('up');
+    await Promise.resolve();
+    expect(hostClient.engineHandleKeyFrame).toHaveBeenCalledTimes(1);
+
+    await controllerPrivates(controller).setRunMode('local', { loadLocalOnEnter: false });
+    const activeCardBeforeCompletion = presenter.getSessionState().activeCardId;
+    applyTimerSnapshot.mockClear();
+    resolveKey?.(
+      frame({
+        activeCardId: 'stale-key',
+        externalNavigationIntent: 'http://example.test/stale-intent.wml'
+      })
+    );
+    await pendingKey;
+
+    expect(presenter.getSessionState()).toMatchObject({
+      runMode: 'local',
+      activeCardId: activeCardBeforeCompletion
+    });
+    expect(presenter.getSnapshot()?.activeCardId).not.toBe('stale-key');
+    expect(refs.fetchUrlInput.value).not.toBe('http://example.test/stale-intent.wml');
+    expect(applyTimerSnapshot).not.toHaveBeenCalled();
+  });
+
   it('clears the frozen skeleton placeholder when the very first deck load fails', async () => {
     const refs = createRefs();
     const presenter = new BrowserPresenter(refs, initialSession, 20);

--- a/browser/frontend/src/app/browser-controller.test-helpers.ts
+++ b/browser/frontend/src/app/browser-controller.test-helpers.ts
@@ -1,4 +1,5 @@
 import type { BrowserController, RunMode } from './browser-controller';
+import type { EngineKey } from '../../../contracts/engine';
 import type { EngineTimerRuntime } from './engine-timer-runtime';
 import type { KeyboardIntentRouter } from './keyboard-intent-router';
 
@@ -9,6 +10,7 @@ import type { KeyboardIntentRouter } from './keyboard-intent-router';
  */
 interface BrowserControllerPrivates {
   setRunMode(mode: RunMode, options: { loadLocalOnEnter: boolean }): Promise<void>;
+  applyEngineKey(key: EngineKey): Promise<void>;
   tickEngineTimerRuntime(): Promise<void>;
   readonly timerRuntime: EngineTimerRuntime;
   readonly keyboardIntentRouter: Omit<KeyboardIntentRouter, 'actionQueue'> & {

--- a/browser/frontend/src/app/browser-controller.ts
+++ b/browser/frontend/src/app/browser-controller.ts
@@ -133,9 +133,19 @@ export class BrowserController {
       wait
     });
     this.timerRuntime = new EngineTimerRuntime({
-      canTick: () => !this.keyboardIntentRouter.isActionInFlight(),
+      canTick: () =>
+        !this.keyboardIntentRouter.isActionInFlight() && !this.navigation.isNavigationInFlight(),
       getRunMode: () => this.runMode,
-      advanceLocal: (deltaMs) => this.hostClient.engineAdvanceTimeMs({ deltaMs }),
+      advanceLocal: async (deltaMs) => {
+        if (this.navigation.isNavigationInFlight()) {
+          return null;
+        }
+        const generation = this.navigation.captureNavigationGeneration();
+        const snapshot = await this.hostClient.engineAdvanceTimeMs({ deltaMs });
+        return this.runMode === 'local' && this.navigation.isCurrentNavigation(generation)
+          ? snapshot
+          : null;
+      },
       advanceNetwork: (deltaMs) => this.navigation.applyEngineTimerTick(deltaMs),
       getSessionState: () => this.presenter.getSessionState(),
       renderLocalSnapshot: async (snapshot) => {
@@ -620,11 +630,24 @@ export class BrowserController {
     };
 
   private async applyEngineKey(key: EngineKey): Promise<void> {
+    if (this.navigation.isNavigationInFlight()) {
+      return;
+    }
+    const startingRunMode = this.runMode;
+    const startingGeneration = this.navigation.captureNavigationGeneration();
     const previousActiveCardId = this.presenter.getSessionState().activeCardId;
     const localFrame =
-      this.runMode === 'local' ? await this.hostClient.engineHandleKeyFrame({ key }) : null;
+      startingRunMode === 'local' ? await this.hostClient.engineHandleKeyFrame({ key }) : null;
     const snapshot = localFrame ? localFrame.snapshot : await this.navigation.applyEngineKey(key);
-    if (this.runMode === 'local' && localFrame) {
+    if (
+      !snapshot ||
+      this.runMode !== startingRunMode ||
+      !this.navigation.isCurrentNavigation(startingGeneration) ||
+      this.navigation.isNavigationInFlight()
+    ) {
+      return;
+    }
+    if (startingRunMode === 'local' && localFrame) {
       this.applyFrame(localFrame, snapshot);
       this.syncLocalSessionFromSnapshot(snapshot);
       this.noteLocalForwardNavigation(previousActiveCardId, snapshot.activeCardId);
@@ -648,22 +671,37 @@ export class BrowserController {
   }
 
   private async navigateBackWithFallback(): Promise<'engine' | 'host' | 'none'> {
+    const startingRunMode = this.runMode;
     const endNavigationProgress = this.presenter.beginNavigationProgress();
     try {
-      if (this.runMode === 'local') {
-        const frame = await this.hostClient.engineNavigateBackFrame();
-        const after = frame.snapshot;
-        if (!after.lastBackNavigationHandled) {
-          // Definitive ground truth: the engine's nav stack was already empty.
-          this.localBackAvailable = false;
-          return 'none';
+      if (startingRunMode === 'local') {
+        const generation = this.navigation.beginNavigationOperation();
+        try {
+          const frame = await this.hostClient.engineNavigateBackFrame();
+          if (
+            this.runMode !== startingRunMode ||
+            !this.navigation.isCurrentNavigation(generation)
+          ) {
+            return 'none';
+          }
+          const after = frame.snapshot;
+          if (!after.lastBackNavigationHandled) {
+            // Definitive ground truth: the engine's nav stack was already empty.
+            this.localBackAvailable = false;
+            return 'none';
+          }
+          this.applyFrame(frame);
+          this.syncLocalSessionFromSnapshot(after);
+          return 'engine';
+        } finally {
+          this.navigation.finishNavigationOperation(generation);
         }
-        this.applyFrame(frame);
-        this.syncLocalSessionFromSnapshot(after);
-        return 'engine';
       }
 
       const mode = await this.navigation.navigateBackWithFallback();
+      if (this.runMode !== startingRunMode) {
+        return 'none';
+      }
       const state = this.navigation.getSessionState();
       const resolvedUrl = state.finalUrl ?? state.requestedUrl;
       if (resolvedUrl) {
@@ -684,11 +722,19 @@ export class BrowserController {
     requestPolicy?: FetchRequestPolicy,
     headers?: Record<string, string>
   ): Promise<EngineRuntimeSnapshot | null> {
-    if (this.runMode === 'local') {
+    const startingRunMode = this.runMode;
+    const startingGeneration = this.navigation.captureNavigationGeneration();
+    if (startingRunMode === 'local') {
       await this.loadSelectedLocalDeck();
       return null;
     }
     await this.setViewportCols();
+    if (
+      this.runMode !== startingRunMode ||
+      !this.navigation.isCurrentNavigation(startingGeneration)
+    ) {
+      return null;
+    }
     const requestedUrl = url.trim();
     const endNavigationProgress = this.presenter.beginNavigationProgress();
     if (source === 'user') {
@@ -700,7 +746,7 @@ export class BrowserController {
     }
 
     try {
-      const snapshot = await this.navigation.loadTransportUrl({
+      const loadPromise = this.navigation.loadTransportUrl({
         url: requestedUrl,
         source,
         followExternalIntent,
@@ -708,6 +754,14 @@ export class BrowserController {
         requestPolicy,
         headers
       });
+      const navigationGeneration = this.navigation.captureNavigationGeneration();
+      const snapshot = await loadPromise;
+      if (
+        this.runMode !== startingRunMode ||
+        !this.navigation.isCurrentNavigation(navigationGeneration)
+      ) {
+        return null;
+      }
       if (snapshot) {
         this.timerRuntime.resetScriptTimers();
         this.timerRuntime.applySnapshot(snapshot);

--- a/browser/frontend/src/app/engine-timer-runtime.ts
+++ b/browser/frontend/src/app/engine-timer-runtime.ts
@@ -7,8 +7,8 @@ import { WAVES_CONFIG } from './waves-config';
 export interface EngineTimerRuntimeDependencies {
   canTick(): boolean;
   getRunMode(): 'local' | 'network';
-  advanceLocal(deltaMs: number): Promise<EngineRuntimeSnapshot>;
-  advanceNetwork(deltaMs: number): Promise<EngineRuntimeSnapshot>;
+  advanceLocal(deltaMs: number): Promise<EngineRuntimeSnapshot | null>;
+  advanceNetwork(deltaMs: number): Promise<EngineRuntimeSnapshot | null>;
   getSessionState(): HostSessionState;
   renderLocalSnapshot(snapshot: EngineRuntimeSnapshot): Promise<void>;
   handleExternalIntent(intentUrl: string, snapshot: EngineRuntimeSnapshot): Promise<void>;
@@ -82,6 +82,9 @@ export class EngineTimerRuntime {
         this.deps.getRunMode() === 'local'
           ? await this.deps.advanceLocal(deltaMs)
           : await this.deps.advanceNetwork(deltaMs);
+      if (!snapshot) {
+        return;
+      }
       if (
         this.deps.getRunMode() === 'local' &&
         shouldRenderTimerSnapshot(snapshot, this.deps.getSessionState())

--- a/browser/frontend/src/app/navigation-state.concurrency.test.ts
+++ b/browser/frontend/src/app/navigation-state.concurrency.test.ts
@@ -1,0 +1,200 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { FetchResponse } from '../../../contracts/transport';
+import type { EngineFrame } from '../../../contracts/engine';
+import { createNavigationStateMachine } from './navigation-state';
+import { createHostClientMock, fetchOk, frame } from './navigation-state.test-helpers';
+
+interface Deferred<T> {
+  promise: Promise<T>;
+  resolve(value: T): void;
+}
+
+const deferred = <T>(): Deferred<T> => {
+  let resolvePromise: ((value: T) => void) | undefined;
+  const promise = new Promise<T>((resolve) => {
+    resolvePromise = resolve;
+  });
+  return {
+    promise,
+    resolve: (value) => resolvePromise?.(value)
+  };
+};
+
+const load = (machine: ReturnType<typeof createNavigationStateMachine>, url: string) =>
+  machine.loadTransportUrl({
+    url,
+    source: 'user',
+    followExternalIntent: false
+  });
+
+describe('NavigationStateMachine concurrency ownership', () => {
+  it('does not begin key or timer engine work while a transport navigation is in flight', async () => {
+    const pendingFetch = deferred<FetchResponse>();
+    const engineHandleKeyFrame = vi.fn(async () => frame({ activeCardId: 'stale-key' }));
+    const engineAdvanceTimeMs = vi.fn(async () => frame({ activeCardId: 'stale-timer' }).snapshot);
+    const machine = createNavigationStateMachine(
+      createHostClientMock({
+        fetchDeck: vi.fn(() => pendingFetch.promise),
+        engineHandleKeyFrame,
+        engineAdvanceTimeMs
+      }),
+      'http://seed.test'
+    );
+
+    const pendingLoad = load(machine, 'http://example.test/pending.wml');
+    await Promise.resolve();
+
+    expect(await machine.applyEngineKey('up')).toBeNull();
+    expect(await machine.applyEngineTimerTick(100)).toBeNull();
+    expect(engineHandleKeyFrame).not.toHaveBeenCalled();
+    expect(engineAdvanceTimeMs).not.toHaveBeenCalled();
+
+    pendingFetch.resolve(fetchOk({ finalUrl: 'http://example.test/pending.wml' }));
+    await pendingLoad;
+  });
+
+  it('discards a key completion when a transport navigation starts during its engine await', async () => {
+    const pendingKey = deferred<EngineFrame>();
+    const pendingFetch = deferred<FetchResponse>();
+    const snapshots: string[] = [];
+    let fetchCount = 0;
+    const machine = createNavigationStateMachine(
+      createHostClientMock({
+        fetchDeck: vi.fn(() => {
+          fetchCount += 1;
+          return fetchCount === 1
+            ? Promise.resolve(fetchOk({ finalUrl: 'http://example.test/current.wml' }))
+            : pendingFetch.promise;
+        }),
+        engineLoadDeckContextFrame: vi.fn(async (request) =>
+          frame({ activeCardId: 'current', baseUrl: request.baseUrl, browserContextEpoch: 1 })
+        ),
+        engineHandleKeyFrame: vi.fn(() => pendingKey.promise)
+      }),
+      'http://seed.test',
+      {
+        onSnapshot: (snapshot) => snapshots.push(snapshot.activeCardId ?? '')
+      }
+    );
+
+    await load(machine, 'http://example.test/current.wml');
+    snapshots.length = 0;
+    const keyResult = machine.applyEngineKey('enter');
+    await Promise.resolve();
+    const nextLoad = load(machine, 'http://example.test/next.wml');
+
+    pendingKey.resolve(
+      frame({
+        activeCardId: 'stale-key',
+        browserContextEpoch: 1,
+        externalNavigationIntent: 'http://example.test/stale-intent.wml'
+      })
+    );
+
+    expect(await keyResult).toBeNull();
+    expect(snapshots).not.toContain('stale-key');
+    expect(machine.getHistoryState().entries.map((entry) => entry.activeCardId)).toEqual([
+      'current'
+    ]);
+
+    pendingFetch.resolve(fetchOk({ finalUrl: 'http://example.test/next.wml' }));
+    await nextLoad;
+  });
+
+  it('discards a timer completion when a transport navigation starts during its engine await', async () => {
+    const pendingTimer = deferred<ReturnType<typeof frame>['snapshot']>();
+    const pendingFetch = deferred<FetchResponse>();
+    const renders: string[] = [];
+    let fetchCount = 0;
+    const machine = createNavigationStateMachine(
+      createHostClientMock({
+        fetchDeck: vi.fn(() => {
+          fetchCount += 1;
+          return fetchCount === 1
+            ? Promise.resolve(fetchOk({ finalUrl: 'http://example.test/current.wml' }))
+            : pendingFetch.promise;
+        }),
+        engineLoadDeckContextFrame: vi.fn(async (request) =>
+          frame({ activeCardId: 'current', baseUrl: request.baseUrl, browserContextEpoch: 1 })
+        ),
+        engineAdvanceTimeMs: vi.fn(() => pendingTimer.promise),
+        engineRenderFrame: vi.fn(async () => frame({ activeCardId: 'stale-timer' }))
+      }),
+      'http://seed.test',
+      {
+        onRender: (render) => renders.push(render.draw[0]?.type ?? '')
+      }
+    );
+
+    await load(machine, 'http://example.test/current.wml');
+    const renderCount = renders.length;
+    const timerResult = machine.applyEngineTimerTick(100);
+    await Promise.resolve();
+    const nextLoad = load(machine, 'http://example.test/next.wml');
+
+    pendingTimer.resolve(
+      frame({
+        activeCardId: 'stale-timer',
+        browserContextEpoch: 1,
+        externalNavigationIntent: 'http://example.test/stale-intent.wml'
+      }).snapshot
+    );
+
+    expect(await timerResult).toBeNull();
+    expect(renders).toHaveLength(renderCount);
+    expect(machine.getHistoryState().entries.map((entry) => entry.activeCardId)).toEqual([
+      'current'
+    ]);
+
+    pendingFetch.resolve(fetchOk({ finalUrl: 'http://example.test/next.wml' }));
+    await nextLoad;
+  });
+
+  it('Back cancels a pending fetch before awaiting or applying engine history state', async () => {
+    const pendingFetch = deferred<FetchResponse>();
+    const pendingBack = deferred<EngineFrame>();
+    const engineLoadDeckContextFrame = vi.fn(async (request) =>
+      frame({
+        activeCardId: request.baseUrl.includes('/one.wml') ? 'one' : 'two',
+        baseUrl: request.baseUrl,
+        browserContextEpoch: 1
+      })
+    );
+    let fetchCount = 0;
+    const machine = createNavigationStateMachine(
+      createHostClientMock({
+        fetchDeck: vi.fn((request) => {
+          fetchCount += 1;
+          return fetchCount <= 2
+            ? Promise.resolve(fetchOk({ finalUrl: request.url }))
+            : pendingFetch.promise;
+        }),
+        engineLoadDeckContextFrame,
+        engineNavigateBackFrame: vi.fn(() => pendingBack.promise)
+      }),
+      'http://seed.test'
+    );
+
+    await load(machine, 'http://example.test/one.wml');
+    await load(machine, 'http://example.test/two.wml');
+    const interruptedLoad = load(machine, 'http://example.test/stale.wml');
+    await Promise.resolve();
+    const back = machine.navigateBackWithFallback();
+    await Promise.resolve();
+
+    pendingFetch.resolve(fetchOk({ finalUrl: 'http://example.test/stale.wml' }));
+    await interruptedLoad;
+    expect(engineLoadDeckContextFrame).toHaveBeenCalledTimes(2);
+
+    pendingBack.resolve(
+      frame({
+        activeCardId: 'one',
+        baseUrl: 'http://example.test/one.wml',
+        browserContextEpoch: 1,
+        lastBackNavigationHandled: true
+      })
+    );
+    expect(await back).toBe('engine');
+    expect(machine.getSessionState().activeCardId).toBe('one');
+  });
+});

--- a/browser/frontend/src/app/navigation-state.load.test.ts
+++ b/browser/frontend/src/app/navigation-state.load.test.ts
@@ -563,9 +563,17 @@ describe('navigation-state load behavior', () => {
     );
 
     const timed = await machine.applyEngineTimerTick(50);
+    expect(timed).not.toBeNull();
+    if (!timed) {
+      throw new Error('expected a timer snapshot');
+    }
     expect(timed.activeCardId).toBe('timed');
 
     const done = await machine.applyEngineTimerTick(100);
+    expect(done).not.toBeNull();
+    if (!done) {
+      throw new Error('expected a timer snapshot');
+    }
     expect(done.activeCardId).toBe('done');
   });
 

--- a/browser/frontend/src/app/navigation-state.ts
+++ b/browser/frontend/src/app/navigation-state.ts
@@ -88,9 +88,14 @@ export interface LoadTransportOptions {
 
 export interface NavigationStateMachine {
   loadTransportUrl(options: LoadTransportOptions): Promise<EngineRuntimeSnapshot | null>;
-  applyEngineKey(key: HandleKeyRequest['key']): Promise<EngineRuntimeSnapshot>;
-  applyEngineTimerTick(deltaMs: number): Promise<EngineRuntimeSnapshot>;
+  applyEngineKey(key: HandleKeyRequest['key']): Promise<EngineRuntimeSnapshot | null>;
+  applyEngineTimerTick(deltaMs: number): Promise<EngineRuntimeSnapshot | null>;
   navigateBackWithFallback(): Promise<BackNavigationMode>;
+  beginNavigationOperation(): number;
+  finishNavigationOperation(generation: number): void;
+  captureNavigationGeneration(): number;
+  isCurrentNavigation(generation: number): boolean;
+  isNavigationInFlight(): boolean;
   cancelPendingNavigation(): void;
   getSessionState(): HostSessionState;
   getHistoryState(): HostHistoryState;
@@ -108,7 +113,13 @@ export const createNavigationStateMachine = (
     navigationStatus: 'idle',
     requestedUrl: initialRequestedUrl.trim()
   };
+  // A navigation is in flight exactly while the current generation owns a
+  // transport load or Back operation. Starting either operation advances the
+  // generation; finishing clears ownership only if that generation is still
+  // current. Mode switches cancel by advancing the generation and clearing
+  // ownership, so stale async completions cannot reclaim it.
   let activeNavigationGeneration = 0;
+  let navigationInFlightGeneration: number | undefined;
   let observedBrowserContextEpoch: number | undefined;
 
   const emitSession = (): void => {
@@ -150,15 +161,23 @@ export const createNavigationStateMachine = (
     syncSessionFromSnapshot(frame.snapshot);
   };
 
-  const renderSnapshot = async (snapshot: EngineRuntimeSnapshot): Promise<void> => {
-    const frame = await hostClient.engineRenderFrame();
-    hooks.onSnapshot?.(snapshot);
-    hooks.onRender?.(frame.render);
-    syncSessionFromSnapshot(snapshot);
-  };
-
   const isCurrentNavigation = (generation: number): boolean =>
     generation === activeNavigationGeneration;
+
+  const isNavigationInFlight = (): boolean =>
+    navigationInFlightGeneration === activeNavigationGeneration;
+
+  const beginNavigationOperation = (): number => {
+    activeNavigationGeneration += 1;
+    navigationInFlightGeneration = activeNavigationGeneration;
+    return activeNavigationGeneration;
+  };
+
+  const finishNavigationOperation = (generation: number): void => {
+    if (isCurrentNavigation(generation) && navigationInFlightGeneration === generation) {
+      navigationInFlightGeneration = undefined;
+    }
+  };
 
   const observeBrowserContext = (snapshot: EngineRuntimeSnapshot): boolean => {
     if (snapshot.browserContextEpoch === undefined) {
@@ -187,13 +206,13 @@ export const createNavigationStateMachine = (
 
   const cancelPendingNavigation = (): void => {
     activeNavigationGeneration += 1;
+    navigationInFlightGeneration = undefined;
   };
 
-  const loadTransportUrl = async (
+  const loadTransportUrlForGeneration = async (
     options: LoadTransportOptions,
-    generation = activeNavigationGeneration + 1
+    generation: number
   ): Promise<EngineRuntimeSnapshot | null> => {
-    activeNavigationGeneration = generation;
     const requestedUrl = options.url.trim();
     const navigationUrl = options.navigationUrl?.trim() || requestedUrl;
     if (!requestedUrl) {
@@ -354,7 +373,7 @@ export const createNavigationStateMachine = (
       let nextUrl = frame.snapshot.externalNavigationIntent;
       let nextRequestPolicy = frame.snapshot.externalNavigationRequestPolicy;
       for (let hop = 1; hop <= maxExternalIntentHops; hop += 1) {
-        const nextSnapshot = await loadTransportUrl(
+        const nextSnapshot = await loadTransportUrlForGeneration(
           {
             url: nextUrl,
             method: 'GET',
@@ -381,9 +400,29 @@ export const createNavigationStateMachine = (
     return frame.snapshot;
   };
 
-  const applyEngineKey = async (key: HandleKeyRequest['key']): Promise<EngineRuntimeSnapshot> => {
+  const loadTransportUrl = async (
+    options: LoadTransportOptions
+  ): Promise<EngineRuntimeSnapshot | null> => {
+    const generation = beginNavigationOperation();
+    try {
+      return await loadTransportUrlForGeneration(options, generation);
+    } finally {
+      finishNavigationOperation(generation);
+    }
+  };
+
+  const applyEngineKey = async (
+    key: HandleKeyRequest['key']
+  ): Promise<EngineRuntimeSnapshot | null> => {
+    if (isNavigationInFlight()) {
+      return null;
+    }
+    const generation = activeNavigationGeneration;
     const previousCardId = hostSessionState.activeCardId;
     const frame = await hostClient.engineHandleKeyFrame({ key });
+    if (!isCurrentNavigation(generation) || isNavigationInFlight()) {
+      return null;
+    }
     if (observeBrowserContext(frame.snapshot)) {
       resetHistoryToCurrentCard(frame.snapshot);
     } else if (frame.snapshot.activeCardId && frame.snapshot.activeCardId !== previousCardId) {
@@ -395,14 +434,26 @@ export const createNavigationStateMachine = (
     return frame.snapshot;
   };
 
-  const applyEngineTimerTick = async (deltaMs: number): Promise<EngineRuntimeSnapshot> => {
+  const applyEngineTimerTick = async (deltaMs: number): Promise<EngineRuntimeSnapshot | null> => {
+    if (isNavigationInFlight()) {
+      return null;
+    }
+    const generation = activeNavigationGeneration;
     const previousCardId = hostSessionState.activeCardId;
     const snapshot = await hostClient.engineAdvanceTimeMs({ deltaMs });
+    if (!isCurrentNavigation(generation) || isNavigationInFlight()) {
+      return null;
+    }
+    const shouldRender = shouldRenderTimerSnapshot(snapshot, hostSessionState);
+    const renderFrame = shouldRender ? await hostClient.engineRenderFrame() : null;
+    if (!isCurrentNavigation(generation) || isNavigationInFlight()) {
+      return null;
+    }
     const browserContextChanged = observeBrowserContext(snapshot);
     if (browserContextChanged) {
       resetHistoryToCurrentCard(snapshot);
     }
-    if (!shouldRenderTimerSnapshot(snapshot, hostSessionState)) {
+    if (!shouldRender) {
       return snapshot;
     }
     if (
@@ -414,79 +465,98 @@ export const createNavigationStateMachine = (
     } else {
       updateCurrentHistoryCard(hostHistory, snapshot.activeCardId);
     }
-    await renderSnapshot(snapshot);
+    if (renderFrame) {
+      applyFrame({ snapshot, render: renderFrame.render });
+    }
     return snapshot;
   };
 
   const navigateBackWithFallback = async (): Promise<BackNavigationMode> => {
-    const afterFrame = await hostClient.engineNavigateBackFrame();
-    const after = afterFrame.snapshot;
-    const browserContextChanged = observeBrowserContext(after);
-    if (browserContextChanged) {
-      resetHistoryToCurrentCard(after);
-    }
-
-    if (after.lastBackNavigationHandled) {
-      const current = hostHistory.entries[hostHistory.index];
-      const previous = peekHistoryBack(hostHistory);
-      if (
-        !browserContextChanged &&
-        hostSessionState.activeCardId !== after.activeCardId &&
-        current &&
-        previous &&
-        previous.activeCardId === after.activeCardId &&
-        sameHistoryDocument(current.url, previous.url)
-      ) {
-        commitHistoryBack(hostHistory);
-      } else {
-        updateCurrentHistoryCard(hostHistory, after.activeCardId);
+    const generation = beginNavigationOperation();
+    try {
+      const afterFrame = await hostClient.engineNavigateBackFrame();
+      if (!isCurrentNavigation(generation)) {
+        return 'none';
       }
-      applyFrame(afterFrame);
-      return 'engine';
-    }
+      const after = afterFrame.snapshot;
+      const browserContextChanged = observeBrowserContext(after);
+      if (browserContextChanged) {
+        resetHistoryToCurrentCard(after);
+      }
 
-    if (canHistoryBack(hostHistory)) {
-      const previous = peekHistoryBack(hostHistory);
-      if (previous?.url) {
-        const prevSnapshot = await loadTransportUrl({
-          url: previous.requestedUrl ?? previous.url,
-          navigationUrl: historyNavigationUrl(previous.url, previous.activeCardId),
-          method: previous.method ?? 'GET',
-          headers: previous.headers,
-          source: 'history-back',
-          followExternalIntent: true,
-          pushHistory: false,
-          requestPolicy: previous.requestPolicy
-        });
-        if (prevSnapshot) {
-          let restoredSnapshot = prevSnapshot;
-          if (previous.activeCardId && previous.activeCardId !== prevSnapshot.activeCardId) {
-            const frame = await hostClient.engineNavigateToCardFrame({
-              cardId: previous.activeCardId
+      if (after.lastBackNavigationHandled) {
+        const current = hostHistory.entries[hostHistory.index];
+        const previous = peekHistoryBack(hostHistory);
+        if (
+          !browserContextChanged &&
+          hostSessionState.activeCardId !== after.activeCardId &&
+          current &&
+          previous &&
+          previous.activeCardId === after.activeCardId &&
+          sameHistoryDocument(current.url, previous.url)
+        ) {
+          commitHistoryBack(hostHistory);
+        } else {
+          updateCurrentHistoryCard(hostHistory, after.activeCardId);
+        }
+        applyFrame(afterFrame);
+        return 'engine';
+      }
+
+      if (canHistoryBack(hostHistory)) {
+        const previous = peekHistoryBack(hostHistory);
+        if (previous?.url) {
+          const prevSnapshot = await loadTransportUrlForGeneration(
+            {
+              url: previous.requestedUrl ?? previous.url,
+              navigationUrl: historyNavigationUrl(previous.url, previous.activeCardId),
+              method: previous.method ?? 'GET',
+              headers: previous.headers,
+              source: 'history-back',
+              followExternalIntent: true,
+              pushHistory: false,
+              requestPolicy: previous.requestPolicy
+            },
+            generation
+          );
+          if (prevSnapshot && isCurrentNavigation(generation)) {
+            let restoredSnapshot = prevSnapshot;
+            let restoredFrame: EngineFrame | undefined;
+            if (previous.activeCardId && previous.activeCardId !== prevSnapshot.activeCardId) {
+              restoredFrame = await hostClient.engineNavigateToCardFrame({
+                cardId: previous.activeCardId
+              });
+              if (!isCurrentNavigation(generation)) {
+                return 'none';
+              }
+              restoredSnapshot = restoredFrame.snapshot;
+            }
+            const committed = commitHistoryBack(hostHistory);
+            if (!committed) {
+              return 'none';
+            }
+            if (restoredFrame) {
+              applyFrame(restoredFrame);
+            }
+            updateCurrentHistoryCard(hostHistory, restoredSnapshot.activeCardId);
+            mergeSessionState({
+              historyIndex: hostHistory.index,
+              history: hostHistory.entries
             });
-            restoredSnapshot = frame.snapshot;
-            applyFrame(frame);
+            hooks.onStateEvent?.('host-history-back', {
+              historyIndex: hostHistory.index,
+              url: previous.url,
+              restoredCardId: restoredSnapshot.activeCardId
+            });
+            return 'host';
           }
-          const committed = commitHistoryBack(hostHistory);
-          if (!committed) {
-            return 'none';
-          }
-          updateCurrentHistoryCard(hostHistory, restoredSnapshot.activeCardId);
-          mergeSessionState({
-            historyIndex: hostHistory.index,
-            history: hostHistory.entries
-          });
-          hooks.onStateEvent?.('host-history-back', {
-            historyIndex: hostHistory.index,
-            url: previous.url,
-            restoredCardId: restoredSnapshot.activeCardId
-          });
-          return 'host';
         }
       }
-    }
 
-    return 'none';
+      return 'none';
+    } finally {
+      finishNavigationOperation(generation);
+    }
   };
 
   function pushCurrentRequestHistoryCard(activeCardId: string): void {
@@ -509,6 +579,11 @@ export const createNavigationStateMachine = (
     applyEngineKey,
     applyEngineTimerTick,
     navigateBackWithFallback,
+    beginNavigationOperation,
+    finishNavigationOperation,
+    captureNavigationGeneration: () => activeNavigationGeneration,
+    isCurrentNavigation,
+    isNavigationInFlight,
     cancelPendingNavigation,
     getSessionState: () => hostSessionState,
     getHistoryState: () => hostHistory


### PR DESCRIPTION
## Summary

- define a single browser navigation generation/in-flight owner for transport loads and Back operations
- gate key and timer engine work while navigation is in flight, and discard completions whose generation or run mode changed while awaiting
- make Back cancel pending navigation before reading or mutating engine/host history
- keep timer wakeups re-arming when navigation temporarily blocks ticks
- add deterministic deferred-promise coverage for fetch-first and engine-first key/timer races, Back/fetch, and mode-switch races

## Root cause

Transport loads advanced a navigation generation, but key and timer operations neither observed in-flight ownership nor validated their starting generation. Back only advanced the generation after falling through to a transport history load, and the controller consulted the current run mode after asynchronous engine calls. Those gaps allowed stale completions to update presenter, history, frame, timer, or external-intent state.

## Verification

- `pnpm verify:change`
  - 222 browser frontend tests
  - 31 WASM boundary tests
  - 51 executable stories, including 19 Waves browser stories
  - browser/engine contract, example-manifest, Tauri schema, and icon drift checks
  - workspace format, lint, typecheck, and repository drift checks
  - Tauri host tests and rendered accessibility
- `pnpm --dir browser/frontend run test:coverage`
  - 88.24% statements, 79.34% branches, 85.84% functions, 88.19% lines
- `pnpm --dir browser/frontend build`
- pre-commit and pre-push hooks

Fixes #464
Fixes #465
Fixes #468
Fixes #469
