### PR TITLE
fix(engine): restore wasm32 panic containment and rollback (#434)

### DIFF
--- a/docs/wml-engine/wavescript-security.md
+++ b/docs/wml-engine/wavescript-security.md
@@ -39,18 +39,24 @@ Purpose: define mandatory safety controls for executing WaveScript bytecode in `
 - Deterministic traps on overflow/underflow.
 
 3. Panic containment at public entrypoints
-- The engine crate does not set `[profile.release] panic = "abort"`, so
-  the public entrypoints most exposed to untrusted deck/script content
-  (`loadDeckContext`, `render`, `handleKey`, `navigateToCard`,
-  `navigateBack`, `advanceTimeMs`, focused-edit session methods, and the
-  `executeScriptRef*`/`invokeScriptRef*` family) run under
-  `std::panic::catch_unwind` and convert an unwinding panic into the
-  engine's existing typed `Result<_, String>` (or, for the two methods
-  with no `Result` in their public signature, a trace entry plus the
-  existing "no-op" return value/outcome shape). This exists as a
-  last-resort net so a future defensive-programming bug degrades to a
-  recoverable error instead of trapping the whole WASM instance
-  uncatchably from JS.
+- Public entrypoints most exposed to untrusted deck/script content
+  (`loadDeckContext`, `render`, `handleKey`, `navigateToCard`, `navigateBack`,
+  `advanceTimeMs`, focused-edit session methods, and the
+  `executeScriptRef*`/`invokeScriptRef*` family) run against an isolated engine
+  candidate and commit it only after the boundary returns. A panic therefore
+  cannot expose partially-mutated live engine state.
+- Native targets use `std::panic::catch_unwind`. Stable
+  `wasm32-unknown-unknown` cannot unwind, so the WASM implementation invokes
+  the candidate operation through a JavaScript re-entry boundary and converts
+  its WebAssembly trap into the same deterministic
+  `engine: internal panic contained` error. The wasm-target test suite
+  deliberately panics inside this boundary, verifies the typed error and state
+  rollback, and then reuses the engine instance.
+- Platform limitation: allocating/cloning the isolated candidate and creating
+  the JavaScript callback happen before the trap boundary. An allocation
+  failure while establishing that boundary still aborts on
+  `wasm32-unknown-unknown`; bounded deck, script, and variable state remains
+  the primary protection for that class of failure.
 
 4. Runtime-owned side effects only
 - `WMLBrowser` mutations happen only in engine runtime state.
@@ -93,8 +99,9 @@ Required recurring checks:
   typed error (nav dispatch-depth guard) instead of overflowing the stack
 - deeply-nested-but-well-formed WML tag trees are rejected during parse
   (parse-tree depth budget), not only in the later semantic walkers
-- `catch_engine_panic` converts an unwinding panic into the engine's
-  typed error path
+- native and wasm panic boundaries convert a deliberate panic into the same
+  typed error, preserve the pre-call engine state, and leave the instance
+  usable for subsequent operations
 
 ## Operational Commands
 

--- a/engine-wasm/engine/src/engine_public_api.rs
+++ b/engine-wasm/engine/src/engine_public_api.rs
@@ -33,6 +33,34 @@ impl WmlEngine {
         }
     }
 
+    fn read_with_panic_boundary<T: 'static>(
+        &self,
+        mut operation: impl FnMut(&Self) -> T + 'static,
+    ) -> Result<T, String> {
+        let candidate = self.clone();
+        catch_engine_panic(move || operation(&candidate))
+    }
+
+    fn mutate_with_panic_boundary<T: 'static>(
+        &mut self,
+        mut operation: impl FnMut(&mut Self) -> T + 'static,
+    ) -> Result<T, String> {
+        use std::cell::RefCell;
+        use std::rc::Rc;
+
+        let candidate = Rc::new(RefCell::new(self.clone()));
+        let operation_candidate = Rc::clone(&candidate);
+        let result = catch_engine_panic(move || {
+            let mut candidate = operation_candidate.borrow_mut();
+            operation(&mut candidate)
+        })?;
+        let candidate = Rc::try_unwrap(candidate)
+            .map_err(|_| "engine: panic boundary retained candidate state".to_string())?
+            .into_inner();
+        *self = candidate;
+        Ok(result)
+    }
+
     /// Load a WML deck using default metadata (`text/vnd.wap.wml`).
     pub fn load_deck(&mut self, xml: &str) -> Result<(), String> {
         self.load_deck_context(xml, "", "text/vnd.wap.wml", None)
@@ -95,13 +123,23 @@ impl WmlEngine {
         raw_bytes_base64: Option<String>,
         navigation: DeckNavigationContext<'_>,
     ) -> Result<(), String> {
-        let result = match catch_engine_panic(|| {
-            self.load_deck_context_bounded(
-                wml_xml,
-                base_url,
-                content_type,
-                raw_bytes_base64,
-                navigation,
+        let wml_xml = wml_xml.to_string();
+        let base_url = base_url.to_string();
+        let content_type = content_type.to_string();
+        let referring_url = navigation.referring_url.map(str::to_string);
+        let navigation_url = navigation.navigation_url.map(str::to_string);
+        let navigation_kind = navigation.kind;
+        let result = match self.mutate_with_panic_boundary(move |engine| {
+            engine.load_deck_context_bounded(
+                &wml_xml,
+                &base_url,
+                &content_type,
+                raw_bytes_base64.clone(),
+                DeckNavigationContext::new(
+                    referring_url.as_deref(),
+                    navigation_url.as_deref(),
+                    navigation_kind,
+                ),
             )
         }) {
             Ok(result) => result,
@@ -126,6 +164,11 @@ impl WmlEngine {
         raw_bytes_base64: Option<String>,
         navigation: DeckNavigationContext<'_>,
     ) -> Result<(), WmlLoadDiagnostic> {
+        #[cfg(test)]
+        if wml_xml == PANIC_BOUNDARY_TEST_WML {
+            self.set_var("panic-boundary-probe".to_string(), "partial".to_string());
+            panic!("test-only engine panic boundary probe");
+        }
         if wml_xml.len() > MAX_DECK_WML_XML_BYTES {
             return Err(WmlLoadDiagnostic::invalid(format!(
                 "Deck payload exceeds {}-byte limit (got {} bytes)",
@@ -270,7 +313,7 @@ impl WmlEngine {
     /// defensive-programming bug here should degrade to a typed error, not
     /// crash the host.
     pub fn render(&self) -> Result<RenderList, String> {
-        catch_engine_panic(|| self.render_bounded())?
+        self.read_with_panic_boundary(Self::render_bounded)?
     }
 
     fn render_bounded(&self) -> Result<RenderList, String> {
@@ -285,7 +328,7 @@ impl WmlEngine {
     /// engine state return the same content-derived `frameId` and do not add
     /// trace entries. Legacy [`Self::render`] remains available during F0/F1.
     pub fn render_frame(&self) -> Result<EnginePresentationFrame, String> {
-        catch_engine_panic(|| self.render_frame_bounded())?
+        self.read_with_panic_boundary(Self::render_frame_bounded)?
     }
 
     fn render_frame_bounded(&self) -> Result<EnginePresentationFrame, String> {
@@ -481,7 +524,7 @@ impl WmlEngine {
     /// defensive-programming bug here should degrade to a typed error, not
     /// crash the host.
     pub fn handle_key(&mut self, key: String) -> Result<(), String> {
-        catch_engine_panic(|| self.handle_key_internal(&key))?
+        self.mutate_with_panic_boundary(move |engine| engine.handle_key_internal(&key))?
     }
 
     /// Dispatch the additive typed F0 input surface.
@@ -490,7 +533,7 @@ impl WmlEngine {
     /// to the exact frame that advertised it so stale host controls cannot
     /// invoke a task after navigation or focus changes.
     pub fn handle_input(&mut self, event: EngineInputEvent) -> Result<(), String> {
-        catch_engine_panic(|| self.handle_input_bounded(event))?
+        self.mutate_with_panic_boundary(move |engine| engine.handle_input_bounded(event.clone()))?
     }
 
     fn handle_input_bounded(&mut self, event: EngineInputEvent) -> Result<(), String> {
@@ -538,7 +581,9 @@ impl WmlEngine {
     ///
     /// Wrapped in the panic-containment boundary (see [`catch_engine_panic`]).
     pub fn navigate_to_card(&mut self, id: String) -> Result<(), String> {
-        catch_engine_panic(|| self.navigate_to_card_without_newcontext_internal(&id))?
+        self.mutate_with_panic_boundary(move |engine| {
+            engine.navigate_to_card_without_newcontext_internal(&id)
+        })?
     }
 
     /// Activate BACK. An effective WML `do type="prev"` binding takes
@@ -551,7 +596,7 @@ impl WmlEngine {
     /// observable outcome as the existing empty-history and
     /// dispatch-depth-exceeded cases.
     pub fn navigate_back(&mut self) -> bool {
-        let handled = match catch_engine_panic(|| self.activate_back_internal()) {
+        let handled = match self.mutate_with_panic_boundary(Self::activate_back_internal) {
             Ok(handled) => handled,
             Err(message) => {
                 self.push_trace("ENGINE_PANIC_CONTAINED", message);
@@ -571,7 +616,7 @@ impl WmlEngine {
     ///
     /// Wrapped in the panic-containment boundary (see [`catch_engine_panic`]).
     pub fn advance_time_ms(&mut self, delta_ms: u32) -> Result<(), String> {
-        catch_engine_panic(|| self.advance_time_ms_internal(delta_ms))?
+        self.mutate_with_panic_boundary(move |engine| engine.advance_time_ms_internal(delta_ms))?
     }
 
     /// Return the deterministic delay until the active native WML timer expires.
@@ -593,7 +638,7 @@ impl WmlEngine {
     ///
     /// Wrapped in the panic-containment boundary (see [`catch_engine_panic`]).
     pub fn begin_focused_input_edit(&mut self) -> Result<bool, String> {
-        catch_engine_panic(|| self.begin_focused_input_edit_internal())?
+        self.mutate_with_panic_boundary(Self::begin_focused_input_edit_internal)?
     }
 
     /// Replace edit-session draft value for the focused input.
@@ -619,7 +664,7 @@ impl WmlEngine {
     ///
     /// Wrapped in the panic-containment boundary (see [`catch_engine_panic`]).
     pub fn commit_focused_input_edit(&mut self) -> Result<bool, String> {
-        catch_engine_panic(|| self.commit_focused_input_edit_internal())?
+        self.mutate_with_panic_boundary(Self::commit_focused_input_edit_internal)?
     }
 
     /// Cancel active focused-input edit session.
@@ -635,7 +680,7 @@ impl WmlEngine {
     ///
     /// Wrapped in the panic-containment boundary (see [`catch_engine_panic`]).
     pub fn begin_focused_select_edit(&mut self) -> Result<bool, String> {
-        catch_engine_panic(|| self.begin_focused_select_edit_internal())?
+        self.mutate_with_panic_boundary(Self::begin_focused_select_edit_internal)?
     }
 
     /// Move the draft selection for the active focused-select edit session.
@@ -665,7 +710,7 @@ impl WmlEngine {
     ///
     /// Wrapped in the panic-containment boundary (see [`catch_engine_panic`]).
     pub fn commit_focused_select_edit(&mut self) -> Result<bool, String> {
-        catch_engine_panic(|| self.commit_focused_select_edit_internal())?
+        self.mutate_with_panic_boundary(Self::commit_focused_select_edit_internal)?
     }
 
     /// Cancel active focused-select edit session.
@@ -776,7 +821,7 @@ impl WmlEngine {
     /// typed `ScriptExecutionOutcome::fatal` instead of unwinding raw through
     /// the `#[wasm_bindgen]` boundary as an uncaught JS exception.
     pub fn execute_script_unit(&self, bytes: Vec<u8>) -> ScriptExecutionOutcome {
-        catch_engine_panic(|| self.execute_script_unit_internal(&bytes))
+        self.read_with_panic_boundary(move |engine| engine.execute_script_unit_internal(&bytes))
             .unwrap_or_else(contained_panic_script_outcome)
     }
 
@@ -832,10 +877,11 @@ impl WmlEngine {
     /// `classify_vm_trap_outcome`), not a bespoke error shape.
     fn execute_script_contained(
         &mut self,
-        execute: impl FnOnce(&mut Self) -> ScriptExecutionOutcome,
+        execute: impl FnMut(&mut Self) -> ScriptExecutionOutcome + 'static,
     ) -> ScriptExecutionOutcome {
-        let outcome =
-            catch_engine_panic(|| execute(self)).unwrap_or_else(contained_panic_script_outcome);
+        let outcome = self
+            .mutate_with_panic_boundary(execute)
+            .unwrap_or_else(contained_panic_script_outcome);
         self.last_script_outcome = Some(outcome.clone());
         self.pending_script_effects = ScriptRuntimeEffects::default();
         self.last_script_dialog_requests.clear();
@@ -852,14 +898,16 @@ impl WmlEngine {
     /// navigation degrades to a typed error instead of crashing the host.
     fn invoke_script_contained(
         &mut self,
-        invoke: impl FnOnce(&mut Self) -> Result<ScriptInvocationOutcome, String>,
+        invoke: impl FnMut(&mut Self) -> Result<ScriptInvocationOutcome, String> + 'static,
     ) -> Result<ScriptInvocationOutcome, String> {
-        catch_engine_panic(|| invoke(self))?
+        self.mutate_with_panic_boundary(invoke)?
     }
 
     /// Execute script reference without applying deferred runtime effects.
     pub fn execute_script_ref(&mut self, src: String) -> ScriptExecutionOutcome {
-        self.execute_script_contained(|engine| engine.execute_script_ref_internal(&src, "main"))
+        self.execute_script_contained(move |engine| {
+            engine.execute_script_ref_internal(&src, "main")
+        })
     }
 
     /// Execute script function without applying deferred runtime effects.
@@ -868,7 +916,7 @@ impl WmlEngine {
         src: String,
         function_name: String,
     ) -> ScriptExecutionOutcome {
-        self.execute_script_contained(|engine| {
+        self.execute_script_contained(move |engine| {
             engine.execute_script_ref_internal(&src, &function_name)
         })
     }
@@ -881,14 +929,16 @@ impl WmlEngine {
         args: Vec<ScriptCallArgLiteral>,
     ) -> ScriptExecutionOutcome {
         let vm_args = convert_script_call_args(&args);
-        self.execute_script_contained(|engine| {
+        self.execute_script_contained(move |engine| {
             engine.execute_script_ref_call_internal(&src, &function_name, &vm_args)
         })
     }
 
     /// Invoke script reference and apply deferred runtime effects at boundary.
     pub fn invoke_script_ref(&mut self, src: String) -> Result<ScriptInvocationOutcome, String> {
-        self.invoke_script_contained(|engine| engine.invoke_script_ref_internal(&src, "main", &[]))
+        self.invoke_script_contained(move |engine| {
+            engine.invoke_script_ref_internal(&src, "main", &[])
+        })
     }
 
     /// Invoke script function and apply deferred runtime effects at boundary.
@@ -897,7 +947,7 @@ impl WmlEngine {
         src: String,
         function_name: String,
     ) -> Result<ScriptInvocationOutcome, String> {
-        self.invoke_script_contained(|engine| {
+        self.invoke_script_contained(move |engine| {
             engine.invoke_script_ref_internal(&src, &function_name, &[])
         })
     }
@@ -910,7 +960,7 @@ impl WmlEngine {
         args: Vec<ScriptCallArgLiteral>,
     ) -> Result<ScriptInvocationOutcome, String> {
         let vm_args = convert_script_call_args(&args);
-        self.invoke_script_contained(|engine| {
+        self.invoke_script_contained(move |engine| {
             engine.invoke_script_ref_internal(&src, &function_name, &vm_args)
         })
     }

--- a/engine-wasm/engine/src/engine_tests/panic_containment.rs
+++ b/engine-wasm/engine/src/engine_tests/panic_containment.rs
@@ -3,7 +3,7 @@ use super::*;
 /// Runs `f` with the default panic hook suppressed, so a deliberately
 /// triggered-and-caught panic in these tests doesn't spam stderr with a
 /// backtrace on every test run. The panic is still caught and converted to
-/// a `Result` by `catch_engine_panic` either way; this only silences the
+/// a `Result` by the native boundary either way; this only silences the
 /// diagnostic print that the default hook performs before unwinding.
 fn without_panic_hook_noise<T>(f: impl FnOnce() -> T) -> T {
     let previous_hook = std::panic::take_hook();
@@ -25,19 +25,12 @@ fn catch_engine_panic_passes_through_non_panicking_results() {
 
 #[test]
 fn catch_engine_panic_converts_str_literal_panics_into_a_typed_error() {
-    // Regression coverage for the panic-containment boundary: this crate
-    // has no `[profile.release] panic = "abort"`, so `catch_unwind` is
-    // expected to actually catch here rather than the process aborting.
     let result = without_panic_hook_noise(|| {
         catch_engine_panic(|| -> Result<(), String> { panic!("boom") })
     });
 
     let err = result.expect_err("a panic must be converted into a typed error, not propagate");
-    assert!(
-        err.contains("engine: internal panic contained"),
-        "unexpected message: {err}"
-    );
-    assert!(err.contains("boom"), "unexpected message: {err}");
+    assert_eq!(err, crate::CONTAINED_ENGINE_PANIC_ERROR);
 }
 
 #[test]
@@ -49,27 +42,36 @@ fn catch_engine_panic_converts_owned_string_panics_into_a_typed_error() {
     });
 
     let err = result.expect_err("a panic must be converted into a typed error, not propagate");
-    assert!(
-        err.contains("engine: internal panic contained"),
-        "unexpected message: {err}"
-    );
-    assert!(err.contains("boom-7"), "unexpected message: {err}");
+    assert_eq!(err, crate::CONTAINED_ENGINE_PANIC_ERROR);
 }
 
 #[test]
-fn catch_engine_panic_keeps_the_caller_usable_afterward() {
-    // A caught panic must not leave the process/thread in a state where
-    // further work is impossible: subsequent calls (including ones that
-    // exercise the same engine instance's normal public API) must keep
-    // working. This is the behavior the WASM host boundary depends on:
-    // one contained panic should not brick the instance.
+fn mutation_boundary_rolls_back_panicking_candidate_and_keeps_engine_usable() {
     let mut engine = WmlEngine::new();
-    let _ = without_panic_hook_noise(|| {
-        catch_engine_panic(|| -> Result<(), String> { panic!("boom") })
-    });
-
     engine
         .load_deck("<wml><card id=\"home\"><p>Home</p></card></wml>")
-        .expect("engine must remain usable after an unrelated caught panic");
-    assert_eq!(engine.active_card_id().expect("active card"), "home");
+        .expect("initial deck should load");
+    assert!(engine.set_var("status".to_string(), "before".to_string()));
+
+    let result = without_panic_hook_noise(|| engine.load_deck(crate::PANIC_BOUNDARY_TEST_WML));
+    assert_eq!(
+        result.expect_err("load panic must be contained"),
+        crate::CONTAINED_ENGINE_PANIC_ERROR
+    );
+    assert_eq!(
+        engine.get_var("status".to_string()).as_deref(),
+        Some("before")
+    );
+    assert_eq!(engine.active_card_id().as_deref(), Ok("home"));
+    assert_eq!(
+        engine
+            .get_var("panic-boundary-probe".to_string())
+            .as_deref(),
+        None
+    );
+
+    engine
+        .load_deck("<wml><card id=\"next\"><p>Next</p></card></wml>")
+        .expect("engine must remain usable after a contained panic");
+    assert_eq!(engine.active_card_id().expect("active card"), "next");
 }

--- a/engine-wasm/engine/src/engine_wasm_bindings_tests.rs
+++ b/engine-wasm/engine/src/engine_wasm_bindings_tests.rs
@@ -45,6 +45,40 @@ fn wmls_501_fixture_bytes(fixture: &str) -> Vec<u8> {
 }
 
 #[wasm_bindgen_test]
+fn wasm_panic_boundary_returns_typed_error_rolls_back_and_remains_usable() {
+    let mut engine = WmlEngine::wasm_new();
+    engine
+        .load_deck_wasm("<wml><card id=\"home\"><p>Home</p></card></wml>")
+        .expect("initial deck should load");
+    assert!(engine.set_var_wasm("status".to_string(), "before".to_string()));
+
+    let result = engine.load_deck_wasm(crate::PANIC_BOUNDARY_TEST_WML);
+    assert_eq!(
+        result
+            .expect_err("wasm load panic must become a typed engine error")
+            .as_string()
+            .as_deref(),
+        Some(crate::CONTAINED_ENGINE_PANIC_ERROR)
+    );
+    assert_eq!(
+        engine.get_var_wasm("status".to_string()).as_deref(),
+        Some("before")
+    );
+    assert_eq!(engine.active_card_id_wasm().as_deref(), Ok("home"));
+    assert_eq!(
+        engine
+            .get_var_wasm("panic-boundary-probe".to_string())
+            .as_deref(),
+        None
+    );
+
+    engine
+        .load_deck_wasm("<wml><card id=\"next\"><p>Next</p></card></wml>")
+        .expect("engine must remain usable after a contained wasm panic");
+    assert_eq!(engine.active_card_id_wasm().as_deref(), Ok("next"));
+}
+
+#[wasm_bindgen_test]
 fn wasm_wmls_501_decoder_matches_native_fixture_and_failure_semantics() {
     let fixture = wmls_501_fixture_bytes(WMLS_501_MINIMAL_UNIT);
     let decoded = decode_wap_compilation_unit(&fixture).expect("WAP-193 fixture must decode");

--- a/engine-wasm/engine/src/lib.rs
+++ b/engine-wasm/engine/src/lib.rs
@@ -106,55 +106,68 @@ const MAX_NAV_DISPATCH_DEPTH: u8 = 8;
 const MAX_DECK_WML_XML_BYTES: usize = 512 * 1024;
 const MAX_DECK_RAW_BYTES_BASE64_BYTES: usize = 1024 * 1024;
 const CARD_ID_NOT_FOUND_ERROR: &str = "Card id not found";
+const CONTAINED_ENGINE_PANIC_ERROR: &str = "engine: internal panic contained";
+#[cfg(test)]
+const PANIC_BOUNDARY_TEST_WML: &str = "<!-- test-only engine panic boundary probe -->";
 
 /// Panic-containment boundary for public engine entrypoints.
 ///
-/// Runs `f` under [`std::panic::catch_unwind`] and converts an unwinding
-/// panic into the engine's existing typed `Result<_, String>` error path
-/// instead of letting it propagate. This exists so a defensive-programming
-/// bug elsewhere in the engine (parser, navigation, VM, ...) degrades to a
-/// recoverable error the host can observe, rather than an uncaught panic —
-/// which, at the `#[wasm_bindgen]` boundary, traps the whole WASM instance
-/// uncatchably from JS (the instance cannot be used again after that).
+/// Native targets use [`std::panic::catch_unwind`]. The shipping
+/// `wasm32-unknown-unknown` target cannot unwind on stable Rust, so its
+/// implementation calls `f` through a small JavaScript re-entry boundary and
+/// converts the resulting WebAssembly trap into the same deterministic error.
 ///
-/// `AssertUnwindSafe` is used because these entrypoints take `&mut self`,
-/// which is not `UnwindSafe` by default: unwinding through a mutable
-/// reference can leave the pointee in a partially-updated state. That
-/// tradeoff is accepted deliberately here — surfacing a typed error and
-/// keeping the host process/instance alive is strictly better than crashing
-/// it, even if the caught-panic path leaves engine state non-pristine. Call
-/// sites that care about state precision (e.g. navigation cycles) already
-/// guard against runaway recursion with typed errors before a panic would
-/// ever occur (see `MAX_NAV_DISPATCH_DEPTH`, `MAX_TIMER_DISPATCH_DEPTH`);
-/// this boundary is a last-resort net for bugs those guards don't cover.
-///
-/// Kept target-agnostic (native and `wasm32` both support unwind-based
-/// `catch_unwind` here, since this crate does not set
-/// `[profile.release] panic = "abort"`) and crate-private: it is glue for
-/// the public API surface, not parser/runtime/layout core logic.
-pub(crate) fn catch_engine_panic<T>(f: impl FnOnce() -> T) -> Result<T, String> {
-    std::panic::catch_unwind(std::panic::AssertUnwindSafe(f)).map_err(|payload| {
-        // NOTE: pass `payload.as_ref()` here, not `&payload`. `payload` is a
-        // `Box<dyn Any + Send>`, and `Box<T: 'static>` itself implements
-        // `Any` via the blanket impl — so `&payload` coerces (via unsized
-        // coercion, not `Deref`) to a `&(dyn Any + Send)` describing the
-        // *Box*, not the panic payload it holds, and every `downcast_ref`
-        // below silently misses. `.as_ref()` forces the `Deref` step first.
-        format!(
-            "engine: internal panic contained: {}",
-            panic_payload_message(payload.as_ref())
-        )
-    })
+/// Mutating entrypoints invoke this boundary only against a cloned candidate
+/// engine and commit the candidate after `f` returns. A panic therefore never
+/// exposes partially-mutated live state, including on wasm where aborting a
+/// nested callback does not run that callback's Rust destructors.
+#[cfg(not(target_arch = "wasm32"))]
+pub(crate) fn catch_engine_panic<T: 'static>(f: impl FnMut() -> T + 'static) -> Result<T, String> {
+    std::panic::catch_unwind(std::panic::AssertUnwindSafe(f))
+        .map_err(|_| CONTAINED_ENGINE_PANIC_ERROR.to_string())
 }
 
-fn panic_payload_message(payload: &(dyn std::any::Any + Send)) -> String {
-    if let Some(message) = payload.downcast_ref::<&str>() {
-        (*message).to_string()
-    } else if let Some(message) = payload.downcast_ref::<String>() {
-        message.clone()
-    } else {
-        "non-string panic payload".to_string()
+#[cfg(all(feature = "wasm-bindings", target_arch = "wasm32"))]
+#[wasm_bindgen(inline_js = r#"
+export function wavenavCatchEngineTrap(callback) {
+    try {
+        callback();
+        return false;
+    } catch (_) {
+        return true;
     }
+}
+"#)]
+extern "C" {
+    #[wasm_bindgen(js_name = wavenavCatchEngineTrap)]
+    fn catch_engine_trap(callback: &wasm_bindgen::JsValue) -> bool;
+}
+
+#[cfg(all(feature = "wasm-bindings", target_arch = "wasm32"))]
+pub(crate) fn catch_engine_panic<T: 'static>(
+    mut f: impl FnMut() -> T + 'static,
+) -> Result<T, String> {
+    use std::cell::RefCell;
+    use std::rc::Rc;
+    use wasm_bindgen::closure::Closure;
+
+    let output = Rc::new(RefCell::new(None));
+    let callback_output = Rc::clone(&output);
+    let callback = Closure::wrap(Box::new(move || {
+        callback_output.borrow_mut().replace(f());
+    }) as Box<dyn FnMut()>);
+
+    let trapped = catch_engine_trap(callback.as_ref());
+    drop(callback);
+    if trapped {
+        return Err(CONTAINED_ENGINE_PANIC_ERROR.to_string());
+    }
+
+    let result = output
+        .borrow_mut()
+        .take()
+        .ok_or_else(|| "engine: panic boundary callback did not run".to_string());
+    result
 }
 
 #[derive(Clone, Debug)]


### PR DESCRIPTION
## Summary

- replace the false wasm32 `catch_unwind` assumption with a JavaScript re-entry trap boundary
- run protected engine operations against an isolated candidate and commit only after the boundary returns
- normalize contained panics to the deterministic `engine: internal panic contained` error on native and WASM
- add native and `wasm-bindgen-test` coverage proving typed failure, state rollback, and instance reuse
- document the remaining wasm allocation-boundary limitation

## Root cause

`wasm32-unknown-unknown` uses an aborting panic runtime on stable Rust. The existing `std::panic::catch_unwind` wrapper therefore never returned `Err` on the shipping target; a deliberate wasm test reproduced `RuntimeError: unreachable` instead.

The wasm implementation now invokes the candidate operation through a small JavaScript callback boundary. JavaScript catches the nested WebAssembly trap and returns control to the outer engine call, which maps it to the same deterministic error used by the native unwind boundary. Because mutating operations run on a cloned candidate, a panic cannot expose partial state.

Allocation while cloning the candidate or creating the callback occurs before the trap boundary and remains uncatchable on `wasm32-unknown-unknown`. Existing deck, script, and variable limits remain the primary mitigation for that platform constraint.

## Validation

- `cargo test --locked` — 400 native tests passed
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo check --target wasm32-unknown-unknown --locked`
- `wasm-pack test --node --release` — 36 WASM tests passed
- `wasm-pack build --target web`
- `pnpm --dir engine-wasm/host-sample run contracts:check`
- repository pre-push checks — all passed

Closes #434
