### PR TITLE
F1-01: migrate host sample to canonical frame renderer

### DIFF
--- a/engine-wasm/README.md
+++ b/engine-wasm/README.md
@@ -82,7 +82,9 @@ cargo test
 - Use the handwritten method facade in `engine-wasm/contracts/wml-engine.ts`; its serialized DTOs
   are generated from engine-owned Rust serde metadata as documented in
   `engine-wasm/contracts/README.md`
-- See host loop sample in `engine-wasm/host-sample/renderer.ts`
+- See the canonical presentation-frame canvas renderer in `engine-wasm/host-sample/renderer.ts`.
+  The sample viewport consumes `renderFrame()` rows and segments directly; it does not use the
+  legacy `RenderList` compatibility path.
 
 ### 8) Quick local harness (no Electron)
 
@@ -164,8 +166,8 @@ Partially supported (phase W0 baseline and active follow-ons):
 
 - `loadDeck(xml: string)`
 - `loadDeckContext(wmlXml: string, baseUrl: string, contentType: string, rawBytesBase64?: string, referringUrl?: string)`
-- `render(): RenderList`
-- `renderFrame(): EnginePresentationFrame`
+- `renderFrame(): EnginePresentationFrame` (canonical host presentation path)
+- `render(): RenderList` (legacy compatibility path during the remaining F1/F4 cutover)
 - `handleKey(key: 'up' | 'down' | 'enter')`
 - `handleInput(event: EngineInputEvent)`
 - `advanceTimeMs(deltaMs: number)` (deterministic timer simulation)
@@ -196,7 +198,8 @@ Behavior must stay aligned with the WASM API for:
 
 - deck loading and metadata handling
 - navigation and focus transitions
-- render output (`RenderList` and `EnginePresentationFrame`) ordering and shape
+- canonical `EnginePresentationFrame` ordering and shape, with equivalent legacy `RenderList`
+  compatibility output during the remaining cutover
 - typed key/action input behavior and trace semantics
 - script execution/invocation outcomes
 - trace entry semantics

--- a/engine-wasm/host-sample/renderer.ts
+++ b/engine-wasm/host-sample/renderer.ts
@@ -80,7 +80,6 @@ export interface EngineHost {
   lastScriptRequiresRefresh(): boolean | undefined;
   traceEntries(): EngineTraceEntry[];
   clearTraceEntries(): void;
-  render(): void;
   getEngine(): WmlEngine;
 }
 
@@ -105,26 +104,27 @@ export async function bootWmlEngine(canvas: HTMLCanvasElement, xml: string): Pro
     ctx.font = '14px "IBM Plex Mono", monospace';
     ctx.textBaseline = 'top';
 
-    const renderList = engine.render();
+    const frame = engine.renderFrame();
 
-    for (const cmd of renderList.draw) {
-      const x = cmd.x * charWidth;
-      const y = cmd.y * lineHeight;
+    for (const row of frame.rows) {
+      const y = row.index * lineHeight;
 
-      if (cmd.type === 'text') {
-        ctx.fillStyle = '#171914';
-        ctx.fillText(cmd.text, x, y);
-        continue;
-      }
+      for (const segment of row.segments) {
+        const x = segment.x * charWidth;
 
-      if (cmd.type === 'link') {
-        if (cmd.focused) {
+        if (segment.type === 'text') {
+          ctx.fillStyle = '#171914';
+          ctx.fillText(segment.text, x, y);
+          continue;
+        }
+
+        if (segment.focused) {
           ctx.fillStyle = '#d8dcef';
           ctx.fillRect(0, y - 1, canvas.width, lineHeight + 2);
         }
 
-        ctx.fillStyle = cmd.focused ? '#171914' : '#1538a1';
-        ctx.fillText(cmd.text, x, y);
+        ctx.fillStyle = segment.focused ? '#171914' : '#1538a1';
+        ctx.fillText(segment.text, x, y);
       }
     }
   }
@@ -255,7 +255,6 @@ export async function bootWmlEngine(canvas: HTMLCanvasElement, xml: string): Pro
     clearTraceEntries() {
       engine.clearTraceEntries();
     },
-    render: paint,
     getEngine() {
       return rawEngine;
     }

--- a/engine-wasm/host-sample/runtime-dto-fixtures.ts
+++ b/engine-wasm/host-sample/runtime-dto-fixtures.ts
@@ -1,15 +1,48 @@
 import type {
-  RenderList,
+  EnginePresentationFrame,
   ScriptExecutionOutcome,
   ScriptInvocationOutcome
 } from '../contracts/wml-engine';
 
-export const representativeRenderFixture = {
-  draw: [
-    { type: 'text', x: 0, y: 0, text: 'Status' },
-    { type: 'link', x: 0, y: 1, text: 'Next', focused: true, href: '#next' }
-  ]
-} satisfies RenderList;
+export const representativeFrameFixture = {
+  contractVersion: 1,
+  frameId: 'fixture-frame',
+  profileId: 'class-c-reference',
+  viewport: { cols: 20 },
+  deck: {
+    baseUrl: 'http://local.test/deck.wml',
+    contentType: 'text/vnd.wap.wml'
+  },
+  card: { id: 'home' },
+  rows: [
+    { index: 0, segments: [{ type: 'text', x: 0, text: 'Status' }] },
+    {
+      index: 1,
+      segments: [
+        {
+          type: 'focusable',
+          x: 0,
+          text: 'Next',
+          focusId: 'focus:0',
+          targetKind: 'link',
+          focused: true
+        }
+      ]
+    }
+  ],
+  focus: { index: 0, focusId: 'focus:0', targetKind: 'link' },
+  selection: { type: 'none' },
+  affordances: [
+    {
+      actionId: 'focus:0',
+      label: 'Next',
+      enabled: true,
+      source: 'focused-link',
+      control: 'primary'
+    }
+  ],
+  backAvailable: false
+} satisfies EnginePresentationFrame;
 
 export const representativeScriptErrorFixture = {
   ok: false,


### PR DESCRIPTION
## Summary

- migrate the host-sample canvas viewport from the legacy `render()/RenderList` path to `renderFrame()/EnginePresentationFrame`
- draw ordered frame rows and text/focusable segments with the existing coordinates, font, colors, and focus highlight
- update the host-sample DTO fixture and engine README to make the canonical frame dependency explicit

## Why

F1-01 cuts the WASM host sample viewport over to the existing engine-owned presentation-frame contract. This removes the sample's legacy render-list dependency without changing engine runtime semantics, contracts, or appearance.

## Impact

The change is limited to the engine host sample and its documentation/type fixture. Browser/frontend, transport, engine runtime/contracts, generated artifacts, and planning boards are unchanged.

## Validation

- `pnpm --dir engine-wasm/host-sample run typecheck`
- `pnpm --dir engine-wasm/host-sample run format:check`
- `pnpm --dir engine-wasm/host-sample run lint`
- `pnpm --dir engine-wasm/host-sample run test` — 19 passed
- `pnpm --dir engine-wasm/host-sample run examples:check` — 44 examples validated
- `pnpm --dir engine-wasm/host-sample run contracts:check`
- `pnpm --dir engine-wasm/host-sample run build`
- `pnpm test:story host-sample` — 34 passed, 0 failed
- repository pre-push hooks — all passed, including 400 engine tests and Rust Clippy gates
