### PR TITLE
feat(browser): give the Waves native console more visual character

### DIFF
--- a/.hallmark/log.json
+++ b/.hallmark/log.json
@@ -1,0 +1,9 @@
+[
+  {
+    "date": "2026-07-28",
+    "macrostructure": "Workbench",
+    "theme": "Almanac",
+    "enrichment": "Tier-A CSS instrument",
+    "brief": "Waves desktop WML browser with period mobile-browser character"
+  }
+]

--- a/.hallmark/preflight.json
+++ b/.hallmark/preflight.json
@@ -1,0 +1,15 @@
+{
+  "date": "2026-07-28",
+  "scope": "browser/frontend",
+  "font_stack": "Native system UI host, system mono technical labels, deterministic Courier LCD",
+  "palette": "OKLCH tokens in browser/frontend/src/tokens.css",
+  "motion": "motion-cut; no animation framework",
+  "spacing": "4pt semantic token scale",
+  "framework": "Lit + Vite",
+  "preserved": [
+    "Tauri native window frame",
+    "HTML/CSS/TypeScript WebView rendering",
+    "WML inverse-video focus semantics",
+    "controller bindings and keyboard order"
+  ]
+}

--- a/browser/frontend/scripts/check-rendered-accessibility.mjs
+++ b/browser/frontend/scripts/check-rendered-accessibility.mjs
@@ -62,6 +62,23 @@ const openAllDisclosures = async (page) => {
   });
 };
 
+const captureDefaultVisual = async (page, name, dimensions) => {
+  const layout = await page.evaluate(() => ({
+    cssViewport: { width: innerWidth, height: innerHeight },
+    scrollWidth: document.documentElement.scrollWidth,
+    horizontalOverflow: document.documentElement.scrollWidth > innerWidth
+  }));
+  assert.equal(layout.horizontalOverflow, false, `${name}: 100% visual has no horizontal overflow`);
+  const screenshot = `${name}-window-100-percent.png`;
+  await page.screenshot({ path: path.join(outputDir, screenshot), fullPage: false });
+  return {
+    physicalWindow: dimensions.physical,
+    cssViewportAt100Percent: layout.cssViewport,
+    scrollWidth: layout.scrollWidth,
+    screenshot
+  };
+};
+
 const resolveBaseRevision = async () => {
   if (requestedBaseRevision) {
     assert.match(
@@ -219,8 +236,16 @@ const auditRenderedPage = async (page, name, windowEvidence) => {
     assert.equal(focused.focusVisible, true, `${name}: #${focused.id} matches :focus-visible`);
     assert.notEqual(focused.outlineStyle, 'none', `${name}: #${focused.id} has an outline`);
     assert.ok(focused.outlineWidth >= 2, `${name}: #${focused.id} outline is at least 2px`);
-    assert.ok(focused.outlineOffset >= 2, `${name}: #${focused.id} outline is offset`);
-    assert.notEqual(focused.boxShadow, 'none', `${name}: #${focused.id} has two-tone separation`);
+    assert.match(
+      focused.boxShadow,
+      /rgb\(255, 255, 255\)/,
+      `${name}: #${focused.id} focus ring has light separation`
+    );
+    assert.match(
+      focused.boxShadow,
+      /rgb\(11, 87, 208\)/,
+      `${name}: #${focused.id} focus ring has a high-contrast outer edge`
+    );
     focusEvidence.push(focused);
   }
   assert.ok(focusEvidence.length > 10, `${name}: keyboard focus evidence covers host controls`);
@@ -272,6 +297,24 @@ try {
   }
 
   browser = await chromium.launch({ headless: true });
+  const visualEvidenceAt100Percent = {};
+  for (const [name, dimensions] of Object.entries(windows)) {
+    const context = await browser.newContext({
+      viewport: dimensions.physical,
+      reducedMotion: 'reduce'
+    });
+    const page = await context.newPage();
+    try {
+      await page.goto(new URL('browser-story.html', baseUrl).href, {
+        waitUntil: 'domcontentloaded'
+      });
+      await waitForReady(page);
+      visualEvidenceAt100Percent[name] = await captureDefaultVisual(page, name, dimensions);
+    } finally {
+      await context.close();
+    }
+  }
+
   const windowEvidence = {};
   for (const [name, dimensions] of Object.entries(windows)) {
     const context = await browser.newContext({
@@ -341,6 +384,7 @@ try {
       headless: true,
       reducedMotion: true
     },
+    visualEvidenceAt100Percent,
     windowEvidence
   };
   const resultPath = path.join(outputDir, 'rendered-accessibility.json');

--- a/browser/frontend/scripts/check-rendered-accessibility.mjs
+++ b/browser/frontend/scripts/check-rendered-accessibility.mjs
@@ -39,6 +39,7 @@ const windows = {
     cssViewport: { width: windowConfig.minWidth / 2, height: windowConfig.minHeight / 2 }
   }
 };
+const hallmarkResponsiveWidths = [320, 375, 414, 768];
 
 const waitForReady = async (page) => {
   await page.waitForFunction(
@@ -77,6 +78,57 @@ const captureDefaultVisual = async (page, name, dimensions) => {
     scrollWidth: layout.scrollWidth,
     screenshot
   };
+};
+
+const captureResponsiveVisual = async (page, width) => {
+  const layout = await page.evaluate(() => {
+    const clickableText = [...document.querySelectorAll('button, summary, .btn')]
+      .filter((element) => {
+        const style = getComputedStyle(element);
+        const rect = element.getBoundingClientRect();
+        return style.display !== 'none' && style.visibility !== 'hidden' && rect.width > 0;
+      })
+      .map((element) => {
+        const style = getComputedStyle(element);
+        return {
+          id: element.id,
+          text: element.textContent?.trim() ?? '',
+          whiteSpace: style.whiteSpace,
+          scrollWidth: element.scrollWidth,
+          clientWidth: element.clientWidth
+        };
+      });
+    const handsetControls = [...document.querySelectorAll('.softkey-row .btn')].map((element) => {
+      const rect = element.getBoundingClientRect();
+      return { id: element.id, left: rect.left, right: rect.right };
+    });
+    return {
+      cssViewport: { width: innerWidth, height: innerHeight },
+      scrollWidth: document.documentElement.scrollWidth,
+      horizontalOverflow: document.documentElement.scrollWidth > innerWidth,
+      clickableText,
+      handsetControls
+    };
+  });
+  assert.equal(layout.horizontalOverflow, false, `${width}px: no horizontal overflow`);
+  for (const action of layout.clickableText) {
+    assert.equal(
+      action.whiteSpace,
+      'nowrap',
+      `${width}px: ${action.id || action.text} stays on one line`
+    );
+    assert.ok(
+      action.scrollWidth <= action.clientWidth,
+      `${width}px: ${action.id || action.text} label is not clipped`
+    );
+  }
+  for (const control of layout.handsetControls) {
+    assert.ok(control.left >= 0, `${width}px: #${control.id} is not clipped left`);
+    assert.ok(control.right <= width, `${width}px: #${control.id} is not clipped right`);
+  }
+  const screenshot = `responsive-${width}px.png`;
+  await page.screenshot({ path: path.join(outputDir, screenshot), fullPage: false });
+  return { ...layout, screenshot };
 };
 
 const resolveBaseRevision = async () => {
@@ -139,6 +191,7 @@ const auditRenderedPage = async (page, name, windowEvidence) => {
     const shell = document.querySelector('.browser-shell');
     const viewport = document.querySelector('#viewport');
     const focusedWmlItem = document.querySelector('.wml-segment-link.is-focused');
+    const rootStyle = getComputedStyle(document.documentElement);
     return {
       cssViewport: { width: innerWidth, height: innerHeight },
       document: {
@@ -155,9 +208,14 @@ const auditRenderedPage = async (page, name, windowEvidence) => {
         ).length,
         hostFontFamily: getComputedStyle(document.body).fontFamily,
         lcdFontFamily: viewport ? getComputedStyle(viewport).fontFamily : null,
+        lcdBackground: viewport ? getComputedStyle(viewport).backgroundColor : null,
+        lcdForeground: viewport ? getComputedStyle(viewport).color : null,
         focusedWmlBackground: focusedWmlItem
           ? getComputedStyle(focusedWmlItem).backgroundColor
           : null,
+        focusedWmlForeground: focusedWmlItem ? getComputedStyle(focusedWmlItem).color : null,
+        focusRingColor: rootStyle.getPropertyValue('--focus-ring-color').trim(),
+        focusRingOuterColor: rootStyle.getPropertyValue('--focus-ring-outer-color').trim(),
         runningAnimationCount: document.getAnimations().length
       }
     };
@@ -187,8 +245,13 @@ const auditRenderedPage = async (page, name, windowEvidence) => {
   );
   assert.equal(
     layout.presentation.focusedWmlBackground,
-    'rgb(28, 43, 28)',
-    `${name}: inverse-video WML focus remains visible`
+    layout.presentation.lcdForeground,
+    `${name}: focused WML background inverts the LCD foreground`
+  );
+  assert.equal(
+    layout.presentation.focusedWmlForeground,
+    layout.presentation.lcdBackground,
+    `${name}: focused WML foreground inverts the LCD background`
   );
   assert.equal(
     layout.presentation.runningAnimationCount,
@@ -238,13 +301,13 @@ const auditRenderedPage = async (page, name, windowEvidence) => {
     assert.ok(focused.outlineWidth >= 2, `${name}: #${focused.id} outline is at least 2px`);
     assert.match(
       focused.boxShadow,
-      /rgb\(255, 255, 255\)/,
-      `${name}: #${focused.id} focus ring has light separation`
+      /0px 0px 0px 2px/,
+      `${name}: #${focused.id} focus ring has a separation layer`
     );
     assert.match(
       focused.boxShadow,
-      /rgb\(11, 87, 208\)/,
-      `${name}: #${focused.id} focus ring has a high-contrast outer edge`
+      /0px 0px 0px 5px/,
+      `${name}: #${focused.id} focus ring has a high-contrast outer layer`
     );
     focusEvidence.push(focused);
   }
@@ -297,6 +360,24 @@ try {
   }
 
   browser = await chromium.launch({ headless: true });
+  const responsiveEvidence = {};
+  for (const width of hallmarkResponsiveWidths) {
+    const context = await browser.newContext({
+      viewport: { width, height: 900 },
+      reducedMotion: 'reduce'
+    });
+    const page = await context.newPage();
+    try {
+      await page.goto(new URL('browser-story.html', baseUrl).href, {
+        waitUntil: 'domcontentloaded'
+      });
+      await waitForReady(page);
+      responsiveEvidence[width] = await captureResponsiveVisual(page, width);
+    } finally {
+      await context.close();
+    }
+  }
+
   const visualEvidenceAt100Percent = {};
   for (const [name, dimensions] of Object.entries(windows)) {
     const context = await browser.newContext({
@@ -384,6 +465,7 @@ try {
       headless: true,
       reducedMotion: true
     },
+    responsiveEvidence,
     visualEvidenceAt100Percent,
     windowEvidence
   };

--- a/browser/frontend/src/app/browser-shell-template.test.ts
+++ b/browser/frontend/src/app/browser-shell-template.test.ts
@@ -66,6 +66,18 @@ describe('mountBrowserShell', () => {
     expect(document.querySelector('.form-95')).toBeNull();
   });
 
+  it('adds a decorative Waves identity without changing the accessible heading', () => {
+    document.body.innerHTML = '<div id="app"></div>';
+    mountBrowserShell('http://example.test/start.wml', 'local');
+
+    const brand = document.querySelector<HTMLHeadingElement>('h1.brand');
+    const brandMark = brand?.querySelector<HTMLElement>('.brand-mark');
+
+    expect(brand?.textContent?.trim()).toBe('Waves');
+    expect(brandMark?.getAttribute('aria-hidden')).toBe('true');
+    expect(brandMark?.textContent).toBe('');
+  });
+
   it('opens the utility rail by default at normal window widths', () => {
     document.body.innerHTML = '<div id="app"></div>';
     mountBrowserShell('http://example.test/start.wml', 'local');

--- a/browser/frontend/src/app/browser-shell-template.ts
+++ b/browser/frontend/src/app/browser-shell-template.ts
@@ -16,7 +16,10 @@ const browserShellTemplate = () => `
   <div class="browser-shell" data-host-presentation="native">
     <header class="browser-chrome">
       <div class="title-row">
-        <h1 class="brand">${WAVES_COPY.app.brand}</h1>
+        <h1 class="brand">
+          <span class="brand-mark" aria-hidden="true"></span>
+          <span>${WAVES_COPY.app.brand}</span>
+        </h1>
         <div class="caption">${WAVES_COPY.app.tagline}</div>
       </div>
       ${navigationToolbarTemplate()}

--- a/browser/frontend/src/app/shell/handset-stage-template.ts
+++ b/browser/frontend/src/app/shell/handset-stage-template.ts
@@ -11,7 +11,7 @@ export const handsetStageTemplate = () => `
     <div class="handset-housing">
       <div class="device-frame">
         <div class="device-header">
-          <span>${WAVES_COPY.shell.deckView}</span>
+          <span class="device-title">${WAVES_COPY.shell.deckView}</span>
           <span id="active-url-label" class="muted-url">${WAVES_COPY.shell.idle}</span>
         </div>
         <div

--- a/browser/frontend/src/app/shell/navigation-toolbar-template.ts
+++ b/browser/frontend/src/app/shell/navigation-toolbar-template.ts
@@ -23,11 +23,11 @@ export const navigationToolbarTemplate = () => `
       <button id="btn-load-local" class="btn chrome-btn">${WAVES_COPY.shell.loadLocal}</button>
     </div>
     <div class="toolbar-meta">
-      <span class="toolbar-meta-item">
+      <span class="toolbar-meta-item route-meta">
         <span class="toolbar-meta-label">${WAVES_COPY.shell.route}</span>
         <span id="route-label"></span>
       </span>
-      <span class="toolbar-meta-item">
+      <span class="toolbar-meta-item profile-meta">
         <span class="toolbar-meta-label">${WAVES_COPY.shell.profile}</span>
         <span id="profile-label">${WAVES_COPY.shell.classCReferenceProfile}</span>
       </span>

--- a/browser/frontend/src/components/primitives/surface-panel.ts
+++ b/browser/frontend/src/components/primitives/surface-panel.ts
@@ -13,24 +13,25 @@ export class WvSurfacePanel extends LitElement {
     .panel {
       overflow: clip;
       border: 1px solid var(--panel-border-mid);
-      border-radius: 7px;
+      border-radius: 9px;
       background: var(--panel-bg);
+      box-shadow: 0 2px 8px rgb(31 52 49 / 7%);
     }
 
     .heading {
       margin: 0;
-      padding: 6px 8px;
+      padding: 7px 9px;
       border-bottom: 1px solid var(--panel-border-mid);
       font-size: 12px;
-      letter-spacing: 0;
-      text-transform: none;
+      letter-spacing: 0.045em;
+      text-transform: uppercase;
       color: var(--panel-heading-text);
-      font-weight: 650;
-      background: var(--host-surface);
+      font-weight: 700;
+      background: var(--panel-heading-bg);
     }
 
     .body {
-      padding: 7px;
+      padding: 8px;
     }
   `;
 

--- a/browser/frontend/src/components/primitives/surface-panel.ts
+++ b/browser/frontend/src/components/primitives/surface-panel.ts
@@ -12,26 +12,26 @@ export class WvSurfacePanel extends LitElement {
 
     .panel {
       overflow: clip;
-      border: 1px solid var(--panel-border-mid);
-      border-radius: 9px;
-      background: var(--panel-bg);
-      box-shadow: 0 2px 8px rgb(31 52 49 / 7%);
+      border-block: 1px solid var(--panel-border-mid);
+      color: var(--host-text);
+      background: transparent;
     }
 
     .heading {
       margin: 0;
-      padding: 7px 9px;
+      padding: var(--space-xs) var(--space-sm);
       border-bottom: 1px solid var(--panel-border-mid);
-      font-size: 12px;
-      letter-spacing: 0.045em;
+      font-family: var(--font-mono);
+      font-size: var(--text-xs);
+      letter-spacing: 0.06em;
       text-transform: uppercase;
       color: var(--panel-heading-text);
       font-weight: 700;
-      background: var(--panel-heading-bg);
+      background: transparent;
     }
 
     .body {
-      padding: 8px;
+      padding: var(--space-sm);
     }
   `;
 

--- a/browser/frontend/src/components/status-panel.ts
+++ b/browser/frontend/src/components/status-panel.ts
@@ -15,15 +15,34 @@ export class WvStatusPanel extends LitElement {
     .status {
       position: relative;
       border: 1px solid var(--panel-border-mid);
-      border-left: 4px solid var(--status-idle-indicator);
-      border-radius: 6px;
-      padding: 9px 10px;
-      font-size: 13px;
+      border-radius: var(--radius-control);
+      padding: var(--space-xs) var(--space-sm) var(--space-xs) 2rem;
+      font-size: var(--text-sm);
       min-height: 44px;
       background: var(--status-idle-bg);
       color: var(--status-idle-text);
-      line-height: 1.35;
-      box-shadow: inset 0 1px 0 rgb(255 255 255 / 55%);
+      line-height: 1.5;
+      box-shadow: inset 0 1px 0 var(--color-highlight-medium);
+    }
+
+    .status::before {
+      position: absolute;
+      inset-block-start: 50%;
+      inset-inline-start: var(--space-sm);
+      display: grid;
+      width: 0.875rem;
+      height: 0.875rem;
+      place-items: center;
+      border: 1px solid currentColor;
+      border-radius: var(--radius-xs);
+      background: var(--status-idle-indicator);
+      color: var(--status-idle-bg);
+      content: '–';
+      font-family: var(--font-mono);
+      font-size: 0.625rem;
+      font-weight: 700;
+      line-height: 1;
+      transform: translateY(-50%);
     }
 
     .status-idle {
@@ -32,21 +51,36 @@ export class WvStatusPanel extends LitElement {
     }
 
     .status-loading {
-      border-left-color: var(--status-loading-indicator);
       background: var(--status-loading-bg);
       color: var(--status-loading-text);
     }
 
+    .status-loading::before {
+      background: var(--status-loading-indicator);
+      color: var(--status-loading-bg);
+      content: '…';
+    }
+
     .status-ok {
-      border-left-color: var(--status-ok-indicator);
       background: var(--status-ok-bg);
       color: var(--status-ok-text);
     }
 
+    .status-ok::before {
+      background: var(--status-ok-indicator);
+      color: var(--status-ok-bg);
+      content: '✓';
+    }
+
     .status-error {
-      border-left-color: var(--status-error-indicator);
       background: var(--status-error-bg);
       color: var(--status-error-text);
+    }
+
+    .status-error::before {
+      background: var(--status-error-indicator);
+      color: var(--status-error-bg);
+      content: '!';
     }
   `;
 

--- a/browser/frontend/src/components/status-panel.ts
+++ b/browser/frontend/src/components/status-panel.ts
@@ -13,14 +13,17 @@ export class WvStatusPanel extends LitElement {
     }
 
     .status {
+      position: relative;
       border: 1px solid var(--panel-border-mid);
-      border-radius: 5px;
-      padding: 8px;
+      border-left: 4px solid var(--status-idle-indicator);
+      border-radius: 6px;
+      padding: 9px 10px;
       font-size: 13px;
       min-height: 44px;
       background: var(--status-idle-bg);
       color: var(--status-idle-text);
       line-height: 1.35;
+      box-shadow: inset 0 1px 0 rgb(255 255 255 / 55%);
     }
 
     .status-idle {
@@ -29,16 +32,19 @@ export class WvStatusPanel extends LitElement {
     }
 
     .status-loading {
+      border-left-color: var(--status-loading-indicator);
       background: var(--status-loading-bg);
       color: var(--status-loading-text);
     }
 
     .status-ok {
+      border-left-color: var(--status-ok-indicator);
       background: var(--status-ok-bg);
       color: var(--status-ok-text);
     }
 
     .status-error {
+      border-left-color: var(--status-error-indicator);
       background: var(--status-error-bg);
       color: var(--status-error-text);
     }

--- a/browser/frontend/src/styles.css
+++ b/browser/frontend/src/styles.css
@@ -1,66 +1,14 @@
+/* Hallmark · genre: editorial/reference · macrostructure: Workbench · theme: Almanac · enrichment: Tier-A CSS instrument · nav: native command strip · footer: status readout */
+/* Hallmark · pre-emit critique: P5 H4 E4 S5 R5 V4 */
+/* Hallmark · contrast: pass (40–41) · slop: pass (42–45) · honest: pass (46) · chrome: pass (47, functional emulator surface) · tokens: pass (48) · mobile: pass (34, 49–57) */
+@import './tokens.css';
+
 :root {
-  color-scheme: light;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif;
-  font-synthesis: none;
-
-  /* Warm native-host surfaces with a restrained WAP-console identity. The
-     operating-system title bar remains the application's only window frame. */
-  --host-canvas: #e7ece9;
-  --host-canvas-deep: #dce4e0;
-  --host-surface: #f5f4ed;
-  --host-surface-raised: #fbfaf5;
-  --host-panel: #fffdf8;
-  --host-border: #bdc9c4;
-  --host-border-strong: #7e918b;
-  --host-text: #182522;
-  --host-muted: #536762;
-  --host-accent: #087b78;
-  --host-accent-hover: #056461;
-  --host-accent-deep: #064f4e;
-  --host-accent-soft: #d8ece8;
-  --host-highlight: #d1902c;
-  --host-highlight-soft: #f7e8c8;
-
-  /* Shared host-panel tones consumed by the lightweight Web Components. */
-  --panel-border-mid: var(--host-border);
-  --panel-bg: var(--host-panel);
-  --panel-heading-bg: #edf3f0;
-  --panel-heading-text: var(--host-accent-deep);
-
-  /* Status-panel semantic tones. */
-  --status-idle-bg: #f2f5f3;
-  --status-idle-text: #31413d;
-  --status-idle-indicator: #72837e;
-  --status-loading-bg: #fff3d8;
-  --status-loading-text: #5b4409;
-  --status-loading-indicator: #bd7711;
-  --status-ok-bg: #e3f3e9;
-  --status-ok-text: #165830;
-  --status-ok-indicator: #27834a;
-  --status-error-bg: #fbe8e4;
-  --status-error-text: #842b24;
-  --status-error-indicator: #bd4a3f;
-
-  /* Toast semantic tones. */
-  --toast-ok-bg: #e3f3e9;
-  --toast-error-bg: #fbe8e4;
-
-  /* Generic Class C reference handset and deterministic monochrome LCD. */
-  --handset-housing-bg: #354b4a;
-  --handset-housing-highlight: #607572;
-  --handset-housing-shadow: #172524;
-  --handset-bezel: #263a38;
-  --lcd-bg: #d8e4c4;
-  --lcd-fg: #1c2b1c;
-  --lcd-focus-bg: #1c2b1c;
-  --lcd-focus-fg: #d8e4c4;
+  font-family: var(--font-body);
 
   /* Integer display scaling changes only rendered pixels, never engine
      columns, line wrapping, focus, or navigation behavior. */
   --handset-scale: 1;
-
-  --focus-ring-color: #0b57d0;
-  --focus-ring-outer-color: #ffffff;
 }
 
 * {
@@ -71,16 +19,16 @@ html,
 body {
   width: 100%;
   min-height: 100%;
+  overflow-x: clip;
 }
 
 body {
   margin: 0;
-  background:
-    radial-gradient(circle at 14% 8%, rgb(255 255 255 / 70%), transparent 34rem),
-    linear-gradient(145deg, var(--host-canvas), var(--host-canvas-deep));
+  background: linear-gradient(180deg, var(--host-canvas), var(--host-canvas-deep));
   color: var(--host-text);
-  font-size: 14px;
-  line-height: 1.35;
+  font-family: var(--font-body);
+  font-size: var(--text-base);
+  line-height: 1.5;
 }
 
 button,
@@ -92,7 +40,7 @@ textarea {
 
 #app {
   width: 100%;
-  min-height: 100vh;
+  min-height: 100dvh;
 }
 
 .visually-hidden {
@@ -109,7 +57,7 @@ textarea {
 
 .browser-shell {
   display: flex;
-  min-height: 100vh;
+  min-height: 100dvh;
   flex-direction: column;
   color: var(--host-text);
   background: transparent;
@@ -117,40 +65,41 @@ textarea {
 
 .browser-chrome {
   position: relative;
-  z-index: 2;
-  padding: 11px 16px 13px;
-  border-bottom: 1px solid var(--host-border);
+  z-index: var(--z-raised, 10);
+  padding: var(--space-sm) var(--space-md);
+  border-bottom: var(--rule-hair) solid var(--host-border-strong);
   background:
     linear-gradient(
         90deg,
-        var(--host-accent) 0 74px,
-        var(--host-highlight) 74px 81px,
-        transparent 81px
+        var(--host-accent) 0 5rem,
+        var(--host-highlight) 5rem 5.5rem,
+        var(--host-border) 5.5rem 100%
       )
-      top / 100% 3px no-repeat,
+      top / 100% var(--space-2xs) no-repeat,
     linear-gradient(180deg, var(--host-surface-raised), var(--host-surface));
-  box-shadow:
-    inset 0 1px 0 rgb(255 255 255 / 75%),
-    0 3px 12px rgb(28 53 49 / 10%);
+  box-shadow: var(--shadow-chrome);
 }
 
 .title-row {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 16px;
-  margin-bottom: 10px;
+  gap: var(--space-md);
+  margin-block: var(--space-2xs) var(--space-xs);
 }
 
 .brand {
   display: inline-flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-xs);
   margin: 0;
   color: var(--host-accent-deep);
-  font-size: 18px;
-  font-weight: 760;
-  letter-spacing: -0.025em;
+  font-family: var(--font-display);
+  font-size: var(--text-lg);
+  font-weight: 800;
+  letter-spacing: -0.03em;
+  min-width: 0;
+  overflow-wrap: anywhere;
 }
 
 .brand-mark {
@@ -159,12 +108,11 @@ textarea {
   height: 24px;
   flex: 0 0 24px;
   overflow: hidden;
-  border: 1px solid rgb(3 65 64 / 42%);
-  border-radius: 7px;
-  background: linear-gradient(155deg, rgb(255 255 255 / 38%), transparent 48%), var(--host-accent);
-  box-shadow:
-    inset 0 1px 0 rgb(255 255 255 / 35%),
-    0 2px 5px rgb(5 79 78 / 22%);
+  border: var(--rule-hair) solid var(--host-accent-deep);
+  border-radius: var(--radius-control);
+  background:
+    linear-gradient(155deg, var(--color-highlight-faint), transparent 48%), var(--host-accent);
+  box-shadow: var(--shadow-panel);
 }
 
 .brand-mark::before,
@@ -173,7 +121,7 @@ textarea {
   left: 4px;
   width: 16px;
   height: 6px;
-  border: 2px solid #fff6dc;
+  border: var(--rule-strong) solid var(--color-highlight-soft);
   border-top: 0;
   border-radius: 0 0 50% 50%;
   content: '';
@@ -189,55 +137,59 @@ textarea {
 }
 
 .caption {
-  padding: 3px 8px;
-  border: 1px solid #c8d9d4;
-  border-radius: 999px;
+  padding: var(--space-2xs) var(--space-xs);
+  border: var(--rule-hair) solid var(--host-border);
+  border-radius: var(--radius-xs);
   color: var(--host-accent-deep);
   background: var(--host-accent-soft);
-  font-size: 11px;
-  font-weight: 650;
-  letter-spacing: 0.025em;
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  font-weight: 600;
+  letter-spacing: 0.04em;
 }
 
 .nav-toolbar {
   display: grid;
-  gap: 9px;
+  gap: var(--space-xs);
 }
 
 .nav-row {
   display: grid;
   grid-template-columns: auto auto minmax(12rem, 1fr) auto;
-  gap: 6px;
+  gap: var(--space-xs);
   align-items: center;
 }
 
 .mode-row {
   display: grid;
   grid-template-columns: minmax(7rem, 0.65fr) minmax(12rem, 1.8fr) auto;
-  gap: 8px;
+  gap: var(--space-xs);
   align-items: end;
-  padding: 8px;
-  border: 1px solid var(--host-border);
-  border-radius: 9px;
-  background: rgb(255 253 248 / 72%);
-  box-shadow: inset 0 1px 0 rgb(255 255 255 / 75%);
+  padding: var(--space-xs);
+  border: var(--rule-hair) solid var(--host-border);
+  border-radius: var(--radius-control);
+  color: var(--host-text);
+  background: var(--host-panel);
 }
 
 .mode-field {
   display: grid;
   min-width: 0;
-  gap: 3px;
-  color: #435a54;
-  font-size: 11px;
-  font-weight: 600;
+  gap: var(--space-2xs);
+  color: var(--host-muted);
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  font-weight: 700;
+  letter-spacing: 0.025em;
 }
 
 .toolbar-meta {
   display: flex;
   flex-wrap: wrap;
-  gap: 6px 8px;
+  gap: var(--space-2xs) var(--space-xs);
   color: var(--host-muted);
-  font-size: 11px;
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
 }
 
 .toolbar-meta-item {
@@ -245,17 +197,18 @@ textarea {
   align-items: center;
   min-width: 0;
   min-height: 24px;
-  padding: 3px 8px;
-  border: 1px solid #c8d4d0;
-  border-radius: 999px;
-  background: rgb(255 253 248 / 66%);
+  padding: var(--space-2xs) var(--space-xs);
+  border: var(--rule-hair) solid var(--host-border);
+  border-radius: var(--radius-xs);
+  color: var(--host-muted);
+  background: var(--host-surface-raised);
 }
 
 .toolbar-meta-item::before {
   width: 7px;
   height: 7px;
   flex: 0 0 7px;
-  margin-right: 6px;
+  margin-inline-end: var(--space-xs);
   border-radius: 50%;
   background: var(--host-accent);
   box-shadow: 0 0 0 2px var(--host-accent-soft);
@@ -269,7 +222,7 @@ textarea {
 }
 
 .toolbar-meta-label {
-  margin-right: 4px;
+  margin-inline-end: var(--space-2xs);
   color: var(--host-text);
   font-weight: 650;
 }
@@ -278,21 +231,20 @@ textarea {
 button,
 .btn {
   min-height: 32px;
-  border: 1px solid var(--host-border-strong);
-  border-radius: 7px;
+  border: var(--rule-hair) solid var(--host-border-strong);
+  border-radius: var(--radius-control);
   color: var(--host-text);
   background: var(--host-surface-raised);
-  box-shadow: inset 0 1px 0 rgb(255 255 255 / 80%);
+  outline: var(--rule-strong) solid transparent;
+  outline-offset: var(--rule-hair);
 }
 
 .host-control {
   width: 100%;
   min-width: 0;
-  padding: 5px 9px;
-  background: #fffefb;
-  box-shadow:
-    inset 0 1px 3px rgb(20 45 40 / 7%),
-    0 1px 0 rgb(255 255 255 / 75%);
+  padding: var(--space-2xs) var(--space-xs);
+  background: var(--host-panel);
+  box-shadow: inset 0 1px 3px var(--color-shadow-faint);
 }
 
 button,
@@ -300,33 +252,35 @@ button,
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  padding: 4px 11px;
-  font-weight: 600;
+  padding: var(--space-2xs) var(--space-sm);
+  font-weight: 700;
   cursor: default;
-  text-shadow: 0 1px 0 rgb(255 255 255 / 70%);
+  white-space: nowrap;
+  transition:
+    background-color var(--dur-micro) var(--ease-out),
+    transform var(--dur-micro) var(--ease-out);
 }
 
 button:active:not(:disabled),
 .btn:active:not(:disabled) {
-  background: #e5ebe7;
-  box-shadow: inset 0 1px 3px rgb(25 52 47 / 16%);
+  background: var(--color-paper-3);
+  box-shadow: inset 0 1px 3px var(--color-shadow-soft);
+  transform: translateY(1px);
 }
 
 button:disabled,
 .btn:disabled {
-  color: #8a929e;
-  background: #ecefeb;
-  opacity: 0.78;
+  color: var(--color-disabled);
+  background: var(--color-paper-3);
+  cursor: not-allowed;
+  opacity: 0.72;
 }
 
 .browser-chrome .chrome-btn.primary {
   border-color: var(--host-accent);
-  color: #ffffff;
+  color: var(--color-accent-ink);
   background: var(--host-accent);
-  box-shadow:
-    inset 0 1px 0 rgb(255 255 255 / 22%),
-    0 2px 5px rgb(5 79 78 / 18%);
-  text-shadow: 0 1px 0 rgb(0 0 0 / 18%);
+  box-shadow: 0 1px 2px var(--color-shadow-soft);
 }
 
 .browser-chrome .chrome-btn.primary:active:not(:disabled) {
@@ -335,6 +289,7 @@ button:disabled,
 
 summary {
   min-height: 32px;
+  white-space: nowrap;
 }
 
 #app button:focus-visible,
@@ -353,11 +308,11 @@ summary {
 
 .browser-main {
   display: grid;
-  grid-template-columns: minmax(0, 1.45fr) minmax(250px, 0.7fr);
-  gap: 18px;
+  grid-template-columns: minmax(0, 1.55fr) minmax(17rem, 0.65fr);
+  gap: var(--space-lg);
   flex: 1;
   align-items: start;
-  padding: 18px;
+  padding: var(--space-lg);
 }
 
 .handset-stage {
@@ -374,9 +329,10 @@ summary {
   flex: 1;
   min-width: 0;
   flex-direction: column;
-  padding: 24px 16px 16px;
-  border: 1px solid var(--handset-housing-shadow);
-  border-radius: 24px;
+  padding: var(--space-lg) var(--space-md) var(--space-md);
+  border: var(--rule-hair) solid var(--handset-housing-shadow);
+  border-radius: var(--radius-handset);
+  color: var(--color-device-label);
   background: linear-gradient(
     150deg,
     var(--handset-housing-highlight),
@@ -384,9 +340,8 @@ summary {
     var(--handset-housing-shadow)
   );
   box-shadow:
-    inset 0 1px 0 rgb(255 255 255 / 28%),
-    inset 0 -2px 5px rgb(7 20 19 / 24%),
-    0 12px 28px rgb(28 47 44 / 24%);
+    inset 0 1px 0 var(--color-highlight-faint),
+    var(--shadow-device);
 }
 
 .handset-housing::before {
@@ -395,9 +350,9 @@ summary {
   left: 50%;
   width: 52px;
   height: 4px;
-  border-radius: 999px;
-  background: #172725;
-  box-shadow: inset 0 1px 1px rgb(0 0 0 / 68%);
+  border-radius: var(--radius-pill);
+  background: var(--color-handset-shadow);
+  box-shadow: inset 0 1px 1px var(--color-shadow-device);
   content: '';
   transform: translateX(-50%);
 }
@@ -408,10 +363,10 @@ summary {
   left: 22px;
   width: 6px;
   height: 6px;
-  border: 1px solid #193632;
+  border: var(--rule-hair) solid var(--color-handset-shadow);
   border-radius: 50%;
-  background: #72c8a7;
-  box-shadow: 0 0 0 2px rgb(19 46 42 / 28%);
+  background: var(--color-led);
+  box-shadow: 0 0 0 2px var(--color-shadow-medium);
   content: '';
 }
 
@@ -423,13 +378,12 @@ summary {
   display: flex;
   min-width: 0;
   flex-direction: column;
-  padding: 8px;
-  border: 1px solid #172725;
-  border-radius: 13px;
-  background: linear-gradient(180deg, #415755, var(--handset-bezel));
-  box-shadow:
-    inset 0 1px 0 rgb(255 255 255 / 12%),
-    0 1px 2px rgb(5 15 14 / 42%);
+  padding: var(--space-xs);
+  border: var(--rule-hair) solid var(--color-handset-shadow);
+  border-radius: var(--radius-device);
+  color: var(--color-device-label);
+  background: linear-gradient(180deg, var(--color-bezel-raised), var(--handset-bezel));
+  box-shadow: 0 1px 2px var(--color-shadow-device);
 }
 
 .device-header {
@@ -437,24 +391,26 @@ summary {
   min-width: 0;
   align-items: center;
   justify-content: space-between;
-  gap: 12px;
-  margin: 0 4px 7px;
-  color: #f3f2e8;
-  font-size: 11px;
-  font-weight: 650;
-  letter-spacing: 0.02em;
+  gap: var(--space-sm);
+  margin: 0 var(--space-2xs) var(--space-xs);
+  color: var(--color-device-label);
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  font-weight: 700;
+  letter-spacing: 0.035em;
 }
 
 .device-title {
   display: inline-flex;
   align-items: center;
+  white-space: nowrap;
 }
 
 .device-title::before {
   width: 4px;
   height: 12px;
-  margin-right: 6px;
-  border-radius: 2px;
+  margin-inline-end: var(--space-xs);
+  border-radius: var(--radius-xs);
   background: var(--host-highlight);
   content: '';
 }
@@ -462,7 +418,7 @@ summary {
 .muted-url {
   max-width: 72%;
   overflow: hidden;
-  color: #d5e2de;
+  color: var(--color-device-muted);
   font-weight: 400;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -471,32 +427,35 @@ summary {
 .viewport {
   flex: 1;
   min-height: 360px;
-  padding: 10px;
-  border: 4px solid #14221f;
-  border-radius: 6px;
+  padding: var(--space-sm);
+  border: var(--rule-lcd) solid var(--color-handset-shadow);
+  border-radius: var(--radius-control);
   color: var(--lcd-fg);
   background-color: var(--lcd-bg);
   background-image:
-    linear-gradient(110deg, rgb(255 255 255 / 13%), transparent 35%),
-    repeating-linear-gradient(0deg, rgb(22 41 26 / 2%) 0 1px, transparent 1px 4px);
+    linear-gradient(110deg, var(--color-lcd-glare), transparent 35%),
+    repeating-linear-gradient(
+      0deg,
+      var(--color-lcd-scanline) 0 var(--rule-hair),
+      transparent var(--rule-hair) var(--space-2xs)
+    );
   box-shadow:
-    inset 0 0 0 1px rgb(245 255 228 / 38%),
-    inset 0 2px 10px rgb(24 39 25 / 18%),
-    0 1px 0 rgb(255 255 255 / 12%);
-  font-family: 'Courier New', Courier, monospace;
+    inset 0 0 0 1px var(--color-highlight-faint),
+    inset 0 2px 10px var(--color-shadow-soft);
+  font-family: var(--font-lcd);
   line-height: 1.4;
 }
 
 .viewport-skeleton {
-  border-color: #39423d;
+  border-color: var(--color-ink-2);
 }
 
 .skeleton-line {
   width: 70%;
   height: 9px;
-  margin-bottom: 8px;
+  margin-block-end: var(--space-xs);
   border-radius: 2px;
-  background: rgb(28 43 28 / 13%);
+  background: var(--color-lcd-skeleton);
 }
 
 .skeleton-line-wide {
@@ -508,20 +467,20 @@ summary {
 }
 
 .skeleton-hint {
-  margin-top: 12px;
+  margin-block-start: var(--space-sm);
   display: inline-flex;
   align-items: center;
-  color: #3d4d3b;
-  font-size: 11px;
+  color: var(--color-lcd-ink);
+  font-size: var(--text-xs);
 }
 
 .skeleton-hint::before {
   width: 7px;
   height: 7px;
-  margin-right: 7px;
-  border: 1px solid #5c714f;
+  margin-inline-end: var(--space-xs);
+  border: var(--rule-hair) solid var(--color-lcd-ink);
   border-radius: 50%;
-  background: #b1c795;
+  background: var(--color-lcd);
   content: '';
 }
 
@@ -534,7 +493,7 @@ summary {
 }
 
 .wml-segment-link {
-  color: #284bc6;
+  color: var(--color-lcd-link);
   text-decoration: underline;
 }
 
@@ -547,49 +506,49 @@ summary {
 .softkey-row {
   display: grid;
   grid-template-columns: repeat(3, 1fr);
-  gap: 8px;
-  margin-top: 9px;
+  gap: var(--space-xs);
+  margin-block-start: var(--space-xs);
 }
 
 .softkey-row .btn {
   min-height: 32px;
-  border-color: #172523;
-  border-radius: 8px;
-  color: #172421;
-  background: linear-gradient(180deg, #eef0ea, #cbd3cf);
-  box-shadow:
-    inset 0 1px 0 rgb(255 255 255 / 78%),
-    0 2px 2px rgb(6 18 17 / 38%);
-  font-size: 12px;
+  border-color: var(--color-handset-shadow);
+  border-radius: var(--radius-control);
+  color: var(--color-ink);
+  background: linear-gradient(180deg, var(--color-paper), var(--color-paper-3));
+  box-shadow: 0 2px 2px var(--color-shadow-device);
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
   font-weight: 700;
 }
 
 .softkey-row #btn-enter {
-  border-color: #845910;
-  background: linear-gradient(180deg, #f5d993, #d9a747);
+  border-color: var(--color-highlight-ink);
+  color: var(--color-highlight-ink);
+  background: linear-gradient(180deg, var(--color-highlight-soft), var(--color-highlight));
 }
 
 .utility-rail {
   display: flex;
   min-width: 0;
   flex-direction: column;
-  gap: 8px;
+  gap: var(--space-xs);
 }
 
 .chrome-disclosure {
   overflow: clip;
-  border: 1px solid var(--host-border);
-  border-radius: 10px;
+  border: var(--rule-hair) solid var(--host-border);
+  border-radius: var(--radius-panel);
   color: var(--host-text);
-  background: rgb(255 253 248 / 92%);
-  box-shadow: 0 3px 12px rgb(28 52 48 / 8%);
+  background: var(--host-panel);
+  box-shadow: var(--shadow-panel);
 }
 
 .chrome-disclosure > summary {
-  padding: 7px 10px;
+  padding: var(--space-xs) var(--space-sm);
   color: var(--host-accent-deep);
-  background: linear-gradient(180deg, #f8f8f2, #edf2ef);
-  font-size: 13px;
+  background: linear-gradient(180deg, var(--host-surface-raised), var(--color-paper-3));
+  font-size: var(--text-sm);
   font-weight: 700;
   cursor: default;
 }
@@ -599,13 +558,12 @@ summary {
 }
 
 .utility-rail-panel > summary {
-  color: #ffffff;
-  background: linear-gradient(100deg, var(--host-accent-deep), var(--host-accent));
-  text-shadow: 0 1px 0 rgb(0 0 0 / 20%);
+  color: var(--color-accent-ink);
+  background: var(--host-accent-deep);
 }
 
 .utility-rail-panel > summary::marker {
-  color: #f7d89c;
+  color: var(--color-highlight-soft);
 }
 
 .utility-rail-panel > summary {
@@ -619,61 +577,68 @@ summary {
 .utility-rail-body {
   display: flex;
   flex-direction: column;
-  gap: 10px;
-  padding: 10px;
+  gap: var(--space-sm);
+  padding: var(--space-sm);
+}
+
+.utility-rail-body > .chrome-disclosure {
+  border-inline: 0;
+  border-radius: 0;
+  box-shadow: none;
 }
 
 .compact-field {
   display: grid;
-  gap: 4px;
+  gap: var(--space-2xs);
   min-width: 0;
-  color: #405650;
-  font-size: 11px;
-  font-weight: 600;
+  color: var(--host-muted);
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  font-weight: 700;
 }
 
 textarea.host-control {
   min-height: 220px;
   resize: vertical;
-  font-family: 'Courier New', Courier, monospace;
-  font-size: 12px;
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
 }
 
 .actions {
   display: flex;
   flex-wrap: wrap;
-  gap: 6px;
+  gap: var(--space-xs);
 }
 
 .toast {
   position: fixed;
-  right: 14px;
-  bottom: 14px;
-  z-index: 1200;
+  inset-inline-end: var(--space-md);
+  inset-block-end: var(--space-md);
+  z-index: var(--z-toast, 500);
   max-width: 380px;
-  padding: 9px 11px;
-  border: 1px solid var(--host-border-strong);
-  border-radius: 10px;
+  padding: var(--space-xs) var(--space-sm);
+  border: var(--rule-hair) solid var(--host-border-strong);
+  border-radius: var(--radius-panel);
   color: var(--host-text);
   background: var(--host-panel);
   box-shadow:
-    inset 4px 0 0 var(--status-idle-indicator),
-    0 10px 28px rgb(25 48 44 / 20%);
-  font-size: 12px;
+    inset var(--space-2xs) 0 0 var(--status-idle-indicator),
+    var(--shadow-toast);
+  font-size: var(--text-sm);
 }
 
 .toast-error {
   background: var(--toast-error-bg);
   box-shadow:
-    inset 4px 0 0 var(--status-error-indicator),
-    0 10px 28px rgb(25 48 44 / 20%);
+    inset var(--space-2xs) 0 0 var(--status-error-indicator),
+    var(--shadow-toast);
 }
 
 .toast-ok {
   background: var(--toast-ok-bg);
   box-shadow:
-    inset 4px 0 0 var(--status-ok-indicator),
-    0 10px 28px rgb(25 48 44 / 20%);
+    inset var(--space-2xs) 0 0 var(--status-ok-indicator),
+    var(--shadow-toast);
 }
 
 .toast-hidden {
@@ -682,37 +647,38 @@ textarea.host-control {
 
 .local-example-notes-body,
 .welcome-help-body {
-  padding: 10px;
-  border-top: 1px solid var(--host-border);
-  font-size: 12px;
+  padding: var(--space-sm);
+  border-top: var(--rule-hair) solid var(--host-border);
+  font-size: var(--text-sm);
 }
 
 .local-example-notes-body p,
 .welcome-help-body p {
-  margin: 0 0 7px;
+  margin: 0 0 var(--space-xs);
 }
 
 .local-example-notes-body h2,
 .welcome-help-body h2 {
-  margin: 10px 0 4px;
+  margin: var(--space-sm) 0 var(--space-2xs);
   color: var(--host-accent-deep);
-  font-size: 11px;
-  letter-spacing: 0.045em;
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  letter-spacing: 0.06em;
   text-transform: uppercase;
 }
 
 .welcome-help-body > p:first-child {
-  padding-left: 9px;
-  border-left: 3px solid var(--host-highlight);
-  color: #293b36;
+  padding-inline-start: var(--space-sm);
+  border-inline-start: var(--rule-strong) solid var(--host-highlight);
+  color: var(--host-text);
 }
 
 .welcome-help-body .actions {
-  padding: 2px 0 3px;
+  padding: var(--space-3xs) 0 var(--space-2xs);
 }
 
 #btn-start-tour {
-  border-color: #7d918b;
+  border-color: var(--host-border-strong);
   color: var(--host-accent-deep);
   background: var(--host-accent-soft);
 }
@@ -723,60 +689,62 @@ textarea.host-control {
 
 .local-example-notes-body ul {
   margin: 0;
-  padding-left: 18px;
+  padding-inline-start: var(--space-lg);
 }
 
 .local-example-notes-body li {
-  margin-bottom: 4px;
+  margin-block-end: var(--space-2xs);
 }
 
 .developer-drawer-section {
-  padding: 0 16px 14px;
+  padding: 0 var(--space-md) var(--space-md);
 }
 
 .dev-drawer {
-  background: rgb(242 246 243 / 78%);
+  background: var(--color-paper-3);
   box-shadow: none;
 }
 
 .dev-drawer > summary {
   color: var(--host-muted);
   background: transparent;
-  font-size: 12px;
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
 }
 
 .dev-drawer[open] > summary {
-  border-bottom: 1px solid var(--host-border);
+  border-bottom: var(--rule-hair) solid var(--host-border);
 }
 
 .panel-body {
-  padding: 10px;
+  padding: var(--space-sm);
 }
 
 .panel-body h2 {
-  margin: 10px 0 4px;
+  margin: var(--space-sm) 0 var(--space-2xs);
   color: var(--host-muted);
-  font-size: 11px;
-  font-weight: 650;
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 0.04em;
 }
 
 .debug-raw-mode {
-  margin-top: 8px;
+  margin-block-start: var(--space-xs);
 }
 
 .debug-raw-mode-content {
   display: grid;
-  gap: 6px;
-  margin-top: 6px;
+  gap: var(--space-xs);
+  margin-block-start: var(--space-xs);
 }
 
 pre {
   margin: 0;
-  color: #303842;
-  font-family: 'Courier New', Courier, monospace;
-  font-size: 12px;
+  color: var(--color-ink-2);
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
   white-space: pre-wrap;
   word-break: break-word;
 }
@@ -785,11 +753,12 @@ pre {
 #snapshot,
 #session-state,
 #transport-response {
-  padding: 7px;
-  border: 1px solid var(--host-border);
-  border-radius: 7px;
-  background: #fffefb;
-  box-shadow: inset 0 1px 3px rgb(20 45 40 / 6%);
+  padding: var(--space-xs);
+  border: var(--rule-hair) solid var(--host-border);
+  border-radius: var(--radius-control);
+  color: var(--host-text);
+  background: var(--host-panel);
+  box-shadow: inset 0 1px 3px var(--color-shadow-faint);
 }
 
 #timeline {
@@ -798,10 +767,14 @@ pre {
 }
 
 @media (hover: hover) {
+  .host-control:hover:not(:disabled) {
+    background: var(--color-paper-2);
+  }
+
   button:hover:not(:disabled),
   .btn:hover:not(:disabled) {
-    border-color: #6f8780;
-    background: #edf2ef;
+    border-color: var(--host-border-strong);
+    background: var(--color-paper-3);
   }
 
   .browser-chrome .chrome-btn.primary:hover:not(:disabled) {
@@ -810,25 +783,54 @@ pre {
   }
 
   .chrome-disclosure > summary:hover {
-    background: #e4eeea;
+    background: var(--host-accent-soft);
   }
 
   .utility-rail-panel > summary:hover {
-    background: linear-gradient(100deg, #043f3e, #08716e);
+    background: var(--host-accent-hover);
   }
 
   .softkey-row #btn-enter:hover:not(:disabled) {
-    border-color: #69450c;
-    background: linear-gradient(180deg, #f8dda0, #d29d38);
+    border-color: var(--color-highlight-ink);
+    background: linear-gradient(180deg, var(--color-highlight-soft), var(--color-highlight-hover));
   }
+}
+
+.host-control:disabled {
+  color: var(--color-disabled);
+  background: var(--color-paper-3);
+  cursor: not-allowed;
+  opacity: 0.72;
+}
+
+.host-control[aria-invalid='true'],
+button[data-state='error'],
+.btn[data-state='error'] {
+  border-color: var(--status-error-indicator);
+  background: var(--status-error-bg);
+}
+
+.host-control[data-state='success'],
+button[data-state='success'],
+.btn[data-state='success'] {
+  border-color: var(--status-ok-indicator);
+  background: var(--status-ok-bg);
+}
+
+.host-control[aria-busy='true'],
+button[aria-busy='true'],
+.btn[aria-busy='true'] {
+  border-color: var(--status-loading-indicator);
+  cursor: progress;
+  opacity: 0.78;
 }
 
 @media (prefers-contrast: more) {
   :root {
-    --host-border: #747d89;
-    --host-border-strong: #3e4650;
-    --host-muted: #3f4751;
-    --host-accent: #00615f;
+    --host-border: var(--color-contrast-rule);
+    --host-border-strong: var(--color-contrast-rule-strong);
+    --host-muted: var(--color-contrast-muted);
+    --host-accent: var(--color-contrast-accent);
   }
 }
 
@@ -842,11 +844,20 @@ pre {
   }
 }
 
+@media (pointer: coarse) {
+  button,
+  .btn,
+  .host-control,
+  summary {
+    min-height: 44px;
+  }
+}
+
 @media (max-width: 900px) {
   .browser-main {
     grid-template-columns: 1fr;
-    gap: 12px;
-    padding: 12px;
+    gap: var(--space-sm);
+    padding: var(--space-sm);
   }
 
   .viewport {
@@ -854,13 +865,13 @@ pre {
   }
 
   .developer-drawer-section {
-    padding: 0 12px 12px;
+    padding: 0 var(--space-sm) var(--space-sm);
   }
 }
 
 @media (max-width: 600px) {
   .browser-chrome {
-    padding: 9px 10px 10px;
+    padding: var(--space-xs) var(--space-sm) var(--space-sm);
   }
 
   .caption {
@@ -895,15 +906,21 @@ pre {
   }
 
   .handset-housing {
-    padding: 22px 10px 10px;
-    border-radius: 16px;
+    padding: var(--space-lg) var(--space-sm) var(--space-sm);
+    border-radius: var(--radius-device);
   }
 
   .device-frame {
-    padding: 6px;
+    padding: var(--space-xs);
   }
 
   .viewport {
     min-height: 250px;
+  }
+}
+
+@media (max-width: 360px) {
+  .muted-url {
+    display: none;
   }
 }

--- a/browser/frontend/src/styles.css
+++ b/browser/frontend/src/styles.css
@@ -3,45 +3,57 @@
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif;
   font-synthesis: none;
 
-  /* Quiet desktop-host surfaces. The native Tauri title bar is the only
-     application window frame; these tokens describe content inside it. */
-  --host-canvas: #edf0f4;
-  --host-surface: #f8f9fb;
-  --host-panel: #ffffff;
-  --host-border: #c8ced7;
-  --host-border-strong: #9da6b2;
-  --host-text: #20242a;
-  --host-muted: #596372;
-  --host-accent: #155eef;
-  --host-accent-hover: #0d4fd4;
+  /* Warm native-host surfaces with a restrained WAP-console identity. The
+     operating-system title bar remains the application's only window frame. */
+  --host-canvas: #e7ece9;
+  --host-canvas-deep: #dce4e0;
+  --host-surface: #f5f4ed;
+  --host-surface-raised: #fbfaf5;
+  --host-panel: #fffdf8;
+  --host-border: #bdc9c4;
+  --host-border-strong: #7e918b;
+  --host-text: #182522;
+  --host-muted: #536762;
+  --host-accent: #087b78;
+  --host-accent-hover: #056461;
+  --host-accent-deep: #064f4e;
+  --host-accent-soft: #d8ece8;
+  --host-highlight: #d1902c;
+  --host-highlight-soft: #f7e8c8;
 
   /* Shared host-panel tones consumed by the lightweight Web Components. */
   --panel-border-mid: var(--host-border);
   --panel-bg: var(--host-panel);
-  --panel-heading-text: var(--host-text);
+  --panel-heading-bg: #edf3f0;
+  --panel-heading-text: var(--host-accent-deep);
 
   /* Status-panel semantic tones. */
-  --status-idle-bg: #f4f6f8;
-  --status-idle-text: #343b45;
-  --status-loading-bg: #fff4cf;
-  --status-loading-text: #604b00;
-  --status-ok-bg: #e5f5e9;
-  --status-ok-text: #195c31;
-  --status-error-bg: #fde8e7;
-  --status-error-text: #8c2520;
+  --status-idle-bg: #f2f5f3;
+  --status-idle-text: #31413d;
+  --status-idle-indicator: #72837e;
+  --status-loading-bg: #fff3d8;
+  --status-loading-text: #5b4409;
+  --status-loading-indicator: #bd7711;
+  --status-ok-bg: #e3f3e9;
+  --status-ok-text: #165830;
+  --status-ok-indicator: #27834a;
+  --status-error-bg: #fbe8e4;
+  --status-error-text: #842b24;
+  --status-error-indicator: #bd4a3f;
 
   /* Toast semantic tones. */
-  --toast-ok-bg: #e5f5e9;
-  --toast-error-bg: #fde8e7;
+  --toast-ok-bg: #e3f3e9;
+  --toast-error-bg: #fbe8e4;
 
-  /* Neutral Class C reference-handset and deterministic LCD tones. */
-  --handset-housing-bg: #5c6265;
-  --handset-housing-highlight: #7b8183;
-  --handset-housing-shadow: #34393b;
-  --lcd-bg: #d7e4d2;
+  /* Generic Class C reference handset and deterministic monochrome LCD. */
+  --handset-housing-bg: #354b4a;
+  --handset-housing-highlight: #607572;
+  --handset-housing-shadow: #172524;
+  --handset-bezel: #263a38;
+  --lcd-bg: #d8e4c4;
   --lcd-fg: #1c2b1c;
   --lcd-focus-bg: #1c2b1c;
-  --lcd-focus-fg: #d7e4d2;
+  --lcd-focus-fg: #d8e4c4;
 
   /* Integer display scaling changes only rendered pixels, never engine
      columns, line wrapping, focus, or navigation behavior. */
@@ -63,7 +75,9 @@ body {
 
 body {
   margin: 0;
-  background: var(--host-canvas);
+  background:
+    radial-gradient(circle at 14% 8%, rgb(255 255 255 / 70%), transparent 34rem),
+    linear-gradient(145deg, var(--host-canvas), var(--host-canvas-deep));
   color: var(--host-text);
   font-size: 14px;
   line-height: 1.35;
@@ -98,41 +112,96 @@ textarea {
   min-height: 100vh;
   flex-direction: column;
   color: var(--host-text);
-  background: var(--host-canvas);
+  background: transparent;
 }
 
 .browser-chrome {
   position: relative;
   z-index: 2;
-  padding: 10px 14px 12px;
+  padding: 11px 16px 13px;
   border-bottom: 1px solid var(--host-border);
-  background: color-mix(in srgb, var(--host-surface) 94%, transparent);
-  box-shadow: 0 1px 3px rgb(27 35 45 / 8%);
+  background:
+    linear-gradient(
+        90deg,
+        var(--host-accent) 0 74px,
+        var(--host-highlight) 74px 81px,
+        transparent 81px
+      )
+      top / 100% 3px no-repeat,
+    linear-gradient(180deg, var(--host-surface-raised), var(--host-surface));
+  box-shadow:
+    inset 0 1px 0 rgb(255 255 255 / 75%),
+    0 3px 12px rgb(28 53 49 / 10%);
 }
 
 .title-row {
   display: flex;
-  align-items: baseline;
+  align-items: center;
   justify-content: space-between;
   gap: 16px;
-  margin-bottom: 8px;
+  margin-bottom: 10px;
 }
 
 .brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
   margin: 0;
-  font-size: 17px;
-  font-weight: 650;
-  letter-spacing: -0.015em;
+  color: var(--host-accent-deep);
+  font-size: 18px;
+  font-weight: 760;
+  letter-spacing: -0.025em;
+}
+
+.brand-mark {
+  position: relative;
+  width: 24px;
+  height: 24px;
+  flex: 0 0 24px;
+  overflow: hidden;
+  border: 1px solid rgb(3 65 64 / 42%);
+  border-radius: 7px;
+  background: linear-gradient(155deg, rgb(255 255 255 / 38%), transparent 48%), var(--host-accent);
+  box-shadow:
+    inset 0 1px 0 rgb(255 255 255 / 35%),
+    0 2px 5px rgb(5 79 78 / 22%);
+}
+
+.brand-mark::before,
+.brand-mark::after {
+  position: absolute;
+  left: 4px;
+  width: 16px;
+  height: 6px;
+  border: 2px solid #fff6dc;
+  border-top: 0;
+  border-radius: 0 0 50% 50%;
+  content: '';
+}
+
+.brand-mark::before {
+  top: 4px;
+}
+
+.brand-mark::after {
+  top: 10px;
+  opacity: 0.72;
 }
 
 .caption {
-  color: var(--host-muted);
-  font-size: 12px;
+  padding: 3px 8px;
+  border: 1px solid #c8d9d4;
+  border-radius: 999px;
+  color: var(--host-accent-deep);
+  background: var(--host-accent-soft);
+  font-size: 11px;
+  font-weight: 650;
+  letter-spacing: 0.025em;
 }
 
 .nav-toolbar {
   display: grid;
-  gap: 8px;
+  gap: 9px;
 }
 
 .nav-row {
@@ -147,13 +216,18 @@ textarea {
   grid-template-columns: minmax(7rem, 0.65fr) minmax(12rem, 1.8fr) auto;
   gap: 8px;
   align-items: end;
+  padding: 8px;
+  border: 1px solid var(--host-border);
+  border-radius: 9px;
+  background: rgb(255 253 248 / 72%);
+  box-shadow: inset 0 1px 0 rgb(255 255 255 / 75%);
 }
 
 .mode-field {
   display: grid;
   min-width: 0;
   gap: 3px;
-  color: var(--host-muted);
+  color: #435a54;
   font-size: 11px;
   font-weight: 600;
 }
@@ -161,13 +235,37 @@ textarea {
 .toolbar-meta {
   display: flex;
   flex-wrap: wrap;
-  gap: 6px 16px;
+  gap: 6px 8px;
   color: var(--host-muted);
   font-size: 11px;
 }
 
 .toolbar-meta-item {
+  display: inline-flex;
+  align-items: center;
   min-width: 0;
+  min-height: 24px;
+  padding: 3px 8px;
+  border: 1px solid #c8d4d0;
+  border-radius: 999px;
+  background: rgb(255 253 248 / 66%);
+}
+
+.toolbar-meta-item::before {
+  width: 7px;
+  height: 7px;
+  flex: 0 0 7px;
+  margin-right: 6px;
+  border-radius: 50%;
+  background: var(--host-accent);
+  box-shadow: 0 0 0 2px var(--host-accent-soft);
+  content: '';
+}
+
+.profile-meta::before {
+  border-radius: 2px;
+  background: var(--host-highlight);
+  box-shadow: 0 0 0 2px var(--host-highlight-soft);
 }
 
 .toolbar-meta-label {
@@ -179,17 +277,22 @@ textarea {
 .host-control,
 button,
 .btn {
-  min-height: 30px;
+  min-height: 32px;
   border: 1px solid var(--host-border-strong);
-  border-radius: 6px;
+  border-radius: 7px;
   color: var(--host-text);
-  background: var(--host-panel);
+  background: var(--host-surface-raised);
+  box-shadow: inset 0 1px 0 rgb(255 255 255 / 80%);
 }
 
 .host-control {
   width: 100%;
   min-width: 0;
-  padding: 4px 8px;
+  padding: 5px 9px;
+  background: #fffefb;
+  box-shadow:
+    inset 0 1px 3px rgb(20 45 40 / 7%),
+    0 1px 0 rgb(255 255 255 / 75%);
 }
 
 button,
@@ -200,17 +303,19 @@ button,
   padding: 4px 11px;
   font-weight: 600;
   cursor: default;
+  text-shadow: 0 1px 0 rgb(255 255 255 / 70%);
 }
 
 button:active:not(:disabled),
 .btn:active:not(:disabled) {
-  background: #e8ecf1;
+  background: #e5ebe7;
+  box-shadow: inset 0 1px 3px rgb(25 52 47 / 16%);
 }
 
 button:disabled,
 .btn:disabled {
   color: #8a929e;
-  background: #eef0f3;
+  background: #ecefeb;
   opacity: 0.78;
 }
 
@@ -218,6 +323,10 @@ button:disabled,
   border-color: var(--host-accent);
   color: #ffffff;
   background: var(--host-accent);
+  box-shadow:
+    inset 0 1px 0 rgb(255 255 255 / 22%),
+    0 2px 5px rgb(5 79 78 / 18%);
+  text-shadow: 0 1px 0 rgb(0 0 0 / 18%);
 }
 
 .browser-chrome .chrome-btn.primary:active:not(:disabled) {
@@ -225,7 +334,7 @@ button:disabled,
 }
 
 summary {
-  min-height: 30px;
+  min-height: 32px;
 }
 
 #app button:focus-visible,
@@ -237,19 +346,22 @@ summary {
 #app [tabindex]:focus-visible {
   outline: 2px solid var(--focus-ring-color) !important;
   outline-offset: 2px !important;
-  box-shadow: 0 0 0 4px var(--focus-ring-outer-color) !important;
+  box-shadow:
+    0 0 0 2px var(--focus-ring-outer-color),
+    0 0 0 5px var(--focus-ring-color) !important;
 }
 
 .browser-main {
   display: grid;
   grid-template-columns: minmax(0, 1.45fr) minmax(250px, 0.7fr);
-  gap: 16px;
+  gap: 18px;
   flex: 1;
   align-items: start;
-  padding: 16px;
+  padding: 18px;
 }
 
 .handset-stage {
+  position: relative;
   display: flex;
   min-width: 0;
   flex-direction: column;
@@ -257,22 +369,50 @@ summary {
 }
 
 .handset-housing {
+  position: relative;
   display: flex;
   flex: 1;
   min-width: 0;
   flex-direction: column;
-  padding: 16px;
+  padding: 24px 16px 16px;
   border: 1px solid var(--handset-housing-shadow);
-  border-radius: 22px;
+  border-radius: 24px;
   background: linear-gradient(
-    145deg,
+    150deg,
     var(--handset-housing-highlight),
-    var(--handset-housing-bg) 55%,
+    var(--handset-housing-bg) 52%,
     var(--handset-housing-shadow)
   );
   box-shadow:
-    inset 0 1px 0 rgb(255 255 255 / 22%),
-    0 8px 22px rgb(31 39 46 / 20%);
+    inset 0 1px 0 rgb(255 255 255 / 28%),
+    inset 0 -2px 5px rgb(7 20 19 / 24%),
+    0 12px 28px rgb(28 47 44 / 24%);
+}
+
+.handset-housing::before {
+  position: absolute;
+  top: 9px;
+  left: 50%;
+  width: 52px;
+  height: 4px;
+  border-radius: 999px;
+  background: #172725;
+  box-shadow: inset 0 1px 1px rgb(0 0 0 / 68%);
+  content: '';
+  transform: translateX(-50%);
+}
+
+.handset-housing::after {
+  position: absolute;
+  top: 8px;
+  left: 22px;
+  width: 6px;
+  height: 6px;
+  border: 1px solid #193632;
+  border-radius: 50%;
+  background: #72c8a7;
+  box-shadow: 0 0 0 2px rgb(19 46 42 / 28%);
+  content: '';
 }
 
 .handset-housing .device-frame {
@@ -284,8 +424,12 @@ summary {
   min-width: 0;
   flex-direction: column;
   padding: 8px;
-  border-radius: 12px;
-  background: #696f71;
+  border: 1px solid #172725;
+  border-radius: 13px;
+  background: linear-gradient(180deg, #415755, var(--handset-bezel));
+  box-shadow:
+    inset 0 1px 0 rgb(255 255 255 / 12%),
+    0 1px 2px rgb(5 15 14 / 42%);
 }
 
 .device-header {
@@ -295,15 +439,30 @@ summary {
   justify-content: space-between;
   gap: 12px;
   margin: 0 4px 7px;
-  color: #f4f5f5;
+  color: #f3f2e8;
   font-size: 11px;
-  font-weight: 600;
+  font-weight: 650;
+  letter-spacing: 0.02em;
+}
+
+.device-title {
+  display: inline-flex;
+  align-items: center;
+}
+
+.device-title::before {
+  width: 4px;
+  height: 12px;
+  margin-right: 6px;
+  border-radius: 2px;
+  background: var(--host-highlight);
+  content: '';
 }
 
 .muted-url {
   max-width: 72%;
   overflow: hidden;
-  color: #ffffff;
+  color: #d5e2de;
   font-weight: 400;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -313,13 +472,17 @@ summary {
   flex: 1;
   min-height: 360px;
   padding: 10px;
-  border: 3px solid #2e3431;
-  border-radius: 4px;
+  border: 4px solid #14221f;
+  border-radius: 6px;
   color: var(--lcd-fg);
-  background: var(--lcd-bg);
+  background-color: var(--lcd-bg);
+  background-image:
+    linear-gradient(110deg, rgb(255 255 255 / 13%), transparent 35%),
+    repeating-linear-gradient(0deg, rgb(22 41 26 / 2%) 0 1px, transparent 1px 4px);
   box-shadow:
-    inset 0 0 0 1px rgb(255 255 255 / 28%),
-    inset 0 2px 8px rgb(24 39 25 / 14%);
+    inset 0 0 0 1px rgb(245 255 228 / 38%),
+    inset 0 2px 10px rgb(24 39 25 / 18%),
+    0 1px 0 rgb(255 255 255 / 12%);
   font-family: 'Courier New', Courier, monospace;
   line-height: 1.4;
 }
@@ -332,7 +495,8 @@ summary {
   width: 70%;
   height: 9px;
   margin-bottom: 8px;
-  background: rgb(28 43 28 / 12%);
+  border-radius: 2px;
+  background: rgb(28 43 28 / 13%);
 }
 
 .skeleton-line-wide {
@@ -345,8 +509,20 @@ summary {
 
 .skeleton-hint {
   margin-top: 12px;
-  color: #445144;
+  display: inline-flex;
+  align-items: center;
+  color: #3d4d3b;
   font-size: 11px;
+}
+
+.skeleton-hint::before {
+  width: 7px;
+  height: 7px;
+  margin-right: 7px;
+  border: 1px solid #5c714f;
+  border-radius: 50%;
+  background: #b1c795;
+  content: '';
 }
 
 .line {
@@ -371,19 +547,26 @@ summary {
 .softkey-row {
   display: grid;
   grid-template-columns: repeat(3, 1fr);
-  gap: 7px;
+  gap: 8px;
   margin-top: 9px;
 }
 
 .softkey-row .btn {
   min-height: 32px;
-  border-color: #303638;
+  border-color: #172523;
   border-radius: 8px;
-  color: #202426;
-  background: #d9dddc;
-  box-shadow: inset 0 1px 0 rgb(255 255 255 / 72%);
+  color: #172421;
+  background: linear-gradient(180deg, #eef0ea, #cbd3cf);
+  box-shadow:
+    inset 0 1px 0 rgb(255 255 255 / 78%),
+    0 2px 2px rgb(6 18 17 / 38%);
   font-size: 12px;
   font-weight: 700;
+}
+
+.softkey-row #btn-enter {
+  border-color: #845910;
+  background: linear-gradient(180deg, #f5d993, #d9a747);
 }
 
 .utility-rail {
@@ -396,22 +579,33 @@ summary {
 .chrome-disclosure {
   overflow: clip;
   border: 1px solid var(--host-border);
-  border-radius: 8px;
+  border-radius: 10px;
   color: var(--host-text);
-  background: var(--host-panel);
+  background: rgb(255 253 248 / 92%);
+  box-shadow: 0 3px 12px rgb(28 52 48 / 8%);
 }
 
 .chrome-disclosure > summary {
-  padding: 6px 9px;
-  color: var(--host-text);
-  background: var(--host-surface);
+  padding: 7px 10px;
+  color: var(--host-accent-deep);
+  background: linear-gradient(180deg, #f8f8f2, #edf2ef);
   font-size: 13px;
-  font-weight: 650;
+  font-weight: 700;
   cursor: default;
 }
 
 .chrome-disclosure > summary::marker {
-  color: var(--host-muted);
+  color: var(--host-accent);
+}
+
+.utility-rail-panel > summary {
+  color: #ffffff;
+  background: linear-gradient(100deg, var(--host-accent-deep), var(--host-accent));
+  text-shadow: 0 1px 0 rgb(0 0 0 / 20%);
+}
+
+.utility-rail-panel > summary::marker {
+  color: #f7d89c;
 }
 
 .utility-rail-panel > summary {
@@ -425,15 +619,15 @@ summary {
 .utility-rail-body {
   display: flex;
   flex-direction: column;
-  gap: 8px;
-  padding: 8px;
+  gap: 10px;
+  padding: 10px;
 }
 
 .compact-field {
   display: grid;
   gap: 4px;
   min-width: 0;
-  color: var(--host-muted);
+  color: #405650;
   font-size: 11px;
   font-weight: 600;
 }
@@ -459,19 +653,27 @@ textarea.host-control {
   max-width: 380px;
   padding: 9px 11px;
   border: 1px solid var(--host-border-strong);
-  border-radius: 8px;
+  border-radius: 10px;
   color: var(--host-text);
   background: var(--host-panel);
-  box-shadow: 0 8px 24px rgb(31 39 46 / 18%);
+  box-shadow:
+    inset 4px 0 0 var(--status-idle-indicator),
+    0 10px 28px rgb(25 48 44 / 20%);
   font-size: 12px;
 }
 
 .toast-error {
   background: var(--toast-error-bg);
+  box-shadow:
+    inset 4px 0 0 var(--status-error-indicator),
+    0 10px 28px rgb(25 48 44 / 20%);
 }
 
 .toast-ok {
   background: var(--toast-ok-bg);
+  box-shadow:
+    inset 4px 0 0 var(--status-ok-indicator),
+    0 10px 28px rgb(25 48 44 / 20%);
 }
 
 .toast-hidden {
@@ -480,7 +682,7 @@ textarea.host-control {
 
 .local-example-notes-body,
 .welcome-help-body {
-  padding: 8px 9px;
+  padding: 10px;
   border-top: 1px solid var(--host-border);
   font-size: 12px;
 }
@@ -493,7 +695,26 @@ textarea.host-control {
 .local-example-notes-body h2,
 .welcome-help-body h2 {
   margin: 10px 0 4px;
-  font-size: 12px;
+  color: var(--host-accent-deep);
+  font-size: 11px;
+  letter-spacing: 0.045em;
+  text-transform: uppercase;
+}
+
+.welcome-help-body > p:first-child {
+  padding-left: 9px;
+  border-left: 3px solid var(--host-highlight);
+  color: #293b36;
+}
+
+.welcome-help-body .actions {
+  padding: 2px 0 3px;
+}
+
+#btn-start-tour {
+  border-color: #7d918b;
+  color: var(--host-accent-deep);
+  background: var(--host-accent-soft);
 }
 
 .local-example-notes-coverage {
@@ -514,7 +735,8 @@ textarea.host-control {
 }
 
 .dev-drawer {
-  background: #f4f6f8;
+  background: rgb(242 246 243 / 78%);
+  box-shadow: none;
 }
 
 .dev-drawer > summary {
@@ -565,8 +787,9 @@ pre {
 #transport-response {
   padding: 7px;
   border: 1px solid var(--host-border);
-  border-radius: 5px;
-  background: var(--host-panel);
+  border-radius: 7px;
+  background: #fffefb;
+  box-shadow: inset 0 1px 3px rgb(20 45 40 / 6%);
 }
 
 #timeline {
@@ -577,8 +800,8 @@ pre {
 @media (hover: hover) {
   button:hover:not(:disabled),
   .btn:hover:not(:disabled) {
-    border-color: #7f8997;
-    background: #f1f3f6;
+    border-color: #6f8780;
+    background: #edf2ef;
   }
 
   .browser-chrome .chrome-btn.primary:hover:not(:disabled) {
@@ -587,7 +810,16 @@ pre {
   }
 
   .chrome-disclosure > summary:hover {
-    background: #eef1f5;
+    background: #e4eeea;
+  }
+
+  .utility-rail-panel > summary:hover {
+    background: linear-gradient(100deg, #043f3e, #08716e);
+  }
+
+  .softkey-row #btn-enter:hover:not(:disabled) {
+    border-color: #69450c;
+    background: linear-gradient(180deg, #f8dda0, #d29d38);
   }
 }
 
@@ -596,6 +828,7 @@ pre {
     --host-border: #747d89;
     --host-border-strong: #3e4650;
     --host-muted: #3f4751;
+    --host-accent: #00615f;
   }
 }
 
@@ -604,6 +837,8 @@ pre {
   *::before,
   *::after {
     scroll-behavior: auto !important;
+    animation: none !important;
+    transition: none !important;
   }
 }
 
@@ -660,7 +895,7 @@ pre {
   }
 
   .handset-housing {
-    padding: 10px;
+    padding: 22px 10px 10px;
     border-radius: 16px;
   }
 

--- a/browser/frontend/src/tokens.css
+++ b/browser/frontend/src/tokens.css
@@ -1,0 +1,169 @@
+:root {
+  color-scheme: light;
+  font-synthesis: none;
+
+  /* Dependency-free typography: native application chrome, technical readouts,
+     and the deterministic period LCD face remain deliberately distinct. */
+  --font-display: 'SFMono-Regular', Menlo, Monaco, Consolas, 'Liberation Mono', monospace;
+  --font-body: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  --font-mono: 'SFMono-Regular', Menlo, Monaco, Consolas, 'Liberation Mono', monospace;
+  --font-lcd: 'Courier New', Courier, monospace;
+
+  --text-xs: 0.6875rem;
+  --text-sm: 0.75rem;
+  --text-base: 0.875rem;
+  --text-md: 1rem;
+  --text-lg: 1.125rem;
+
+  --space-3xs: 0.125rem;
+  --space-2xs: 0.25rem;
+  --space-xs: 0.5rem;
+  --space-sm: 0.75rem;
+  --space-md: 1rem;
+  --space-lg: 1.5rem;
+  --space-xl: 2.5rem;
+
+  --ease-out: cubic-bezier(0.16, 1, 0.3, 1);
+  --ease-in: cubic-bezier(0.7, 0, 0.84, 0);
+  --ease-in-out: cubic-bezier(0.65, 0, 0.35, 1);
+  --dur-micro: 120ms;
+  --dur-short: 180ms;
+  --dur-long: 420ms;
+
+  --rule-hair: 1px;
+  --rule-strong: 2px;
+  --rule-lcd: 4px;
+  --radius-xs: 2px;
+  --radius-control: 6px;
+  --radius-panel: 8px;
+  --radius-device: 14px;
+  --radius-handset: 24px;
+  --radius-pill: 999px;
+
+  --z-base: 1;
+  --z-raised: 10;
+  --z-dropdown: 100;
+  --z-sticky: 200;
+  --z-modal: 400;
+  --z-toast: 500;
+  --z-tooltip: 600;
+
+  /* Almanac-inspired host palette: warm reference-book paper and cool
+     instrument-panel neutrals, with one teal signal and one amber action. */
+  --color-canvas: oklch(91% 0.018 165);
+  --color-canvas-deep: oklch(87% 0.022 165);
+  --color-paper: oklch(97% 0.014 92);
+  --color-paper-2: oklch(94% 0.016 96);
+  --color-paper-3: oklch(90% 0.02 150);
+  --color-panel: oklch(98% 0.012 92);
+  --color-rule: oklch(77% 0.025 165);
+  --color-rule-2: oklch(60% 0.035 175);
+  --color-ink: oklch(24% 0.028 175);
+  --color-ink-2: oklch(31% 0.03 175);
+  --color-muted: oklch(43% 0.03 175);
+  --color-disabled: oklch(61% 0.014 170);
+
+  --color-accent: oklch(51% 0.095 188);
+  --color-accent-hover: oklch(43% 0.09 188);
+  --color-accent-deep: oklch(34% 0.07 188);
+  --color-accent-soft: oklch(90% 0.04 180);
+  --color-accent-ink: oklch(98% 0.012 92);
+  --color-highlight: oklch(68% 0.14 75);
+  --color-highlight-hover: oklch(63% 0.15 72);
+  --color-highlight-soft: oklch(91% 0.065 84);
+  --color-highlight-ink: oklch(27% 0.045 70);
+  --color-focus: oklch(52% 0.2 255);
+  --color-focus-outer: oklch(98% 0.012 92);
+  --color-contrast-rule: oklch(54% 0.025 175);
+  --color-contrast-rule-strong: oklch(32% 0.03 175);
+  --color-contrast-muted: oklch(34% 0.025 175);
+  --color-contrast-accent: oklch(42% 0.1 188);
+
+  --color-idle-bg: oklch(95% 0.012 165);
+  --color-idle-ink: oklch(31% 0.025 175);
+  --color-idle-signal: oklch(56% 0.025 175);
+  --color-loading-bg: oklch(94% 0.06 86);
+  --color-loading-ink: oklch(35% 0.08 78);
+  --color-loading-signal: oklch(58% 0.14 68);
+  --color-success-bg: oklch(93% 0.045 150);
+  --color-success-ink: oklch(34% 0.09 150);
+  --color-success-signal: oklch(53% 0.14 150);
+  --color-error-bg: oklch(93% 0.045 30);
+  --color-error-ink: oklch(38% 0.13 30);
+  --color-error-signal: oklch(55% 0.17 30);
+
+  /* Functional Class C reference handset and deterministic monochrome LCD. */
+  --color-handset: oklch(36% 0.035 180);
+  --color-handset-raised: oklch(48% 0.03 180);
+  --color-handset-shadow: oklch(20% 0.025 180);
+  --color-bezel: oklch(27% 0.03 180);
+  --color-bezel-raised: oklch(39% 0.035 180);
+  --color-device-label: oklch(94% 0.012 105);
+  --color-device-muted: oklch(84% 0.025 175);
+  --color-led: oklch(73% 0.12 160);
+  --color-lcd: oklch(88% 0.06 120);
+  --color-lcd-ink: oklch(25% 0.04 130);
+  --color-lcd-link: oklch(42% 0.17 255);
+  --color-lcd-skeleton: oklch(25% 0.04 130 / 0.13);
+  --color-lcd-scanline: oklch(25% 0.04 130 / 0.025);
+  --color-lcd-glare: oklch(99% 0.018 110 / 0.14);
+
+  /* Optical highlights and shadows are named modifiers, not palette entries. */
+  --color-highlight-strong: oklch(99% 0.012 92 / 0.8);
+  --color-highlight-medium: oklch(99% 0.012 92 / 0.55);
+  --color-highlight-faint: oklch(99% 0.012 92 / 0.24);
+  --color-shadow-faint: oklch(22% 0.025 175 / 0.07);
+  --color-shadow-soft: oklch(22% 0.025 175 / 0.12);
+  --color-shadow-medium: oklch(20% 0.025 175 / 0.2);
+  --color-shadow-device: oklch(17% 0.025 180 / 0.34);
+
+  --shadow-panel: 0 2px 8px var(--color-shadow-faint);
+  --shadow-chrome: 0 3px 12px var(--color-shadow-soft);
+  --shadow-device: 0 12px 28px var(--color-shadow-device);
+  --shadow-toast: 0 10px 28px var(--color-shadow-medium);
+
+  /* Compatibility aliases consumed by the existing shell and Web Components. */
+  --host-canvas: var(--color-canvas);
+  --host-canvas-deep: var(--color-canvas-deep);
+  --host-surface: var(--color-paper-2);
+  --host-surface-raised: var(--color-paper);
+  --host-panel: var(--color-panel);
+  --host-border: var(--color-rule);
+  --host-border-strong: var(--color-rule-2);
+  --host-text: var(--color-ink);
+  --host-muted: var(--color-muted);
+  --host-accent: var(--color-accent);
+  --host-accent-hover: var(--color-accent-hover);
+  --host-accent-deep: var(--color-accent-deep);
+  --host-accent-soft: var(--color-accent-soft);
+  --host-highlight: var(--color-highlight);
+  --host-highlight-soft: var(--color-highlight-soft);
+  --panel-border-mid: var(--color-rule);
+  --panel-bg: var(--color-panel);
+  --panel-heading-bg: var(--color-paper-3);
+  --panel-heading-text: var(--color-accent-deep);
+  --status-idle-bg: var(--color-idle-bg);
+  --status-idle-text: var(--color-idle-ink);
+  --status-idle-indicator: var(--color-idle-signal);
+  --status-loading-bg: var(--color-loading-bg);
+  --status-loading-text: var(--color-loading-ink);
+  --status-loading-indicator: var(--color-loading-signal);
+  --status-ok-bg: var(--color-success-bg);
+  --status-ok-text: var(--color-success-ink);
+  --status-ok-indicator: var(--color-success-signal);
+  --status-error-bg: var(--color-error-bg);
+  --status-error-text: var(--color-error-ink);
+  --status-error-indicator: var(--color-error-signal);
+  --toast-ok-bg: var(--color-success-bg);
+  --toast-error-bg: var(--color-error-bg);
+  --handset-housing-bg: var(--color-handset);
+  --handset-housing-highlight: var(--color-handset-raised);
+  --handset-housing-shadow: var(--color-handset-shadow);
+  --handset-bezel: var(--color-bezel);
+  --lcd-bg: var(--color-lcd);
+  --lcd-fg: var(--color-lcd-ink);
+  --lcd-focus-bg: var(--color-lcd-ink);
+  --lcd-focus-fg: var(--color-lcd);
+  --focus-ring-color: var(--color-focus);
+  --focus-ring-outer-color: var(--color-focus-outer);
+}


### PR DESCRIPTION
## Summary

- apply Hallmark's Workbench/Almanac direction: native desktop command chrome, warm reference-paper surfaces, teal navigation/brand signals, amber selection accents, and restrained technical typography
- centralize the visual system in semantic tokens for color, type, spacing, focus, motion, state, handset hardware, and LCD presentation without adding fonts, images, frameworks, or runtime effects
- make the functional handset and deterministic period-correct LCD the visual hero while flattening utility, help, status, and developer surfaces into a quieter supporting rail
- strengthen resilient rendered acceptance at 320, 375, 414, 768, 880×640, and 1024×768, including 200% host zoom, collapsed/expanded disclosures, target clipping, horizontal overflow, focus geometry, and inverse-video semantics

## Architecture and behavior

This is a WebView presentation-only refinement inside `browser/frontend`. It does not change the Tauri/Rust host boundary, engine/runtime/contracts, browser controller, navigation state, transport behavior, route logic, WML layout/wrapping, IDs, keyboard order, or live-announcement channel. The native OS title bar remains the sole window frame, and the handset remains the real emulator surface rather than decorative fake chrome.

## Verification

- `pnpm --dir browser/frontend run format:check`
- `pnpm --dir browser/frontend run test` — 37 files, 224 tests
- `pnpm --dir browser/frontend run typecheck`
- `pnpm --dir browser/frontend run lint`
- `pnpm --dir browser/frontend run build`
- `pnpm --dir browser/frontend run test:accessibility:rendered` — axe, semantic inverse video, focus geometry, minimum targets, label/softkey clipping, and overflow across the supported viewports
- `pnpm test:story:waves` — 19 Waves stories
- `pnpm --dir browser run contracts:check`
- `pnpm --dir browser run tauri:generated:check`
- `pnpm run verify:change` — all selected lanes passed, including all 51 executable stories, 224 frontend tests, and 61 Tauri host tests
- pre-push repository checks — passed, including 383 engine tests and Rust fmt/clippy across engine, host, and transport
