### PR TITLE
fix(browser): quarantine terminal external intent failures

### DIFF
--- a/browser/frontend/src/app/browser-controller.behavior.test.ts
+++ b/browser/frontend/src/app/browser-controller.behavior.test.ts
@@ -193,6 +193,16 @@ const gatewayTimeoutResponse = (): FetchResponse => ({
   engineDeckInput: undefined
 });
 
+const wbxmlDecodeFailureResponse = (url: string): FetchResponse => ({
+  ok: false,
+  status: 502,
+  finalUrl: url,
+  contentType: 'application/vnd.wap.wmlc',
+  error: { code: 'WBXML_DECODE_FAILED', message: 'WML public ID mismatch' },
+  timingMs: { encode: 0, udpRtt: 1, decode: 0 },
+  engineDeckInput: undefined
+});
+
 describe('BrowserController behavior coverage', () => {
   it('opens and closes the visible Developer Tools rail from the keyboard shortcut', () => {
     const refs = createRefs();
@@ -478,6 +488,132 @@ describe('BrowserController behavior coverage', () => {
       }
     });
     await flushAsyncWork();
+  });
+
+  it('does not replay a terminally failed external intent on later timer ticks', async () => {
+    const refs = createRefs();
+    const presenter = new BrowserPresenter(refs, initialSession, 20);
+    const hostClient = createHostClient();
+    const invokingUrl = 'http://example.test/invoking.wml';
+    const targetUrl = 'http://example.test/invalid.wml';
+    const changedTargetUrl = 'http://example.test/recovered.wml';
+    let timerIntent: string | undefined = targetUrl;
+    const invokingSnapshot = snapshot({
+      activeCardId: 'invoking-card',
+      focusedLinkIndex: 2,
+      baseUrl: invokingUrl,
+      externalNavigationIntent: targetUrl
+    });
+    vi.mocked(hostClient.engineLoadDeckContextFrame).mockImplementation(async (request) => {
+      if (request.baseUrl === changedTargetUrl) {
+        timerIntent = undefined;
+        return frame({ activeCardId: 'recovered-card', baseUrl: changedTargetUrl });
+      }
+      return frame({ activeCardId: 'invoking-card', focusedLinkIndex: 2, baseUrl: invokingUrl });
+    });
+    vi.mocked(hostClient.engineHandleKeyFrame).mockResolvedValue(frame(invokingSnapshot));
+    vi.mocked(hostClient.engineAdvanceTimeMs).mockImplementation(async () =>
+      snapshot({
+        activeCardId: timerIntent ? 'invoking-card' : 'recovered-card',
+        focusedLinkIndex: timerIntent ? 2 : 0,
+        baseUrl: timerIntent ? invokingUrl : changedTargetUrl,
+        externalNavigationIntent: timerIntent
+      })
+    );
+    vi.mocked(hostClient.fetchDeck).mockImplementation(async (request) =>
+      request.url === targetUrl
+        ? wbxmlDecodeFailureResponse(request.url)
+        : {
+            ok: true,
+            status: 200,
+            finalUrl: request.url,
+            contentType: 'text/vnd.wap.wml',
+            wml: '<wml><card id="invoking-card"><p>state</p></card></wml>',
+            timingMs: { encode: 0, udpRtt: 1, decode: 0 },
+            engineDeckInput: {
+              wmlXml: '<wml><card id="invoking-card"><p>state</p></card></wml>',
+              baseUrl: request.url,
+              contentType: 'text/vnd.wap.wml'
+            }
+          }
+    );
+    const showToast = vi.spyOn(presenter, 'showToast');
+    const controller = new BrowserController(hostClient as never, presenter, refs);
+
+    await controller.init('<wml><card id="seed"/></wml>');
+    controllerPrivates(controller).timerRuntime.stop();
+    await controllerPrivates(controller).setRunMode('network', { loadLocalOnEnter: false });
+    vi.mocked(hostClient.fetchDeck).mockClear();
+    vi.mocked(hostClient.engineLoadDeckContextFrame).mockClear();
+    showToast.mockClear();
+
+    refs.fetchUrlInput.value = invokingUrl;
+    document.querySelector<HTMLButtonElement>('#btn-fetch-url')?.click();
+    await flushAsyncWork();
+    await controllerPrivates(controller).applyEngineKey('enter');
+
+    const stateAfterFailure = presenter.getSessionState();
+    const snapshotAfterFailure = presenter.getSnapshot();
+    for (let tick = 0; tick < 50; tick += 1) {
+      await controllerPrivates(controller).tickEngineTimerRuntime();
+    }
+
+    const targetFetches = vi
+      .mocked(hostClient.fetchDeck)
+      .mock.calls.filter(([request]) => request.url === targetUrl);
+    expect(targetFetches).toHaveLength(1);
+    expect(hostClient.engineLoadDeckContextFrame).toHaveBeenCalledTimes(1);
+    expect(hostClient.engineClearExternalNavigationIntent).not.toHaveBeenCalled();
+    expect(presenter.getSessionState()).toEqual(stateAfterFailure);
+    expect(presenter.getSnapshot()).toEqual(snapshotAfterFailure);
+    expect(stateAfterFailure).toMatchObject({
+      navigationStatus: 'error',
+      finalUrl: invokingUrl,
+      activeCardId: 'invoking-card',
+      focusedLinkIndex: 2,
+      externalNavigationIntent: targetUrl,
+      history: [expect.objectContaining({ url: invokingUrl, activeCardId: 'invoking-card' })]
+    });
+    expect(showToast).toHaveBeenCalledTimes(1);
+    expect(refs.fetchUrlInput.value).toBe(targetUrl);
+
+    document.querySelector<HTMLButtonElement>('#btn-fetch-url')?.click();
+    await flushAsyncWork();
+    for (let tick = 0; tick < 50; tick += 1) {
+      await controllerPrivates(controller).tickEngineTimerRuntime();
+    }
+    expect(
+      vi.mocked(hostClient.fetchDeck).mock.calls.filter(([request]) => request.url === targetUrl)
+    ).toHaveLength(2);
+    expect(showToast).toHaveBeenCalledTimes(2);
+
+    document.querySelector<HTMLButtonElement>('#btn-reload')?.click();
+    await flushAsyncWork();
+    for (let tick = 0; tick < 50; tick += 1) {
+      await controllerPrivates(controller).tickEngineTimerRuntime();
+    }
+    expect(
+      vi.mocked(hostClient.fetchDeck).mock.calls.filter(([request]) => request.url === targetUrl)
+    ).toHaveLength(3);
+    expect(showToast).toHaveBeenCalledTimes(3);
+
+    timerIntent = changedTargetUrl;
+    await controllerPrivates(controller).tickEngineTimerRuntime();
+
+    expect(
+      vi
+        .mocked(hostClient.fetchDeck)
+        .mock.calls.filter(([request]) => request.url === changedTargetUrl)
+    ).toHaveLength(1);
+    expect(presenter.getSessionState()).toMatchObject({
+      navigationStatus: 'loaded',
+      finalUrl: changedTargetUrl,
+      activeCardId: 'recovered-card',
+      externalNavigationIntent: undefined,
+      lastError: undefined
+    });
+
+    controller.dispose();
   });
 
   it('discards an engine key result after its starting run mode changes', async () => {

--- a/browser/frontend/src/app/browser-controller.ts
+++ b/browser/frontend/src/app/browser-controller.ts
@@ -159,6 +159,14 @@ export class BrowserController {
           await this.handleExternalIntentInLocalMode(intentUrl);
           return;
         }
+        if (
+          this.navigation.isExternalIntentQuarantined(
+            intentUrl,
+            snapshot.externalNavigationRequestPolicy
+          )
+        ) {
+          return;
+        }
         this.refs.fetchUrlInput.value = intentUrl;
         await this.loadTransportUrl(
           intentUrl,
@@ -314,6 +322,27 @@ export class BrowserController {
   private readonly handleReloadClick = async (): Promise<void> => {
     if (this.runMode === 'local') {
       await this.loadSelectedLocalDeck();
+      return;
+    }
+    const snapshot = this.presenter.getSnapshot();
+    // Reload is the explicit retry affordance for a quarantined engine task;
+    // retry its preserved request once instead of clearing the engine intent.
+    if (
+      snapshot?.externalNavigationIntent &&
+      this.navigation.isExternalIntentQuarantined(
+        snapshot.externalNavigationIntent,
+        snapshot.externalNavigationRequestPolicy
+      )
+    ) {
+      this.refs.fetchUrlInput.value = snapshot.externalNavigationIntent;
+      await this.loadTransportUrl(
+        snapshot.externalNavigationIntent,
+        'external-intent',
+        true,
+        true,
+        snapshot.externalNavigationRequestPolicy,
+        this.defaultNavigationHeaders()
+      );
       return;
     }
     const state = this.presenter.getSessionState();
@@ -772,9 +801,23 @@ export class BrowserController {
       }
 
       const state = this.navigation.getSessionState();
+      const currentSnapshot = snapshot ?? this.presenter.getSnapshot();
+      const pendingExternalIntent = currentSnapshot?.externalNavigationIntent;
+      const failedExternalIntent =
+        state.navigationStatus === 'error' &&
+        pendingExternalIntent &&
+        (state.navigationSource === 'external-intent' || requestedUrl === pendingExternalIntent)
+          ? pendingExternalIntent
+          : undefined;
+      if (failedExternalIntent) {
+        this.navigation.quarantineExternalIntent(
+          failedExternalIntent,
+          currentSnapshot?.externalNavigationRequestPolicy
+        );
+      }
       if (state.finalUrl) {
         this.lastNetworkUrl = state.finalUrl;
-        this.refs.fetchUrlInput.value = state.finalUrl;
+        this.refs.fetchUrlInput.value = failedExternalIntent ?? state.finalUrl;
       } else if (requestedUrl) {
         this.lastNetworkUrl = requestedUrl;
       }

--- a/browser/frontend/src/app/navigation-state.external-intent.test.ts
+++ b/browser/frontend/src/app/navigation-state.external-intent.test.ts
@@ -52,6 +52,16 @@ describe('navigation-state external intent behavior', () => {
     let fetchCount = 0;
     let clearCount = 0;
     const navigationErrors: string[] = [];
+    const targetUrl = 'http://example.test/target.wml';
+    const requestPolicy = {
+      requestIntent: {
+        method: 'post' as const,
+        enctype: 'application/x-www-form-urlencoded',
+        sendReferer: true,
+        sameDeck: false,
+        postFields: [{ name: 'token', value: 'preserved' }]
+      }
+    };
     const host = createHostClientMock({
       fetchDeck: async (request) => {
         fetchCount += 1;
@@ -60,10 +70,10 @@ describe('navigation-state external intent behavior', () => {
         }
         return fetchOk({
           ok: false,
-          status: 504,
+          status: 502,
           finalUrl: request.url,
-          contentType: 'text/plain',
-          error: { code: 'GATEWAY_TIMEOUT', message: 'target fetch failed' },
+          contentType: 'application/vnd.wap.wmlc',
+          error: { code: 'WBXML_DECODE_FAILED', message: 'target fetch failed' },
           engineDeckInput: undefined,
           wml: undefined
         });
@@ -73,7 +83,8 @@ describe('navigation-state external intent behavior', () => {
           activeCardId: 'invoking-card',
           focusedLinkIndex: 1,
           baseUrl: 'http://example.test/start.wml',
-          externalNavigationIntent: 'http://example.test/target.wml'
+          externalNavigationIntent: targetUrl,
+          externalNavigationRequestPolicy: requestPolicy
         }),
       engineClearExternalNavigationIntent: async () => {
         clearCount += 1;
@@ -93,21 +104,35 @@ describe('navigation-state external intent behavior', () => {
     expect(result).toMatchObject({
       activeCardId: 'invoking-card',
       focusedLinkIndex: 1,
-      externalNavigationIntent: 'http://example.test/target.wml'
+      externalNavigationIntent: targetUrl,
+      externalNavigationRequestPolicy: requestPolicy
     });
     expect(clearCount).toBe(0);
     expect(machine.getSessionState()).toMatchObject({
       navigationStatus: 'error',
-      requestedUrl: 'http://example.test/target.wml',
+      requestedUrl: targetUrl,
       finalUrl: 'http://example.test/start.wml',
       contentType: 'text/vnd.wap.wml',
       activeCardId: 'invoking-card',
       focusedLinkIndex: 1,
-      externalNavigationIntent: 'http://example.test/target.wml',
+      externalNavigationIntent: targetUrl,
       lastError: 'target fetch failed'
     });
     expect(machine.getHistoryState().entries).toHaveLength(1);
     expect(navigationErrors).toEqual(['target fetch failed']);
+    expect(machine.isExternalIntentQuarantined(targetUrl, requestPolicy)).toBe(true);
+    expect(
+      machine.isExternalIntentQuarantined(targetUrl, {
+        requestIntent: {
+          ...requestPolicy.requestIntent,
+          postFields: [{ name: 'token', value: 'changed' }]
+        }
+      })
+    ).toBe(false);
+
+    const nextGeneration = machine.beginNavigationOperation();
+    expect(machine.isExternalIntentQuarantined(targetUrl, requestPolicy)).toBe(false);
+    machine.finishNavigationOperation(nextGeneration);
   });
 
   it('uses runtime-provided external intent request policy when following intents', async () => {

--- a/browser/frontend/src/app/navigation-state.ts
+++ b/browser/frontend/src/app/navigation-state.ts
@@ -96,6 +96,8 @@ export interface NavigationStateMachine {
   captureNavigationGeneration(): number;
   isCurrentNavigation(generation: number): boolean;
   isNavigationInFlight(): boolean;
+  isExternalIntentQuarantined(intentUrl: string, requestPolicy?: FetchRequestPolicy): boolean;
+  quarantineExternalIntent(intentUrl: string, requestPolicy?: FetchRequestPolicy): void;
   cancelPendingNavigation(): void;
   getSessionState(): HostSessionState;
   getHistoryState(): HostHistoryState;
@@ -121,6 +123,17 @@ export const createNavigationStateMachine = (
   let activeNavigationGeneration = 0;
   let navigationInFlightGeneration: number | undefined;
   let observedBrowserContextEpoch: number | undefined;
+  // WML-205 keeps a failed task's engine state and intent intact. This
+  // browser-only record prevents that preserved intent from becoming an
+  // implicit retry loop while retaining it for an explicit user retry.
+  let quarantinedExternalIntent:
+    | {
+        generation: number;
+        requestedUrl: string;
+        method: string;
+        requestPolicy?: FetchRequestPolicy;
+      }
+    | undefined;
 
   const emitSession = (): void => {
     hooks.onSessionState?.(hostSessionState);
@@ -209,6 +222,78 @@ export const createNavigationStateMachine = (
     navigationInFlightGeneration = undefined;
   };
 
+  const externalIntentRequestIdentity = (
+    intentUrl: string,
+    requestPolicy?: FetchRequestPolicy
+  ): Omit<NonNullable<typeof quarantinedExternalIntent>, 'generation'> => {
+    const requestedUrl = intentUrl.trim();
+    const defaultRequestPolicy = defaultRequestPolicyForSource(
+      'external-intent',
+      requestedUrl,
+      hostSessionState.finalUrl
+    );
+    const mergedRequestPolicy = requestPolicy
+      ? { ...defaultRequestPolicy, ...requestPolicy }
+      : defaultRequestPolicy;
+    const resolvedRequestPolicy = withSubmissionSourceContentType(
+      mergedRequestPolicy,
+      hostSessionState.contentType
+    );
+    return {
+      requestedUrl,
+      method: resolveTransportMethod('GET', resolvedRequestPolicy),
+      requestPolicy: resolvedRequestPolicy
+    };
+  };
+
+  const quarantineExternalIntentRequest = (
+    requestedUrl: string,
+    method: string,
+    requestPolicy: FetchRequestPolicy | undefined,
+    generation: number
+  ): void => {
+    const next = { generation, requestedUrl, method, requestPolicy };
+    if (
+      quarantinedExternalIntent?.generation === next.generation &&
+      externalIntentRequestIdentitiesEqual(quarantinedExternalIntent, next)
+    ) {
+      return;
+    }
+    quarantinedExternalIntent = next;
+    hooks.onStateEvent?.('external-intent-quarantined', {
+      generation,
+      requestedUrl,
+      method
+    });
+  };
+
+  const quarantineExternalIntent = (
+    intentUrl: string,
+    requestPolicy?: FetchRequestPolicy
+  ): void => {
+    const identity = externalIntentRequestIdentity(intentUrl, requestPolicy);
+    quarantineExternalIntentRequest(
+      identity.requestedUrl,
+      identity.method,
+      identity.requestPolicy,
+      activeNavigationGeneration
+    );
+  };
+
+  const isExternalIntentQuarantined = (
+    intentUrl: string,
+    requestPolicy?: FetchRequestPolicy
+  ): boolean => {
+    if (!quarantinedExternalIntent) {
+      return false;
+    }
+    const identity = externalIntentRequestIdentity(intentUrl, requestPolicy);
+    return (
+      quarantinedExternalIntent.generation === activeNavigationGeneration &&
+      externalIntentRequestIdentitiesEqual(quarantinedExternalIntent, identity)
+    );
+  };
+
   const loadTransportUrlForGeneration = async (
     options: LoadTransportOptions,
     generation: number
@@ -283,6 +368,9 @@ export const createNavigationStateMachine = (
       if (transport.error?.code === 'TRANSPORT_UNAVAILABLE') {
         hooks.onNetworkUnavailable?.();
       }
+      if (options.source === 'external-intent') {
+        quarantineExternalIntentRequest(requestedUrl, method, requestPolicy, generation);
+      }
       hooks.onNavigationError?.(errorMessage, 'network');
       return null;
     }
@@ -299,6 +387,9 @@ export const createNavigationStateMachine = (
         navigationStatus: 'error',
         lastError: WAVES_COPY.errors.missingWmlPayload
       });
+      if (options.source === 'external-intent') {
+        quarantineExternalIntentRequest(requestedUrl, method, requestPolicy, generation);
+      }
       hooks.onNavigationError?.(WAVES_COPY.errors.missingWmlPayload, 'parse');
       return null;
     }
@@ -323,6 +414,9 @@ export const createNavigationStateMachine = (
         navigationStatus: 'error',
         lastError: message
       });
+      if (options.source === 'external-intent') {
+        quarantineExternalIntentRequest(requestedUrl, method, requestPolicy, generation);
+      }
       hooks.onNavigationError?.(message, 'parse');
       return null;
     }
@@ -342,6 +436,9 @@ export const createNavigationStateMachine = (
       externalNavigationIntent: frame.snapshot.externalNavigationIntent
     });
     applyFrame(frame);
+    // A committed navigation establishes a fresh engine state, so a prior
+    // terminal-intent quarantine no longer applies.
+    quarantinedExternalIntent = undefined;
 
     mergeSessionState({
       navigationStatus: 'loaded',
@@ -588,6 +685,8 @@ export const createNavigationStateMachine = (
     captureNavigationGeneration: () => activeNavigationGeneration,
     isCurrentNavigation,
     isNavigationInFlight,
+    isExternalIntentQuarantined,
+    quarantineExternalIntent,
     cancelPendingNavigation,
     getSessionState: () => hostSessionState,
     getHistoryState: () => hostHistory
@@ -764,7 +863,16 @@ const requestPolicyEqual = (a?: FetchRequestPolicy, b?: FetchRequestPolicy): boo
     a.cacheControl === b.cacheControl &&
     a.refererUrl === b.refererUrl &&
     a.uaCapabilityProfile === b.uaCapabilityProfile &&
-    postContextEqual(a.postContext, b.postContext));
+    postContextEqual(a.postContext, b.postContext) &&
+    requestIntentEqual(a.requestIntent, b.requestIntent));
+
+const externalIntentRequestIdentitiesEqual = (
+  a: { requestedUrl: string; method: string; requestPolicy?: FetchRequestPolicy },
+  b: { requestedUrl: string; method: string; requestPolicy?: FetchRequestPolicy }
+): boolean =>
+  a.requestedUrl === b.requestedUrl &&
+  a.method === b.method &&
+  requestPolicyEqual(a.requestPolicy, b.requestPolicy);
 
 const postContextEqual = (
   a?: FetchRequestPolicy['postContext'],
@@ -776,3 +884,22 @@ const postContextEqual = (
     a.sameDeck === b.sameDeck &&
     a.contentType === b.contentType &&
     a.payload === b.payload);
+
+const requestIntentEqual = (
+  a?: FetchRequestPolicy['requestIntent'],
+  b?: FetchRequestPolicy['requestIntent']
+): boolean =>
+  a === b ||
+  (!!a &&
+    !!b &&
+    a.method === b.method &&
+    a.enctype === b.enctype &&
+    a.sendReferer === b.sendReferer &&
+    a.acceptCharset === b.acceptCharset &&
+    a.sameDeck === b.sameDeck &&
+    a.sourceContentType === b.sourceContentType &&
+    a.postFields.length === b.postFields.length &&
+    a.postFields.every(
+      (field, index) =>
+        field.name === b.postFields[index]?.name && field.value === b.postFields[index]?.value
+    ));

--- a/docs/waves/MAINTENANCE_WORK_ITEMS.md
+++ b/docs/waves/MAINTENANCE_WORK_ITEMS.md
@@ -327,7 +327,7 @@ Completed maintenance tickets are archived in:
 
 ### M1-26 Suppress automatic re-follow of a terminally failed external intent (2026-07-29)
 
-1. `Status`: `todo`
+1. `Status`: `done`
 2. `Priority`: `P1`
 3. `Depends On`: `WML-205`
 4. `Files`:
@@ -347,6 +347,12 @@ Completed maintenance tickets are archived in:
 - Timer ticks cannot turn one terminal external-navigation failure into repeated network requests.
 - The original card and failed intent remain available for diagnosis and explicit retry.
 - No decoder compatibility broadening or service-side workaround is used to hide the client state bug.
+9. `Resolution`:
+- The browser records the failed intent's resolved request identity and navigation generation at the
+  terminal host boundary. Automatic timer re-follow is suppressed without mutating the engine,
+  while explicit Reload/Go and distinct intents remain eligible for one fresh attempt.
+- A bounded WBXML regression covers 50 timer ticks, state/history preservation, notification
+  deduplication, explicit retry, distinct-intent admission, and successful recovery.
 
 ### M1-03 Engine API generator design and bootstrap (non-priority)
 

--- a/docs/waves/RESILIENCE_WORK_ITEMS.md
+++ b/docs/waves/RESILIENCE_WORK_ITEMS.md
@@ -42,7 +42,7 @@ WBXML trigger, but current main will still replay an equivalent terminal externa
 ### RSL-01 Terminal external-intent failure quarantine
 
 1. `Issue`: [#510](https://github.com/dills122/wap-labs/issues/510)
-2. `Status`: `todo`
+2. `Status`: `done`
 3. `Priority`: `P1` release blocker; treat as `P0` for a distributed build exposed to uncontrolled
    public content
 4. `Depends On`: none
@@ -66,6 +66,13 @@ WBXML trigger, but current main will still replay an equivalent terminal externa
 8. `Accept`:
 - Terminal failure produces one bounded outcome and one useful error surface.
 - No timer-driven automatic replay occurs without a changed intent or explicit user action.
+9. `Resolution`:
+- Browser navigation now quarantines terminally failed external intents by resolved request identity
+  and navigation generation without clearing engine state. Timer snapshots suppress the same
+  quarantined intent, while explicit Reload/Go and changed intents receive one fresh attempt.
+- Focused controller coverage proves one WBXML decode failure plus 50 timer ticks issues one target
+  fetch, preserves the invoking state, deduplicates the failure notification, permits one explicit
+  retry, and recovers through a changed known-good target.
 
 ### RSL-02 Cancellable and admission-controlled navigation
 


### PR DESCRIPTION
## Summary

- quarantine terminally failed external intents in the browser by resolved request identity and navigation generation
- suppress automatic timer re-follow without clearing the engine-owned WML state or pending intent
- admit one fresh explicit Reload/Go attempt, changed intents, new generations, and normal known-good recovery
- deduplicate the automatic failure notification and mark RSL-01/M1-26 complete

## Root cause

After a terminal target-fetch failure, WML-205 correctly preserves the invoking engine snapshot and its pending `externalNavigationIntent`. The browser timer runtime treated each later snapshot as a new instruction and dispatched the same target again because it had no memory of the host-terminal failure.

A red regression on current `origin/main` reproduced 51 identical target requests: the initial WBXML decode failure plus 50 timer ticks.

## Verification

- bounded controller regression: one `WBXML_DECODE_FAILED` response plus 50 timer ticks produces one target fetch
- invoking card, history, focus, variables/snapshot, and pending intent remain intact
- explicit Go and Reload each admit exactly one fresh attempt
- changed intent and known-good navigation recover normally
- terminal failure notification remains one per attempt
- `fnm exec --using=22.22.1 -- pnpm verify:change`
- `fnm exec --using=22.22.1 -- pnpm test:story WML-205`
- `cargo test --manifest-path engine-wasm/engine/Cargo.toml wml_205`
- repository pre-commit and pre-push hook suites

## Scope

This is browser-owned containment only. It does not change engine semantics, transport/public service behavior, deployment, or visual styling. Cancellable fetches, admission control, and broader concurrency handling remain intentionally scoped to #509.

Fixes #510
