### PR TITLE
feat(transport): add protocol-aware wapcurl CLI

### DIFF
--- a/docs/architecture/decisions/0005-use-a-standalone-lowband-wap-cli.md
+++ b/docs/architecture/decisions/0005-use-a-standalone-lowband-wap-cli.md
@@ -1,0 +1,143 @@
+# ADR 0005: Use a Standalone Lowband WAP CLI
+
+Date: 2026-07-29
+Status: accepted
+
+## Context
+
+Developers repeatedly need to send bounded WAP requests, preserve response bytes, inspect WMLC,
+and report protocol/decode failures without starting the desktop UI. Existing repository tools
+cover Docker/Kannel smoke paths and library tests, but there is no small general-purpose client.
+
+The implementation must keep WSP, WDP, and WBXML behavior in `transport-rust`, reuse the same
+fetch policy and codecs as Waves, remain deterministic in CI, and distinguish a resource URL from
+the selected WAP proxy/gateway endpoint.
+
+## Repository inventory
+
+- `transport-rust` already owns `fetch_deck_in_process`, the `gateway-bridged` and
+  `wap-net-core` profiles, connectionless WSP/WDP, destination policy, response bounds, and the
+  pinned WML 1.3 WBXML decoder. The browser host calls this same facade.
+- Canonical byte fixtures live in `transport-rust/wbxml_samples/` and
+  `transport-rust/tests/fixtures/transport/`; focused WSP/WDP replays live under
+  `transport-rust/tests/network/interop/`.
+- `scripts/transport-wap-smoke.sh`, `make smoke-transport-wap`, the ignored Kannel Rust smoke
+  tests, and `scripts/native-tauri-kannel-e2e.sh` exercise progressively larger local stacks.
+  They are valuable release checks, but are not a general request inspector.
+- The desktop transport contract is generated from exported Rust types into
+  `browser/contracts/transport.ts` and `browser/contracts/generated/transport-host.ts`.
+  A CLI-only routing option should remain Rust-only unless the desktop contract also needs it.
+- The public preview resources are `wap://home.wap.shrimpworks.dev/`,
+  `wap://forms.wap.shrimpworks.dev/`, and `wap://interop.wap.shrimpworks.dev/`; the established
+  static deep link is `wap://home.wap.shrimpworks.dev/examples/index.wml`. Their WDP/WSP peer is
+  configured separately as `159.89.254.0:9200`.
+- Ordinary contributor verification is already available through `make lint-rust-transport`,
+  `make test-rust-transport`, `pnpm --dir browser run contracts:check`, and
+  `pnpm verify:change`.
+
+## Curl investigation
+
+As of 2026-07-29, curl's documented URL schemes are protocols compiled into a curl/libcurl build;
+an unsupported scheme returns `CURLE_UNSUPPORTED_PROTOCOL`. The public libcurl API exposes
+transfer handles, callbacks, and supported-protocol discovery, but not a protocol-handler
+registration ABI:
+
+- [curl URL syntax](https://curl.se/docs/url-syntax.html)
+- [libcurl error codes](https://curl.se/libcurl/c/libcurl-errors.html)
+- [`curl_version_info`](https://curl.se/libcurl/c/curl_version_info.html)
+
+Curl's official guidance for adding a protocol describes contributing protocol code, tests, and
+documentation to curl itself, with an expectation of wide public use and long-term curl-project
+maintenance. It does not describe a loadable plugin:
+
+- [Adding a new protocol to curl](https://curl.se/dev/new-protocol.html)
+
+`CURLOPT_OPENSOCKETFUNCTION` can replace socket creation or supply a connected socket, but
+libcurl still executes one of its built-in protocol implementations. It cannot delegate WSP,
+WDP, or WBXML semantics to Lowband:
+
+- [`CURLOPT_OPENSOCKETFUNCTION`](https://curl.se/libcurl/c/CURLOPT_OPENSOCKETFUNCTION.html)
+
+Therefore, a true `wap://` curl integration would currently mean carrying a curl fork or pursuing
+an upstream protocol implementation. A wrapper that rewrites `wap://` to HTTP would only exercise
+the repository's gateway bridge and would conceal the native WSP/WDP path.
+
+## Options considered
+
+| Criterion                  | Curl/libcurl protocol implementation                                   | Curl wrapper                     | Standalone Rust CLI over Lowband                                       |
+| -------------------------- | ---------------------------------------------------------------------- | -------------------------------- | ---------------------------------------------------------------------- |
+| Protocol fidelity          | Potentially high, but duplicates or tightly adapts Lowband inside curl | Low; bridge-only                 | High; calls the production Lowband facade                              |
+| Raw-byte visibility        | Possible after substantial curl integration                            | HTTP-side bytes only             | Existing successful normalized response retains original payload bytes |
+| Existing codec reuse       | Awkward across curl's C internals                                      | Decode would need a second tool  | Direct reuse of WSP/WBXML Rust code                                    |
+| Portability/install weight | Custom curl build and distribution                                     | Requires curl plus wrapper/tool  | One Rust binary; no new runtime dependency                             |
+| CI testability             | Requires curl's protocol harness plus repository harness               | Easy but incomplete              | Deterministic local fixture servers                                    |
+| Security/policy parity     | Separate policy implementation risk                                    | Curl policy differs from Waves   | Existing destination policy, limits, and error taxonomy                |
+| Maintenance                | Curl fork/upstream maintenance                                         | Small, but misleading capability | Small Rust adapter maintained with transport                           |
+
+## Decision
+
+Build `wapcurl`, a deliberately curl-like standalone Rust binary in `transport-rust`.
+
+The binary is a thin adapter:
+
+1. Parse a bounded GET-only command contract.
+2. Select native `wap-net-core`, HTTP, or the explicit gateway bridge.
+3. Call `fetch_deck_in_process_with_options`.
+4. Render metadata, decoded inspection, raw bytes, hex, a file, or JSON.
+5. Map Lowband's stable error taxonomy to documented nonzero exit codes.
+
+The Rust facade now accepts `FetchTransportOptions`, which keeps the resource URL separate from
+an optional gateway endpoint. This is a Rust-only seam and does not change the generated browser
+contract. The browser, deployment, and engine surfaces are unchanged.
+
+## Safety and scope
+
+- Default destination policy remains `PublicOnly`; local/private targets require
+  `--allow-private`.
+- The default is one attempt. `--retry` is capped at two additional attempts.
+- Whole-request timeout is 5 seconds by default and constrained to 100–30,000 milliseconds.
+- HTTP redirects remain capped at 10 and payloads at 524,288 bytes by the shared transport.
+- There is no automatic native-to-bridge fallback.
+- Verbose trace goes to stderr and redacts credentials, sensitive query values, authorization,
+  proxy authorization, and cookies.
+- `waps://` does not imply working WTLS; existing Lowband warnings and limitations remain.
+- The CLI is a developer probe, not an interactive browser, crawler, cookie jar, or deployment
+  tool.
+
+## Consequences
+
+Positive:
+
+- CLI and desktop diagnostics share one protocol implementation and error taxonomy.
+- Native public services and deterministic local HTTP/gateway fixtures are both testable.
+- No curl fork, plugin ABI, new parser, async runtime, or external decoder is introduced.
+- Machine-readable output remains clean because protocol trace is on stderr and opt-in.
+
+Costs and limitations:
+
+- GET is the only CLI method in this slice, even though native Lowband also has constrained POST
+  support.
+- Raw response bytes are available after a successful normalized fetch; failure responses do not
+  currently retain rejected payload bytes in the public response contract.
+- Native WAP is the existing constrained connectionless WSP/WDP profile, not full WSP
+  connection-mode, WTP, or WTLS.
+- Custom per-invocation payload and redirect limits are not yet exposed; the shared safe fixed
+  limits apply.
+
+## Rejected alternatives
+
+### Carry a curl fork
+
+Rejected because it creates a second protocol integration and distribution stream while the
+repository already has the required Rust codecs and policy. Upstream curl support could be
+revisited only if WAP use and long-term maintainers satisfy curl's protocol-admission bar.
+
+### Ship a shell wrapper around curl
+
+Rejected because it can only exercise an HTTP bridge, cannot speak native WSP/WDP, and would
+either omit WBXML inspection or invoke a parallel decoder.
+
+### Add protocol logic to TypeScript
+
+Rejected because it violates the repository's layer contract and would duplicate untrusted-input
+handling outside Lowband.

--- a/transport-rust/README.md
+++ b/transport-rust/README.md
@@ -2,6 +2,91 @@
 
 In-process Rust transport boundary used by the Waves browser host.
 
+## `wapcurl` diagnostic CLI
+
+`wapcurl` is a small curl-like developer probe built on the same Lowband fetch facade, WSP codec,
+WBXML decoder, destination policy, retry bounds, and response-size limit as the desktop host.
+Install it locally or run it from the repository:
+
+```sh
+cargo install --path transport-rust --bin wapcurl
+cargo run --manifest-path transport-rust/Cargo.toml --bin wapcurl -- --help
+```
+
+Inspect decoded WML over direct HTTP:
+
+```sh
+wapcurl https://example.test/deck.wml
+```
+
+Use native connectionless WSP/WDP while keeping the resource URL separate from the gateway peer:
+
+```sh
+wapcurl \
+  --profile wap-net-core \
+  --gateway 159.89.254.0:9200 \
+  wap://home.wap.shrimpworks.dev/
+```
+
+Inspect the original WMLC bytes or save them:
+
+```sh
+wapcurl --gateway 159.89.254.0:9200 --hex \
+  wap://home.wap.shrimpworks.dev/examples/index.wml
+wapcurl --gateway 159.89.254.0:9200 --raw \
+  wap://interop.wap.shrimpworks.dev/ > response.wbxml
+wapcurl --gateway 159.89.254.0:9200 --output response.wbxml \
+  wap://interop.wap.shrimpworks.dev/
+```
+
+Use the explicit HTTP gateway bridge or a controlled local fixture:
+
+```sh
+wapcurl --profile gateway-bridged --gateway http://localhost:13002 \
+  --allow-private wap://localhost/examples/index.wml
+wapcurl --allow-private http://127.0.0.1:8080/fixture.wml
+```
+
+`--json` emits one object on stdout. `--verbose` emits redacted trace events on stderr. Header
+values for authorization and cookies, URL credentials, and sensitive query parameters are
+redacted from diagnostics by default.
+
+The default is one attempt with a 5-second whole-request timeout. `--retry` is limited to `0..2`,
+`--timeout-ms` to `100..30000`, HTTP redirects to 10, and bodies to 524,288 bytes. There is no
+automatic native-to-bridge fallback.
+
+Exit codes:
+
+| Code | Meaning                                          |
+| ---: | ------------------------------------------------ |
+|    0 | Success                                          |
+|    2 | CLI usage/configuration error                    |
+|    3 | Invalid request or destination-policy rejection  |
+|    4 | Request timeout                                  |
+|    5 | Unreachable/unavailable transport                |
+|    6 | Protocol/status failure                          |
+|    7 | Unsupported content type or WBXML decode failure |
+|    8 | Response exceeded the shared payload limit       |
+|    9 | Local output/write failure                       |
+
+### Opt-in public smoke
+
+This live command is intentionally manual and bounded. It performs one request, has a 5-second
+timeout, allows no retries, and expects the public service to return WML 1.3 WBXML (numeric public
+identifier 10):
+
+```sh
+cargo run --manifest-path transport-rust/Cargo.toml --bin wapcurl -- \
+  --gateway 159.89.254.0:9200 \
+  --timeout-ms 5000 \
+  --retry 0 \
+  --hex \
+  wap://home.wap.shrimpworks.dev/examples/index.wml
+```
+
+The public lab is unencrypted test infrastructure. Do not send real credentials, cookies, or
+personal data. Ordinary tests use local fixtures and never depend on this service.
+
 ## Scope
 
 - HTTP/HTTPS fetch transport

--- a/transport-rust/src/bin/wapcurl.rs
+++ b/transport-rust/src/bin/wapcurl.rs
@@ -1,0 +1,713 @@
+use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
+use lowband_transport_rust::{
+    fetch_deck_in_process_with_options, is_sensitive_transport_field, redact_transport_url,
+    FetchDeckRequest, FetchDeckResponse, FetchDestinationPolicy, FetchRequestPolicy,
+    FetchTransportOptions, FetchTransportProfile, TRANSPORT_TRACE_ENV,
+};
+use serde_json::json;
+use std::collections::HashMap;
+use std::ffi::OsString;
+use std::io::{self, Write};
+use std::path::PathBuf;
+use std::time::Instant;
+use url::Url;
+
+const HELP: &str = r#"wapcurl - inspect WAP/WML services with Lowband
+
+Usage: wapcurl [OPTIONS] <URL>
+
+Options:
+  --profile <PROFILE>       auto, wap-net-core, or gateway-bridged [default: auto]
+  --gateway <ENDPOINT>      Native host[:port]/wap:// endpoint, or bridge http(s) base
+  --allow-private           Permit loopback/private destinations for controlled local tests
+  -H, --header <H: V>       Add a request header supported by the Lowband fetch contract
+  --timeout-ms <MS>         Whole-request timeout, including connect [100..30000; default: 5000]
+  --retry <COUNT>           Additional attempts [0..2; default: 0]
+  --request-id <ID>         Correlation identifier for trace output
+  --raw                     Write original response bytes to stdout
+  --hex                     Write a deterministic hex dump to stdout
+  -o, --output <FILE>       Save original response bytes instead of printing the body
+  --json                    Emit one machine-readable JSON response
+  -v, --verbose             Emit redacted Lowband transport trace events to stderr
+  -h, --help                Print help
+  -V, --version             Print version
+
+The default output is decoded WML inspection. Metadata is written to stderr in a stable field
+order. Redirects are limited to 10, response bodies to 524288 bytes, and retries to 2. Native
+wap:// requests use bounded connectionless WSP over WDP/UDP; no fallback is automatic.
+"#;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum Profile {
+    Auto,
+    WapNetCore,
+    GatewayBridged,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum OutputMode {
+    Inspect,
+    Raw,
+    Hex,
+    Json,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct Config {
+    url: String,
+    profile: Profile,
+    gateway: Option<String>,
+    allow_private: bool,
+    headers: HashMap<String, String>,
+    timeout_ms: u64,
+    retries: u8,
+    request_id: Option<String>,
+    output_mode: OutputMode,
+    output_path: Option<PathBuf>,
+    verbose: bool,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum ParseOutcome {
+    Run(Config),
+    Help,
+    Version,
+}
+
+fn main() {
+    let exit_code = match parse_args(std::env::args_os().skip(1)) {
+        Ok(ParseOutcome::Help) => {
+            print!("{HELP}");
+            0
+        }
+        Ok(ParseOutcome::Version) => {
+            println!("wapcurl {}", env!("CARGO_PKG_VERSION"));
+            0
+        }
+        Ok(ParseOutcome::Run(config)) => run(config),
+        Err(message) => {
+            eprintln!("wapcurl: {message}");
+            eprintln!("Try 'wapcurl --help' for usage.");
+            2
+        }
+    };
+    std::process::exit(exit_code);
+}
+
+fn parse_args(arguments: impl IntoIterator<Item = OsString>) -> Result<ParseOutcome, String> {
+    let mut arguments = arguments.into_iter();
+    let mut profile = Profile::Auto;
+    let mut gateway = None;
+    let mut allow_private = false;
+    let mut headers = HashMap::new();
+    let mut timeout_ms = 5_000;
+    let mut retries = 0;
+    let mut request_id = None;
+    let mut output_mode = OutputMode::Inspect;
+    let mut selected_output_mode = false;
+    let mut output_path = None;
+    let mut verbose = false;
+    let mut url = None;
+
+    while let Some(argument) = arguments.next() {
+        let argument = argument
+            .into_string()
+            .map_err(|_| "arguments must be valid UTF-8".to_string())?;
+        match argument.as_str() {
+            "-h" | "--help" => return Ok(ParseOutcome::Help),
+            "-V" | "--version" => return Ok(ParseOutcome::Version),
+            "--allow-private" => allow_private = true,
+            "-v" | "--verbose" => verbose = true,
+            "--profile" => {
+                profile = match next_value(&mut arguments, "--profile")?.as_str() {
+                    "auto" => Profile::Auto,
+                    "wap-net-core" => Profile::WapNetCore,
+                    "gateway-bridged" => Profile::GatewayBridged,
+                    value => return Err(format!("unsupported profile: {value}")),
+                };
+            }
+            "--gateway" => gateway = Some(next_value(&mut arguments, "--gateway")?),
+            "-H" | "--header" => {
+                let header = next_value(&mut arguments, "--header")?;
+                let (name, value) = parse_header(&header)?;
+                headers.insert(name, value);
+            }
+            "--timeout-ms" => {
+                let value = next_value(&mut arguments, "--timeout-ms")?;
+                timeout_ms = value
+                    .parse::<u64>()
+                    .map_err(|_| "--timeout-ms must be an integer".to_string())?;
+                if !(100..=30_000).contains(&timeout_ms) {
+                    return Err("--timeout-ms must be between 100 and 30000".to_string());
+                }
+            }
+            "--retry" => {
+                let value = next_value(&mut arguments, "--retry")?;
+                retries = value
+                    .parse::<u8>()
+                    .map_err(|_| "--retry must be an integer".to_string())?;
+                if retries > 2 {
+                    return Err("--retry must be between 0 and 2".to_string());
+                }
+            }
+            "--request-id" => {
+                let value = next_value(&mut arguments, "--request-id")?;
+                if value.trim().is_empty() {
+                    return Err("--request-id must not be empty".to_string());
+                }
+                request_id = Some(value);
+            }
+            "--raw" => {
+                set_output_mode(&mut output_mode, &mut selected_output_mode, OutputMode::Raw)?
+            }
+            "--hex" => {
+                set_output_mode(&mut output_mode, &mut selected_output_mode, OutputMode::Hex)?
+            }
+            "--json" => set_output_mode(
+                &mut output_mode,
+                &mut selected_output_mode,
+                OutputMode::Json,
+            )?,
+            "-o" | "--output" => {
+                if output_path.is_some() {
+                    return Err("--output may be specified only once".to_string());
+                }
+                output_path = Some(PathBuf::from(next_value(&mut arguments, "--output")?));
+            }
+            "--" => {
+                let value = next_value(&mut arguments, "--")?;
+                if url.replace(value).is_some() || arguments.next().is_some() {
+                    return Err("exactly one URL is required".to_string());
+                }
+                break;
+            }
+            value if value.starts_with('-') => return Err(format!("unknown option: {value}")),
+            value => {
+                if url.replace(value.to_string()).is_some() {
+                    return Err("exactly one URL is required".to_string());
+                }
+            }
+        }
+    }
+
+    if output_path.is_some() && selected_output_mode {
+        return Err("--output cannot be combined with --raw, --hex, or --json".to_string());
+    }
+    let url = url.ok_or_else(|| "a URL is required".to_string())?;
+    validate_request_url(&url)?;
+    let scheme = Url::parse(&url)
+        .map(|url| url.scheme().to_string())
+        .unwrap_or_default();
+    if gateway.is_some() && !matches!(scheme.as_str(), "wap" | "waps") {
+        return Err("--gateway is only valid for wap:// or waps:// resource URLs".to_string());
+    }
+
+    Ok(ParseOutcome::Run(Config {
+        url,
+        profile,
+        gateway,
+        allow_private,
+        headers,
+        timeout_ms,
+        retries,
+        request_id,
+        output_mode,
+        output_path,
+        verbose,
+    }))
+}
+
+fn next_value(
+    arguments: &mut impl Iterator<Item = OsString>,
+    option: &str,
+) -> Result<String, String> {
+    arguments
+        .next()
+        .ok_or_else(|| format!("{option} requires a value"))?
+        .into_string()
+        .map_err(|_| format!("{option} value must be valid UTF-8"))
+}
+
+fn parse_header(header: &str) -> Result<(String, String), String> {
+    let (name, value) = header
+        .split_once(':')
+        .ok_or_else(|| "headers must use 'Name: value' syntax".to_string())?;
+    let name = name.trim();
+    if name.is_empty()
+        || !name
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || b"!#$%&'*+-.^_|~".contains(&byte))
+    {
+        return Err("header name contains invalid characters".to_string());
+    }
+    let value = value.trim();
+    if value.contains(['\r', '\n']) {
+        return Err("header values must not contain line breaks".to_string());
+    }
+    Ok((name.to_string(), value.to_string()))
+}
+
+fn set_output_mode(
+    current: &mut OutputMode,
+    selected: &mut bool,
+    requested: OutputMode,
+) -> Result<(), String> {
+    if *selected {
+        return Err("choose only one of --raw, --hex, or --json".to_string());
+    }
+    *current = requested;
+    *selected = true;
+    Ok(())
+}
+
+fn validate_request_url(value: &str) -> Result<(), String> {
+    let parsed =
+        Url::parse(value).map_err(|_| "URL must be absolute and include a scheme".to_string())?;
+    if !matches!(parsed.scheme(), "http" | "https" | "wap" | "waps") {
+        return Err(format!("unsupported URL scheme: {}", parsed.scheme()));
+    }
+    if parsed.host_str().is_none() {
+        return Err("URL must include a host".to_string());
+    }
+    Ok(())
+}
+
+fn run(config: Config) -> i32 {
+    let parsed = Url::parse(&config.url).expect("validated URL should parse");
+    let profile = match config.profile {
+        Profile::Auto if matches!(parsed.scheme(), "wap" | "waps") => {
+            FetchTransportProfile::WapNetCore
+        }
+        Profile::Auto => FetchTransportProfile::GatewayBridged,
+        Profile::WapNetCore => FetchTransportProfile::WapNetCore,
+        Profile::GatewayBridged => FetchTransportProfile::GatewayBridged,
+    };
+    let gateway_endpoint =
+        match normalize_gateway(config.gateway.as_deref(), profile, parsed.scheme()) {
+            Ok(endpoint) => endpoint,
+            Err(message) => {
+                eprintln!("wapcurl: {message}");
+                return 2;
+            }
+        };
+
+    std::env::set_var(
+        TRANSPORT_TRACE_ENV,
+        if config.verbose { "on" } else { "off" },
+    );
+    if config.verbose {
+        emit_cli_trace(&config, profile, gateway_endpoint.as_deref());
+    }
+
+    let request = FetchDeckRequest {
+        url: config.url.clone(),
+        method: Some("GET".to_string()),
+        headers: (!config.headers.is_empty()).then_some(config.headers.clone()),
+        timeout_ms: Some(config.timeout_ms),
+        retries: Some(config.retries),
+        request_id: config
+            .request_id
+            .clone()
+            .or_else(|| Some("wapcurl-1".to_string())),
+        request_policy: Some(FetchRequestPolicy {
+            destination_policy: Some(if config.allow_private {
+                FetchDestinationPolicy::AllowPrivate
+            } else {
+                FetchDestinationPolicy::PublicOnly
+            }),
+            cache_control: None,
+            referer_url: None,
+            post_context: None,
+            request_intent: None,
+            ua_capability_profile: None,
+        }),
+    };
+    let wall_start = Instant::now();
+    let response = fetch_deck_in_process_with_options(
+        request,
+        FetchTransportOptions {
+            profile,
+            gateway_endpoint: gateway_endpoint.clone(),
+        },
+    );
+    let wall_elapsed_ms = wall_start.elapsed().as_secs_f64() * 1000.0;
+    let body = response_body_bytes(&response);
+    let transport = transport_classification(parsed.scheme(), profile);
+    let decode = decode_classification(&response);
+
+    if config.output_mode == OutputMode::Json {
+        if let Err(error) = write_json_response(
+            &config,
+            &response,
+            body.as_deref(),
+            wall_elapsed_ms,
+            transport,
+            decode,
+            gateway_endpoint.as_deref(),
+        ) {
+            eprintln!("wapcurl: failed to write JSON output: {error}");
+            return 9;
+        }
+    } else {
+        write_metadata(
+            &config,
+            &response,
+            body.as_deref(),
+            wall_elapsed_ms,
+            transport,
+            decode,
+            gateway_endpoint.as_deref(),
+        );
+        if response.ok {
+            if let Err(error) = write_body(&config, &response, body.as_deref()) {
+                eprintln!("wapcurl: failed to write response body: {error}");
+                return 9;
+            }
+        }
+    }
+
+    exit_code_for_response(&response)
+}
+
+fn normalize_gateway(
+    gateway: Option<&str>,
+    profile: FetchTransportProfile,
+    resource_scheme: &str,
+) -> Result<Option<String>, String> {
+    let Some(gateway) = gateway else {
+        return Ok(None);
+    };
+    let normalized = match profile {
+        FetchTransportProfile::WapNetCore if gateway.contains("://") => gateway.to_string(),
+        FetchTransportProfile::WapNetCore => format!("{resource_scheme}://{gateway}"),
+        FetchTransportProfile::GatewayBridged => gateway.to_string(),
+    };
+    let parsed =
+        Url::parse(&normalized).map_err(|_| "--gateway endpoint is malformed".to_string())?;
+    let valid_scheme = match profile {
+        FetchTransportProfile::WapNetCore => matches!(parsed.scheme(), "wap" | "waps"),
+        FetchTransportProfile::GatewayBridged => matches!(parsed.scheme(), "http" | "https"),
+    };
+    if !valid_scheme || parsed.host_str().is_none() {
+        return Err(match profile {
+            FetchTransportProfile::WapNetCore => {
+                "native --gateway must be host[:port] or an absolute wap:// URL".to_string()
+            }
+            FetchTransportProfile::GatewayBridged => {
+                "bridged --gateway must be an absolute http:// or https:// URL".to_string()
+            }
+        });
+    }
+    if !parsed.username().is_empty() || parsed.password().is_some() {
+        return Err("--gateway must not contain credentials".to_string());
+    }
+    Ok(Some(normalized))
+}
+
+fn response_body_bytes(response: &FetchDeckResponse) -> Option<Vec<u8>> {
+    let deck = response.engine_deck_input.as_ref()?;
+    match deck.raw_bytes_base64.as_deref() {
+        Some(encoded) => BASE64.decode(encoded).ok(),
+        None => Some(deck.wml_xml.as_bytes().to_vec()),
+    }
+}
+
+fn transport_classification(scheme: &str, profile: FetchTransportProfile) -> &'static str {
+    if matches!(scheme, "http" | "https") {
+        "http"
+    } else {
+        match profile {
+            FetchTransportProfile::WapNetCore => "wsp-connectionless/wdp-udp",
+            FetchTransportProfile::GatewayBridged => "gateway-bridged/http",
+        }
+    }
+}
+
+fn decode_classification(response: &FetchDeckResponse) -> &'static str {
+    if response.content_type == "application/vnd.wap.wmlc" {
+        if response.ok {
+            "wbxml-to-wml"
+        } else {
+            "wbxml-error"
+        }
+    } else if response.ok {
+        "text-wml"
+    } else if response
+        .error
+        .as_ref()
+        .is_some_and(|error| error.code == "UNSUPPORTED_CONTENT_TYPE")
+    {
+        "unsupported-content-type"
+    } else {
+        "not-decoded"
+    }
+}
+
+fn write_metadata(
+    config: &Config,
+    response: &FetchDeckResponse,
+    body: Option<&[u8]>,
+    wall_elapsed_ms: f64,
+    transport: &str,
+    decode: &str,
+    gateway_endpoint: Option<&str>,
+) {
+    eprintln!("requested-url: {}", redact_transport_url(&config.url));
+    eprintln!("final-url: {}", redact_transport_url(&response.final_url));
+    if let Some(endpoint) = gateway_endpoint {
+        eprintln!("gateway: {}", redact_transport_url(endpoint));
+    }
+    eprintln!("status: {}", response.status);
+    eprintln!(
+        "outcome: {}",
+        response
+            .error
+            .as_ref()
+            .map(|error| error.code.as_str())
+            .unwrap_or("success")
+    );
+    eprintln!("content-type: {}", response.content_type);
+    eprintln!("bytes: {}", body.map_or(0, <[u8]>::len));
+    eprintln!("elapsed-ms: {wall_elapsed_ms:.3}");
+    eprintln!("transport: {transport}");
+    eprintln!("decode: {decode}");
+    if let Some(error) = response.error.as_ref() {
+        eprintln!("error: {}", redact_text(&error.message, &config.url));
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn write_json_response(
+    config: &Config,
+    response: &FetchDeckResponse,
+    body: Option<&[u8]>,
+    wall_elapsed_ms: f64,
+    transport: &str,
+    decode: &str,
+    gateway_endpoint: Option<&str>,
+) -> io::Result<()> {
+    let value = json!({
+        "requestedUrl": redact_transport_url(&config.url),
+        "finalUrl": redact_transport_url(&response.final_url),
+        "gateway": gateway_endpoint.map(redact_transport_url),
+        "ok": response.ok,
+        "status": response.status,
+        "outcome": response.error.as_ref().map(|error| error.code.as_str()).unwrap_or("success"),
+        "contentType": response.content_type,
+        "byteCount": body.map_or(0, <[u8]>::len),
+        "elapsedMs": (wall_elapsed_ms * 1000.0).round() / 1000.0,
+        "transport": transport,
+        "decode": decode,
+        "wml": response.wml,
+        "rawBytesBase64": body.map(|bytes| BASE64.encode(bytes)),
+        "error": response.error.as_ref().map(|error| json!({
+            "code": error.code,
+            "message": redact_text(&error.message, &config.url),
+        })),
+    });
+    let mut stdout = io::stdout().lock();
+    serde_json::to_writer(&mut stdout, &value)?;
+    stdout.write_all(b"\n")
+}
+
+fn write_body(
+    config: &Config,
+    response: &FetchDeckResponse,
+    body: Option<&[u8]>,
+) -> io::Result<()> {
+    if let Some(path) = config.output_path.as_ref() {
+        let bytes = body.ok_or_else(|| io::Error::other("raw response bytes are unavailable"))?;
+        return std::fs::write(path, bytes);
+    }
+
+    let mut stdout = io::stdout().lock();
+    match config.output_mode {
+        OutputMode::Inspect => {
+            let wml = response
+                .wml
+                .as_deref()
+                .ok_or_else(|| io::Error::other("decoded WML is unavailable"))?;
+            stdout.write_all(wml.as_bytes())?;
+            if !wml.ends_with('\n') {
+                stdout.write_all(b"\n")?;
+            }
+            Ok(())
+        }
+        OutputMode::Raw => stdout
+            .write_all(body.ok_or_else(|| io::Error::other("raw response bytes are unavailable"))?),
+        OutputMode::Hex => {
+            let bytes =
+                body.ok_or_else(|| io::Error::other("raw response bytes are unavailable"))?;
+            stdout.write_all(hex_dump(bytes).as_bytes())
+        }
+        OutputMode::Json => unreachable!("JSON output is handled separately"),
+    }
+}
+
+fn hex_dump(bytes: &[u8]) -> String {
+    let mut output = String::new();
+    for (line, chunk) in bytes.chunks(16).enumerate() {
+        use std::fmt::Write as _;
+        let _ = write!(output, "{:08x}  ", line * 16);
+        for index in 0..16 {
+            if let Some(byte) = chunk.get(index) {
+                let _ = write!(output, "{byte:02x} ");
+            } else {
+                output.push_str("   ");
+            }
+            if index == 7 {
+                output.push(' ');
+            }
+        }
+        output.push_str(" |");
+        for byte in chunk {
+            output.push(if byte.is_ascii_graphic() || *byte == b' ' {
+                char::from(*byte)
+            } else {
+                '.'
+            });
+        }
+        output.push_str("|\n");
+    }
+    output
+}
+
+fn emit_cli_trace(config: &Config, profile: FetchTransportProfile, gateway_endpoint: Option<&str>) {
+    let headers = config
+        .headers
+        .iter()
+        .map(|(name, value)| {
+            let value = if is_sensitive_transport_field(&name.to_ascii_lowercase()) {
+                "<redacted>"
+            } else {
+                value
+            };
+            (name, value)
+        })
+        .collect::<std::collections::BTreeMap<_, _>>();
+    eprintln!(
+        "{}",
+        json!({
+            "event": "wapcurl.request",
+            "requestUrl": redact_transport_url(&config.url),
+            "profile": match profile {
+                FetchTransportProfile::WapNetCore => "wap-net-core",
+                FetchTransportProfile::GatewayBridged => "gateway-bridged",
+            },
+            "gateway": gateway_endpoint.map(redact_transport_url),
+            "timeoutMs": config.timeout_ms,
+            "attempts": config.retries + 1,
+            "headers": headers,
+        })
+    );
+}
+
+fn redact_text(text: &str, request_url: &str) -> String {
+    text.replace(request_url, &redact_transport_url(request_url))
+}
+
+fn exit_code_for_response(response: &FetchDeckResponse) -> i32 {
+    match response.error.as_ref().map(|error| error.code.as_str()) {
+        None => 0,
+        Some("INVALID_REQUEST") => 3,
+        Some("GATEWAY_TIMEOUT") => 4,
+        Some("TRANSPORT_UNAVAILABLE") => 5,
+        Some("PROTOCOL_ERROR") => 6,
+        Some("UNSUPPORTED_CONTENT_TYPE" | "WBXML_DECODE_FAILED") => 7,
+        Some("PAYLOAD_TOO_LARGE") => 8,
+        Some(_) => 6,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse(values: &[&str]) -> Result<ParseOutcome, String> {
+        parse_args(values.iter().map(OsString::from))
+    }
+
+    #[test]
+    fn help_is_available_without_a_url() {
+        assert_eq!(parse(&["--help"]), Ok(ParseOutcome::Help));
+    }
+
+    #[test]
+    fn parser_accepts_curl_like_request_options() {
+        let ParseOutcome::Run(config) = parse(&[
+            "--profile",
+            "wap-net-core",
+            "--gateway",
+            "159.89.254.0:9200",
+            "--timeout-ms",
+            "750",
+            "--retry",
+            "1",
+            "-H",
+            "Accept: application/vnd.wap.wmlc",
+            "--hex",
+            "wap://home.wap.shrimpworks.dev/",
+        ])
+        .expect("arguments should parse") else {
+            panic!("expected runnable config");
+        };
+        assert_eq!(config.profile, Profile::WapNetCore);
+        assert_eq!(config.gateway.as_deref(), Some("159.89.254.0:9200"));
+        assert_eq!(config.timeout_ms, 750);
+        assert_eq!(config.retries, 1);
+        assert_eq!(config.output_mode, OutputMode::Hex);
+        assert_eq!(
+            config.headers.get("Accept").map(String::as_str),
+            Some("application/vnd.wap.wmlc")
+        );
+    }
+
+    #[test]
+    fn parser_rejects_retry_storms_and_conflicting_outputs() {
+        assert!(parse(&["--retry", "3", "wap://example.test/"])
+            .expect_err("retry count should be bounded")
+            .contains("between 0 and 2"));
+        assert!(parse(&["--raw", "--hex", "wap://example.test/"])
+            .expect_err("outputs should conflict")
+            .contains("choose only one"));
+    }
+
+    #[test]
+    fn parser_rejects_malformed_urls_and_header_injection() {
+        assert!(parse(&["example.test"]).is_err());
+        assert!(parse(&["-H", "X-Test: ok\r\nInjected: yes", "wap://example.test/"]).is_err());
+    }
+
+    #[test]
+    fn native_gateway_host_port_is_normalized_separately_from_resource_url() {
+        assert_eq!(
+            normalize_gateway(
+                Some("159.89.254.0:9200"),
+                FetchTransportProfile::WapNetCore,
+                "wap"
+            )
+            .expect("gateway should normalize")
+            .as_deref(),
+            Some("wap://159.89.254.0:9200")
+        );
+    }
+
+    #[test]
+    fn hex_dump_is_stable_and_safe_for_binary_data() {
+        assert_eq!(
+            hex_dump(&[0x03, 0x0a, 0x00, b'A']),
+            "00000000  03 0a 00 41                                       |...A|\n"
+        );
+    }
+
+    #[test]
+    fn redaction_hides_credentials_cookies_and_query_secrets() {
+        let url = redact_transport_url("wap://alice:secret@example.test/?pin=1234&card=home");
+        assert!(!url.contains("alice"));
+        assert!(!url.contains("secret"));
+        assert!(!url.contains("1234"));
+        assert!(url.contains("card=home"));
+        assert!(is_sensitive_transport_field("authorization"));
+        assert!(is_sensitive_transport_field("cookie"));
+    }
+}

--- a/transport-rust/src/fetch_runtime.rs
+++ b/transport-rust/src/fetch_runtime.rs
@@ -3,7 +3,7 @@ mod execution;
 use crate::fetch_policy::{
     apply_request_policy, resolve_fetch_destination_policy, validate_fetch_destination,
 };
-use crate::gateway::build_gateway_request;
+use crate::gateway::build_gateway_request_with_endpoint;
 use crate::native_fetch::{
     execute_native_wap_request, should_use_native_wap_request, NativeFetchPlan,
 };
@@ -12,7 +12,7 @@ use crate::request_serialization::serialize_fetch_request;
 use crate::responses::{invalid_request_response, transport_unavailable_response};
 use crate::{
     FetchDeckRequest, FetchDeckResponse, FetchDestinationPolicy, FetchRequestPolicy,
-    FetchTransportProfile, MAX_URI_OCTETS,
+    FetchTransportOptions, FetchTransportProfile, MAX_URI_OCTETS,
 };
 use url::Url;
 
@@ -20,7 +20,7 @@ use self::execution::{execute_fetch, FetchExecutionPlan};
 
 pub(crate) fn fetch_deck_in_process_impl(
     request: FetchDeckRequest,
-    profile_override: Option<FetchTransportProfile>,
+    transport_options: Option<FetchTransportOptions>,
 ) -> FetchDeckResponse {
     let FetchDeckRequest {
         url,
@@ -122,9 +122,15 @@ pub(crate) fn fetch_deck_in_process_impl(
         }),
     );
 
+    let profile_override = transport_options.as_ref().map(|options| options.profile);
+    let gateway_endpoint = transport_options
+        .as_ref()
+        .and_then(|options| options.gateway_endpoint.clone());
+
     if should_use_native_wap_request_for_profile(&parsed, &method, profile_override) {
         return execute_native_wap_request(NativeFetchPlan {
             request_url: url,
+            gateway_endpoint,
             method,
             outbound_headers,
             post_body: request_body,
@@ -145,7 +151,12 @@ pub(crate) fn fetch_deck_in_process_impl(
     }
 
     if is_wap_scheme {
-        match build_gateway_request(&url, &method, &outbound_headers) {
+        match build_gateway_request_with_endpoint(
+            &url,
+            &method,
+            &outbound_headers,
+            gateway_endpoint.as_deref(),
+        ) {
             Ok((gateway_url, headers)) => {
                 upstream_url = gateway_url;
                 outbound_headers = headers;

--- a/transport-rust/src/gateway.rs
+++ b/transport-rust/src/gateway.rs
@@ -6,10 +6,20 @@ fn gateway_http_base() -> String {
     env::var("GATEWAY_HTTP_BASE").unwrap_or_else(|_| "http://localhost:13002".to_string())
 }
 
+#[cfg(test)]
 pub(crate) fn build_gateway_request(
     original_url: &str,
     method: &str,
     headers: &HashMap<String, String>,
+) -> Result<(String, HashMap<String, String>), String> {
+    build_gateway_request_with_endpoint(original_url, method, headers, None)
+}
+
+pub(crate) fn build_gateway_request_with_endpoint(
+    original_url: &str,
+    method: &str,
+    headers: &HashMap<String, String>,
+    configured_base: Option<&str>,
 ) -> Result<(String, HashMap<String, String>), String> {
     let parsed = Url::parse(original_url).map_err(|err| format!("invalid wap url: {err}"))?;
     if !matches!(parsed.scheme(), "wap" | "waps") {
@@ -24,7 +34,10 @@ pub(crate) fn build_gateway_request(
         ));
     }
 
-    let base = Url::parse(&gateway_http_base())
+    let base_value = configured_base
+        .map(str::to_owned)
+        .unwrap_or_else(gateway_http_base);
+    let base = Url::parse(&base_value)
         .map_err(|_| "GATEWAY_HTTP_BASE must be an absolute http(s) URL".to_string())?;
     if !matches!(base.scheme(), "http" | "https") || base.host_str().is_none() {
         return Err("GATEWAY_HTTP_BASE must be an absolute http(s) URL".to_string());

--- a/transport-rust/src/lib.rs
+++ b/transport-rust/src/lib.rs
@@ -24,6 +24,7 @@ pub mod wsp_registry;
 mod wtp_replay_window;
 
 use fetch_runtime::fetch_deck_in_process_impl;
+pub use request_meta::{is_sensitive_transport_field, redact_transport_url, TRANSPORT_TRACE_ENV};
 pub use wbxml::preflight_wbxml_decoder;
 
 pub(crate) const MAX_URI_OCTETS: usize = 1024;
@@ -136,6 +137,18 @@ pub enum FetchTransportProfile {
     WapNetCore,
 }
 
+/// Rust-only routing options for Lowband clients such as the diagnostic CLI.
+///
+/// `gateway_endpoint` is deliberately separate from [`FetchDeckRequest::url`]: the request URL
+/// identifies the WAP resource, while the endpoint identifies the selected proxy/gateway peer.
+/// Native WAP endpoints use `wap://host[:port]`; gateway-bridged endpoints use an absolute
+/// `http://` or `https://` base URL.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct FetchTransportOptions {
+    pub profile: FetchTransportProfile,
+    pub gateway_endpoint: Option<String>,
+}
+
 #[derive(Debug, Serialize, Deserialize, TS)]
 #[serde(rename_all = "camelCase")]
 pub struct FetchTiming {
@@ -190,7 +203,21 @@ pub fn fetch_deck_in_process_with_profile(
     request: FetchDeckRequest,
     profile: FetchTransportProfile,
 ) -> FetchDeckResponse {
-    fetch_deck_in_process_impl(request, Some(profile))
+    fetch_deck_in_process_impl(
+        request,
+        Some(FetchTransportOptions {
+            profile,
+            gateway_endpoint: None,
+        }),
+    )
+}
+
+/// Fetches a deck with an explicit transport profile and optional gateway endpoint.
+pub fn fetch_deck_in_process_with_options(
+    request: FetchDeckRequest,
+    options: FetchTransportOptions,
+) -> FetchDeckResponse {
+    fetch_deck_in_process_impl(request, Some(options))
 }
 
 #[cfg(test)]

--- a/transport-rust/src/native_fetch.rs
+++ b/transport-rust/src/native_fetch.rs
@@ -37,6 +37,7 @@ pub(crate) enum TransportProfile {
 
 pub(crate) struct NativeFetchPlan {
     pub(crate) request_url: String,
+    pub(crate) gateway_endpoint: Option<String>,
     pub(crate) method: String,
     pub(crate) outbound_headers: HashMap<String, String>,
     pub(crate) post_body: Option<Vec<u8>>,
@@ -104,7 +105,21 @@ pub(crate) fn execute_native_wap_request(plan: NativeFetchPlan) -> FetchDeckResp
         }
     };
 
-    let peer = match resolve_destination_socket_addr(&parsed, &plan.destination_policy) {
+    let peer_url = match plan.gateway_endpoint.as_deref() {
+        Some(endpoint) => match parse_native_gateway_endpoint(endpoint) {
+            Ok(endpoint) => endpoint,
+            Err(error) => {
+                return invalid_request_response(
+                    plan.request_url,
+                    error,
+                    plan.request_id.as_deref(),
+                );
+            }
+        },
+        None => parsed.clone(),
+    };
+
+    let peer = match resolve_destination_socket_addr(&peer_url, &plan.destination_policy) {
         Ok(peer) => peer,
         Err(error) => {
             return map_destination_resolution_error(
@@ -136,6 +151,27 @@ pub(crate) fn execute_native_wap_request(plan: NativeFetchPlan) -> FetchDeckResp
     };
 
     execute_native_wap_request_with_transport(&mut transport, peer, plan)
+}
+
+fn parse_native_gateway_endpoint(endpoint: &str) -> Result<Url, String> {
+    let parsed = Url::parse(endpoint)
+        .map_err(|_| "native gateway endpoint must be an absolute wap:// URL".to_string())?;
+    if !matches!(parsed.scheme(), "wap" | "waps") || parsed.host_str().is_none() {
+        return Err(
+            "native gateway endpoint must be an absolute wap:// or waps:// URL".to_string(),
+        );
+    }
+    if !parsed.username().is_empty()
+        || parsed.password().is_some()
+        || !matches!(parsed.path(), "" | "/")
+        || parsed.query().is_some()
+        || parsed.fragment().is_some()
+    {
+        return Err(
+            "native gateway endpoint may contain only scheme, host, and optional port".to_string(),
+        );
+    }
+    Ok(parsed)
 }
 
 pub(crate) fn execute_native_wap_request_with_transport(
@@ -592,6 +628,26 @@ mod tests {
     }
 
     #[test]
+    fn native_gateway_endpoint_is_resource_independent_and_strictly_shaped() {
+        let endpoint = parse_native_gateway_endpoint("wap://159.89.254.0:9200")
+            .expect("gateway endpoint should parse");
+        assert_eq!(endpoint.host_str(), Some("159.89.254.0"));
+        assert_eq!(endpoint.port(), Some(9200));
+
+        for invalid in [
+            "http://159.89.254.0:9200",
+            "wap://user:secret@159.89.254.0:9200",
+            "wap://159.89.254.0:9200/path",
+            "wap://159.89.254.0:9200?token=secret",
+        ] {
+            assert!(
+                parse_native_gateway_endpoint(invalid).is_err(),
+                "endpoint should be rejected: {invalid}"
+            );
+        }
+    }
+
+    #[test]
     fn native_fetch_roundtrip_maps_reply_to_normalized_response() {
         let request_url = "wap://127.0.0.1/login".to_string();
         let peer: SocketAddr = "127.0.0.1:9200".parse().expect("literal should parse");
@@ -618,6 +674,7 @@ mod tests {
             peer,
             NativeFetchPlan {
                 request_url: request_url.clone(),
+                gateway_endpoint: None,
                 method: "GET".to_string(),
                 outbound_headers: HashMap::from([(
                     "Accept".to_string(),
@@ -666,6 +723,7 @@ mod tests {
             "127.0.0.1:9200".parse().expect("literal should parse"),
             NativeFetchPlan {
                 request_url: "wap://127.0.0.1/".to_string(),
+                gateway_endpoint: None,
                 method: "GET".to_string(),
                 outbound_headers: HashMap::new(),
                 post_body: None,
@@ -717,6 +775,7 @@ mod tests {
             peer,
             NativeFetchPlan {
                 request_url: request_url.clone(),
+                gateway_endpoint: None,
                 method: "GET".to_string(),
                 outbound_headers: HashMap::new(),
                 post_body: None,
@@ -1061,6 +1120,7 @@ mod tests {
             "127.0.0.1:9200".parse().expect("literal should parse"),
             NativeFetchPlan {
                 request_url: "wap://127.0.0.1/".to_string(),
+                gateway_endpoint: None,
                 method: "GET".to_string(),
                 outbound_headers: HashMap::new(),
                 post_body: None,

--- a/transport-rust/src/request_meta.rs
+++ b/transport-rust/src/request_meta.rs
@@ -1,4 +1,7 @@
 use serde_json::{Map, Value};
+use url::Url;
+
+pub const TRANSPORT_TRACE_ENV: &str = "LOWBAND_TRANSPORT_TRACE";
 
 pub(crate) fn normalized_request_id(value: Option<&str>) -> Option<&str> {
     value.and_then(|raw| {
@@ -35,17 +38,115 @@ pub(crate) fn log_transport_event(
     request_url: &str,
     payload: Value,
 ) {
+    if !transport_trace_enabled() {
+        return;
+    }
+    let redacted_request_url = redact_transport_url(request_url);
+    let payload = redact_event_value(payload, request_url, &redacted_request_url);
     let mut entry = Map::new();
     entry.insert("event".to_string(), Value::String(event.to_string()));
     entry.insert(
         "requestUrl".to_string(),
-        Value::String(request_url.to_string()),
+        Value::String(redacted_request_url),
     );
     if let Some(id) = normalized_request_id(request_id) {
         entry.insert("requestId".to_string(), Value::String(id.to_string()));
     }
     entry.insert("payload".to_string(), payload);
-    println!("{}", Value::Object(entry));
+    eprintln!("{}", Value::Object(entry));
+}
+
+fn transport_trace_enabled() -> bool {
+    !matches!(
+        std::env::var(TRANSPORT_TRACE_ENV)
+            .unwrap_or_else(|_| "on".to_string())
+            .trim()
+            .to_ascii_lowercase()
+            .as_str(),
+        "0" | "false" | "off"
+    )
+}
+
+fn redact_event_value(value: Value, request_url: &str, redacted_request_url: &str) -> Value {
+    match value {
+        Value::Object(map) => Value::Object(
+            map.into_iter()
+                .map(|(key, value)| {
+                    let lowered = key.to_ascii_lowercase();
+                    let value = if is_sensitive_transport_field(&lowered) {
+                        Value::String("<redacted>".to_string())
+                    } else if lowered.contains("url") {
+                        match value {
+                            Value::String(url) => Value::String(redact_transport_url(&url)),
+                            other => redact_event_value(other, request_url, redacted_request_url),
+                        }
+                    } else {
+                        redact_event_value(value, request_url, redacted_request_url)
+                    };
+                    (key, value)
+                })
+                .collect(),
+        ),
+        Value::Array(values) => Value::Array(
+            values
+                .into_iter()
+                .map(|value| redact_event_value(value, request_url, redacted_request_url))
+                .collect(),
+        ),
+        Value::String(text) if !request_url.is_empty() && text.contains(request_url) => {
+            Value::String(text.replace(request_url, redacted_request_url))
+        }
+        other => other,
+    }
+}
+
+/// Redacts userinfo and known secret-bearing query values for diagnostics.
+pub fn redact_transport_url(value: &str) -> String {
+    let Ok(mut parsed) = Url::parse(value) else {
+        return "<invalid-url>".to_string();
+    };
+    if !parsed.username().is_empty() {
+        let _ = parsed.set_username("<redacted>");
+    }
+    if parsed.password().is_some() {
+        let _ = parsed.set_password(Some("<redacted>"));
+    }
+    if parsed.query().is_some() {
+        let pairs = parsed
+            .query_pairs()
+            .map(|(name, value)| {
+                let value = if is_sensitive_transport_field(&name.to_ascii_lowercase()) {
+                    "<redacted>".to_string()
+                } else {
+                    value.into_owned()
+                };
+                (name.into_owned(), value)
+            })
+            .collect::<Vec<_>>();
+        parsed.query_pairs_mut().clear().extend_pairs(pairs);
+    }
+    parsed.to_string()
+}
+
+/// Returns whether a normalized field/header/query name is secret-bearing by default.
+pub fn is_sensitive_transport_field(name: &str) -> bool {
+    matches!(
+        name,
+        "authorization"
+            | "cookie"
+            | "credentials"
+            | "password"
+            | "passwd"
+            | "pin"
+            | "proxy-authorization"
+            | "secret"
+            | "session"
+            | "sid"
+            | "token"
+    ) || name.ends_with("_key")
+        || name.ends_with("-key")
+        || name.ends_with("_token")
+        || name.ends_with("-token")
 }
 
 /// Emits the retry-or-failure event for a consumed fetch attempt.
@@ -88,5 +189,38 @@ pub(crate) fn log_fetch_attempt_failure(
                 "elapsedMs": elapsed_ms
             }),
         );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn trace_url_redacts_credentials_and_sensitive_query_values() {
+        let redacted = redact_transport_url(
+            "wap://alice:secret@example.test/path?card=home&pin=1234&session=abcdef",
+        );
+        assert!(!redacted.contains("alice"));
+        assert!(!redacted.contains("secret"));
+        assert!(!redacted.contains("1234"));
+        assert!(!redacted.contains("abcdef"));
+        assert!(redacted.contains("card=home"));
+        assert!(redacted.contains("pin=%3Credacted%3E"));
+    }
+
+    #[test]
+    fn trace_payload_redacts_header_like_secret_fields() {
+        let value = redact_event_value(
+            serde_json::json!({
+                "Authorization": "Bearer do-not-print",
+                "nested": { "cookie": "sid=secret", "status": 200 }
+            }),
+            "wap://example.test/",
+            "wap://example.test/",
+        );
+        assert_eq!(value["Authorization"], "<redacted>");
+        assert_eq!(value["nested"]["cookie"], "<redacted>");
+        assert_eq!(value["nested"]["status"], 200);
     }
 }

--- a/transport-rust/src/tests/mod.rs
+++ b/transport-rust/src/tests/mod.rs
@@ -22,7 +22,7 @@ pub(super) use crate::fetch_policy::{
     validate_fetch_destination, validate_resolved_destination_addresses, AppliedRequestPolicy,
     DestinationHostClass,
 };
-pub(super) use crate::gateway::build_gateway_request;
+pub(super) use crate::gateway::{build_gateway_request, build_gateway_request_with_endpoint};
 pub(super) use crate::request_meta::{
     details_with_request_id, log_transport_event, normalized_request_id,
 };

--- a/transport-rust/src/tests/request_gateway_policy.rs
+++ b/transport-rust/src/tests/request_gateway_policy.rs
@@ -11,6 +11,22 @@ fn transport_normalize_content_type_handles_charset_and_empty() {
 }
 
 #[test]
+fn explicit_gateway_bridge_endpoint_overrides_process_default() {
+    let (gateway_url, headers) = build_gateway_request_with_endpoint(
+        "wap://resource.example/decks/home.wml?card=1",
+        "GET",
+        &HashMap::new(),
+        Some("https://gateway.example/base"),
+    )
+    .expect("explicit gateway should build");
+    assert_eq!(gateway_url, "https://gateway.example/decks/home.wml?card=1");
+    assert_eq!(
+        headers.get("X-Wap-Target-Url").map(String::as_str),
+        Some("wap://resource.example/decks/home.wml?card=1")
+    );
+}
+
+#[test]
 fn transport_normalized_request_id_trims_and_rejects_blank() {
     assert_eq!(normalized_request_id(Some(" req-1 ")), Some("req-1"));
     assert_eq!(normalized_request_id(Some("   ")), None);

--- a/transport-rust/tests/wapcurl_cli.rs
+++ b/transport-rust/tests/wapcurl_cli.rs
@@ -1,0 +1,277 @@
+use serde_json::Value;
+use std::io::{Read, Write};
+use std::net::TcpListener;
+use std::process::{Command, Output};
+use std::sync::mpsc;
+use std::thread;
+use std::time::Duration;
+
+const WML: &[u8] =
+    br#"<?xml version="1.0"?><!DOCTYPE wml PUBLIC "-//WAPFORUM//DTD WML 1.3//EN" "http://www.wapforum.org/DTD/wml13.dtd"><wml><card id="home"/></wml>"#;
+
+fn response(status: &str, content_type: &str, body: &[u8]) -> Vec<u8> {
+    let mut response = format!(
+        "HTTP/1.1 {status}\r\nContent-Type: {content_type}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+        body.len()
+    )
+    .into_bytes();
+    response.extend_from_slice(body);
+    response
+}
+
+fn serve_once(
+    response: Vec<u8>,
+    delay: Duration,
+) -> (String, mpsc::Receiver<String>, thread::JoinHandle<()>) {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("fixture listener should bind");
+    let address = listener
+        .local_addr()
+        .expect("fixture listener should have an address");
+    let (request_tx, request_rx) = mpsc::channel();
+    let handle = thread::spawn(move || {
+        let (mut stream, _) = listener
+            .accept()
+            .expect("fixture should accept one request");
+        stream
+            .set_read_timeout(Some(Duration::from_secs(2)))
+            .expect("read timeout should apply");
+        let mut request = Vec::new();
+        let mut buffer = [0u8; 1024];
+        loop {
+            match stream.read(&mut buffer) {
+                Ok(0) => break,
+                Ok(count) => {
+                    request.extend_from_slice(&buffer[..count]);
+                    if request.windows(4).any(|window| window == b"\r\n\r\n") {
+                        break;
+                    }
+                }
+                Err(error)
+                    if matches!(
+                        error.kind(),
+                        std::io::ErrorKind::WouldBlock | std::io::ErrorKind::TimedOut
+                    ) =>
+                {
+                    break;
+                }
+                Err(error) => panic!("fixture request read failed: {error}"),
+            }
+        }
+        let _ = request_tx.send(String::from_utf8_lossy(&request).into_owned());
+        thread::sleep(delay);
+        let _ = stream.write_all(&response);
+    });
+    (format!("http://{address}"), request_rx, handle)
+}
+
+fn run(arguments: &[&str]) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_wapcurl"))
+        .args(arguments)
+        .output()
+        .expect("wapcurl should run")
+}
+
+fn assert_success(output: &Output) {
+    assert!(
+        output.status.success(),
+        "expected success, status={:?}\nstdout={}\nstderr={}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+fn help_describes_bounded_curl_like_workflow() {
+    let output = run(&["--help"]);
+    assert_success(&output);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("Usage: wapcurl [OPTIONS] <URL>"));
+    assert!(stdout.contains("--gateway <ENDPOINT>"));
+    assert!(stdout.contains("--retry <COUNT>"));
+    assert!(stdout.contains("--raw"));
+    assert!(stdout.contains("--hex"));
+    assert!(stdout.contains("--json"));
+    assert!(stdout.contains("Redirects are limited to 10"));
+}
+
+#[test]
+fn raw_hex_json_and_file_outputs_preserve_fixture_bytes() {
+    let (base, _, handle) = serve_once(response("200 OK", "text/vnd.wap.wml", WML), Duration::ZERO);
+    let output = run(&["--allow-private", "--raw", &format!("{base}/deck.wml")]);
+    handle.join().expect("fixture should stop");
+    assert_success(&output);
+    assert_eq!(output.stdout, WML);
+    assert!(String::from_utf8_lossy(&output.stderr).contains("decode: text-wml"));
+
+    let (base, _, handle) = serve_once(response("200 OK", "text/vnd.wap.wml", WML), Duration::ZERO);
+    let output = run(&["--allow-private", "--hex", &format!("{base}/deck.wml")]);
+    handle.join().expect("fixture should stop");
+    assert_success(&output);
+    let hex = String::from_utf8_lossy(&output.stdout);
+    assert!(hex.starts_with("00000000  3c 3f 78 6d"));
+    assert!(hex.contains("|<?xml version=\"1|"));
+
+    let (base, _, handle) = serve_once(response("200 OK", "text/vnd.wap.wml", WML), Duration::ZERO);
+    let output = run(&["--allow-private", "--json", &format!("{base}/deck.wml")]);
+    handle.join().expect("fixture should stop");
+    assert_success(&output);
+    assert!(
+        output.stderr.is_empty(),
+        "JSON mode should keep stderr clean"
+    );
+    let json: Value = serde_json::from_slice(&output.stdout).expect("JSON output should parse");
+    assert_eq!(json["ok"], true);
+    assert_eq!(json["byteCount"], WML.len());
+    assert_eq!(json["decode"], "text-wml");
+    assert_eq!(json["transport"], "http");
+
+    let directory = tempfile::tempdir().expect("temp directory should create");
+    let output_path = directory.path().join("deck.wml");
+    let (base, _, handle) = serve_once(response("200 OK", "text/vnd.wap.wml", WML), Duration::ZERO);
+    let output = Command::new(env!("CARGO_BIN_EXE_wapcurl"))
+        .arg("--allow-private")
+        .arg("--output")
+        .arg(&output_path)
+        .arg(format!("{base}/deck.wml"))
+        .output()
+        .expect("wapcurl should run");
+    handle.join().expect("fixture should stop");
+    assert_success(&output);
+    assert!(output.stdout.is_empty());
+    assert_eq!(
+        std::fs::read(output_path).expect("saved output should read"),
+        WML
+    );
+}
+
+#[test]
+fn request_headers_are_supported_and_verbose_trace_redacts_secrets() {
+    let (base, request, handle) =
+        serve_once(response("200 OK", "text/vnd.wap.wml", WML), Duration::ZERO);
+    let target = format!("{base}/deck.wml?pin=1234&card=home");
+    let output = run(&[
+        "--allow-private",
+        "--json",
+        "--verbose",
+        "--header",
+        "X-Wap-Test: enabled",
+        "--header",
+        "Authorization: Bearer do-not-print",
+        "--header",
+        "Cookie: sid=also-secret",
+        &target,
+    ]);
+    handle.join().expect("fixture should stop");
+    assert_success(&output);
+    let observed = request.recv().expect("request should be observed");
+    assert!(observed.contains("x-wap-test: enabled"));
+    assert!(observed.contains("authorization: Bearer do-not-print"));
+    assert!(observed.contains("cookie: sid=also-secret"));
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    for secret in ["1234", "do-not-print", "also-secret"] {
+        assert!(!stdout.contains(secret), "stdout leaked {secret}");
+        assert!(!stderr.contains(secret), "stderr leaked {secret}");
+    }
+    assert!(stderr.contains("\"Authorization\":\"<redacted>\""));
+    assert!(stderr.contains("\"Cookie\":\"<redacted>\""));
+}
+
+#[test]
+fn public_identifier_four_has_specific_wml13_diagnostic_and_recovers_next_run() {
+    let public_id_four = [0x03, 0x04, 0x6a, 0x00, 0x3f];
+    let (gateway, _, handle) = serve_once(
+        response("200 OK", "application/vnd.wap.wmlc", &public_id_four),
+        Duration::ZERO,
+    );
+    let output = run(&[
+        "--profile",
+        "gateway-bridged",
+        "--gateway",
+        &gateway,
+        "--allow-private",
+        "wap://home.wap.shrimpworks.dev/examples/index.wml",
+    ]);
+    handle.join().expect("fixture should stop");
+    assert_eq!(output.status.code(), Some(7));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("outcome: WBXML_DECODE_FAILED"));
+    assert!(
+        stderr.contains("unsupported numeric public identifier 4; expected WML 1.3 identifier 10")
+    );
+    assert!(stderr.contains("decode: wbxml-error"));
+
+    let (base, _, handle) = serve_once(response("200 OK", "text/vnd.wap.wml", WML), Duration::ZERO);
+    let recovery = run(&["--allow-private", &format!("{base}/healthy.wml")]);
+    handle.join().expect("fixture should stop");
+    assert_success(&recovery);
+    assert!(String::from_utf8_lossy(&recovery.stdout).contains("<card id=\"home\"/>"));
+}
+
+#[test]
+fn malformed_wbxml_size_limit_timeout_policy_and_unreachable_host_have_exit_codes() {
+    let (gateway, _, handle) = serve_once(
+        response("200 OK", "application/vnd.wap.wmlc", &[0x03, 0x80]),
+        Duration::ZERO,
+    );
+    let malformed = run(&[
+        "--profile",
+        "gateway-bridged",
+        "--gateway",
+        &gateway,
+        "--allow-private",
+        "wap://interop.wap.shrimpworks.dev/truncated",
+    ]);
+    handle.join().expect("fixture should stop");
+    assert_eq!(malformed.status.code(), Some(7));
+    assert!(String::from_utf8_lossy(&malformed.stderr).contains("truncated public identifier"));
+
+    let (base, _, handle) = serve_once(
+        response("200 OK", "application/json", br#"{\"not\":\"wml\"}"#),
+        Duration::ZERO,
+    );
+    let unsupported = run(&["--allow-private", &format!("{base}/not-wml")]);
+    handle.join().expect("fixture should stop");
+    assert_eq!(unsupported.status.code(), Some(7));
+    assert!(String::from_utf8_lossy(&unsupported.stderr).contains("UNSUPPORTED_CONTENT_TYPE"));
+
+    let oversized_length = 524_289;
+    let oversized_response = format!(
+        "HTTP/1.1 200 OK\r\nContent-Type: text/vnd.wap.wml\r\nContent-Length: {oversized_length}\r\nConnection: close\r\n\r\n"
+    )
+    .into_bytes();
+    let (base, _, handle) = serve_once(oversized_response, Duration::ZERO);
+    let oversized = run(&["--allow-private", &format!("{base}/large.wml")]);
+    handle.join().expect("fixture should stop");
+    assert_eq!(oversized.status.code(), Some(8));
+    assert!(String::from_utf8_lossy(&oversized.stderr).contains("PAYLOAD_TOO_LARGE"));
+
+    let (base, _, handle) = serve_once(
+        response("200 OK", "text/vnd.wap.wml", WML),
+        Duration::from_millis(300),
+    );
+    let timed_out = run(&[
+        "--allow-private",
+        "--timeout-ms",
+        "100",
+        &format!("{base}/slow.wml"),
+    ]);
+    handle.join().expect("fixture should stop");
+    assert_eq!(timed_out.status.code(), Some(4));
+    assert!(String::from_utf8_lossy(&timed_out.stderr).contains("GATEWAY_TIMEOUT"));
+
+    let policy = run(&["http://127.0.0.1:9/private.wml"]);
+    assert_eq!(policy.status.code(), Some(3));
+    assert!(String::from_utf8_lossy(&policy.stderr).contains("INVALID_REQUEST"));
+
+    let unreachable = run(&[
+        "--allow-private",
+        "--timeout-ms",
+        "100",
+        "http://127.0.0.1:9/unreachable.wml",
+    ]);
+    assert_eq!(unreachable.status.code(), Some(5));
+    assert!(String::from_utf8_lossy(&unreachable.stderr).contains("TRANSPORT_UNAVAILABLE"));
+}


### PR DESCRIPTION
## What

- add `wapcurl`, a GET-only curl-like Rust CLI over the existing Lowband transport facade
- add explicit resource URL vs native/bridge gateway endpoint routing
- add decoded WML, raw, hex, file, JSON, and redacted verbose output modes
- add bounded timeouts/retries, stable metadata, and useful exit codes
- add deterministic local integration coverage, including WML public ID 4 vs expected ID 10
- record the curl-extension investigation and standalone-tool decision in ADR 0005

## Why

Official curl documentation exposes built-in protocol support and socket callbacks, but no public loadable protocol-handler ABI. A real `wap://` implementation would require a curl fork/upstream protocol implementation. Reusing Lowband keeps WSP/WDP/WBXML and policy behavior in the transport layer and avoids a second decoder.

## Impact

The new Rust-only `FetchTransportOptions` seam separates the WAP resource URI from the selected gateway peer without changing generated browser contracts. Existing browser, engine, deployment, and example surfaces are unchanged. Default behavior is one attempt, a 5-second timeout, public-only destination policy, no automatic fallback, a 512 KiB body cap, and redacted diagnostics.

## Verification

- `pnpm verify:change` — passed all selected workspace, transport, browser, contract, and Atlas lanes
- `make test-rust-transport` — passed (live Kannel cases ignored as designed)
- `make lint-rust-transport` — passed
- `cargo test --test wapcurl_cli -- --test-threads=1` — 5 passed
- `pnpm --dir browser run contracts:check` — passed; generated contracts unchanged
- WBXML/WML ledger and knowledge-graph checks — passed
- pre-commit and pre-push hooks — passed
- bounded public smoke — reached `159.89.254.0:9200`, status 200/WMLC, and correctly diagnosed the currently deployed stale numeric public ID 4 rather than WML 1.3 ID 10

## Known limitations

- GET only
- raw rejected payload bytes are not retained after a normalization/decode failure
- native mode is the existing connectionless WSP/WDP profile; no WTLS
- payload and redirect limits use the shared fixed transport bounds
