### PR TITLE
feat(wml-server): expand the WML 1.3 public examples

### DIFF
--- a/.github/workflows/native-tauri-kannel-e2e.yml
+++ b/.github/workflows/native-tauri-kannel-e2e.yml
@@ -9,6 +9,7 @@ on:
       - 'browser/frontend/package.json'
       - 'browser/frontend/scripts/native-tauri-kannel-e2e.mjs'
       - 'scripts/native-tauri-kannel-e2e.sh'
+      - 'wml-server/**'
   schedule:
     - cron: '17 5 * * 1'
   workflow_dispatch:

--- a/.github/workflows/transport-wap-smoke.yml
+++ b/.github/workflows/transport-wap-smoke.yml
@@ -109,6 +109,9 @@ jobs:
           WAP_SMOKE_LOGIN_URL: wap://127.0.0.1/login
           WAP_SMOKE_REGISTER_URL: wap://127.0.0.1/register
           WAP_SMOKE_EXAMPLE_URL: wap://127.0.0.1/examples/index.wml
+          WAP_SMOKE_PORTAL_EXAMPLE_URL: wap://127.0.0.1/examples/pocket-portal.wml
+          WAP_SMOKE_PREFERENCES_EXAMPLE_URL: wap://127.0.0.1/examples/preferences.wml
+          WAP_SMOKE_INTEROP_EXAMPLE_URL: wap://127.0.0.1/examples/interop-check.wml
           WAP_SMOKE_DENIED_URL: wap://127.0.0.1:9200/
         run: |
           test "$(docker compose -f deploy/network-preview/compose.yaml port --protocol udp wap-gateway 9200 | wc -l)" -eq 1

--- a/browser/frontend/scripts/native-tauri-kannel-e2e.mjs
+++ b/browser/frontend/scripts/native-tauri-kannel-e2e.mjs
@@ -200,10 +200,10 @@ const run = async () => {
 
   await replaceInput('#fetch-url', 'wap://localhost/examples/pocket-portal.wml');
   await driver.findElement(By.css('#btn-fetch-url')).click();
-  const portalViewport = await waitForText('#viewport', 'Pocket Portal');
+  const portalViewport = await waitForText('#viewport', 'first-party service');
   assert.match(await portalViewport.getText(), /first-party service directory/);
   await driver.findElement(By.css('#btn-enter')).click();
-  const directoryViewport = await waitForText('#viewport', 'Local Services');
+  const directoryViewport = await waitForText('#viewport', 'Forms');
   assert.match(await directoryViewport.getText(), /Forms/);
   assert.match(await directoryViewport.getText(), /Examples/);
   recordAssertion(
@@ -214,7 +214,7 @@ const run = async () => {
 
   await replaceInput('#fetch-url', 'wap://localhost/examples/preferences.wml');
   await driver.findElement(By.css('#btn-fetch-url')).click();
-  const preferencesViewport = await waitForText('#viewport', 'Local Preferences');
+  const preferencesViewport = await waitForText('#viewport', 'made-up alias');
   const preferencesText = await preferencesViewport.getText();
   assert.match(preferencesText, /made-up alias/);
   assert.match(preferencesText, /Layout/);
@@ -227,18 +227,18 @@ const run = async () => {
 
   await replaceInput('#fetch-url', 'wap://localhost/examples/interop-check.wml');
   await driver.findElement(By.css('#btn-fetch-url')).click();
-  const interopViewport = await waitForText('#viewport', 'Interop Wire Check');
+  const interopViewport = await waitForText('#viewport', 'W13-A');
   assert.match(await interopViewport.getText(), /W13-A/);
   const requestsBeforeRepeat = await readOriginRequestCount();
   await driver.findElement(By.css('#btn-enter')).click();
   await driver.wait(
     async () =>
-      (
-        await driver.findElement(By.css('#fetch-url')).getAttribute('value')
-      ).endsWith('/examples/interop-check.wml?probe=repeat'),
+      (await driver.findElement(By.css('#fetch-url')).getAttribute('value')).endsWith(
+        '/examples/interop-check.wml?probe=repeat'
+      ),
     timeoutMs
   );
-  const repeatedInteropViewport = await waitForText('#viewport', 'Interop Wire Check');
+  const repeatedInteropViewport = await waitForText('#viewport', 'W13-A');
   assert.match(await repeatedInteropViewport.getText(), /W13-A/);
   await delay(2000);
   const requestsAfterRepeat = await readOriginRequestCount();
@@ -279,7 +279,7 @@ const run = async () => {
 try {
   await run();
 } catch (error) {
-  const message = error instanceof Error ? error.stack ?? error.message : String(error);
+  const message = error instanceof Error ? (error.stack ?? error.message) : String(error);
   process.stderr.write(`native-tauri-kannel-e2e: FAIL\n${message}\n`);
   if (driver) {
     await capture('failure').catch(() => undefined);

--- a/browser/frontend/scripts/native-tauri-kannel-e2e.mjs
+++ b/browser/frontend/scripts/native-tauri-kannel-e2e.mjs
@@ -17,6 +17,7 @@ const artifactDir = path.resolve(
   process.env.NATIVE_E2E_ARTIFACT_DIR ?? 'test-results/native-tauri-kannel'
 );
 const tauriDriverBin = process.env.TAURI_DRIVER_BIN ?? 'tauri-driver';
+const metricsUrl = process.env.WML_METRICS_URL ?? 'http://localhost:3001/metrics';
 
 let driver;
 let tauriDriver;
@@ -73,6 +74,15 @@ const replaceInput = async (selector, value) => {
   await input.click();
   await input.clear();
   await input.sendKeys(value);
+};
+
+const readOriginRequestCount = async () => {
+  const response = await fetch(metricsUrl);
+  assert.equal(response.ok, true, `origin metrics request failed with ${response.status}`);
+  const body = await response.text();
+  const match = /^requests_total (\d+)$/m.exec(body);
+  assert.ok(match, 'origin metrics omitted requests_total');
+  return Number.parseInt(match[1], 10);
 };
 
 const capture = async (name) => {
@@ -188,12 +198,67 @@ const run = async () => {
   );
   await capture('04-static-example');
 
+  await replaceInput('#fetch-url', 'wap://localhost/examples/pocket-portal.wml');
+  await driver.findElement(By.css('#btn-fetch-url')).click();
+  const portalViewport = await waitForText('#viewport', 'Pocket Portal');
+  assert.match(await portalViewport.getText(), /first-party service directory/);
+  await driver.findElement(By.css('#btn-enter')).click();
+  const directoryViewport = await waitForText('#viewport', 'Local Services');
+  assert.match(await directoryViewport.getText(), /Forms/);
+  assert.match(await directoryViewport.getText(), /Examples/);
+  recordAssertion(
+    'pocket portal navigation',
+    'the native WSP/WBXML path rendered the portal and followed its fragment directory link'
+  );
+  await capture('05-pocket-portal');
+
+  await replaceInput('#fetch-url', 'wap://localhost/examples/preferences.wml');
+  await driver.findElement(By.css('#btn-fetch-url')).click();
+  const preferencesViewport = await waitForText('#viewport', 'Local Preferences');
+  const preferencesText = await preferencesViewport.getText();
+  assert.match(preferencesText, /made-up alias/);
+  assert.match(preferencesText, /Layout/);
+  assert.match(preferencesText, /Review Preference/);
+  recordAssertion(
+    'local preferences render',
+    'the native WSP/WBXML path rendered bounded input and select controls without submission'
+  );
+  await capture('06-local-preferences');
+
+  await replaceInput('#fetch-url', 'wap://localhost/examples/interop-check.wml');
+  await driver.findElement(By.css('#btn-fetch-url')).click();
+  const interopViewport = await waitForText('#viewport', 'Interop Wire Check');
+  assert.match(await interopViewport.getText(), /W13-A/);
+  const requestsBeforeRepeat = await readOriginRequestCount();
+  await driver.findElement(By.css('#btn-enter')).click();
+  await driver.wait(
+    async () =>
+      (
+        await driver.findElement(By.css('#fetch-url')).getAttribute('value')
+      ).endsWith('/examples/interop-check.wml?probe=repeat'),
+    timeoutMs
+  );
+  const repeatedInteropViewport = await waitForText('#viewport', 'Interop Wire Check');
+  assert.match(await repeatedInteropViewport.getText(), /W13-A/);
+  await delay(2000);
+  const requestsAfterRepeat = await readOriginRequestCount();
+  assert.equal(
+    requestsAfterRepeat - requestsBeforeRepeat,
+    1,
+    'one successful repeat navigation must produce exactly one origin request'
+  );
+  recordAssertion(
+    'successful navigation request bound',
+    `one repeat navigation produced one origin request over a 2s observation window (${requestsBeforeRepeat} -> ${requestsAfterRepeat})`
+  );
+  await capture('07-interop-repeat');
+
   await replaceInput('#fetch-url', 'not a url');
   await driver.findElement(By.css('#btn-fetch-url')).click();
   const toast = await waitForText('#toast', 'Fetch failed:');
   assert.match(await toast.getText(), /INVALID_REQUEST|invalid|URL/i);
   recordAssertion('deterministic failure', 'invalid URL surfaced a visible Fetch failed message');
-  await capture('05-invalid-url-failure');
+  await capture('08-invalid-url-failure');
 
   await replaceInput('#fetch-url', 'wap://localhost/');
   await driver.findElement(By.css('#btn-fetch-url')).click();
@@ -201,7 +266,7 @@ const run = async () => {
   assert.match(await recoveredViewport.getText(), /environment\./);
   assert.match(await recoveredViewport.getText(), /Open Menu/);
   recordAssertion('failure recovery', 'a subsequent native Kannel load restored the home deck');
-  await capture('06-recovered-home');
+  await capture('09-recovered-home');
 
   await writeFile(path.join(artifactDir, 'page-source.html'), await driver.getPageSource());
   await writeFile(
@@ -214,7 +279,7 @@ const run = async () => {
 try {
   await run();
 } catch (error) {
-  const message = error instanceof Error ? (error.stack ?? error.message) : String(error);
+  const message = error instanceof Error ? error.stack ?? error.message : String(error);
   process.stderr.write(`native-tauri-kannel-e2e: FAIL\n${message}\n`);
   if (driver) {
     await capture('failure').catch(() => undefined);

--- a/browser/frontend/scripts/native-tauri-kannel-e2e.mjs
+++ b/browser/frontend/scripts/native-tauri-kannel-e2e.mjs
@@ -201,7 +201,9 @@ const run = async () => {
   await replaceInput('#fetch-url', 'wap://localhost/examples/pocket-portal.wml');
   await driver.findElement(By.css('#btn-fetch-url')).click();
   const portalViewport = await waitForText('#viewport', 'first-party service');
-  assert.match(await portalViewport.getText(), /first-party service directory/);
+  const portalText = await portalViewport.getText();
+  assert.match(portalText, /first-party service/);
+  assert.match(portalText, /directory\./);
   await driver.findElement(By.css('#btn-enter')).click();
   const directoryViewport = await waitForText('#viewport', 'Forms');
   assert.match(await directoryViewport.getText(), /Forms/);

--- a/browser/src-tauri/tests/kannel_smoke.rs
+++ b/browser/src-tauri/tests/kannel_smoke.rs
@@ -189,6 +189,100 @@ fn kannel_fetch_deck_smoke_navigates_into_menu_card() {
 
 #[test]
 #[ignore = "runs against external Kannel dev stack (make up)"]
+fn kannel_fetch_deck_smoke_renders_public_examples() {
+    let cases = [
+        (
+            "WAP_SMOKE_EXAMPLE_URL",
+            "wap://localhost/examples/index.wml",
+            "welcome",
+            "This is a static WML",
+        ),
+        (
+            "WAP_SMOKE_PORTAL_EXAMPLE_URL",
+            "wap://localhost/examples/pocket-portal.wml",
+            "portal",
+            "first-party",
+        ),
+        (
+            "WAP_SMOKE_PREFERENCES_EXAMPLE_URL",
+            "wap://localhost/examples/preferences.wml",
+            "preferences",
+            "made-up",
+        ),
+        (
+            "WAP_SMOKE_INTEROP_EXAMPLE_URL",
+            "wap://localhost/examples/interop-check.wml",
+            "wire-check",
+            "W13-A",
+        ),
+    ];
+
+    for (environment, default_url, active_card, marker) in cases {
+        let target = std::env::var(environment).unwrap_or_else(|_| default_url.to_string());
+        let transport =
+            fetch_deck_in_process_with_profile(request(&target), FetchTransportProfile::WapNetCore);
+        assert!(
+            transport.ok,
+            "expected example fetch to succeed for {target}: {:?}",
+            transport.error
+        );
+        assert_eq!(transport.content_type, "application/vnd.wap.wmlc");
+
+        let mut engine = WmlEngine::new();
+        load_transport_response_into_engine(&mut engine, transport);
+        assert_eq!(engine.active_card_id().as_deref(), Ok(active_card));
+        assert!(
+            render_contains(&engine, marker),
+            "rendered example {target} omitted {marker:?}"
+        );
+    }
+
+    let preferences_url = std::env::var("WAP_SMOKE_PREFERENCES_EXAMPLE_URL")
+        .unwrap_or_else(|_| "wap://localhost/examples/preferences.wml".to_string());
+    let preferences = fetch_deck_in_process_with_profile(
+        request(&preferences_url),
+        FetchTransportProfile::WapNetCore,
+    );
+    let mut engine = WmlEngine::new();
+    load_transport_response_into_engine(&mut engine, preferences);
+    assert_eq!(
+        engine.get_var("alias".to_string()).as_deref(),
+        Some("GUEST")
+    );
+    assert_eq!(
+        engine.get_var("layout".to_string()).as_deref(),
+        Some("compact")
+    );
+    assert!(engine
+        .begin_focused_input_edit()
+        .expect("alias edit should begin"));
+    assert!(engine.set_focused_input_edit_draft("SCOUT".to_string()));
+    assert!(engine
+        .commit_focused_input_edit()
+        .expect("alias edit should commit"));
+    engine
+        .handle_key("down".to_string())
+        .expect("focus should move from alias to layout");
+    assert!(engine
+        .begin_focused_select_edit()
+        .expect("layout edit should begin"));
+    assert!(engine.move_focused_select_edit(1));
+    assert!(engine
+        .commit_focused_select_edit()
+        .expect("layout edit should commit"));
+    engine
+        .handle_key("down".to_string())
+        .expect("focus should move from layout to review link");
+    engine
+        .handle_key("enter".to_string())
+        .expect("review link should open the local saved card");
+    assert_eq!(engine.active_card_id().as_deref(), Ok("saved"));
+    assert!(render_contains(&engine, "SCOUT"));
+    assert!(render_contains(&engine, "roomy"));
+}
+
+#[test]
+#[ignore = "runs against external Kannel dev stack (make up)"]
 fn kannel_public_auth_forms_conceal_pin_and_submit_actual_value() {
     let register_url = std::env::var("WAP_SMOKE_REGISTER_URL")
         .unwrap_or_else(|_| "wap://localhost/register".to_string());

--- a/deploy/network-preview/README.md
+++ b/deploy/network-preview/README.md
@@ -71,12 +71,18 @@ policy:
 WAP_SMOKE_URL=wap://waves-network-preview/ \
 WAP_SMOKE_LOGIN_URL=wap://waves-network-preview/login \
 WAP_SMOKE_REGISTER_URL=wap://waves-network-preview/register \
+WAP_SMOKE_EXAMPLE_URL=wap://waves-network-preview/examples/index.wml \
+WAP_SMOKE_PORTAL_EXAMPLE_URL=wap://waves-network-preview/examples/pocket-portal.wml \
+WAP_SMOKE_PREFERENCES_EXAMPLE_URL=wap://waves-network-preview/examples/preferences.wml \
+WAP_SMOKE_INTEROP_EXAMPLE_URL=wap://waves-network-preview/examples/interop-check.wml \
 WAP_SMOKE_DENIED_URL=wap://waves-network-preview:9200/ \
 TRANSPORT_WAP_SKIP_INTERNAL_HEALTH=1 \
   make smoke-transport-wap
 ```
 
-The smoke suite also requests an intentionally unmapped origin and requires an explicit failure.
+The smoke suite requires each compiled example to return `application/vnd.wap.wmlc`, retain raw
+WBXML bytes beginning `03 0a`, and normalize to its stable WML markers. It also requests an
+intentionally unmapped origin and requires an explicit failure.
 Kannel's final catch-all maps both HTTP and HTTPS origins to a local 404 route, while the host
 firewall independently prevents container egress.
 

--- a/docs/ci/CI_SETUP.md
+++ b/docs/ci/CI_SETUP.md
@@ -367,7 +367,9 @@ Behavior:
 
 - starts Docker services (`kannel`, `wml-server`)
 - serves WML 1.3 through an explicit test-only DTD setting; the server default remains WML 1.1
-- fetches the static `/examples/index.wml` route through Kannel and verifies its normalized deck
+- fetches the example directory plus the Pocket Portal, Local Preferences, and Interop Wire Check
+  routes through Kannel; verifies `application/vnd.wap.wmlc`, the raw `03 0a` WBXML
+  version/public-ID prefix, and each normalized deck marker
 - sends `Encoding-Version: 1.3` as the WSP-defined short-integer version-value, and uses the
   locally patched Kannel connectionless path to decode and carry that request negotiation into WML
   compilation
@@ -408,6 +410,8 @@ Behavior:
 - pins `wap-net-core` and disables gateway fallback
 - serves WML 1.3 through the same explicit WML-server test boundary and requires Kannel to emit
   the negotiated WBXML 1.3 envelope accepted by the pinned decoder
+- fetches and renders every first-party example through the visible native path, and observes the
+  origin counter for two seconds to require one successful repeat navigation to issue one request
 - uses Selenium to click the real Go and Select controls, assert the gateway-served home/menu UI,
   traverse menu option 4 into the static example deck, assert a visible invalid-URL failure, and
   recover with another real gateway load

--- a/docs/wap-test-environment/README.md
+++ b/docs/wap-test-environment/README.md
@@ -59,7 +59,11 @@ wap-labs/
   - `/examples/index.wml`
   - `/examples/login.wml`
   - `/examples/register.wml`
+  - `/examples/pocket-portal.wml` (multi-card directory, table, softkeys, and history)
+  - `/examples/preferences.wml` (local-only input/select preference review)
+  - `/examples/interop-check.wml` (deterministic WML 1.3/WBXML markers)
   - each example is served with the configured `WML_DTD_VERSION`, matching the dynamic decks
+  - each embedded source is WML 1.3, deterministic, and limited to 4 KiB
 - Basic observability:
   - redacted structured request logs with request ID
   - internal `/metrics` plain text counters on port `3001`
@@ -84,6 +88,8 @@ Configured in `docker/kannel/kannel.conf`:
   - `url = "http://10.0.2.2/*"` -> `map-url = "http://wml-server:3000/*"`
   - `home.wap.test`, `forms.wap.test`, and `interop.wap.test` map to private origin profile
     prefixes because Kannel rewrites the upstream `Host` header.
+  - each profile root links its focused example: Pocket Portal, Local Preferences, or Interop
+    Wire Check respectively.
 
 ## Quickstart (3 Minutes)
 

--- a/docs/waves/MAINTENANCE_WORK_ITEMS.md
+++ b/docs/waves/MAINTENANCE_WORK_ITEMS.md
@@ -325,6 +325,29 @@ Completed maintenance tickets are archived in:
 9. `Resolution`:
 - The guard now checks the exact derived fragments, and focused regressions prove both previously missed drift cases.
 
+### M1-26 Suppress automatic re-follow of a terminally failed external intent (2026-07-29)
+
+1. `Status`: `todo`
+2. `Priority`: `P1`
+3. `Depends On`: `WML-205`
+4. `Files`:
+- `browser/frontend/src/app/browser-controller.ts`
+- `browser/frontend/src/app/engine-timer-runtime.ts`
+- focused browser controller/timer tests and native failure-path E2E coverage
+5. `Finding`:
+- A stale public origin compiled the static example as WML 1.1. The strict WML 1.3 decoder correctly rejected public ID 4, but the invoking engine state retained the pending external navigation intent. Later timer ticks automatically followed that same terminally failed intent again, producing 97 identical origin requests in about 7.7 seconds.
+- Correcting the origin removes the immediate trigger but does not close this independent client resilience gap. Broadening the WBXML decoder would mask both problems and is out of scope.
+6. `Build`:
+- After a terminal external-intent fetch failure, preserve the invoking card and failed intent for inspection and explicit user retry, while suppressing automatic re-follow of that same intent.
+- Clear the suppression only for a distinct engine intent, a successful navigation, or an explicit user retry action.
+7. `Tests`:
+- Prove one terminal WBXML failure produces one fetch, a stable visible error, and no additional origin request over a bounded observation window.
+- Preserve existing success, distinct-intent, timer, and manual-retry behavior.
+8. `Accept`:
+- Timer ticks cannot turn one terminal external-navigation failure into repeated network requests.
+- The original card and failed intent remain available for diagnosis and explicit retry.
+- No decoder compatibility broadening or service-side workaround is used to hide the client state bug.
+
 ### M1-03 Engine API generator design and bootstrap (non-priority)
 
 1. `Status`: `todo`

--- a/scripts/native-tauri-kannel-e2e.sh
+++ b/scripts/native-tauri-kannel-e2e.sh
@@ -4,6 +4,7 @@ set -eu
 ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 KANNEL_ADMIN_URL="${KANNEL_ADMIN_URL:-http://localhost:13000/status?password=changeme}"
 WML_HEALTH_URL="${WML_HEALTH_URL:-http://localhost:3001/health}"
+WML_METRICS_URL="${WML_METRICS_URL:-http://localhost:3001/metrics}"
 
 if [ "$(uname -s)" != "Linux" ]; then
   echo "native Tauri WebDriver smoke requires Linux (tauri-driver does not support macOS)" >&2
@@ -84,6 +85,7 @@ export VITE_WAVES_DEFAULT_RUN_MODE=network
 export GATEWAY_HTTP_BASE="${GATEWAY_HTTP_BASE:-http://localhost:13002}"
 export NATIVE_E2E_APP_BINARY="${NATIVE_E2E_APP_BINARY:-${ROOT_DIR}/browser/src-tauri/target/debug/wavenav_host}"
 export NATIVE_E2E_ARTIFACT_DIR="${ARTIFACT_DIR}"
+export WML_METRICS_URL
 export WEBKIT_DISABLE_COMPOSITING_MODE="${WEBKIT_DISABLE_COMPOSITING_MODE:-1}"
 
 {
@@ -95,6 +97,7 @@ export WEBKIT_DISABLE_COMPOSITING_MODE="${WEBKIT_DISABLE_COMPOSITING_MODE:-1}"
   echo "transport-fallback: ${WAVES_FETCH_TRANSPORT_FALLBACK}"
   echo "destination-policy: ${WAVES_FETCH_DESTINATION_POLICY}"
   echo "wml-dtd-version: ${WML_DTD_VERSION}"
+  echo "request-observation: ${WML_METRICS_URL}"
 } >"${ARTIFACT_DIR}/environment.txt"
 
 echo "==> Building the production Tauri frontend and debug application binary"

--- a/scripts/transport-wap-smoke.sh
+++ b/scripts/transport-wap-smoke.sh
@@ -10,6 +10,9 @@ WAP_SMOKE_URL="${WAP_SMOKE_URL:-wap://localhost/}"
 WAP_SMOKE_LOGIN_URL="${WAP_SMOKE_LOGIN_URL:-wap://localhost/login}"
 WAP_SMOKE_REGISTER_URL="${WAP_SMOKE_REGISTER_URL:-wap://localhost/register}"
 WAP_SMOKE_EXAMPLE_URL="${WAP_SMOKE_EXAMPLE_URL:-wap://localhost/examples/index.wml}"
+WAP_SMOKE_PORTAL_EXAMPLE_URL="${WAP_SMOKE_PORTAL_EXAMPLE_URL:-wap://localhost/examples/pocket-portal.wml}"
+WAP_SMOKE_PREFERENCES_EXAMPLE_URL="${WAP_SMOKE_PREFERENCES_EXAMPLE_URL:-wap://localhost/examples/preferences.wml}"
+WAP_SMOKE_INTEROP_EXAMPLE_URL="${WAP_SMOKE_INTEROP_EXAMPLE_URL:-wap://localhost/examples/interop-check.wml}"
 WAP_SMOKE_DENIED_URL="${WAP_SMOKE_DENIED_URL:-wap://127.0.0.1:9200/}"
 TRANSPORT_WAP_TIMEOUT_MS="${TRANSPORT_WAP_TIMEOUT_MS:-15000}"
 TRANSPORT_WAP_RETRIES="${TRANSPORT_WAP_RETRIES:-1}"
@@ -103,7 +106,7 @@ fi
 echo "==> Running transport-rust WAP smoke integration test"
 (
   cd "${ROOT_DIR}/transport-rust"
-  export WAP_SMOKE_URL WAP_SMOKE_LOGIN_URL WAP_SMOKE_REGISTER_URL WAP_SMOKE_EXAMPLE_URL WAP_SMOKE_DENIED_URL TRANSPORT_WAP_TIMEOUT_MS TRANSPORT_WAP_RETRIES
+  export WAP_SMOKE_URL WAP_SMOKE_LOGIN_URL WAP_SMOKE_REGISTER_URL WAP_SMOKE_EXAMPLE_URL WAP_SMOKE_PORTAL_EXAMPLE_URL WAP_SMOKE_PREFERENCES_EXAMPLE_URL WAP_SMOKE_INTEROP_EXAMPLE_URL WAP_SMOKE_DENIED_URL TRANSPORT_WAP_TIMEOUT_MS TRANSPORT_WAP_RETRIES
   run_and_tee "${SMOKE_ARTIFACT_DIR}/transport-kannel-smoke.log" \
     cargo test --test kannel_smoke -- --ignored --test-threads=1
 )
@@ -119,9 +122,9 @@ echo "==> Running browser host native Kannel smoke unit test"
 echo "==> Running browser engine/render native Kannel smoke integration test"
 (
   cd "${ROOT_DIR}/browser/src-tauri"
-  export WAP_SMOKE_URL WAP_SMOKE_LOGIN_URL WAP_SMOKE_REGISTER_URL TRANSPORT_WAP_TIMEOUT_MS TRANSPORT_WAP_RETRIES
+  export WAP_SMOKE_URL WAP_SMOKE_LOGIN_URL WAP_SMOKE_REGISTER_URL WAP_SMOKE_EXAMPLE_URL WAP_SMOKE_PORTAL_EXAMPLE_URL WAP_SMOKE_PREFERENCES_EXAMPLE_URL WAP_SMOKE_INTEROP_EXAMPLE_URL TRANSPORT_WAP_TIMEOUT_MS TRANSPORT_WAP_RETRIES
   run_and_tee "${SMOKE_ARTIFACT_DIR}/browser-render-native-smoke.log" \
-    cargo test kannel_fetch_deck_smoke_navigates_into_menu_card -- --ignored --test-threads=1
+    cargo test kannel_fetch_deck_smoke -- --ignored --test-threads=1
 )
 
 echo "==> Running browser auth-form privacy native Kannel smoke integration test"

--- a/transport-rust/tests/kannel_smoke.rs
+++ b/transport-rust/tests/kannel_smoke.rs
@@ -1,6 +1,8 @@
 mod kannel_support;
 
-use kannel_support::{assert_engine_input_contains, post_request, request};
+use kannel_support::{
+    assert_engine_input_contains, assert_wbxml_13_response, post_request, request,
+};
 use lowband_transport_rust::{
     fetch_deck_in_process_with_profile, FetchDeckResponse, FetchTransportProfile,
 };
@@ -75,20 +77,52 @@ fn kannel_wap_home_smoke_normalizes_expected_root_deck() {
 
 #[test]
 #[ignore = "runs against external Kannel dev stack (make up)"]
-fn kannel_wap_static_example_smoke_normalizes_expected_deck() {
-    let target = std::env::var("WAP_SMOKE_EXAMPLE_URL")
-        .unwrap_or_else(|_| "wap://localhost/examples/index.wml".to_string());
-    let response = fetch_ok_response(&target);
-    assert_engine_input_contains(
-        &response,
-        &target,
-        &[
-            "card id=\"welcome\"",
-            "title=\"Static Demo\"",
-            "This is a static WML sample deck.",
-            "href=\"#nav\"",
-        ],
-    );
+fn kannel_wap_examples_smoke_normalizes_wml13_decks() {
+    let cases = [
+        (
+            "WAP_SMOKE_EXAMPLE_URL",
+            "wap://localhost/examples/index.wml",
+            [
+                "card id=\"welcome\"",
+                "title=\"Static Demo\"",
+                "href=\"#nav\"",
+            ],
+        ),
+        (
+            "WAP_SMOKE_PORTAL_EXAMPLE_URL",
+            "wap://localhost/examples/pocket-portal.wml",
+            [
+                "card id=\"portal\"",
+                "title=\"Pocket Portal\"",
+                "Local Services",
+            ],
+        ),
+        (
+            "WAP_SMOKE_PREFERENCES_EXAMPLE_URL",
+            "wap://localhost/examples/preferences.wml",
+            [
+                "card id=\"preferences\"",
+                "title=\"Local Preferences\"",
+                "select name=\"layout\"",
+            ],
+        ),
+        (
+            "WAP_SMOKE_INTEROP_EXAMPLE_URL",
+            "wap://localhost/examples/interop-check.wml",
+            [
+                "card id=\"wire-check\"",
+                "title=\"Interop Wire Check\"",
+                "W13-A",
+            ],
+        ),
+    ];
+
+    for (environment, default_url, markers) in cases {
+        let target = std::env::var(environment).unwrap_or_else(|_| default_url.to_string());
+        let response = fetch_ok_response(&target);
+        assert_wbxml_13_response(&response);
+        assert_engine_input_contains(&response, &target, &markers);
+    }
 }
 
 #[test]

--- a/transport-rust/tests/kannel_support.rs
+++ b/transport-rust/tests/kannel_support.rs
@@ -1,3 +1,4 @@
+use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
 use lowband_transport_rust::{
     FetchDeckRequest, FetchDeckResponse, FetchDestinationPolicy, FetchRequestIntent,
     FetchRequestMethod, FetchRequestPolicy, FetchRequestPostField,
@@ -8,6 +9,23 @@ fn smoke_timeout_ms() -> u64 {
         .ok()
         .and_then(|value| value.parse::<u64>().ok())
         .unwrap_or(15000)
+}
+
+pub fn assert_wbxml_13_response(response: &FetchDeckResponse) {
+    assert_eq!(response.content_type, "application/vnd.wap.wmlc");
+    let encoded = response
+        .engine_deck_input
+        .as_ref()
+        .and_then(|deck| deck.raw_bytes_base64.as_deref())
+        .expect("compiled WML response should retain raw WBXML bytes");
+    let raw = BASE64
+        .decode(encoded)
+        .expect("rawBytesBase64 should contain valid base64");
+    assert!(
+        raw.starts_with(&[0x03, 0x0a]),
+        "expected WBXML 1.3 version/public-id prefix 03 0a, got {:02x?}",
+        raw.get(..2).unwrap_or(&raw)
+    );
 }
 
 fn smoke_retries() -> u8 {

--- a/wml-server/internal/origin/app.go
+++ b/wml-server/internal/origin/app.go
@@ -33,6 +33,7 @@ const (
 	maxUsernameBytes   = 32
 	maxPINBytes        = 6
 	maxSessionIDBytes  = 64
+	maxExampleBytes    = 4 << 10
 	pageSize           = 2
 )
 
@@ -452,6 +453,14 @@ func (a *App) example(w http.ResponseWriter, r *http.Request) {
 	body, err = configureExampleDTD(body, a.dtdVersion)
 	if err != nil {
 		a.logger.Error("invalid embedded example", "file", fileName, "error", err)
+		a.sendWML(w,
+			`<card id="error" title="Error"><p>Unable to load `+xmlEscape(fileName)+`</p><do type="prev" label="Back"><prev/></do></card>`,
+			http.StatusInternalServerError,
+		)
+		return
+	}
+	if len(body) > maxExampleBytes {
+		a.logger.Error("embedded example exceeds response limit", "file", fileName, "bytes", len(body))
 		a.sendWML(w,
 			`<card id="error" title="Error"><p>Unable to load `+xmlEscape(fileName)+`</p><do type="prev" label="Back"><prev/></do></card>`,
 			http.StatusInternalServerError,

--- a/wml-server/internal/origin/app_test.go
+++ b/wml-server/internal/origin/app_test.go
@@ -2,6 +2,7 @@ package origin
 
 import (
 	"bytes"
+	"encoding/xml"
 	"io"
 	"log/slog"
 	"net/http"
@@ -57,6 +58,21 @@ func perform(handler http.Handler, method, target, body, contentType string) *ht
 	response := httptest.NewRecorder()
 	handler.ServeHTTP(response, request)
 	return response
+}
+
+func embeddedExampleNames(t *testing.T) []string {
+	t.Helper()
+	entries, err := exampleFiles.ReadDir("routes")
+	if err != nil {
+		t.Fatal(err)
+	}
+	names := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		if !entry.IsDir() && strings.HasSuffix(entry.Name(), ".wml") {
+			names = append(names, entry.Name())
+		}
+	}
+	return names
 }
 
 func registerAndLogin(t *testing.T, app *App, username string) string {
@@ -155,6 +171,31 @@ func TestHostProfilesAndAllowlist(t *testing.T) {
 		app.Handler().ServeHTTP(response, request)
 		if response.Code != http.StatusOK || !strings.Contains(response.Body.String(), test.want) {
 			t.Errorf("GET %s = %d %s", test.path, response.Code, response.Body.String())
+		}
+	}
+}
+
+func TestHostProfilesLinkToTheirExamples(t *testing.T) {
+	app, _ := newTestApp(t, func(config *Config) {
+		config.AllowedHosts = []string{"home.test", "forms.test", "interop.test"}
+		config.HomeHosts = []string{"home.test"}
+		config.FormsHosts = []string{"forms.test"}
+		config.InteropHosts = []string{"interop.test"}
+	})
+
+	for _, test := range []struct {
+		host string
+		link string
+	}{
+		{"home.test", `/examples/pocket-portal.wml`},
+		{"forms.test", `/examples/preferences.wml`},
+		{"interop.test", `/examples/interop-check.wml`},
+	} {
+		request := httptest.NewRequest(http.MethodGet, "http://"+test.host+"/", nil)
+		response := httptest.NewRecorder()
+		app.Handler().ServeHTTP(response, request)
+		if response.Code != http.StatusOK || !strings.Contains(response.Body.String(), `href="`+test.link+`"`) {
+			t.Errorf("GET http://%s/ does not link %s: %d %s", test.host, test.link, response.Code, response.Body.String())
 		}
 	}
 }
@@ -351,14 +392,22 @@ func TestExamplesAndClosedRoutes(t *testing.T) {
 	app, _ := newTestApp(t, nil)
 	handler := app.Handler()
 
-	for _, file := range []string{"index.wml", "login.wml", "register.wml"} {
+	for _, file := range embeddedExampleNames(t) {
 		response := perform(handler, http.MethodGet, "/examples/"+file, "", "")
 		want, err := exampleFiles.ReadFile("routes/" + file)
 		if err != nil {
 			t.Fatal(err)
 		}
+		want, err = configureExampleDTD(want, app.dtdVersion)
+		if err != nil {
+			t.Fatal(err)
+		}
 		if response.Code != http.StatusOK || !bytes.Equal(response.Body.Bytes(), want) {
 			t.Errorf("example %s differs: %d", file, response.Code)
+		}
+		repeat := perform(handler, http.MethodGet, "/examples/"+file, "", "")
+		if !bytes.Equal(response.Body.Bytes(), repeat.Body.Bytes()) {
+			t.Errorf("example %s is not deterministic", file)
 		}
 	}
 	invalid := perform(handler, http.MethodGet, "/examples/nope.txt", "", "")
@@ -385,7 +434,7 @@ func TestExamplesUseConfiguredDTDVersion(t *testing.T) {
 	for _, version := range []string{"1.1", "1.2", "1.3"} {
 		t.Run(version, func(t *testing.T) {
 			app, _ := newTestApp(t, func(config *Config) { config.DTDVersion = version })
-			for _, file := range []string{"index.wml", "login.wml", "register.wml"} {
+			for _, file := range embeddedExampleNames(t) {
 				response := perform(app.Handler(), http.MethodGet, "/examples/"+file, "", "")
 				if response.Code != http.StatusOK {
 					t.Fatalf("GET /examples/%s = %d", file, response.Code)
@@ -399,6 +448,71 @@ func TestExamplesUseConfiguredDTDVersion(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestEmbeddedExamplesAreWML13WellFormedLinkedAndBounded(t *testing.T) {
+	names := embeddedExampleNames(t)
+	if len(names) != 6 {
+		t.Fatalf("embedded example count = %d, want 6: %v", len(names), names)
+	}
+	for _, file := range names {
+		body, err := exampleFiles.ReadFile("routes/" + file)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(body) > maxExampleBytes {
+			t.Errorf("example %s = %d bytes, limit %d", file, len(body), maxExampleBytes)
+		}
+		if !strings.Contains(string(body), `-//WAPFORUM//DTD WML 1.3//EN`) ||
+			!strings.Contains(string(body), `http://www.wapforum.org/DTD/wml_1.3.xml`) {
+			t.Errorf("example %s does not declare the canonical embedded WML 1.3 doctype", file)
+		}
+		decoder := xml.NewDecoder(bytes.NewReader(body))
+		for {
+			if _, err = decoder.Token(); err == io.EOF {
+				break
+			}
+			if err != nil {
+				t.Errorf("example %s is not well-formed XML: %v", file, err)
+				break
+			}
+		}
+	}
+
+	index, err := exampleFiles.ReadFile("routes/index.wml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, link := range []string{
+		`href="/examples/pocket-portal.wml"`,
+		`href="/examples/preferences.wml"`,
+		`href="/examples/interop-check.wml"`,
+	} {
+		if !strings.Contains(string(index), link) {
+			t.Errorf("example directory missing stable link %s", link)
+		}
+	}
+}
+
+func TestNewExamplesContainExpectedDeterministicFlows(t *testing.T) {
+	for _, test := range []struct {
+		file    string
+		markers []string
+	}{
+		{"pocket-portal.wml", []string{`id="portal"`, `id="directory"`, `<table columns="2"`, `<prev/>`}},
+		{"preferences.wml", []string{`id="preferences"`, `<input name="alias"`, `<select name="layout"`, `href="#saved"`, `Nothing is stored or sent.`}},
+		{"interop-check.wml", []string{`id="wire-check"`, `Public ID</td><td>10`, `Cache</td><td>no-store`, `?probe=repeat`, `W13-A`}},
+	} {
+		body, err := exampleFiles.ReadFile("routes/" + test.file)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, marker := range test.markers {
+			if !strings.Contains(string(body), marker) {
+				t.Errorf("example %s missing marker %q", test.file, marker)
+			}
+		}
 	}
 }
 

--- a/wml-server/internal/origin/render.go
+++ b/wml-server/internal/origin/render.go
@@ -28,7 +28,8 @@ func renderHomeDeck() string {
 		`<p><a href="/login">1. Login</a></p>` +
 		`<p><a href="/register">2. Register</a></p>` +
 		`<p><a href="/about">3. About Stack</a></p>` +
-		`<p><a href="/examples/index.wml">4. Static Example</a></p>` +
+		`<p><a href="/examples/index.wml">4. Example Directory</a></p>` +
+		`<p><a href="/examples/pocket-portal.wml">5. Pocket Portal</a></p>` +
 		`<do type="options" label="About"><go href="/about"/></do>` +
 		`<do type="prev" label="Back"><prev/></do>` +
 		`</card>`
@@ -39,6 +40,7 @@ func renderFormsHomeDeck() string {
 		`<p>Deterministic registration and login exercises.</p>` +
 		`<p><a href="/register">Register a demo user</a></p>` +
 		`<p><a href="/login">Login to the portal</a></p>` +
+		`<p><a href="/examples/preferences.wml">Try local preferences</a></p>` +
 		`<do type="accept" label="Register"><go href="/register"/></do>` +
 		`</card>`
 }
@@ -47,8 +49,9 @@ func renderInteropHomeDeck() string {
 	return `<card id="interop" title="Interop Lab">` +
 		`<p>Deterministic WML response profile.</p>` +
 		`<p>Content type: text/vnd.wap.wml</p>` +
-		`<p><a href="/examples/index.wml">Static WML 1.1 deck</a></p>` +
-		`<do type="accept" label="Example"><go href="/examples/index.wml"/></do>` +
+		`<p><a href="/examples/interop-check.wml">WML 1.3 wire check</a></p>` +
+		`<p><a href="/examples/index.wml">Example directory</a></p>` +
+		`<do type="accept" label="Wire Check"><go href="/examples/interop-check.wml"/></do>` +
 		`</card>`
 }
 

--- a/wml-server/internal/origin/routes/index.wml
+++ b/wml-server/internal/origin/routes/index.wml
@@ -1,19 +1,23 @@
 <?xml version="1.0"?>
-<!DOCTYPE wml PUBLIC "-//WAPFORUM//DTD WML 1.1//EN" "http://www.wapforum.org/DTD/wml_1.1.xml">
+<!DOCTYPE wml PUBLIC "-//WAPFORUM//DTD WML 1.3//EN" "http://www.wapforum.org/DTD/wml_1.3.xml">
 <wml>
   <card id="welcome" title="Static Demo">
     <p>This is a static WML sample deck.</p>
+    <p>Original examples for the Waves compatibility lab.</p>
     <p><a href="#nav">Open Navigation</a></p>
     <do type="accept" label="Next">
       <go href="#nav"/>
     </do>
   </card>
 
-  <card id="nav" title="Navigation">
-    <p>Use anchor links and softkeys.</p>
-    <p><a href="#form">Open Form Card</a></p>
-    <do type="accept" label="Form">
-      <go href="#form"/>
+  <card id="nav" title="Example Directory">
+    <p>Use links, softkeys, and history.</p>
+    <p><a href="/examples/pocket-portal.wml">Pocket Portal</a></p>
+    <p><a href="/examples/preferences.wml">Local Preferences</a></p>
+    <p><a href="/examples/interop-check.wml">Interop Wire Check</a></p>
+    <p><a href="#form">Legacy Form Card</a></p>
+    <do type="accept" label="Portal">
+      <go href="/examples/pocket-portal.wml"/>
     </do>
     <do type="prev" label="Back">
       <prev/>

--- a/wml-server/internal/origin/routes/interop-check.wml
+++ b/wml-server/internal/origin/routes/interop-check.wml
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<!DOCTYPE wml PUBLIC "-//WAPFORUM//DTD WML 1.3//EN" "http://www.wapforum.org/DTD/wml_1.3.xml">
+<wml>
+  <card id="wire-check" title="Interop Wire Check">
+    <p>Deterministic WML 1.3 target.</p>
+    <p>
+      <table columns="2" align="LL">
+        <tr><td>Media</td><td>WMLC</td></tr>
+        <tr><td>Public ID</td><td>10</td></tr>
+        <tr><td>Cache</td><td>no-store</td></tr>
+        <tr><td>Token</td><td>W13-A</td></tr>
+      </table>
+    </p>
+    <p><a href="/examples/interop-check.wml?probe=repeat">Repeat Check</a></p>
+    <p><a href="#meaning">Read Marker Guide</a></p>
+    <do type="accept" label="Repeat"><go href="/examples/interop-check.wml?probe=repeat"/></do>
+    <do type="prev" label="Back"><prev/></do>
+  </card>
+
+  <card id="meaning" title="Marker Guide">
+    <p>W13-A is fixed synthetic content for transport tests.</p>
+    <p>The client verifies the compiled WBXML header separately.</p>
+    <do type="prev" label="Back"><prev/></do>
+  </card>
+</wml>

--- a/wml-server/internal/origin/routes/login.wml
+++ b/wml-server/internal/origin/routes/login.wml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE wml PUBLIC "-//WAPFORUM//DTD WML 1.1//EN" "http://www.wapforum.org/DTD/wml_1.1.xml">
+<!DOCTYPE wml PUBLIC "-//WAPFORUM//DTD WML 1.3//EN" "http://www.wapforum.org/DTD/wml_1.3.xml">
 <wml>
   <card id="login-example" title="Login Example">
     <p>This static page documents login fields:</p>

--- a/wml-server/internal/origin/routes/pocket-portal.wml
+++ b/wml-server/internal/origin/routes/pocket-portal.wml
@@ -1,0 +1,31 @@
+<?xml version="1.0"?>
+<!DOCTYPE wml PUBLIC "-//WAPFORUM//DTD WML 1.3//EN" "http://www.wapforum.org/DTD/wml_1.3.xml">
+<wml>
+  <card id="portal" title="Pocket Portal">
+    <p>Welcome to a small, first-party service directory.</p>
+    <p><a href="#directory">Open Local Services</a></p>
+    <p><a href="#bulletin">Read Bulletin</a></p>
+    <do type="accept" label="Directory"><go href="#directory"/></do>
+  </card>
+
+  <card id="directory" title="Local Services">
+    <p>
+      <table columns="2" align="LL">
+        <tr><td>Forms</td><td><a href="/register">Register</a></td></tr>
+        <tr><td>Account</td><td><a href="/login">Login</a></td></tr>
+        <tr><td>About</td><td><a href="/about">Stack</a></td></tr>
+        <tr><td>Lab</td><td><a href="/examples/index.wml">Examples</a></td></tr>
+      </table>
+    </p>
+    <do type="options" label="Bulletin"><go href="#bulletin"/></do>
+    <do type="prev" label="Back"><prev/></do>
+  </card>
+
+  <card id="bulletin" title="Pocket Bulletin">
+    <p>09:00 - Gateway practice window open.</p>
+    <p>12:00 - Forms lab accepts made-up data only.</p>
+    <p>18:00 - Interop check remains deterministic.</p>
+    <do type="accept" label="Directory"><go href="#directory"/></do>
+    <do type="prev" label="Back"><prev/></do>
+  </card>
+</wml>

--- a/wml-server/internal/origin/routes/preferences.wml
+++ b/wml-server/internal/origin/routes/preferences.wml
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<!DOCTYPE wml PUBLIC "-//WAPFORUM//DTD WML 1.3//EN" "http://www.wapforum.org/DTD/wml_1.3.xml">
+<wml>
+  <card id="preferences" title="Local Preferences">
+    <p>Use a made-up alias. Nothing is stored or sent.</p>
+    <p>Alias: <input name="alias" value="GUEST" title="Alias" format="*M" maxlength="12" emptyok="false"/></p>
+    <p>
+      Layout:
+      <select name="layout" title="Layout">
+        <option value="compact">Compact</option>
+        <option value="roomy">Roomy</option>
+      </select>
+    </p>
+    <p><a href="#saved">Review Preference</a></p>
+    <do type="accept" label="Review"><go href="#saved"/></do>
+    <do type="prev" label="Back"><prev/></do>
+  </card>
+
+  <card id="saved" title="Preference Review">
+    <p>Alias: $(alias)</p>
+    <p>Layout: $(layout)</p>
+    <p>This preview remains local to the current deck.</p>
+    <do type="accept" label="Edit"><go href="#preferences"/></do>
+    <do type="prev" label="Back"><prev/></do>
+  </card>
+</wml>

--- a/wml-server/internal/origin/routes/register.wml
+++ b/wml-server/internal/origin/routes/register.wml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE wml PUBLIC "-//WAPFORUM//DTD WML 1.1//EN" "http://www.wapforum.org/DTD/wml_1.1.xml">
+<!DOCTYPE wml PUBLIC "-//WAPFORUM//DTD WML 1.3//EN" "http://www.wapforum.org/DTD/wml_1.3.xml">
 <wml>
   <card id="register-example" title="Register Example">
     <p>Registration in this lab uses:</p>

--- a/wml-server/internal/origin/testdata/home.golden.wml
+++ b/wml-server/internal/origin/testdata/home.golden.wml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
 <!DOCTYPE wml PUBLIC "-//WAPFORUM//DTD WML 1.1//EN" "http://www.wapforum.org/DTD/wml_1.1.xml">
 <wml>
-<card id="home" title="WAP Lab"><p>Local WAP training environment.</p><p><a href="#menu">Open Menu</a></p><do type="accept" label="Menu"><go href="#menu"/></do></card><card id="menu" title="Main Menu"><p><a href="/login">1. Login</a></p><p><a href="/register">2. Register</a></p><p><a href="/about">3. About Stack</a></p><p><a href="/examples/index.wml">4. Static Example</a></p><do type="options" label="About"><go href="/about"/></do><do type="prev" label="Back"><prev/></do></card>
+<card id="home" title="WAP Lab"><p>Local WAP training environment.</p><p><a href="#menu">Open Menu</a></p><do type="accept" label="Menu"><go href="#menu"/></do></card><card id="menu" title="Main Menu"><p><a href="/login">1. Login</a></p><p><a href="/register">2. Register</a></p><p><a href="/about">3. About Stack</a></p><p><a href="/examples/index.wml">4. Example Directory</a></p><p><a href="/examples/pocket-portal.wml">5. Pocket Portal</a></p><do type="options" label="About"><go href="/about"/></do><do type="prev" label="Back"><prev/></do></card>
 </wml>


### PR DESCRIPTION
## Summary

- add three original, deterministic WML 1.3 examples: Pocket Portal, Local Preferences, and Interop Wire Check
- turn the existing static deck into a stable example directory while preserving its existing route and markers
- verify every embedded example is canonical WML 1.3 source, configurable at runtime, deterministic, well formed, and at most 4 KiB
- exercise the directory and all new examples through real connectionless WSP/WBXML in transport and native Waves smoke paths
- assert WMLC responses retain WBXML bytes beginning `03 0a` and one successful repeat navigation produces exactly one origin request over two seconds
- record M1-26 as the additive browser failed-intent suppression follow-up without broadening WBXML compatibility

## Why

The public service release predates #495, so its embedded examples are compiled with WBXML public ID 4 even though Waves correctly requires public ID 10 for WML 1.3. This release slice packages the merged fix with a small, useful first-party example expansion and direct production-equivalent regression coverage.

## Verification

- `fnm exec --using=22.22.1 -- pnpm run verify:change`
- production Compose validation and deployment contract tests
- hardened local production Compose/Kannel smoke for all examples
- native Waves WSP/WBXML fetch, render, navigation, and preferences interaction smoke
- Go tests/vet, transport/browser Rust tests and Clippy, frontend unit/lint/type/build, shell syntax, docs/link/drift, compliance/graph, and executable stories

## Deployment and rollback

Do not deploy this feature commit. After merge, build the immutable release from a clean merged `origin/main`, validate with ingress sealed, and restore only the exact pre-deployment UDP 9200 posture if the captured pre-state proves it was already public. The current release remains the rollback target until the merged release is fully verified.

No new domains, ports, infrastructure, OpenTofu state changes, credentials, arbitrary proxying, or persistent sensitive data are introduced.
