### PR TITLE
F1-02: replace Tauri viewport HTML rendering with Canvas2D

### DIFF
--- a/browser/frontend/scripts/check-rendered-accessibility.mjs
+++ b/browser/frontend/scripts/check-rendered-accessibility.mjs
@@ -153,7 +153,8 @@ const assertDeveloperToolsPanelContainment = async (
     );
     for (const action of metrics.actions) {
       assert.ok(
-        action.left >= metrics.workspace.left - 0.5 && action.right <= metrics.workspace.right + 0.5,
+        action.left >= metrics.workspace.left - 0.5 &&
+          action.right <= metrics.workspace.right + 0.5,
         `${name}: #${action.id} stays inside the Developer Tools workspace`
       );
     }
@@ -192,7 +193,8 @@ const assertDeveloperToolsCommandFeedback = async (page, name) => {
 
   await page.locator('#btn-health').click();
   await page.waitForFunction(
-    () => document.querySelector('#developer-tools-host-status')?.textContent?.startsWith('Health:'),
+    () =>
+      document.querySelector('#developer-tools-host-status')?.textContent?.startsWith('Health:'),
     null,
     { timeout: 5_000 }
   );
@@ -208,7 +210,11 @@ const assertDeveloperToolsCommandFeedback = async (page, name) => {
     { timeout: 5_000 }
   );
   const render = (await activity.textContent())?.trim() ?? '';
-  assert.equal(render, 'Rendered current card.', `${name}: Render confirms completion inside DevTools`);
+  assert.equal(
+    render,
+    'Rendered current card.',
+    `${name}: Render confirms completion inside DevTools`
+  );
   assert.notEqual(
     (await page.locator('#snapshot').textContent())?.trim(),
     '',
@@ -248,10 +254,15 @@ const assertStatusRegionsDoNotOverlap = async (page, name) => {
   for (const regions of [statusLayout.top, statusLayout.context]) {
     const visibleRegions = regions.filter((region) => region.visible);
     for (let index = 0; index < visibleRegions.length; index += 1) {
-      for (let candidateIndex = index + 1; candidateIndex < visibleRegions.length; candidateIndex += 1) {
+      for (
+        let candidateIndex = index + 1;
+        candidateIndex < visibleRegions.length;
+        candidateIndex += 1
+      ) {
         const first = visibleRegions[index];
         const second = visibleRegions[candidateIndex];
-        const horizontalOverlap = first.left < second.right - 0.5 && second.left < first.right - 0.5;
+        const horizontalOverlap =
+          first.left < second.right - 0.5 && second.left < first.right - 0.5;
         const verticalOverlap = first.top < second.bottom - 0.5 && second.top < first.bottom - 0.5;
         if (horizontalOverlap && verticalOverlap) {
           overlaps.push(`${first.selector}/${second.selector}`);
@@ -451,8 +462,17 @@ const auditRenderedPage = async (page, name, windowEvidence) => {
     }));
     const shell = document.querySelector('.browser-shell');
     const viewport = document.querySelector('#viewport');
-    const focusedWmlItem = document.querySelector('.wml-segment-link.is-focused');
     const rootStyle = getComputedStyle(document.documentElement);
+    const resolveColor = (propertyName) => {
+      const probe = document.createElement('span');
+      probe.style.color = `var(${propertyName})`;
+      probe.style.position = 'absolute';
+      probe.style.visibility = 'hidden';
+      document.body.append(probe);
+      const color = getComputedStyle(probe).color;
+      probe.remove();
+      return color;
+    };
     return {
       cssViewport: { width: innerWidth, height: innerHeight },
       document: {
@@ -471,10 +491,11 @@ const auditRenderedPage = async (page, name, windowEvidence) => {
         lcdFontFamily: viewport ? getComputedStyle(viewport).fontFamily : null,
         lcdBackground: viewport ? getComputedStyle(viewport).backgroundColor : null,
         lcdForeground: viewport ? getComputedStyle(viewport).color : null,
-        focusedWmlBackground: focusedWmlItem
-          ? getComputedStyle(focusedWmlItem).backgroundColor
-          : null,
-        focusedWmlForeground: focusedWmlItem ? getComputedStyle(focusedWmlItem).color : null,
+        focusedWmlBackground: resolveColor('--lcd-focus-bg'),
+        focusedWmlForeground: resolveColor('--lcd-focus-fg'),
+        canvasSurfaceCount: document.querySelectorAll('#viewport > canvas.viewport-canvas').length,
+        legacyWmlDomCount: document.querySelectorAll('#viewport .line, #viewport .wml-segment')
+          .length,
         focusRingColor: rootStyle.getPropertyValue('--focus-ring-color').trim(),
         focusRingOuterColor: rootStyle.getPropertyValue('--focus-ring-outer-color').trim(),
         runningAnimationCount: document.getAnimations().length
@@ -503,6 +524,12 @@ const auditRenderedPage = async (page, name, windowEvidence) => {
     layout.presentation.lcdFontFamily ?? '',
     /Courier New/,
     `${name}: period LCD font remains scoped to the viewport`
+  );
+  assert.equal(layout.presentation.canvasSurfaceCount, 1, `${name}: one Canvas2D WML surface`);
+  assert.equal(
+    layout.presentation.legacyWmlDomCount,
+    0,
+    `${name}: no legacy WML line injection remains`
   );
   assert.equal(
     layout.presentation.focusedWmlBackground,

--- a/browser/frontend/scripts/native-tauri-kannel-e2e.mjs
+++ b/browser/frontend/scripts/native-tauri-kannel-e2e.mjs
@@ -63,9 +63,12 @@ const waitForPort = async () => {
   throw new Error(`timed out waiting for tauri-driver at ${driverUrl.origin}`);
 };
 
+const readElementText = async (element) =>
+  driver.executeScript('return arguments[0].textContent ?? "";', element);
+
 const waitForText = async (selector, expected) => {
   const element = await driver.wait(until.elementLocated(By.css(selector)), timeoutMs);
-  await driver.wait(async () => (await element.getText()).includes(expected), timeoutMs);
+  await driver.wait(async () => (await readElementText(element)).includes(expected), timeoutMs);
   return element;
 };
 
@@ -188,15 +191,15 @@ const run = async () => {
 
   await driver.findElement(By.css('#btn-fetch-url')).click();
   const homeViewport = await waitForText('#viewport', 'Local WAP training');
-  assert.match(await homeViewport.getText(), /environment\./);
-  assert.match(await homeViewport.getText(), /Open Menu/);
+  assert.match(await readElementText(homeViewport), /environment\./);
+  assert.match(await readElementText(homeViewport), /Open Menu/);
   assert.equal(await body.getAttribute('data-boot-phase'), 'deck-ready');
   recordAssertion('gateway deck render', 'wap://localhost/ rendered the Kannel-served home deck');
   await capture('02-gateway-home');
 
   await driver.findElement(By.css('#btn-enter')).click();
   const menuViewport = await waitForText('#viewport', '1. Login');
-  assert.match(await menuViewport.getText(), /2\. Register/);
+  assert.match(await readElementText(menuViewport), /2\. Register/);
   recordAssertion(
     'visible card navigation',
     'Select navigated the native engine from home to menu'
@@ -208,7 +211,7 @@ const run = async () => {
   }
   await driver.findElement(By.css('#btn-enter')).click();
   const staticExampleViewport = await waitForText('#viewport', 'Open Navigation');
-  const staticExampleText = await staticExampleViewport.getText();
+  const staticExampleText = await readElementText(staticExampleViewport);
   assert.match(staticExampleText, /This is a static WML/);
   assert.match(staticExampleText, /sample deck\./);
   assert.match(
@@ -224,13 +227,13 @@ const run = async () => {
   await replaceInput('#fetch-url', 'wap://localhost/examples/pocket-portal.wml');
   await driver.findElement(By.css('#btn-fetch-url')).click();
   const portalViewport = await waitForText('#viewport', 'first-party service');
-  const portalText = await portalViewport.getText();
+  const portalText = await readElementText(portalViewport);
   assert.match(portalText, /first-party service/);
   assert.match(portalText, /directory\./);
   await driver.findElement(By.css('#btn-enter')).click();
   const directoryViewport = await waitForText('#viewport', 'Forms');
-  assert.match(await directoryViewport.getText(), /Forms/);
-  assert.match(await directoryViewport.getText(), /Examples/);
+  assert.match(await readElementText(directoryViewport), /Forms/);
+  assert.match(await readElementText(directoryViewport), /Examples/);
   recordAssertion(
     'pocket portal navigation',
     'the native WSP/WBXML path rendered the portal and followed its fragment directory link'
@@ -240,7 +243,7 @@ const run = async () => {
   await replaceInput('#fetch-url', 'wap://localhost/examples/preferences.wml');
   await driver.findElement(By.css('#btn-fetch-url')).click();
   const preferencesViewport = await waitForText('#viewport', 'made-up alias');
-  const preferencesText = await preferencesViewport.getText();
+  const preferencesText = await readElementText(preferencesViewport);
   assert.match(preferencesText, /made-up alias/);
   assert.match(preferencesText, /Layout/);
   assert.match(preferencesText, /Review Preference/);
@@ -253,7 +256,7 @@ const run = async () => {
   await replaceInput('#fetch-url', 'wap://localhost/examples/interop-check.wml');
   await driver.findElement(By.css('#btn-fetch-url')).click();
   const interopViewport = await waitForText('#viewport', 'W13-A');
-  assert.match(await interopViewport.getText(), /W13-A/);
+  assert.match(await readElementText(interopViewport), /W13-A/);
   const requestsBeforeRepeat = await readOriginRequestCount();
   await driver.findElement(By.css('#btn-enter')).click();
   await driver.wait(
@@ -264,7 +267,7 @@ const run = async () => {
     timeoutMs
   );
   const repeatedInteropViewport = await waitForText('#viewport', 'W13-A');
-  assert.match(await repeatedInteropViewport.getText(), /W13-A/);
+  assert.match(await readElementText(repeatedInteropViewport), /W13-A/);
   await delay(2000);
   const requestsAfterRepeat = await readOriginRequestCount();
   assert.equal(
@@ -293,8 +296,8 @@ const run = async () => {
   await replaceInput('#fetch-url', 'wap://localhost/');
   await driver.findElement(By.css('#btn-fetch-url')).click();
   const recoveredViewport = await waitForText('#viewport', 'Local WAP training');
-  assert.match(await recoveredViewport.getText(), /environment\./);
-  assert.match(await recoveredViewport.getText(), /Open Menu/);
+  assert.match(await readElementText(recoveredViewport), /environment\./);
+  assert.match(await readElementText(recoveredViewport), /Open Menu/);
   recordAssertion('failure recovery', 'a subsequent native Kannel load restored the home deck');
   await capture('09-recovered-home');
 

--- a/browser/frontend/src/app/browser-presenter.test.ts
+++ b/browser/frontend/src/app/browser-presenter.test.ts
@@ -90,6 +90,7 @@ describe('BrowserPresenter', () => {
   it('clears viewport skeleton after first render', () => {
     const refs = createRefs();
     const presenter = new BrowserPresenter(refs, initialSession, 20);
+    const innerHtmlSetter = vi.spyOn(refs.viewportEl, 'innerHTML', 'set');
 
     presenter.setViewportSkeleton(true);
     expect(refs.viewportEl.classList.contains('viewport-skeleton')).toBe(true);
@@ -103,6 +104,9 @@ describe('BrowserPresenter', () => {
     expect(refs.viewportEl.classList.contains('viewport-skeleton')).toBe(false);
     expect(refs.viewportEl.getAttribute('aria-busy')).toBe('false');
     expect(refs.viewportEl.textContent).toContain('hello');
+    expect(refs.viewportEl.querySelector('canvas.viewport-canvas')).not.toBeNull();
+    expect(refs.viewportEl.querySelector('.line')).toBeNull();
+    expect(innerHtmlSetter).not.toHaveBeenCalled();
   });
 
   it('does not append timeline entries when replacing session state directly', () => {
@@ -225,7 +229,8 @@ describe('BrowserPresenter', () => {
     expect(refs.viewportEl.classList.contains('viewport-skeleton')).toBe(false);
     expect(refs.viewportEl.getAttribute('aria-busy')).toBe('false');
     expect(refs.viewportEl.querySelector('.skeleton-hint')).toBeNull();
-    expect(refs.viewportEl.innerHTML).toBe('');
+    expect(refs.viewportEl.querySelectorAll('.skeleton-line, .skeleton-hint')).toHaveLength(0);
+    expect(refs.viewportEl.querySelector('canvas.viewport-canvas')).not.toBeNull();
   });
 
   it('does not touch viewport markup when hiding the skeleton after a successful render', () => {
@@ -332,7 +337,8 @@ describe('BrowserPresenter', () => {
 
     endProgress();
     expect(refs.viewportEl.classList.contains('viewport-skeleton')).toBe(false);
-    expect(refs.viewportEl.innerHTML).toBe('');
+    expect(refs.viewportEl.querySelectorAll('.skeleton-line, .skeleton-hint')).toHaveLength(0);
+    expect(refs.viewportEl.querySelector('canvas.viewport-canvas')).not.toBeNull();
   });
 
   it('does not flash an in-progress indicator for a repeat navigation that resolves within the delay', () => {

--- a/browser/frontend/src/app/browser-presenter.ts
+++ b/browser/frontend/src/app/browser-presenter.ts
@@ -18,13 +18,26 @@ import type { BrowserShellRefs } from './browser-shell-template';
 import { inferStatusTone, uiEvents } from '../ui-helpers';
 import { WAVES_CONFIG } from './waves-config';
 import { WAVES_COPY } from './waves-copy';
-import { renderWmlViewportHtml } from '../components/primitives/wml-render-primitives';
 import type { DeveloperToolsHostBridge } from './developer-tools-bridge';
 import { renderDeveloperToolsSummary, type DeveloperToolsState } from './developer-tools-workspace';
+import {
+  canvasFrameFromRenderList,
+  CanvasViewportRenderer,
+  ensureCanvasViewportElements
+} from './canvas-viewport-renderer';
 
 export type BootPhase = 'booting' | 'shell-ready' | 'engine-ready' | 'deck-ready';
 
 const REPEAT_NAV_HINT_CLASS = 'viewport-navigation-hint';
+const SKELETON_LINE_CLASSES = [
+  'skeleton-line',
+  'skeleton-line skeleton-line-wide',
+  'skeleton-line',
+  'skeleton-line skeleton-line-short',
+  'skeleton-line',
+  'skeleton-line skeleton-line-wide',
+  'skeleton-line'
+] as const;
 
 export class BrowserPresenter {
   private readonly refs: BrowserShellRefs;
@@ -64,6 +77,7 @@ export class BrowserPresenter {
   private transportResponseDirty = true;
   private navigationProgressTimer: ReturnType<typeof setTimeout> | undefined;
   private developerToolsBridge: DeveloperToolsHostBridge | undefined;
+  private readonly viewportRenderer: CanvasViewportRenderer;
   // U7: flushDeveloperPanels() re-serializes whichever dev-panel sub-object
   // is dirty via JSON.stringify(..., null, 2). Each mutating setter used to
   // call it immediately and synchronously, so a burst of same-tick mutations
@@ -84,6 +98,11 @@ export class BrowserPresenter {
     this.refs = refs;
     this.maxTimelineEvents = maxTimelineEvents;
     this.hostSessionState = initialSession;
+    const viewportElements =
+      refs.viewportCanvasEl && refs.viewportAccessibleTextEl
+        ? { canvas: refs.viewportCanvasEl, accessibleText: refs.viewportAccessibleTextEl }
+        : ensureCanvasViewportElements(refs.viewportEl);
+    this.viewportRenderer = new CanvasViewportRenderer(refs.viewportEl, viewportElements);
     this.refs.devDrawerEl.addEventListener('toggle', this.handleDevDrawerToggle);
   }
 
@@ -104,6 +123,7 @@ export class BrowserPresenter {
     }
     this.developerToolsBridge?.dispose();
     this.developerToolsBridge = undefined;
+    this.viewportRenderer.dispose();
   }
 
   attachDeveloperToolsBridge(bridge: DeveloperToolsHostBridge): void {
@@ -210,16 +230,7 @@ export class BrowserPresenter {
       this.refs.viewportEl.classList.add('viewport-skeleton');
       this.refs.viewportEl.setAttribute('aria-busy', 'true');
       if (!this.hasRenderedContent) {
-        this.refs.viewportEl.innerHTML = `
-          <div class="skeleton-line"></div>
-          <div class="skeleton-line skeleton-line-wide"></div>
-          <div class="skeleton-line"></div>
-          <div class="skeleton-line skeleton-line-short"></div>
-          <div class="skeleton-line"></div>
-          <div class="skeleton-line skeleton-line-wide"></div>
-          <div class="skeleton-line"></div>
-          <div class="skeleton-hint">${escapeHtml(WAVES_COPY.shell.firstRenderPending)}</div>
-        `;
+        this.showInitialSkeleton();
       } else {
         // A repeat navigation (link click, reload, back/forward, external
         // intent) -- content is already on screen, so don't wipe it. Append a
@@ -233,14 +244,7 @@ export class BrowserPresenter {
     this.refs.viewportEl.classList.remove('viewport-skeleton');
     this.refs.viewportEl.setAttribute('aria-busy', 'false');
     if (!this.hasRenderedContent) {
-      // Nothing has ever successfully rendered yet, so the viewport still
-      // contains the injected skeleton placeholder markup (shimmering bars +
-      // "waiting for first render" hint). Removing just the CSS class above
-      // does not stop that markup from sitting there indefinitely if the
-      // load that was supposed to replace it instead failed. Clear it so a
-      // failed first load doesn't leave a frozen "still loading" viewport
-      // behind the real error, which is surfaced via status/toast instead.
-      this.refs.viewportEl.innerHTML = '';
+      this.clearSkeletonElements();
     } else {
       this.hideRepeatNavigationHint();
     }
@@ -293,6 +297,27 @@ export class BrowserPresenter {
     hint.className = `skeleton-hint ${REPEAT_NAV_HINT_CLASS}`;
     hint.textContent = WAVES_COPY.shell.navigationPending;
     this.refs.viewportEl.append(hint);
+  }
+
+  private showInitialSkeleton(): void {
+    if (this.refs.viewportEl.querySelector('.skeleton-line')) {
+      return;
+    }
+    for (const className of SKELETON_LINE_CLASSES) {
+      const line = document.createElement('div');
+      line.className = className;
+      this.refs.viewportEl.append(line);
+    }
+    const hint = document.createElement('div');
+    hint.className = 'skeleton-hint';
+    hint.textContent = WAVES_COPY.shell.firstRenderPending;
+    this.refs.viewportEl.append(hint);
+  }
+
+  private clearSkeletonElements(): void {
+    this.refs.viewportEl
+      .querySelectorAll('.skeleton-line, .skeleton-hint')
+      .forEach((element) => element.remove());
   }
 
   private hideRepeatNavigationHint(): void {
@@ -368,7 +393,6 @@ export class BrowserPresenter {
     this.latestRenderList = {
       draw: renderList.draw.map((command) => ({ ...command }))
     };
-    this.hasRenderedContent = true;
     // Real content just landed -- cancel any pending delayed in-progress
     // indicator so it can't appear after the fact (see beginNavigationProgress).
     if (this.navigationProgressTimer) {
@@ -376,7 +400,9 @@ export class BrowserPresenter {
       this.navigationProgressTimer = undefined;
     }
     this.setViewportSkeleton(false);
-    this.refs.viewportEl.innerHTML = renderWmlViewportHtml(renderList);
+    this.hasRenderedContent = true;
+    this.refs.viewportEl.classList.add('viewport-has-content');
+    this.viewportRenderer.render(canvasFrameFromRenderList(renderList));
   }
 
   getRenderList(): RenderList | null {
@@ -542,14 +568,6 @@ export class BrowserPresenter {
     return nextText;
   }
 }
-
-const escapeHtml = (input: string): string =>
-  input
-    .replaceAll('&', '&amp;')
-    .replaceAll('<', '&lt;')
-    .replaceAll('>', '&gt;')
-    .replaceAll('"', '&quot;')
-    .replaceAll("'", '&#39;');
 
 const dialogRequestListsEqual = (
   a: readonly ScriptDialogRequestSnapshot[],

--- a/browser/frontend/src/app/browser-shell-template.test.ts
+++ b/browser/frontend/src/app/browser-shell-template.test.ts
@@ -19,6 +19,10 @@ describe('mountBrowserShell', () => {
     expect(document.querySelectorAll('#fetch-url')).toHaveLength(1);
     expect(document.querySelectorAll('#base-url')).toHaveLength(1);
     expect(refs.viewportEl.getAttribute('tabindex')).toBe('0');
+    expect(refs.viewportCanvasEl?.classList.contains('viewport-canvas')).toBe(true);
+    expect(refs.viewportCanvasEl?.getAttribute('aria-hidden')).toBe('true');
+    expect(refs.viewportAccessibleTextEl?.dataset.canvasTextFallback).toBe('');
+    expect(refs.viewportEl.querySelectorAll('canvas.viewport-canvas')).toHaveLength(1);
 
     const softkeyRow = document.querySelector('.softkey-row');
     expect(softkeyRow?.getAttribute('role')).toBe('group');

--- a/browser/frontend/src/app/browser-shell-template.ts
+++ b/browser/frontend/src/app/browser-shell-template.ts
@@ -8,6 +8,7 @@ import { handsetStageTemplate } from './shell/handset-stage-template';
 import { navigationToolbarTemplate } from './shell/navigation-toolbar-template';
 import { statusBarTemplate } from './shell/status-bar-template';
 import { utilityRailTemplate } from './shell/utility-rail-template';
+import { ensureCanvasViewportElements } from './canvas-viewport-renderer';
 
 const browserShellTemplate = () => `
   <div class="browser-shell" data-host-presentation="native">
@@ -39,6 +40,8 @@ export interface BrowserShellRefs {
   baseUrlInput: HTMLInputElement;
   viewportColsInput: HTMLInputElement;
   viewportEl: HTMLDivElement;
+  viewportCanvasEl?: HTMLCanvasElement;
+  viewportAccessibleTextEl?: HTMLSpanElement;
   snapshotEl: HTMLPreElement;
   statusEl: WvStatusPanel;
   fetchUrlInput: HTMLInputElement;
@@ -136,6 +139,8 @@ export const mountBrowserShell = (
   runModeSelectEl.value = defaultRunMode;
   baseUrlInput.value = WAVES_CONFIG.defaultDebugBaseUrl;
 
+  const viewportSurface = ensureCanvasViewportElements(viewportEl);
+
   const utilityRailPanelEl = document.querySelector<HTMLDetailsElement>('#utility-rail-panel');
   const inspectorButtonEl = document.querySelector<HTMLButtonElement>('#btn-inspector');
   const localModeButtonEl = document.querySelector<HTMLButtonElement>('#btn-mode-local');
@@ -228,6 +233,8 @@ export const mountBrowserShell = (
     baseUrlInput,
     viewportColsInput,
     viewportEl,
+    viewportCanvasEl: viewportSurface.canvas,
+    viewportAccessibleTextEl: viewportSurface.accessibleText,
     snapshotEl,
     statusEl,
     fetchUrlInput,

--- a/browser/frontend/src/app/canvas-viewport-renderer.test.ts
+++ b/browser/frontend/src/app/canvas-viewport-renderer.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  canvasFrameFromRenderList,
+  CanvasViewportRenderer,
+  ensureCanvasViewportElements,
+  type CanvasViewportContext,
+  type CanvasViewportStyle
+} from './canvas-viewport-renderer';
+
+interface DrawOperation {
+  kind: 'clear' | 'fill-rect' | 'fill-text' | 'transform';
+  args: readonly (number | string)[];
+  fillStyle?: string;
+}
+
+const FIXED_STYLE: CanvasViewportStyle = {
+  font: '14px monospace',
+  fontSize: 14,
+  lineHeight: 18,
+  inlinePadding: 3,
+  underlineOffset: 1,
+  underlineThickness: 1,
+  textColor: '#111111',
+  linkColor: '#0000aa',
+  focusForeground: '#eeeecc',
+  focusBackground: '#223322'
+};
+
+const createContext = (operations: DrawOperation[]): CanvasViewportContext => ({
+  fillStyle: '#000000',
+  font: '',
+  textBaseline: 'alphabetic',
+  setTransform(...args) {
+    operations.push({ kind: 'transform', args });
+  },
+  clearRect(...args) {
+    operations.push({ kind: 'clear', args });
+  },
+  fillRect(...args) {
+    operations.push({ kind: 'fill-rect', args, fillStyle: String(this.fillStyle) });
+  },
+  fillText(...args) {
+    operations.push({ kind: 'fill-text', args, fillStyle: String(this.fillStyle) });
+  },
+  measureText(text) {
+    return { width: text.length * 6 };
+  }
+});
+
+describe('CanvasViewportRenderer', () => {
+  it('adapts legacy draw commands to presentation-frame-shaped rows', () => {
+    const frame = canvasFrameFromRenderList({
+      draw: [
+        { type: 'text', x: 0, y: 2, text: 'tail' },
+        { type: 'link', x: 0, y: 1, text: 'Go', focused: true, href: '#next' },
+        { type: 'text', x: 2, y: 1, text: ' now' }
+      ]
+    });
+
+    expect(frame).toEqual({
+      rows: [
+        {
+          index: 1,
+          segments: [
+            { type: 'focusable', text: 'Go', focused: true },
+            { type: 'text', text: ' now' }
+          ]
+        },
+        { index: 2, segments: [{ type: 'text', text: 'tail' }] }
+      ]
+    });
+  });
+
+  it('draws rows in visual order with deterministic focus and link treatment', () => {
+    const viewport = document.createElement('div');
+    const elements = ensureCanvasViewportElements(viewport);
+    const operations: DrawOperation[] = [];
+    const renderer = new CanvasViewportRenderer(viewport, elements, {
+      context: createContext(operations),
+      getPixelRatio: () => 2,
+      getSize: () => ({ width: 100, height: 60 }),
+      getStyle: () => FIXED_STYLE,
+      observeResize: () => ({ disconnect: vi.fn() })
+    });
+
+    renderer.render({
+      rows: [
+        { index: 2, segments: [{ type: 'text', text: 'Last' }] },
+        {
+          index: 1,
+          segments: [
+            { type: 'focusable', text: 'Go', focused: true },
+            { type: 'text', text: ' ' },
+            { type: 'focusable', text: 'Next', focused: false }
+          ]
+        }
+      ]
+    });
+
+    expect(elements.canvas.width).toBe(200);
+    expect(elements.canvas.height).toBe(120);
+    expect(elements.canvas.style.height).toBe('60px');
+    expect(elements.accessibleText.textContent).toBe('Go NextLast');
+    expect(operations.filter(({ kind }) => kind === 'fill-text')).toEqual([
+      { kind: 'fill-text', args: ['Go', 3, 0], fillStyle: '#eeeecc' },
+      { kind: 'fill-text', args: [' ', 15, 0], fillStyle: '#111111' },
+      { kind: 'fill-text', args: ['Next', 21, 0], fillStyle: '#0000aa' },
+      { kind: 'fill-text', args: ['Last', 3, 18], fillStyle: '#111111' }
+    ]);
+    expect(operations.filter(({ kind }) => kind === 'fill-rect')).toEqual([
+      { kind: 'fill-rect', args: [3, 0, 12, 18], fillStyle: '#223322' },
+      { kind: 'fill-rect', args: [21, 15, 24, 1], fillStyle: '#0000aa' }
+    ]);
+  });
+
+  it('redraws on resize and disconnects its observer', () => {
+    const viewport = document.createElement('div');
+    const elements = ensureCanvasViewportElements(viewport);
+    const operations: DrawOperation[] = [];
+    const disconnect = vi.fn();
+    let redraw: (() => void) | undefined;
+    const renderer = new CanvasViewportRenderer(viewport, elements, {
+      context: createContext(operations),
+      getPixelRatio: () => 1,
+      getSize: () => ({ width: 80, height: 40 }),
+      getStyle: () => FIXED_STYLE,
+      observeResize: (callback) => {
+        redraw = callback;
+        return { disconnect };
+      }
+    });
+
+    renderer.render({ rows: [{ index: 0, segments: [{ type: 'text', text: 'Ready' }] }] });
+    const drawCount = operations.filter(({ kind }) => kind === 'fill-text').length;
+
+    redraw?.();
+    expect(operations.filter(({ kind }) => kind === 'fill-text')).toHaveLength(drawCount + 1);
+
+    renderer.dispose();
+    expect(disconnect).toHaveBeenCalledOnce();
+  });
+});

--- a/browser/frontend/src/app/canvas-viewport-renderer.ts
+++ b/browser/frontend/src/app/canvas-viewport-renderer.ts
@@ -1,0 +1,276 @@
+import type { RenderList } from '../../../contracts/engine';
+
+export interface CanvasViewportSegment {
+  type: 'text' | 'focusable';
+  text: string;
+  focused?: boolean;
+}
+
+export interface CanvasViewportRow {
+  index: number;
+  segments: readonly CanvasViewportSegment[];
+}
+
+// This is deliberately a structural subset of EnginePresentationFrame. F1-03
+// can pass presentation frames directly once the controller owns that input;
+// until then the presenter adapts the legacy RenderList through the helper
+// below.
+export interface CanvasViewportFrame {
+  rows: readonly CanvasViewportRow[];
+}
+
+export interface CanvasViewportElements {
+  canvas: HTMLCanvasElement;
+  accessibleText: HTMLSpanElement;
+}
+
+export interface CanvasViewportStyle {
+  font: string;
+  fontSize: number;
+  lineHeight: number;
+  inlinePadding: number;
+  underlineOffset: number;
+  underlineThickness: number;
+  textColor: string;
+  linkColor: string;
+  focusForeground: string;
+  focusBackground: string;
+}
+
+export interface CanvasViewportContext {
+  fillStyle: string | CanvasGradient | CanvasPattern;
+  font: string;
+  textBaseline: CanvasTextBaseline;
+  setTransform(a: number, b: number, c: number, d: number, e: number, f: number): void;
+  clearRect(x: number, y: number, width: number, height: number): void;
+  fillRect(x: number, y: number, width: number, height: number): void;
+  fillText(text: string, x: number, y: number): void;
+  measureText(text: string): Pick<TextMetrics, 'width'>;
+}
+
+interface ResizeSubscription {
+  disconnect(): void;
+}
+
+export interface CanvasViewportRendererOptions {
+  context?: CanvasViewportContext | null;
+  getPixelRatio?: () => number;
+  getSize?: () => { width: number; height: number };
+  getStyle?: () => CanvasViewportStyle;
+  observeResize?: (redraw: () => void) => ResizeSubscription;
+}
+
+const CANVAS_CLASS = 'viewport-canvas';
+const ACCESSIBLE_TEXT_CLASS = 'viewport-accessible-text';
+
+export const ensureCanvasViewportElements = (viewport: HTMLElement): CanvasViewportElements => {
+  let canvas = viewport.querySelector<HTMLCanvasElement>(`.${CANVAS_CLASS}`);
+  if (!canvas) {
+    canvas = document.createElement('canvas');
+    canvas.className = CANVAS_CLASS;
+    canvas.setAttribute('aria-hidden', 'true');
+    viewport.prepend(canvas);
+  }
+
+  let accessibleText = viewport.querySelector<HTMLSpanElement>(`.${ACCESSIBLE_TEXT_CLASS}`);
+  if (!accessibleText) {
+    accessibleText = document.createElement('span');
+    accessibleText.className = `visually-hidden ${ACCESSIBLE_TEXT_CLASS}`;
+    accessibleText.setAttribute('data-canvas-text-fallback', '');
+    viewport.append(accessibleText);
+  }
+
+  return { canvas, accessibleText };
+};
+
+export const canvasFrameFromRenderList = (renderList: RenderList): CanvasViewportFrame => {
+  const rows = new Map<number, CanvasViewportSegment[]>();
+  for (const command of renderList.draw) {
+    const segments = rows.get(command.y) ?? [];
+    segments.push(
+      command.type === 'link'
+        ? { type: 'focusable', text: command.text, focused: command.focused }
+        : { type: 'text', text: command.text }
+    );
+    rows.set(command.y, segments);
+  }
+
+  return {
+    rows: Array.from(rows, ([index, segments]) => ({ index, segments })).sort(
+      (left, right) => left.index - right.index
+    )
+  };
+};
+
+export class CanvasViewportRenderer {
+  private readonly context: CanvasViewportContext | null;
+  private readonly getPixelRatio: () => number;
+  private readonly getSize: () => { width: number; height: number };
+  private readonly getStyle: () => CanvasViewportStyle;
+  private readonly resizeSubscription: ResizeSubscription | undefined;
+  private lastFrame: CanvasViewportFrame | null = null;
+
+  constructor(
+    private readonly viewport: HTMLElement,
+    private readonly elements: CanvasViewportElements,
+    options: CanvasViewportRendererOptions = {}
+  ) {
+    this.context =
+      options.context === undefined ? getCanvasContext(elements.canvas) : options.context;
+    this.getPixelRatio = options.getPixelRatio ?? (() => window.devicePixelRatio || 1);
+    this.getSize = options.getSize ?? (() => measureViewport(viewport));
+    this.getStyle = options.getStyle ?? (() => readViewportStyle(viewport));
+    const observeResize = options.observeResize ?? defaultResizeObserver(viewport);
+    this.resizeSubscription = observeResize?.(() => {
+      if (this.lastFrame) {
+        this.render(this.lastFrame);
+      }
+    });
+  }
+
+  render(frame: CanvasViewportFrame): void {
+    const rows = [...frame.rows].sort((left, right) => left.index - right.index);
+    this.lastFrame = { rows };
+    this.elements.accessibleText.textContent = rows
+      .map((row) => row.segments.map((segment) => segment.text).join(''))
+      .join('');
+
+    const context = this.context;
+    if (!context) {
+      return;
+    }
+
+    const style = this.getStyle();
+    const contentHeight = rows.length * style.lineHeight;
+    // Release the previous measured height before reading the viewport. This
+    // lets a handset-scale decrease shrink the surface instead of allowing
+    // the old inline canvas height to keep its parent artificially tall.
+    this.elements.canvas.style.height = `${contentHeight}px`;
+    const measuredSize = this.getSize();
+    const cssWidth = positiveDimension(measuredSize.width, 320);
+    const cssHeight = Math.max(positiveDimension(measuredSize.height, 400), contentHeight);
+    const pixelRatio = positiveDimension(this.getPixelRatio(), 1);
+    const backingWidth = Math.max(1, Math.round(cssWidth * pixelRatio));
+    const backingHeight = Math.max(1, Math.round(cssHeight * pixelRatio));
+
+    if (this.elements.canvas.width !== backingWidth) {
+      this.elements.canvas.width = backingWidth;
+    }
+    if (this.elements.canvas.height !== backingHeight) {
+      this.elements.canvas.height = backingHeight;
+    }
+    this.elements.canvas.style.height = `${cssHeight}px`;
+
+    context.setTransform(1, 0, 0, 1, 0, 0);
+    context.clearRect(0, 0, backingWidth, backingHeight);
+    context.setTransform(pixelRatio, 0, 0, pixelRatio, 0, 0);
+    context.font = style.font;
+    context.textBaseline = 'top';
+
+    rows.forEach((row, rowIndex) => {
+      let cursorX = style.inlinePadding;
+      const rowY = rowIndex * style.lineHeight;
+      for (const segment of row.segments) {
+        const textWidth = context.measureText(segment.text).width;
+        if (segment.type === 'focusable' && segment.focused) {
+          context.fillStyle = style.focusBackground;
+          context.fillRect(cursorX, rowY, textWidth, style.lineHeight);
+          context.fillStyle = style.focusForeground;
+        } else {
+          context.fillStyle = segment.type === 'focusable' ? style.linkColor : style.textColor;
+        }
+        context.fillText(segment.text, cursorX, rowY);
+        if (segment.type === 'focusable' && !segment.focused) {
+          context.fillRect(
+            cursorX,
+            rowY + style.fontSize + style.underlineOffset,
+            textWidth,
+            style.underlineThickness
+          );
+        }
+        cursorX += textWidth;
+      }
+    });
+  }
+
+  dispose(): void {
+    this.resizeSubscription?.disconnect();
+  }
+}
+
+const getCanvasContext = (canvas: HTMLCanvasElement): CanvasViewportContext | null => {
+  // jsdom deliberately has no Canvas implementation. Avoid calling its
+  // not-implemented getContext stub; deterministic unit tests inject a fake.
+  if (typeof CanvasRenderingContext2D === 'undefined') {
+    return null;
+  }
+  return canvas.getContext('2d');
+};
+
+const positiveDimension = (value: number, fallback: number): number =>
+  Number.isFinite(value) && value > 0 ? value : fallback;
+
+const measureViewport = (viewport: HTMLElement): { width: number; height: number } => {
+  const bounds = viewport.getBoundingClientRect();
+  return {
+    width: viewport.clientWidth || bounds.width,
+    height: viewport.clientHeight || bounds.height
+  };
+};
+
+const defaultResizeObserver = (
+  viewport: HTMLElement
+): CanvasViewportRendererOptions['observeResize'] | undefined => {
+  if (typeof ResizeObserver === 'undefined') {
+    return undefined;
+  }
+  return (redraw) => {
+    const observer = new ResizeObserver(redraw);
+    observer.observe(viewport);
+    return observer;
+  };
+};
+
+const readViewportStyle = (viewport: HTMLElement): CanvasViewportStyle => {
+  const computed = getComputedStyle(viewport);
+  const rootComputed = getComputedStyle(document.documentElement);
+  const fontSize = Number.parseFloat(computed.fontSize) || 14;
+  const scale =
+    Number.parseFloat(rootComputed.getPropertyValue('--handset-scale')) || fontSize / 14;
+  const computedLineHeight = Number.parseFloat(computed.lineHeight);
+
+  return {
+    font: computed.font || `${fontSize}px ${computed.fontFamily || "'Courier New', monospace"}`,
+    fontSize,
+    lineHeight: computedLineHeight || fontSize * 1.25,
+    inlinePadding: 3 * scale,
+    underlineOffset: 1 * scale,
+    underlineThickness: Math.max(1, scale),
+    textColor: computed.color || '#415148',
+    linkColor: resolveCssVariable(computed, '--color-lcd-link', '#2252a3'),
+    focusForeground: resolveCssVariable(computed, '--lcd-focus-fg', '#e6e8a3'),
+    focusBackground: resolveCssVariable(computed, '--lcd-focus-bg', '#415148')
+  };
+};
+
+const resolveCssVariable = (
+  computed: CSSStyleDeclaration,
+  property: string,
+  fallback: string
+): string => {
+  let value = computed.getPropertyValue(property).trim();
+  const visited = new Set<string>();
+  while (value.startsWith('var(')) {
+    const match = value.match(/^var\(\s*(--[^,\s)]+)(?:\s*,\s*([^)]*))?\s*\)$/);
+    if (!match) {
+      return fallback;
+    }
+    const nextProperty = match[1];
+    if (!nextProperty || visited.has(nextProperty)) {
+      return fallback;
+    }
+    visited.add(nextProperty);
+    value = computed.getPropertyValue(nextProperty).trim() || match[2]?.trim() || '';
+  }
+  return value || fallback;
+};

--- a/browser/frontend/src/styles.css
+++ b/browser/frontend/src/styles.css
@@ -548,6 +548,7 @@ body:not([data-boot-phase='deck-ready']) .reference-view,
 }
 
 .viewport {
+  position: relative;
   width: calc(320px * var(--handset-scale));
   max-width: calc(100vw - 4rem);
   min-height: calc(400px * var(--handset-scale));
@@ -572,10 +573,28 @@ body:not([data-boot-phase='deck-ready']) .reference-view,
 }
 
 .viewport-skeleton {
+  position: relative;
   display: grid;
   align-content: start;
   gap: calc(8px * var(--handset-scale));
   padding: calc(16px * var(--handset-scale));
+}
+
+.viewport-skeleton.viewport-has-content {
+  display: block;
+  padding: 0;
+}
+
+.viewport-canvas {
+  display: block;
+  width: 100%;
+  min-height: calc(396px * var(--handset-scale));
+}
+
+.viewport-skeleton:not(.viewport-has-content) .viewport-canvas {
+  position: absolute;
+  inset: 0;
+  visibility: hidden;
 }
 
 .skeleton-line {
@@ -611,28 +630,14 @@ body:not([data-boot-phase='deck-ready']) .reference-view,
   content: '';
 }
 
-.line {
-  min-height: calc(1.25em * var(--handset-scale));
-  padding-inline: calc(3px * var(--handset-scale));
-  white-space: pre-wrap;
-  overflow-wrap: anywhere;
-}
-
-.wml-segment {
-  display: inline;
-}
-
-.wml-segment-link {
-  color: var(--color-lcd-link);
-  text-decoration: underline;
-  text-decoration-thickness: max(1px, calc(1px * var(--handset-scale)));
-  text-underline-offset: calc(1px * var(--handset-scale));
-}
-
-.wml-segment-link.is-focused {
-  color: var(--lcd-focus-fg);
-  background: var(--lcd-focus-bg);
-  text-decoration: none;
+.viewport-navigation-hint {
+  position: absolute;
+  z-index: var(--z-raised);
+  inset-inline: calc(10px * var(--handset-scale));
+  inset-block-end: calc(10px * var(--handset-scale));
+  width: fit-content;
+  padding: calc(4px * var(--handset-scale)) calc(6px * var(--handset-scale));
+  background: var(--lcd-bg);
 }
 
 .softkey-row {


### PR DESCRIPTION
## Summary

- replace the Tauri browser frontend's HTML line-injection viewport with a Canvas2D renderer
- preserve RenderList row ordering, focused-link treatment, loading skeletons, navigation progress, status, and timeline behavior
- add a structural presentation-frame seam so F1-03 can switch the renderer input to `EnginePresentationFrame`
- retain a hidden text fallback while the visible deck is painted exclusively through Canvas2D

## User impact

Deck content now renders through a device-pixel-ratio-aware canvas without changing the current handset controls or navigation UX.

## Validation

- `pnpm --dir browser/frontend test` — 245 tests passed
- `pnpm --dir browser/frontend typecheck`
- `pnpm --dir browser/frontend lint`
- `pnpm --dir browser/frontend format:check`
- `pnpm --dir browser/frontend build`
- local Basic Navigation fixture verified in-browser with Canvas2D focus repaint
- repository pre-push hooks passed, including 400 engine tests and Rust/Go/OpenTofu checks
