### PR TITLE
fix(wml-server): stop static example navigation loop

### DIFF
--- a/.github/workflows/transport-wap-smoke.yml
+++ b/.github/workflows/transport-wap-smoke.yml
@@ -108,6 +108,7 @@ jobs:
           WAP_SMOKE_URL: wap://127.0.0.1/
           WAP_SMOKE_LOGIN_URL: wap://127.0.0.1/login
           WAP_SMOKE_REGISTER_URL: wap://127.0.0.1/register
+          WAP_SMOKE_EXAMPLE_URL: wap://127.0.0.1/examples/index.wml
           WAP_SMOKE_DENIED_URL: wap://127.0.0.1:9200/
         run: |
           test "$(docker compose -f deploy/network-preview/compose.yaml port --protocol udp wap-gateway 9200 | wc -l)" -eq 1

--- a/browser/frontend/scripts/native-tauri-kannel-e2e.mjs
+++ b/browser/frontend/scripts/native-tauri-kannel-e2e.mjs
@@ -141,10 +141,7 @@ const run = async () => {
   const capabilities = new Capabilities();
   capabilities.set('tauri:options', { application: appBinary });
   capabilities.setBrowserName('wry');
-  driver = await new Builder()
-    .withCapabilities(capabilities)
-    .usingServer(driverUrl.href)
-    .build();
+  driver = await new Builder().withCapabilities(capabilities).usingServer(driverUrl.href).build();
 
   const body = await driver.wait(until.elementLocated(By.css('body')), timeoutMs);
   await driver.wait(async () => {
@@ -167,15 +164,34 @@ const run = async () => {
   await driver.findElement(By.css('#btn-enter')).click();
   const menuViewport = await waitForText('#viewport', '1. Login');
   assert.match(await menuViewport.getText(), /2\. Register/);
-  recordAssertion('visible card navigation', 'Select navigated the native engine from home to menu');
+  recordAssertion(
+    'visible card navigation',
+    'Select navigated the native engine from home to menu'
+  );
   await capture('03-menu-navigation');
+
+  for (let index = 0; index < 3; index += 1) {
+    await driver.findElement(By.css('#btn-down')).click();
+  }
+  await driver.findElement(By.css('#btn-enter')).click();
+  const staticExampleViewport = await waitForText('#viewport', 'This is a static WML sample deck.');
+  assert.match(await staticExampleViewport.getText(), /Open Navigation/);
+  assert.match(
+    await driver.findElement(By.css('#fetch-url')).getAttribute('value'),
+    /\/examples\/index\.wml$/
+  );
+  recordAssertion(
+    'static example navigation',
+    'menu option 4 loaded and rendered the gateway-compiled WML 1.3 static deck'
+  );
+  await capture('04-static-example');
 
   await replaceInput('#fetch-url', 'not a url');
   await driver.findElement(By.css('#btn-fetch-url')).click();
   const toast = await waitForText('#toast', 'Fetch failed:');
   assert.match(await toast.getText(), /INVALID_REQUEST|invalid|URL/i);
   recordAssertion('deterministic failure', 'invalid URL surfaced a visible Fetch failed message');
-  await capture('04-invalid-url-failure');
+  await capture('05-invalid-url-failure');
 
   await replaceInput('#fetch-url', 'wap://localhost/');
   await driver.findElement(By.css('#btn-fetch-url')).click();
@@ -183,7 +199,7 @@ const run = async () => {
   assert.match(await recoveredViewport.getText(), /environment\./);
   assert.match(await recoveredViewport.getText(), /Open Menu/);
   recordAssertion('failure recovery', 'a subsequent native Kannel load restored the home deck');
-  await capture('05-recovered-home');
+  await capture('06-recovered-home');
 
   await writeFile(path.join(artifactDir, 'page-source.html'), await driver.getPageSource());
   await writeFile(
@@ -196,7 +212,7 @@ const run = async () => {
 try {
   await run();
 } catch (error) {
-  const message = error instanceof Error ? error.stack ?? error.message : String(error);
+  const message = error instanceof Error ? (error.stack ?? error.message) : String(error);
   process.stderr.write(`native-tauri-kannel-e2e: FAIL\n${message}\n`);
   if (driver) {
     await capture('failure').catch(() => undefined);

--- a/browser/frontend/scripts/native-tauri-kannel-e2e.mjs
+++ b/browser/frontend/scripts/native-tauri-kannel-e2e.mjs
@@ -174,8 +174,11 @@ const run = async () => {
     await driver.findElement(By.css('#btn-down')).click();
   }
   await driver.findElement(By.css('#btn-enter')).click();
-  const staticExampleViewport = await waitForText('#viewport', 'This is a static WML sample deck.');
-  assert.match(await staticExampleViewport.getText(), /Open Navigation/);
+  const staticExampleViewport = await waitForText('#viewport', 'Open Navigation');
+  assert.match(
+    (await staticExampleViewport.getText()).replace(/\s+/g, ' '),
+    /This is a static WML sample deck\./
+  );
   assert.match(
     await driver.findElement(By.css('#fetch-url')).getAttribute('value'),
     /\/examples\/index\.wml$/

--- a/browser/frontend/scripts/native-tauri-kannel-e2e.mjs
+++ b/browser/frontend/scripts/native-tauri-kannel-e2e.mjs
@@ -175,10 +175,9 @@ const run = async () => {
   }
   await driver.findElement(By.css('#btn-enter')).click();
   const staticExampleViewport = await waitForText('#viewport', 'Open Navigation');
-  assert.match(
-    (await staticExampleViewport.getText()).replace(/\s+/g, ' '),
-    /This is a static WML sample deck\./
-  );
+  const staticExampleText = await staticExampleViewport.getText();
+  assert.match(staticExampleText, /This is a static WML/);
+  assert.match(staticExampleText, /sample deck\./);
   assert.match(
     await driver.findElement(By.css('#fetch-url')).getAttribute('value'),
     /\/examples\/index\.wml$/

--- a/docs/ci/CI_SETUP.md
+++ b/docs/ci/CI_SETUP.md
@@ -367,6 +367,7 @@ Behavior:
 
 - starts Docker services (`kannel`, `wml-server`)
 - serves WML 1.3 through an explicit test-only DTD setting; the server default remains WML 1.1
+- fetches the static `/examples/index.wml` route through Kannel and verifies its normalized deck
 - sends `Encoding-Version: 1.3` as the WSP-defined short-integer version-value, and uses the
   locally patched Kannel connectionless path to decode and carry that request negotiation into WML
   compilation
@@ -408,7 +409,8 @@ Behavior:
 - serves WML 1.3 through the same explicit WML-server test boundary and requires Kannel to emit
   the negotiated WBXML 1.3 envelope accepted by the pinned decoder
 - uses Selenium to click the real Go and Select controls, assert the gateway-served home/menu UI,
-  assert a visible invalid-URL failure, and recover with another real gateway load
+  traverse menu option 4 into the static example deck, assert a visible invalid-URL failure, and
+  recover with another real gateway load
 - uploads fixed-name screenshots, page source, structured evidence, driver logs, environment
   versions, service logs, and pre/post-teardown state with 21-day retention
 - closes the WebDriver session, terminates the isolated GUI process group, and always tears down

--- a/docs/wap-test-environment/README.md
+++ b/docs/wap-test-environment/README.md
@@ -59,6 +59,7 @@ wap-labs/
   - `/examples/index.wml`
   - `/examples/login.wml`
   - `/examples/register.wml`
+  - each example is served with the configured `WML_DTD_VERSION`, matching the dynamic decks
 - Basic observability:
   - redacted structured request logs with request ID
   - internal `/metrics` plain text counters on port `3001`

--- a/scripts/transport-wap-smoke.sh
+++ b/scripts/transport-wap-smoke.sh
@@ -9,6 +9,7 @@ WML_HEALTH_URL="${WML_HEALTH_URL:-http://localhost:3001/health}"
 WAP_SMOKE_URL="${WAP_SMOKE_URL:-wap://localhost/}"
 WAP_SMOKE_LOGIN_URL="${WAP_SMOKE_LOGIN_URL:-wap://localhost/login}"
 WAP_SMOKE_REGISTER_URL="${WAP_SMOKE_REGISTER_URL:-wap://localhost/register}"
+WAP_SMOKE_EXAMPLE_URL="${WAP_SMOKE_EXAMPLE_URL:-wap://localhost/examples/index.wml}"
 WAP_SMOKE_DENIED_URL="${WAP_SMOKE_DENIED_URL:-wap://127.0.0.1:9200/}"
 TRANSPORT_WAP_TIMEOUT_MS="${TRANSPORT_WAP_TIMEOUT_MS:-15000}"
 TRANSPORT_WAP_RETRIES="${TRANSPORT_WAP_RETRIES:-1}"
@@ -102,7 +103,7 @@ fi
 echo "==> Running transport-rust WAP smoke integration test"
 (
   cd "${ROOT_DIR}/transport-rust"
-  export WAP_SMOKE_URL WAP_SMOKE_LOGIN_URL WAP_SMOKE_REGISTER_URL WAP_SMOKE_DENIED_URL TRANSPORT_WAP_TIMEOUT_MS TRANSPORT_WAP_RETRIES
+  export WAP_SMOKE_URL WAP_SMOKE_LOGIN_URL WAP_SMOKE_REGISTER_URL WAP_SMOKE_EXAMPLE_URL WAP_SMOKE_DENIED_URL TRANSPORT_WAP_TIMEOUT_MS TRANSPORT_WAP_RETRIES
   run_and_tee "${SMOKE_ARTIFACT_DIR}/transport-kannel-smoke.log" \
     cargo test --test kannel_smoke -- --ignored --test-threads=1
 )

--- a/transport-rust/tests/kannel_smoke.rs
+++ b/transport-rust/tests/kannel_smoke.rs
@@ -75,6 +75,24 @@ fn kannel_wap_home_smoke_normalizes_expected_root_deck() {
 
 #[test]
 #[ignore = "runs against external Kannel dev stack (make up)"]
+fn kannel_wap_static_example_smoke_normalizes_expected_deck() {
+    let target = std::env::var("WAP_SMOKE_EXAMPLE_URL")
+        .unwrap_or_else(|_| "wap://localhost/examples/index.wml".to_string());
+    let response = fetch_ok_response(&target);
+    assert_engine_input_contains(
+        &response,
+        &target,
+        &[
+            "card id=\"welcome\"",
+            "title=\"Static Demo\"",
+            "This is a static WML sample deck.",
+            "href=\"#nav\"",
+        ],
+    );
+}
+
+#[test]
+#[ignore = "runs against external Kannel dev stack (make up)"]
 fn kannel_wap_multi_deck_smoke_fetches_root_and_login_decks() {
     let root_url =
         std::env::var("WAP_SMOKE_URL").unwrap_or_else(|_| "wap://localhost/".to_string());

--- a/wml-server/internal/origin/app.go
+++ b/wml-server/internal/origin/app.go
@@ -40,6 +40,7 @@ var (
 	validPIN         = regexp.MustCompile(`^[0-9]{4,6}$`)
 	validSessionID   = regexp.MustCompile(`^[a-f0-9]{16}$`)
 	validExampleName = regexp.MustCompile(`^[a-zA-Z0-9._-]+\.wml$`)
+	exampleDTD       = regexp.MustCompile(`<!DOCTYPE wml PUBLIC "-//WAPFORUM//DTD WML (1\.[123])//EN" "http://www\.wapforum\.org/DTD/wml_(1\.[123])\.xml">`)
 	validDTDs        = map[string]bool{"1.1": true, "1.2": true, "1.3": true}
 )
 
@@ -448,9 +449,31 @@ func (a *App) example(w http.ResponseWriter, r *http.Request) {
 		)
 		return
 	}
+	body, err = configureExampleDTD(body, a.dtdVersion)
+	if err != nil {
+		a.logger.Error("invalid embedded example", "file", fileName, "error", err)
+		a.sendWML(w,
+			`<card id="error" title="Error"><p>Unable to load `+xmlEscape(fileName)+`</p><do type="prev" label="Back"><prev/></do></card>`,
+			http.StatusInternalServerError,
+		)
+		return
+	}
 	setWMLHeaders(w.Header())
 	w.WriteHeader(http.StatusOK)
 	_, _ = w.Write(body)
+}
+
+func configureExampleDTD(body []byte, version string) ([]byte, error) {
+	matches := exampleDTD.FindAllStringSubmatch(string(body), 2)
+	if len(matches) != 1 || len(matches[0]) != 3 || matches[0][1] != matches[0][2] {
+		return nil, errors.New("example must contain exactly one consistent supported WML doctype")
+	}
+	replacement := fmt.Sprintf(
+		`<!DOCTYPE wml PUBLIC "-//WAPFORUM//DTD WML %s//EN" "http://www.wapforum.org/DTD/wml_%s.xml">`,
+		version,
+		version,
+	)
+	return []byte(exampleDTD.ReplaceAllString(string(body), replacement)), nil
 }
 
 func (a *App) health(w http.ResponseWriter, _ *http.Request) {

--- a/wml-server/internal/origin/app_test.go
+++ b/wml-server/internal/origin/app_test.go
@@ -381,6 +381,27 @@ func TestExamplesAndClosedRoutes(t *testing.T) {
 	}
 }
 
+func TestExamplesUseConfiguredDTDVersion(t *testing.T) {
+	for _, version := range []string{"1.1", "1.2", "1.3"} {
+		t.Run(version, func(t *testing.T) {
+			app, _ := newTestApp(t, func(config *Config) { config.DTDVersion = version })
+			for _, file := range []string{"index.wml", "login.wml", "register.wml"} {
+				response := perform(app.Handler(), http.MethodGet, "/examples/"+file, "", "")
+				if response.Code != http.StatusOK {
+					t.Fatalf("GET /examples/%s = %d", file, response.Code)
+				}
+				body := response.Body.String()
+				if !strings.Contains(body, `-//WAPFORUM//DTD WML `+version+`//EN`) {
+					t.Errorf("example %s public identifier does not use WML %s: %s", file, version, body)
+				}
+				if !strings.Contains(body, `http://www.wapforum.org/DTD/wml_`+version+`.xml`) {
+					t.Errorf("example %s system identifier does not use WML %s: %s", file, version, body)
+				}
+			}
+		})
+	}
+}
+
 func TestInternalHealthMetricsAndRedactedLogs(t *testing.T) {
 	var logOutput bytes.Buffer
 	app, _ := newTestApp(t, func(config *Config) {


### PR DESCRIPTION
## Summary

- serve embedded static WML examples with the configured WML_DTD_VERSION instead of their authored WML 1.1 declaration
- add an exact Kannel transport regression for /examples/index.wml
- extend the native desktop pilot through Home -> Menu -> option 4 -> rendered static deck
- document the static-example coverage and DTD behavior

## Root cause and direct trace

The production transport reaches wap://home.wap.shrimpworks.dev/examples/index.wml and receives HTTP/WSP status 200 with application/vnd.wap.wmlc, but Kannel compiled the embedded static file with numeric public identifier 4 (WML 1.1). Lowband correctly rejects that envelope because the active desktop profile is pinned to WML 1.3 identifier 10. Dynamic routes already honor WML_DTD_VERSION; the embedded static route bypassed that rendering path.

The browser retaining the menu deck and pending external intent after the failed fetch is intentional failure-atomic behavior, so this fixes the producer rather than weakening decoder or engine state rules.

## Verification

- live production negative reproduction via ignored kannel_smoke target (WBXML_DECODE_FAILED: public identifier 4, expected 10)
- local WML 1.3 Docker/Kannel exact static-example smoke: pass
- ./scripts/transport-wap-smoke.sh: pass (transport 5/5 plus browser host, engine/render, and auth/privacy lanes)
- fnm exec --using=22.22.1 -- pnpm verify:change: pass
- make lint-go test-go: pass
- make lint-rust-transport: pass
- make test-rust-transport: pass
- pre-commit and pre-push repository hooks: pass

The native Tauri UI flow is committed for the Linux WebDriver CI lane; tauri-driver does not support macOS.