### PR TITLE
feat(engine): emit bounded debug events and snapshots

### DIFF
--- a/docs/waves/ENGINE_DEBUG_CONNECTOR_PLAN.md
+++ b/docs/waves/ENGINE_DEBUG_CONNECTOR_PLAN.md
@@ -1,6 +1,6 @@
 # Engine Debug Connector Plan
 
-Status: D0-01 done; implementation deferred to D0-02 through D0-04
+Status: D0-01 and D0-02 done; host and consumer implementation deferred to D0-03 and D0-04
 Owner lane: `engine-wasm` + `browser`
 
 Related reference:
@@ -221,16 +221,18 @@ must not include raw internal errors, WML values, URLs, credentials, or panic pa
 This sequence removes the contract-file collision that blocked WBP-06/F0, but does not itself
 activate WBP-06 or implement F0.
 
-## Explicitly Deferred Work
+## Delivery Status and Deferred Work
 
-### D0-02
+### D0-02 (implemented)
 
-- runtime emission points
-- fixed-capacity ring buffer and cursor/drop accounting
-- snapshot construction and ordering
-- sensitive-name derivation tracking and sanitization
-- recorder activation/deactivation hooks
-- native/WASM parity tests for emitted events and snapshots
+- Runtime emission points cover the contract event families at existing deterministic boundaries.
+- The engine-owned source uses fixed-capacity drop-oldest storage with decimal sequence/cursor and
+  exact retained-window drop accounting.
+- Snapshot construction bounds and orders variables/timers and reports collection/buffer summaries.
+- Password inputs, sensitive names and derivations, credential-bearing URLs, transport material,
+  and oversized values are masked or omitted before entering debug DTOs.
+- Recorder activation/deactivation hooks remain separate from D0-03 host policy and sessions.
+- Native and WASM tests cover event/snapshot parity, ordering, overflow, and secret canaries.
 
 ### D0-03
 

--- a/docs/waves/WORK_ITEMS.md
+++ b/docs/waves/WORK_ITEMS.md
@@ -1957,7 +1957,7 @@ Reference plan:
 
 ### D0-02 Engine event stream and snapshot emitter
 
-1. `Status`: `todo`
+1. `Status`: `done`
 2. `Depends On`: `D0-01`
 3. `Owner`: `engine-wasm`
 4. `Files`:
@@ -1989,6 +1989,22 @@ Reference plan:
 9. `Notes`:
 
 - keep emitter path allocation-light and side-effect free for non-debug execution
+- implemented in `engine-wasm/engine/src/engine_debug_recorder.rs` and
+  `engine-wasm/engine/src/engine_runtime_internal/debug.rs`, with recorder state absent until the
+  D0-03-owned host policy activates it
+- all 17 D0-01 event kinds are emitted through payload-derived kind construction; fixed-capacity
+  polling, retained-window drop accounting, bounded snapshots, sorted variables, and deterministic
+  runtime-logical timestamps have direct native tests
+- password/sensitive-name and derived-variable values, credential-bearing URLs, transport-secret
+  post bodies, script trap details, and oversized values are masked or omitted before DTO insertion;
+  native and WASM canary tests assert the raw values never serialize
+- evidence: `engine-wasm/engine/src/engine_tests/debug_recorder.rs` and
+  `engine-wasm/engine/src/engine_wasm_bindings_tests.rs`; `cargo fmt --all -- --check`, `cargo test`
+  (410 tests), warning-denied all-target/all-feature Clippy, and `wasm-pack test --node` (37 tests)
+  pass; `make coverage-rust-engine` reports 94.88% line and 93.04% function coverage, while
+  Rust-owned contract regeneration produces no DTO drift
+- no executable story was added because D0-03 host attach/poll IPC and D0-04 consumer UI remain
+  explicitly out of scope; D0-02 exposes only the engine-owned source hooks
 
 ### D0-03 Host bridge integration for attach/poll/close
 

--- a/engine-wasm/engine/src/engine_debug_recorder.rs
+++ b/engine-wasm/engine/src/engine_debug_recorder.rs
@@ -1,0 +1,400 @@
+use std::collections::{HashMap, VecDeque};
+
+use crate::{
+    EngineDebugBufferSnapshot, EngineDebugError, EngineDebugErrorCode, EngineDebugEvent,
+    EngineDebugEventBatch, EngineDebugEventPayload, EngineDebugRedactionReason, EngineDebugValue,
+    ENGINE_DEBUG_EVENT_BUFFER_CAPACITY, ENGINE_DEBUG_MAX_EVENTS_PER_POLL,
+    ENGINE_DEBUG_MAX_TEXT_BYTES,
+};
+
+#[derive(Clone, Debug)]
+pub(crate) struct EngineDebugRecorder {
+    events: VecDeque<EngineDebugEvent>,
+    capacity: usize,
+    next_seq: u64,
+    dropped_count: u32,
+    monotonic_time_ms: u32,
+    masked_variables: HashMap<String, EngineDebugRedactionReason>,
+}
+
+impl EngineDebugRecorder {
+    pub(crate) fn new() -> Self {
+        Self::with_capacity(ENGINE_DEBUG_EVENT_BUFFER_CAPACITY as usize)
+    }
+
+    fn with_capacity(capacity: usize) -> Self {
+        Self {
+            events: VecDeque::with_capacity(capacity),
+            capacity,
+            next_seq: 1,
+            dropped_count: 0,
+            monotonic_time_ms: 0,
+            masked_variables: HashMap::new(),
+        }
+    }
+
+    pub(crate) fn record(&mut self, card_id: Option<String>, payload: EngineDebugEventPayload) {
+        if self.capacity == 0 {
+            return;
+        }
+        if self.events.len() == self.capacity {
+            self.events.pop_front();
+            self.dropped_count = self.dropped_count.saturating_add(1);
+        }
+        let kind = payload.kind();
+        let event = EngineDebugEvent {
+            seq: self.next_seq.to_string(),
+            kind,
+            monotonic_time_ms: self.monotonic_time_ms,
+            card_id,
+            payload,
+        };
+        debug_assert!(event.has_matching_kind());
+        self.events.push_back(event);
+        self.next_seq = self.next_seq.saturating_add(1);
+    }
+
+    pub(crate) fn advance_time(&mut self, delta_ms: u32) {
+        self.monotonic_time_ms = self.monotonic_time_ms.saturating_add(delta_ms);
+    }
+
+    pub(crate) fn cursor(&self) -> String {
+        self.latest_seq().unwrap_or(0).to_string()
+    }
+
+    pub(crate) fn poll(
+        &self,
+        cursor: &str,
+        max_events: u16,
+    ) -> Result<EngineDebugEventBatch, EngineDebugError> {
+        if max_events == 0 || max_events > ENGINE_DEBUG_MAX_EVENTS_PER_POLL {
+            return Err(debug_error(
+                EngineDebugErrorCode::InvalidRequest,
+                "debug event poll bounds are invalid",
+            ));
+        }
+        let Some(cursor_seq) = parse_cursor(cursor) else {
+            return Err(debug_error(
+                EngineDebugErrorCode::InvalidCursor,
+                "debug event cursor is invalid",
+            ));
+        };
+        let latest_seq = self.latest_seq().unwrap_or(0);
+        if cursor_seq > latest_seq {
+            return Err(debug_error(
+                EngineDebugErrorCode::InvalidCursor,
+                "debug event cursor is invalid",
+            ));
+        }
+
+        let oldest_seq = self.oldest_seq().unwrap_or(cursor_seq.saturating_add(1));
+        let requested_seq = cursor_seq.saturating_add(1);
+        let first_seq = requested_seq.max(oldest_seq);
+        let dropped_count =
+            u32::try_from(oldest_seq.saturating_sub(requested_seq)).unwrap_or(u32::MAX);
+        let events: Vec<_> = self
+            .events
+            .iter()
+            .filter(|event| parse_event_seq(event) >= first_seq)
+            .take(max_events as usize)
+            .cloned()
+            .collect();
+        let next_cursor = events
+            .last()
+            .map(|event| event.seq.clone())
+            .unwrap_or_else(|| cursor.to_string());
+        let next_seq = parse_cursor(&next_cursor).unwrap_or(cursor_seq);
+
+        Ok(EngineDebugEventBatch {
+            events,
+            next_cursor,
+            dropped_count,
+            has_more: next_seq < latest_seq,
+        })
+    }
+
+    pub(crate) fn buffer_snapshot(&self) -> EngineDebugBufferSnapshot {
+        EngineDebugBufferSnapshot {
+            oldest_seq: self.oldest_seq().map(|seq| seq.to_string()),
+            latest_seq: self.latest_seq().map(|seq| seq.to_string()),
+            dropped_count: self.dropped_count,
+            capacity: self.capacity as u32,
+        }
+    }
+
+    pub(crate) fn mark_variable(&mut self, name: String, reason: EngineDebugRedactionReason) {
+        self.masked_variables
+            .entry(name)
+            .and_modify(|current| {
+                if redaction_priority(&reason) < redaction_priority(current) {
+                    *current = reason.clone();
+                }
+            })
+            .or_insert(reason);
+    }
+
+    pub(crate) fn variable_reason(&self, name: &str) -> Option<EngineDebugRedactionReason> {
+        self.masked_variables.get(name).cloned()
+    }
+
+    pub(crate) fn clear_variable_marks(&mut self) {
+        self.masked_variables.clear();
+    }
+
+    fn oldest_seq(&self) -> Option<u64> {
+        self.events.front().map(parse_event_seq)
+    }
+
+    fn latest_seq(&self) -> Option<u64> {
+        self.events.back().map(parse_event_seq)
+    }
+}
+
+pub(crate) fn redaction_priority(reason: &EngineDebugRedactionReason) -> u8 {
+    match reason {
+        EngineDebugRedactionReason::PasswordInput => 0,
+        EngineDebugRedactionReason::SensitiveName => 1,
+        EngineDebugRedactionReason::CredentialBearingUrl => 2,
+        EngineDebugRedactionReason::TransportSecret => 3,
+        EngineDebugRedactionReason::Policy => 4,
+        EngineDebugRedactionReason::BoundedOutput => 5,
+    }
+}
+
+fn parse_event_seq(event: &EngineDebugEvent) -> u64 {
+    event
+        .seq
+        .parse()
+        .expect("recorder-created decimal sequence must parse")
+}
+
+fn parse_cursor(cursor: &str) -> Option<u64> {
+    let parsed = cursor.parse::<u64>().ok()?;
+    (parsed.to_string() == cursor).then_some(parsed)
+}
+
+pub(crate) fn debug_error(code: EngineDebugErrorCode, message: &str) -> EngineDebugError {
+    let retryable = matches!(
+        code,
+        EngineDebugErrorCode::SessionLimitReached
+            | EngineDebugErrorCode::DebugSourceUnavailable
+            | EngineDebugErrorCode::InternalError
+    );
+    EngineDebugError {
+        code,
+        message: message.to_string(),
+        retryable,
+    }
+}
+
+pub(crate) fn sanitize_text(
+    value: &str,
+    reason: Option<EngineDebugRedactionReason>,
+) -> EngineDebugValue {
+    if let Some(reason) = reason {
+        return EngineDebugValue::Masked { reason };
+    }
+    if value.len() > ENGINE_DEBUG_MAX_TEXT_BYTES as usize {
+        return EngineDebugValue::Omitted {
+            reason: EngineDebugRedactionReason::BoundedOutput,
+        };
+    }
+    EngineDebugValue::Visible {
+        value: value.to_string(),
+    }
+}
+
+pub(crate) fn sanitize_url(value: &str) -> EngineDebugValue {
+    if url_contains_credentials(value) {
+        return EngineDebugValue::Masked {
+            reason: EngineDebugRedactionReason::CredentialBearingUrl,
+        };
+    }
+    sanitize_text(value, None)
+}
+
+pub(crate) fn is_sensitive_name(name: &str) -> bool {
+    const SENSITIVE: &[&str] = &[
+        "pin",
+        "pass",
+        "passwd",
+        "password",
+        "secret",
+        "token",
+        "credential",
+        "auth",
+    ];
+
+    let tokens = name_tokens(name);
+    if tokens
+        .iter()
+        .any(|token| SENSITIVE.contains(&token.as_str()))
+    {
+        return true;
+    }
+
+    let collapsed = tokens.concat();
+    collapsed.starts_with("pass")
+        || collapsed.starts_with("auth")
+        || collapsed.ends_with("auth")
+        || ["passwd", "password", "secret", "token", "credential"]
+            .iter()
+            .any(|needle| collapsed.contains(needle))
+}
+
+fn name_tokens(name: &str) -> Vec<String> {
+    let mut tokens = Vec::new();
+    let mut current = String::new();
+    let mut previous_was_lower_or_digit = false;
+    for character in name.chars() {
+        if !character.is_ascii_alphanumeric() {
+            if !current.is_empty() {
+                tokens.push(std::mem::take(&mut current));
+            }
+            previous_was_lower_or_digit = false;
+            continue;
+        }
+        if character.is_ascii_uppercase() && previous_was_lower_or_digit && !current.is_empty() {
+            tokens.push(std::mem::take(&mut current));
+        }
+        current.push(character.to_ascii_lowercase());
+        previous_was_lower_or_digit = character.is_ascii_lowercase() || character.is_ascii_digit();
+    }
+    if !current.is_empty() {
+        tokens.push(current);
+    }
+    tokens
+}
+
+fn url_contains_credentials(value: &str) -> bool {
+    if let Ok(parsed) = url::Url::parse(value) {
+        if !parsed.username().is_empty() || parsed.password().is_some() {
+            return true;
+        }
+        if parsed
+            .query_pairs()
+            .any(|(name, _)| sensitive_query_name(name.as_ref()))
+        {
+            return true;
+        }
+    }
+
+    value
+        .split_once('?')
+        .map(|(_, query)| {
+            url::form_urlencoded::parse(query.as_bytes())
+                .any(|(name, _)| sensitive_query_name(name.as_ref()))
+        })
+        .unwrap_or(false)
+}
+
+fn sensitive_query_name(name: &str) -> bool {
+    is_sensitive_name(name)
+        || matches!(
+            name.to_ascii_lowercase().as_str(),
+            "api_key"
+                | "apikey"
+                | "access_key"
+                | "signature"
+                | "sig"
+                | "sessionid"
+                | "session_id"
+                | "jwt"
+                | "cookie"
+        )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn payload(index: usize) -> EngineDebugEventPayload {
+        EngineDebugEventPayload::InputEditDraft {
+            name: "field".to_string(),
+            value: EngineDebugValue::Visible {
+                value: index.to_string(),
+            },
+        }
+    }
+
+    #[test]
+    fn fixed_capacity_poll_resumes_at_oldest_and_reports_exact_gap() {
+        let mut recorder = EngineDebugRecorder::with_capacity(3);
+        for index in 0..5 {
+            recorder.record(None, payload(index));
+        }
+
+        let batch = recorder.poll("0", 3).expect("old cursor should resume");
+        assert_eq!(
+            batch
+                .events
+                .iter()
+                .map(|event| event.seq.as_str())
+                .collect::<Vec<_>>(),
+            ["3", "4", "5"]
+        );
+        assert_eq!(batch.dropped_count, 2);
+        assert_eq!(batch.next_cursor, "5");
+        assert!(!batch.has_more);
+        assert_eq!(recorder.buffer_snapshot().dropped_count, 2);
+    }
+
+    #[test]
+    fn polling_is_bounded_and_rejects_malformed_or_forward_cursors() {
+        let mut recorder = EngineDebugRecorder::with_capacity(4);
+        recorder.record(None, payload(1));
+        recorder.record(None, payload(2));
+
+        let first = recorder.poll("0", 1).expect("first page should poll");
+        assert_eq!(first.events.len(), 1);
+        assert_eq!(first.next_cursor, "1");
+        assert!(first.has_more);
+
+        for cursor in ["", "01", " 1", "3"] {
+            assert_eq!(
+                recorder.poll(cursor, 1).expect_err("cursor must fail").code,
+                EngineDebugErrorCode::InvalidCursor
+            );
+        }
+        assert_eq!(
+            recorder
+                .poll("0", 0)
+                .expect_err("zero bound must fail")
+                .code,
+            EngineDebugErrorCode::InvalidRequest
+        );
+    }
+
+    #[test]
+    fn sanitizer_masks_sensitive_names_urls_and_oversized_values() {
+        for name in [
+            "PIN",
+            "user_password",
+            "authToken",
+            "clientCredential",
+            "passcode",
+        ] {
+            assert!(is_sensitive_name(name), "{name} should be sensitive");
+        }
+        assert!(!is_sensitive_name("shipping"));
+        assert!(!is_sensitive_name("compassion"));
+        assert!(matches!(
+            sanitize_url("https://user:canary@example.test/path"),
+            EngineDebugValue::Masked {
+                reason: EngineDebugRedactionReason::CredentialBearingUrl
+            }
+        ));
+        assert!(matches!(
+            sanitize_url("/submit?access_token=canary"),
+            EngineDebugValue::Masked {
+                reason: EngineDebugRedactionReason::CredentialBearingUrl
+            }
+        ));
+        assert!(matches!(
+            sanitize_text(&"x".repeat(ENGINE_DEBUG_MAX_TEXT_BYTES as usize + 1), None),
+            EngineDebugValue::Omitted {
+                reason: EngineDebugRedactionReason::BoundedOutput
+            }
+        ));
+    }
+}

--- a/engine-wasm/engine/src/engine_public_api.rs
+++ b/engine-wasm/engine/src/engine_public_api.rs
@@ -30,6 +30,7 @@ impl WmlEngine {
             last_back_navigation_handled: false,
             last_wml_load_diagnostics: Vec::new(),
             browser_context_epoch: 0,
+            debug_recorder: None,
         }
     }
 
@@ -202,10 +203,33 @@ impl WmlEngine {
             ));
         }
         let previous_context_epoch = self.browser_context_epoch;
+        let previous_card_id = self.debug_recorder.as_ref().and_then(|_| {
+            self.deck
+                .as_ref()
+                .and_then(|deck| deck.cards.get(self.active_card_idx))
+                .map(|card| card.id.clone())
+        });
+        let previous_timer_token = self
+            .debug_recorder
+            .as_ref()
+            .and(self.active_timer.as_ref())
+            .map(|timer| {
+                timer
+                    .name
+                    .clone()
+                    .unwrap_or_else(|| "card-timer".to_string())
+            });
+        let previous_input_edit_name = self
+            .debug_recorder
+            .as_ref()
+            .and(self.active_input_edit.as_ref())
+            .map(|edit| edit.input_name.clone());
         let mut next = WmlEngine::new();
         next.viewport_cols = self.viewport_cols;
+        next.debug_recorder = self.debug_recorder.clone();
         if navigation.kind == DeckNavigationKind::Independent {
             next.browser_context_epoch = previous_context_epoch.saturating_add(1);
+            next.debug_clear_variable_marks();
         } else {
             next.browser_context_epoch = previous_context_epoch;
             next.vars = self.vars.clone();
@@ -237,6 +261,37 @@ impl WmlEngine {
                 "NEWCONTEXT",
                 format!("target={}", next.active_card_id().unwrap_or_default()),
             );
+        }
+        if next.debug_recorder.is_some() {
+            if previous_card_id.is_some() {
+                next.debug_emit_for_card(
+                    previous_card_id.clone(),
+                    EngineDebugEventPayload::CardExit,
+                );
+            }
+            if let Some(token) = previous_timer_token {
+                let reason = crate::engine_debug_recorder::is_sensitive_name(&token)
+                    .then_some(EngineDebugRedactionReason::SensitiveName);
+                next.debug_emit_for_card(
+                    previous_card_id.clone(),
+                    EngineDebugEventPayload::TimerCancel {
+                        token: crate::engine_debug_recorder::sanitize_text(&token, reason),
+                    },
+                );
+            }
+            if let Some(name) = previous_input_edit_name {
+                next.debug_emit_for_card(
+                    previous_card_id,
+                    EngineDebugEventPayload::InputEditCancel { name },
+                );
+            }
+            let card_count = next.deck.as_ref().map_or(0, |deck| deck.cards.len());
+            next.debug_emit(EngineDebugEventPayload::DeckLoad {
+                base_url: crate::engine_debug_recorder::sanitize_url(base_url),
+                content_type: content_type.to_string(),
+                card_count: u32::try_from(card_count).unwrap_or(u32::MAX),
+            });
+            next.debug_emit(EngineDebugEventPayload::CardEnter);
         }
         next.push_trace("LOAD_DECK", format!("contentType={content_type}"));
         next.initialize_controls_on_active_card()
@@ -571,6 +626,12 @@ impl WmlEngine {
                     .and_then(|deck| deck.active_do_action_by_name(self.active_card_idx, name))
                     .cloned()
                     .ok_or_else(|| "Engine input references an unavailable action".to_string())?;
+                if name == "accept" {
+                    self.debug_emit_lazy(|| EngineDebugEventPayload::ActionAccept {
+                        action_type: "accept".to_string(),
+                        name: Some(name.to_string()),
+                    });
+                }
                 self.push_trace("ACTION_AFFORDANCE", format!("action_id={action_id}"));
                 self.execute_card_task_action(&action)
             }
@@ -652,12 +713,27 @@ impl WmlEngine {
         };
         let max_len = self.input_max_len_on_active_card(&control_id);
         let draft = truncate_to_chars(&value, max_len);
-        if let Some(edit) = self.active_input_edit.as_mut() {
+        let recording = self.debug_recorder.is_some();
+        let event = if let Some(edit) = self.active_input_edit.as_mut() {
             edit.draft_value = draft;
-            true
+            recording.then(|| {
+                (
+                    edit.control_id.clone(),
+                    edit.input_name.clone(),
+                    edit.draft_value.clone(),
+                )
+            })
         } else {
-            false
+            None
+        };
+        if let Some((control_id, input_name, draft_value)) = event {
+            let reason = self.debug_input_reason(&control_id, &input_name);
+            self.debug_emit(EngineDebugEventPayload::InputEditDraft {
+                name: input_name,
+                value: crate::engine_debug_recorder::sanitize_text(&draft_value, reason),
+            });
         }
+        true
     }
 
     /// Commit active focused-input edit session.
@@ -669,11 +745,7 @@ impl WmlEngine {
 
     /// Cancel active focused-input edit session.
     pub fn cancel_focused_input_edit(&mut self) -> bool {
-        if self.active_input_edit.is_none() {
-            return false;
-        }
-        self.active_input_edit = None;
-        true
+        self.cancel_active_input_edit_with_debug()
     }
 
     /// Start edit session for the currently focused select control.
@@ -1023,6 +1095,60 @@ impl WmlEngine {
     pub fn clear_trace_entries(&mut self) {
         self.trace_entries.clear();
         self.next_trace_seq = 1;
+    }
+
+    /// Enable or disable the engine-owned debug source.
+    ///
+    /// Enabling starts a fresh bounded recorder. Repeating the current state
+    /// is idempotent. Host policy and session lifecycle remain D0-03-owned.
+    pub fn set_debug_recording_enabled(&mut self, enabled: bool) {
+        match (enabled, self.debug_recorder.is_some()) {
+            (true, false) => {
+                self.debug_recorder = Some(crate::engine_debug_recorder::EngineDebugRecorder::new())
+            }
+            (false, true) => self.debug_recorder = None,
+            (true, true) | (false, false) => {}
+        }
+    }
+
+    /// Return whether the engine-owned debug source is active.
+    pub fn debug_recording_enabled(&self) -> bool {
+        self.debug_recorder.is_some()
+    }
+
+    /// Return the recorder's current cursor for a newly attached host session.
+    pub fn debug_event_cursor(&self) -> Result<String, EngineDebugError> {
+        self.debug_recorder
+            .as_ref()
+            .map(crate::engine_debug_recorder::EngineDebugRecorder::cursor)
+            .ok_or_else(|| {
+                crate::engine_debug_recorder::debug_error(
+                    EngineDebugErrorCode::DebugSourceUnavailable,
+                    "debug recorder is disabled",
+                )
+            })
+    }
+
+    /// Read a bounded debug event batch without mutating recorder state.
+    pub fn poll_debug_events(
+        &self,
+        cursor: &str,
+        max_events: u16,
+    ) -> Result<EngineDebugEventBatch, EngineDebugError> {
+        self.debug_recorder
+            .as_ref()
+            .ok_or_else(|| {
+                crate::engine_debug_recorder::debug_error(
+                    EngineDebugErrorCode::DebugSourceUnavailable,
+                    "debug recorder is disabled",
+                )
+            })?
+            .poll(cursor, max_events)
+    }
+
+    /// Construct a bounded, sanitized, read-only runtime snapshot.
+    pub fn debug_snapshot(&self) -> Result<EngineDebugSnapshot, EngineDebugError> {
+        self.debug_snapshot_internal()
     }
 }
 

--- a/engine-wasm/engine/src/engine_runtime_internal.rs
+++ b/engine-wasm/engine/src/engine_runtime_internal.rs
@@ -4,6 +4,7 @@ use crate::runtime::variable::{
 };
 use crate::*;
 
+mod debug;
 mod navigation;
 mod node_lookup;
 mod script_effects;
@@ -45,6 +46,31 @@ impl WmlEngine {
     }
 
     pub(crate) fn execute_script_ref_call_internal(
+        &mut self,
+        src: &str,
+        function_name: &str,
+        args: &[ScriptValue],
+    ) -> ScriptExecutionOutcome {
+        if self.debug_recorder.is_some() {
+            self.debug_emit(EngineDebugEventPayload::ScriptInvoke {
+                source: crate::engine_debug_recorder::sanitize_url(src),
+                function_name: self.debug_safe_function_name(function_name),
+            });
+        }
+        let outcome = self.execute_script_ref_call_uninstrumented(src, function_name, args);
+        if outcome.trap.is_some() && self.debug_recorder.is_some() {
+            self.debug_emit(EngineDebugEventPayload::ScriptTrap {
+                source: crate::engine_debug_recorder::sanitize_url(src),
+                function_name: self.debug_safe_function_name(function_name),
+                detail: EngineDebugValue::Omitted {
+                    reason: EngineDebugRedactionReason::Policy,
+                },
+            });
+        }
+        outcome
+    }
+
+    fn execute_script_ref_call_uninstrumented(
         &mut self,
         src: &str,
         function_name: &str,
@@ -231,7 +257,10 @@ impl WmlEngine {
                 if self.active_input_edit.is_some() {
                     self.commit_focused_input_edit_internal()?;
                 }
-                self.focused_link_idx = move_focus_up(self.focused_link_idx, target_total);
+                self.set_focused_link_idx_with_debug(move_focus_up(
+                    self.focused_link_idx,
+                    target_total,
+                ));
             }
             "down" => {
                 if self.active_select_edit.is_some() {
@@ -241,12 +270,19 @@ impl WmlEngine {
                 if self.active_input_edit.is_some() {
                     self.commit_focused_input_edit_internal()?;
                 }
-                self.focused_link_idx = move_focus_down(self.focused_link_idx, target_total);
+                self.set_focused_link_idx_with_debug(move_focus_down(
+                    self.focused_link_idx,
+                    target_total,
+                ));
             }
             "enter" => {
                 if target_total == 0 {
                     if let Some(action) = accept_action {
                         self.push_trace("ACTION_ACCEPT", String::new());
+                        self.debug_emit_lazy(|| EngineDebugEventPayload::ActionAccept {
+                            action_type: "accept".to_string(),
+                            name: None,
+                        });
                         self.execute_card_task_action(&action)?;
                     }
                     return Ok(());
@@ -263,10 +299,18 @@ impl WmlEngine {
                             self.commit_focused_input_edit_internal()?;
                             if let Some(action) = accept_action {
                                 self.push_trace("ACTION_ACCEPT", String::new());
+                                self.debug_emit_lazy(|| EngineDebugEventPayload::ActionAccept {
+                                    action_type: "accept".to_string(),
+                                    name: None,
+                                });
                                 self.execute_card_task_action(&action)?;
                             }
                         } else if let Some(action) = accept_action {
                             self.push_trace("ACTION_ACCEPT", String::new());
+                            self.debug_emit_lazy(|| EngineDebugEventPayload::ActionAccept {
+                                action_type: "accept".to_string(),
+                                name: None,
+                            });
                             self.execute_card_task_action(&action)?;
                         } else {
                             self.begin_focused_input_edit_internal()?;
@@ -274,7 +318,7 @@ impl WmlEngine {
                         return Ok(());
                     }
                     FocusTarget::Select(name) => {
-                        self.active_input_edit = None;
+                        self.cancel_active_input_edit_with_debug();
                         self.push_trace("ACTION_SELECT", name.clone());
                         if self.active_select_edit.is_some() {
                             self.commit_focused_select_edit_internal()?;
@@ -284,7 +328,7 @@ impl WmlEngine {
                         return Ok(());
                     }
                     FocusTarget::Link(href) => {
-                        self.active_input_edit = None;
+                        self.cancel_active_input_edit_with_debug();
                         self.active_select_edit = None;
                         self.execute_action_href(href)?;
                     }
@@ -304,11 +348,22 @@ impl WmlEngine {
             .input_value_on_active_card(&control_id)
             .unwrap_or_default();
         self.active_select_edit = None;
+        let debug_reason = self
+            .debug_recorder
+            .is_some()
+            .then(|| self.debug_input_reason(&control_id, &input_name))
+            .flatten();
         self.active_input_edit = Some(InputEditState {
             control_id,
             input_name: input_name.clone(),
             original_value: current.clone(),
             draft_value: current,
+        });
+        if let Some(reason) = debug_reason {
+            self.debug_mark_variable(input_name.clone(), reason);
+        }
+        self.debug_emit_lazy(|| EngineDebugEventPayload::InputEditStart {
+            name: input_name.clone(),
         });
         self.push_trace("INPUT_EDIT_START", input_name);
         Ok(true)
@@ -343,6 +398,16 @@ impl WmlEngine {
             return Ok(false);
         }
         self.set_var(edit.input_name.clone(), edit.draft_value.clone());
+        if self.debug_recorder.is_some() {
+            let reason = self.debug_input_reason(&edit.control_id, &edit.input_name);
+            if let Some(reason) = reason.clone() {
+                self.debug_mark_variable(edit.input_name.clone(), reason);
+            }
+            self.debug_emit(EngineDebugEventPayload::InputEditCommit {
+                name: edit.input_name.clone(),
+                value: crate::engine_debug_recorder::sanitize_text(&edit.draft_value, reason),
+            });
+        }
         self.active_input_edit = None;
         self.push_trace("INPUT_EDIT_COMMIT", edit.input_name);
         Ok(true)
@@ -414,7 +479,7 @@ impl WmlEngine {
         let Some(current_index) = self.select_selected_index_on_active_card(&select_name) else {
             return Ok(false);
         };
-        self.active_input_edit = None;
+        self.cancel_active_input_edit_with_debug();
         self.active_select_edit = Some(SelectEditState {
             select_name: select_name.clone(),
             draft_index: current_index,

--- a/engine-wasm/engine/src/engine_runtime_internal/debug.rs
+++ b/engine-wasm/engine/src/engine_runtime_internal/debug.rs
@@ -1,0 +1,276 @@
+use crate::engine_debug_recorder::{debug_error, is_sensitive_name, sanitize_text, sanitize_url};
+use crate::*;
+
+use super::node_lookup;
+
+impl WmlEngine {
+    pub(crate) fn debug_emit(&mut self, payload: EngineDebugEventPayload) {
+        if self.debug_recorder.is_none() {
+            return;
+        }
+        let card_id = self
+            .deck
+            .as_ref()
+            .and_then(|deck| deck.cards.get(self.active_card_idx))
+            .map(|card| card.id.clone());
+        if let Some(recorder) = self.debug_recorder.as_mut() {
+            recorder.record(card_id, payload);
+        }
+    }
+
+    pub(crate) fn debug_emit_lazy(&mut self, build: impl FnOnce() -> EngineDebugEventPayload) {
+        if self.debug_recorder.is_none() {
+            return;
+        }
+        self.debug_emit(build());
+    }
+
+    pub(crate) fn debug_emit_for_card(
+        &mut self,
+        card_id: Option<String>,
+        payload: EngineDebugEventPayload,
+    ) {
+        if let Some(recorder) = self.debug_recorder.as_mut() {
+            recorder.record(card_id, payload);
+        }
+    }
+
+    pub(crate) fn debug_advance_time(&mut self, delta_ms: u32) {
+        if let Some(recorder) = self.debug_recorder.as_mut() {
+            recorder.advance_time(delta_ms);
+        }
+    }
+
+    pub(crate) fn set_focused_link_idx_with_debug(&mut self, next_index: usize) {
+        let previous_index = self.focused_link_idx;
+        self.focused_link_idx = next_index;
+        if previous_index == next_index {
+            return;
+        }
+        self.debug_emit(EngineDebugEventPayload::FocusChange {
+            previous_index: u32::try_from(previous_index).ok(),
+            current_index: u32::try_from(next_index).ok(),
+        });
+    }
+
+    pub(crate) fn cancel_active_input_edit_with_debug(&mut self) -> bool {
+        let Some(edit) = self.active_input_edit.take() else {
+            return false;
+        };
+        self.debug_emit_lazy(|| EngineDebugEventPayload::InputEditCancel {
+            name: edit.input_name,
+        });
+        true
+    }
+
+    pub(crate) fn debug_input_reason(
+        &self,
+        control_id: &str,
+        name: &str,
+    ) -> Option<EngineDebugRedactionReason> {
+        if self
+            .deck
+            .as_ref()
+            .and_then(|deck| deck.cards.get(self.active_card_idx))
+            .and_then(|card| node_lookup::find_input(card, control_id))
+            .is_some_and(|input| input.is_password)
+        {
+            return Some(EngineDebugRedactionReason::PasswordInput);
+        }
+        self.debug_variable_reason(name)
+    }
+
+    pub(crate) fn debug_variable_reason(&self, name: &str) -> Option<EngineDebugRedactionReason> {
+        if self.deck.as_ref().is_some_and(|deck| {
+            deck.cards.iter().any(|card| {
+                node_lookup::inputs(card).any(|input| input.name == name && input.is_password)
+            })
+        }) {
+            return Some(EngineDebugRedactionReason::PasswordInput);
+        }
+        if is_sensitive_name(name) {
+            return Some(EngineDebugRedactionReason::SensitiveName);
+        }
+        self.debug_recorder
+            .as_ref()
+            .and_then(|recorder| recorder.variable_reason(name))
+    }
+
+    pub(crate) fn debug_mark_variable(&mut self, name: String, reason: EngineDebugRedactionReason) {
+        if let Some(recorder) = self.debug_recorder.as_mut() {
+            recorder.mark_variable(name, reason);
+        }
+    }
+
+    pub(crate) fn debug_assignment_marks(
+        &self,
+        assignments: &[(String, String)],
+    ) -> Vec<(String, EngineDebugRedactionReason)> {
+        if self.debug_recorder.is_none() {
+            return Vec::new();
+        }
+        assignments
+            .iter()
+            .filter_map(|(name, value)| {
+                self.debug_value_reason(value)
+                    .map(|reason| (name.clone(), reason))
+            })
+            .collect()
+    }
+
+    pub(crate) fn debug_value_reason(&self, value: &str) -> Option<EngineDebugRedactionReason> {
+        if value.is_empty() || self.debug_recorder.is_none() {
+            return None;
+        }
+        self.vars
+            .iter()
+            .filter(|(_, candidate)| candidate.as_str() == value)
+            .filter_map(|(name, _)| self.debug_variable_reason(name))
+            .min_by_key(crate::engine_debug_recorder::redaction_priority)
+    }
+
+    pub(crate) fn debug_safe_label(&self, value: &str) -> String {
+        if self.debug_value_reason(value).is_some() {
+            "<masked>".to_string()
+        } else {
+            value.to_string()
+        }
+    }
+
+    pub(crate) fn debug_safe_function_name(&self, value: &str) -> String {
+        if is_sensitive_name(value) {
+            "<masked>".to_string()
+        } else {
+            self.debug_safe_label(value)
+        }
+    }
+
+    pub(crate) fn debug_clear_variable_marks(&mut self) {
+        if let Some(recorder) = self.debug_recorder.as_mut() {
+            recorder.clear_variable_marks();
+        }
+    }
+
+    pub(crate) fn debug_snapshot_internal(&self) -> Result<EngineDebugSnapshot, EngineDebugError> {
+        let Some(recorder) = self.debug_recorder.as_ref() else {
+            return Err(debug_error(
+                EngineDebugErrorCode::DebugSourceUnavailable,
+                "debug recorder is disabled",
+            ));
+        };
+
+        let mut variables: Vec<_> = self.vars.iter().collect();
+        variables.sort_by(|(left, _), (right, _)| left.cmp(right));
+        let total_variables = variables.len();
+        let runtime_vars = variables
+            .into_iter()
+            .take(ENGINE_DEBUG_MAX_SNAPSHOT_VARIABLES as usize)
+            .map(|(name, value)| EngineDebugNamedValue {
+                name: self.debug_safe_label(name),
+                value: sanitize_text(value, self.debug_variable_reason(name)),
+            })
+            .collect::<Vec<_>>();
+
+        let focused_input_edit =
+            self.active_input_edit
+                .as_ref()
+                .map(|edit| EngineDebugNamedValue {
+                    name: edit.input_name.clone(),
+                    value: sanitize_text(
+                        &edit.draft_value,
+                        self.debug_input_reason(&edit.control_id, &edit.input_name),
+                    ),
+                });
+
+        let timers = self
+            .active_timer
+            .as_ref()
+            .into_iter()
+            .take(ENGINE_DEBUG_MAX_SNAPSHOT_TIMERS as usize)
+            .map(|timer| {
+                let token = timer.name.as_deref().unwrap_or("card-timer");
+                EngineDebugTimerSnapshot {
+                    remaining_ms: timer.remaining_ms,
+                    token: sanitize_text(
+                        token,
+                        is_sensitive_name(token)
+                            .then_some(EngineDebugRedactionReason::SensitiveName),
+                    ),
+                }
+            })
+            .collect::<Vec<_>>();
+        let total_timers = usize::from(self.active_timer.is_some());
+
+        Ok(EngineDebugSnapshot {
+            protocol_version: ENGINE_DEBUG_PROTOCOL_VERSION,
+            captured_seq: recorder.cursor(),
+            active_card_id: self
+                .deck
+                .as_ref()
+                .and_then(|deck| deck.cards.get(self.active_card_idx))
+                .map(|card| card.id.clone()),
+            focused_link_index: to_debug_count(self.focused_link_idx),
+            focused_input_edit,
+            runtime_vars_summary: collection_summary(total_variables, runtime_vars.len()),
+            runtime_vars,
+            pending_external_navigation: self.debug_external_navigation_snapshot(),
+            timers_summary: collection_summary(total_timers, timers.len()),
+            timers,
+            buffer: recorder.buffer_snapshot(),
+            viewport_cols: to_debug_count(self.viewport_cols),
+            base_url: sanitize_url(&self.base_url),
+            content_type: self.content_type.clone(),
+        })
+    }
+
+    fn debug_external_navigation_snapshot(&self) -> Option<EngineDebugExternalNavigationSnapshot> {
+        let target = self.external_nav_intent.as_deref()?;
+        let policy = self.external_nav_request_policy.as_ref();
+        let method = policy
+            .and_then(|policy| policy.request_intent.as_ref())
+            .map(|intent| match intent.method {
+                ScriptNavigationMethodLiteral::Get => "get".to_string(),
+                ScriptNavigationMethodLiteral::Post => "post".to_string(),
+            });
+        let referer_url = policy
+            .and_then(|policy| policy.referer_url.as_deref())
+            .map(sanitize_url);
+        let post_body = policy
+            .and_then(|policy| policy.post_context.as_ref())
+            .and_then(|post_context| post_context.payload.as_deref())
+            .map(|payload| {
+                let contains_secret = policy
+                    .and_then(|policy| policy.request_intent.as_ref())
+                    .is_some_and(|intent| {
+                        intent.post_fields.iter().any(|field| {
+                            self.debug_variable_reason(&field.name).is_some()
+                                || self.debug_value_reason(&field.name).is_some()
+                                || is_sensitive_name(&field.name)
+                        })
+                    });
+                sanitize_text(
+                    payload,
+                    contains_secret.then_some(EngineDebugRedactionReason::TransportSecret),
+                )
+            });
+
+        Some(EngineDebugExternalNavigationSnapshot {
+            target: sanitize_url(target),
+            method,
+            referer_url,
+            post_body,
+        })
+    }
+}
+
+fn collection_summary(total: usize, returned: usize) -> EngineDebugCollectionSummary {
+    EngineDebugCollectionSummary {
+        total_count: to_debug_count(total),
+        returned_count: to_debug_count(returned),
+        truncated: returned < total,
+    }
+}
+
+fn to_debug_count(value: usize) -> u32 {
+    u32::try_from(value).unwrap_or(u32::MAX)
+}

--- a/engine-wasm/engine/src/engine_runtime_internal/debug.rs
+++ b/engine-wasm/engine/src/engine_runtime_internal/debug.rs
@@ -160,7 +160,7 @@ impl WmlEngine {
         };
 
         let mut variables: Vec<_> = self.vars.iter().collect();
-        variables.sort_by(|(left, _), (right, _)| left.cmp(right));
+        variables.sort_by_key(|(name, _)| *name);
         let total_variables = variables.len();
         let runtime_vars = variables
             .into_iter()

--- a/engine-wasm/engine/src/engine_runtime_internal/navigation.rs
+++ b/engine-wasm/engine/src/engine_runtime_internal/navigation.rs
@@ -111,8 +111,9 @@ impl WmlEngine {
         // state, so the engine ends up back on the last card that was fully,
         // successfully entered before the cycle was detected.
         let nav = NavRollbackGuard::forward(self);
+        nav.engine.debug_emit(EngineDebugEventPayload::CardExit);
         nav.engine.stop_active_timer_for_exit();
-        nav.engine.active_input_edit = None;
+        nav.engine.cancel_active_input_edit_with_debug();
         nav.engine.active_select_edit = None;
         let previous_idx = nav.engine.active_card_idx;
         if reset_context {
@@ -122,7 +123,8 @@ impl WmlEngine {
             nav.engine.nav_stack.push(previous_idx);
         }
         nav.engine.active_card_idx = next_idx;
-        nav.engine.focused_link_idx = 0;
+        nav.engine.set_focused_link_idx_with_debug(0);
+        nav.engine.debug_emit(EngineDebugEventPayload::CardEnter);
         nav.engine.initialize_controls_on_active_card()?;
         if nav.engine.run_onenterforward_for_active_card()? {
             nav.commit();
@@ -153,12 +155,13 @@ impl WmlEngine {
     pub(crate) fn reset_browser_context_state(&mut self) {
         self.browser_context_epoch = self.browser_context_epoch.saturating_add(1);
         self.vars.clear();
+        self.debug_clear_variable_marks();
         self.nav_stack.clear();
         self.focused_link_idx = 0;
         self.external_nav_intent = None;
         self.external_nav_request_policy = None;
         self.active_timer = None;
-        self.active_input_edit = None;
+        self.cancel_active_input_edit_with_debug();
         self.active_select_edit = None;
     }
 
@@ -190,11 +193,13 @@ impl WmlEngine {
             return false;
         };
 
+        nav.engine.debug_emit(EngineDebugEventPayload::CardExit);
         nav.engine.stop_active_timer_for_exit();
-        nav.engine.active_input_edit = None;
+        nav.engine.cancel_active_input_edit_with_debug();
         nav.engine.active_select_edit = None;
         nav.engine.active_card_idx = back_target_idx;
-        nav.engine.focused_link_idx = 0;
+        nav.engine.set_focused_link_idx_with_debug(0);
+        nav.engine.debug_emit(EngineDebugEventPayload::CardEnter);
         if let Err(err) = nav.engine.apply_set_var_assignments(assignments) {
             nav.engine.push_trace("SETVAR_BUDGET_ERROR", err);
             return true;
@@ -334,24 +339,41 @@ impl WmlEngine {
             if request.cache_control.as_deref() == Some("no-cache") {
                 let resolved_href = self.resolve_external_href(href);
                 self.push_trace("ACTION_EXTERNAL", resolved_href.clone());
+                if self.debug_recorder.is_some() {
+                    let target = crate::engine_debug_recorder::sanitize_url(&resolved_href);
+                    self.debug_emit(EngineDebugEventPayload::ActionExternal {
+                        target: target.clone(),
+                    });
+                    self.debug_emit(EngineDebugEventPayload::NavigationIntent { target });
+                }
                 self.external_nav_intent = Some(resolved_href.clone());
                 self.external_nav_request_policy =
                     Some(self.wml_go_request_policy(&resolved_href, request)?);
-                self.active_input_edit = None;
+                self.cancel_active_input_edit_with_debug();
                 self.active_select_edit = None;
                 return Ok(());
             }
             self.push_trace("ACTION_FRAGMENT", card_id.to_string());
+            self.debug_emit_lazy(|| EngineDebugEventPayload::NavigationIntent {
+                target: crate::engine_debug_recorder::sanitize_url(href),
+            });
             self.navigate_to_card_internal(card_id)?;
             return Ok(());
         }
 
-        self.push_trace("ACTION_EXTERNAL", href.to_string());
         let resolved_href = self.resolve_external_href(href);
+        self.push_trace("ACTION_EXTERNAL", href.to_string());
+        if self.debug_recorder.is_some() {
+            let target = crate::engine_debug_recorder::sanitize_url(&resolved_href);
+            self.debug_emit(EngineDebugEventPayload::ActionExternal {
+                target: target.clone(),
+            });
+            self.debug_emit(EngineDebugEventPayload::NavigationIntent { target });
+        }
         self.external_nav_intent = Some(resolved_href.clone());
         self.external_nav_request_policy =
             Some(self.wml_go_request_policy(&resolved_href, request)?);
-        self.active_input_edit = None;
+        self.cancel_active_input_edit_with_debug();
         self.active_select_edit = None;
         Ok(())
     }
@@ -372,12 +394,17 @@ impl WmlEngine {
         &mut self,
         assignments: &[(String, String)],
     ) -> Result<(), String> {
+        let debug_marks = self.debug_assignment_marks(assignments);
         let valid_assignments: Vec<(String, String)> = assignments
             .iter()
             .filter(|(name, _)| is_valid_name(name))
             .cloned()
             .collect();
-        checked_apply_assignments(&mut self.vars, &valid_assignments)
+        checked_apply_assignments(&mut self.vars, &valid_assignments)?;
+        for (name, reason) in debug_marks {
+            self.debug_mark_variable(name, reason);
+        }
+        Ok(())
     }
 
     pub(crate) fn resolve_external_href(&self, href: &str) -> String {
@@ -407,7 +434,7 @@ impl WmlEngine {
     }
 
     fn wml_go_request_policy(
-        &self,
+        &mut self,
         resolved_href: &str,
         request: &CardGoRequest,
     ) -> Result<ScriptNavigationRequestPolicyLiteral, String> {
@@ -454,37 +481,76 @@ impl WmlEngine {
     }
 
     fn resolve_post_fields(
-        &self,
+        &mut self,
         post_fields: &[CardPostField],
     ) -> Result<Vec<ScriptNavigationPostFieldLiteral>, String> {
-        post_fields
-            .iter()
-            .map(|field| {
-                let name = evaluate_vdata(&field.name, &self.vars)?;
-                let value = if field.value.is_empty() {
+        let recording = self.debug_recorder.is_some();
+        let mut resolved_fields = Vec::with_capacity(post_fields.len());
+        let mut debug_fields = Vec::new();
+        for field in post_fields {
+            let name = evaluate_vdata(&field.name, &self.vars)?;
+            let mut source_name = None;
+            let (value, source) = if field.value.is_empty() {
+                self.resolve_post_field_name_fallback(&name)
+            } else if let Some(variable_name) = field
+                .value
+                .strip_prefix("$(")
+                .and_then(|value| value.strip_suffix(')'))
+            {
+                let variable_name = variable_name.trim();
+                if recording {
+                    source_name = Some(variable_name.to_string());
+                }
+                let resolved = self.resolve_post_field_name_fallback(variable_name);
+                if resolved.0.is_empty() {
                     self.resolve_post_field_name_fallback(&name)
-                } else if let Some(variable_name) = field
-                    .value
-                    .strip_prefix("$(")
-                    .and_then(|value| value.strip_suffix(')'))
-                {
-                    let resolved = self.resolve_post_field_name_fallback(variable_name.trim());
-                    if resolved.is_empty() {
-                        self.resolve_post_field_name_fallback(&name)
-                    } else {
-                        resolved
-                    }
                 } else {
-                    let resolved = evaluate_vdata(&field.value, &self.vars)?;
-                    if resolved.is_empty() {
-                        self.resolve_post_field_name_fallback(&name)
+                    resolved
+                }
+            } else {
+                let resolved = evaluate_vdata(&field.value, &self.vars)?;
+                if resolved.is_empty() {
+                    self.resolve_post_field_name_fallback(&name)
+                } else {
+                    let source = if field.value.contains("$(") {
+                        EngineDebugPostfieldResolutionSource::Variable
                     } else {
-                        resolved
-                    }
+                        EngineDebugPostfieldResolutionSource::Fallback
+                    };
+                    (resolved, source)
+                }
+            };
+
+            if recording {
+                let reason = [
+                    self.debug_variable_reason(&name),
+                    source_name
+                        .as_deref()
+                        .and_then(|source_name| self.debug_variable_reason(source_name)),
+                    self.debug_value_reason(&value),
+                ]
+                .into_iter()
+                .flatten()
+                .min_by_key(crate::engine_debug_recorder::redaction_priority);
+                let debug_name = if self.debug_value_reason(&name).is_some() {
+                    "<masked>".to_string()
+                } else {
+                    name.clone()
                 };
-                Ok(ScriptNavigationPostFieldLiteral { name, value })
-            })
-            .collect()
+                debug_fields.push(EngineDebugPostfieldResolution {
+                    name: debug_name,
+                    value: crate::engine_debug_recorder::sanitize_text(&value, reason),
+                    source,
+                });
+            }
+            resolved_fields.push(ScriptNavigationPostFieldLiteral { name, value });
+        }
+        if recording && !debug_fields.is_empty() {
+            self.debug_emit(EngineDebugEventPayload::PostfieldResolve {
+                fields: debug_fields,
+            });
+        }
+        Ok(resolved_fields)
     }
 
     fn encode_post_fields(post_fields: &[ScriptNavigationPostFieldLiteral]) -> String {
@@ -495,19 +561,28 @@ impl WmlEngine {
         serializer.finish()
     }
 
-    fn resolve_post_field_name_fallback(&self, name: &str) -> String {
+    fn resolve_post_field_name_fallback(
+        &self,
+        name: &str,
+    ) -> (String, EngineDebugPostfieldResolutionSource) {
         if let Some(edit) = &self.active_input_edit {
             if edit.input_name == name {
-                return edit.draft_value.clone();
+                return (
+                    edit.draft_value.clone(),
+                    EngineDebugPostfieldResolutionSource::Draft,
+                );
             }
         }
         if let Some(value) = self.vars.get(name).cloned() {
-            return value;
+            return (value, EngineDebugPostfieldResolutionSource::Variable);
         }
         if let Some(value) = self.input_value_for_name_on_active_card(name) {
-            return value;
+            return (value, EngineDebugPostfieldResolutionSource::Card);
         }
-        String::new()
+        (
+            String::new(),
+            EngineDebugPostfieldResolutionSource::Fallback,
+        )
     }
 
     fn is_same_document_navigation(&self, resolved_href: &str) -> bool {

--- a/engine-wasm/engine/src/engine_runtime_internal/node_lookup.rs
+++ b/engine-wasm/engine/src/engine_runtime_internal/node_lookup.rs
@@ -14,6 +14,7 @@ pub(crate) struct InputRef<'a> {
     pub(crate) control_id: &'a str,
     pub(crate) name: &'a str,
     pub(crate) value: &'a str,
+    pub(crate) is_password: bool,
     pub(crate) max_length: Option<usize>,
     pub(crate) mask: &'a InputMask,
     pub(crate) empty_ok: bool,
@@ -75,6 +76,11 @@ pub(crate) fn find_input_by_name<'a>(card: &'a Card, name: &str) -> Option<Input
     inline_nodes(card)
         .filter_map(as_input)
         .find(|input| input.name == name)
+}
+
+/// Every input on a card, in document order.
+pub(crate) fn inputs(card: &Card) -> impl Iterator<Item = InputRef<'_>> {
+    inline_nodes(card).filter_map(as_input)
 }
 
 /// Input with `control_id`, in document order, for mutation.
@@ -152,6 +158,7 @@ fn as_input(item: &InlineNode) -> Option<InputRef<'_>> {
             control_id,
             name,
             value,
+            is_password,
             max_length,
             mask,
             empty_ok,
@@ -160,6 +167,7 @@ fn as_input(item: &InlineNode) -> Option<InputRef<'_>> {
             control_id,
             name,
             value,
+            is_password: *is_password,
             max_length: *max_length,
             mask,
             empty_ok: *empty_ok,

--- a/engine-wasm/engine/src/engine_runtime_internal/script_effects.rs
+++ b/engine-wasm/engine/src/engine_runtime_internal/script_effects.rs
@@ -39,9 +39,29 @@ impl WmlEngine {
                             token.clone().unwrap_or_default()
                         ),
                     );
+                    let token = token.as_deref().unwrap_or("timer");
+                    if self.debug_recorder.is_some() {
+                        let reason = self.debug_value_reason(token).or_else(|| {
+                            crate::engine_debug_recorder::is_sensitive_name(token)
+                                .then_some(EngineDebugRedactionReason::SensitiveName)
+                        });
+                        self.debug_emit(EngineDebugEventPayload::TimerSchedule {
+                            delay_ms: *delay_ms,
+                            token: crate::engine_debug_recorder::sanitize_text(token, reason),
+                        });
+                    }
                 }
                 ScriptTimerRequest::Cancel { token } => {
                     self.push_trace("TIMER_CANCEL", token.clone());
+                    if self.debug_recorder.is_some() {
+                        let reason = self.debug_value_reason(token).or_else(|| {
+                            crate::engine_debug_recorder::is_sensitive_name(token)
+                                .then_some(EngineDebugRedactionReason::SensitiveName)
+                        });
+                        self.debug_emit(EngineDebugEventPayload::TimerCancel {
+                            token: crate::engine_debug_recorder::sanitize_text(token, reason),
+                        });
+                    }
                 }
             }
         }
@@ -65,9 +85,29 @@ impl WmlEngine {
         match effective_nav_intent {
             ScriptNavigationIntent::None => {}
             ScriptNavigationIntent::Prev => {
+                self.debug_emit_lazy(|| EngineDebugEventPayload::NavigationIntent {
+                    target: EngineDebugValue::Visible {
+                        value: "prev".to_string(),
+                    },
+                });
                 self.navigate_back_internal();
             }
             ScriptNavigationIntent::Go(href) => {
+                if self.debug_recorder.is_some() {
+                    let target = if href.starts_with('#') {
+                        crate::engine_debug_recorder::sanitize_url(&href)
+                    } else {
+                        crate::engine_debug_recorder::sanitize_url(
+                            &self.resolve_external_href(&href),
+                        )
+                    };
+                    self.debug_emit(EngineDebugEventPayload::NavigationIntent {
+                        target: target.clone(),
+                    });
+                    if !href.is_empty() && !href.starts_with('#') {
+                        self.debug_emit(EngineDebugEventPayload::ActionExternal { target });
+                    }
+                }
                 if let Some(card_id) = href.strip_prefix('#') {
                     self.navigate_to_card_internal(card_id)?;
                 } else if !href.is_empty() {

--- a/engine-wasm/engine/src/engine_runtime_internal/timers.rs
+++ b/engine-wasm/engine/src/engine_runtime_internal/timers.rs
@@ -39,6 +39,22 @@ impl WmlEngine {
             name: timer.name,
             ontimer_action,
         });
+        if self.debug_recorder.is_some() {
+            let token = self
+                .active_timer
+                .as_ref()
+                .and_then(|timer| timer.name.as_deref())
+                .unwrap_or("card-timer")
+                .to_string();
+            self.debug_emit(EngineDebugEventPayload::TimerSchedule {
+                delay_ms: remaining_ms,
+                token: crate::engine_debug_recorder::sanitize_text(
+                    &token,
+                    crate::engine_debug_recorder::is_sensitive_name(&token)
+                        .then_some(EngineDebugRedactionReason::SensitiveName),
+                ),
+            });
+        }
         self.push_trace("TIMER_START", format!("valueDs={value_ds}"));
         Ok(())
     }
@@ -47,6 +63,14 @@ impl WmlEngine {
         let Some(timer) = self.active_timer.take() else {
             return;
         };
+        let token = timer.name.as_deref().unwrap_or("card-timer");
+        self.debug_emit_lazy(|| EngineDebugEventPayload::TimerCancel {
+            token: crate::engine_debug_recorder::sanitize_text(
+                token,
+                crate::engine_debug_recorder::is_sensitive_name(token)
+                    .then_some(EngineDebugRedactionReason::SensitiveName),
+            ),
+        });
         self.persist_timer_value(&timer, Self::remaining_timer_deciseconds(&timer));
         self.push_trace("TIMER_STOP", format!("remainingMs={}", timer.remaining_ms));
     }
@@ -55,6 +79,14 @@ impl WmlEngine {
         let Some(timer) = self.active_timer.take() else {
             return Ok(());
         };
+        let token = timer.name.as_deref().unwrap_or("card-timer");
+        self.debug_emit_lazy(|| EngineDebugEventPayload::TimerFire {
+            token: crate::engine_debug_recorder::sanitize_text(
+                token,
+                crate::engine_debug_recorder::is_sensitive_name(token)
+                    .then_some(EngineDebugRedactionReason::SensitiveName),
+            ),
+        });
         self.persist_timer_value(&timer, 0);
         self.push_trace("TIMER_EXPIRE", String::new());
         let Some(action) = timer.ontimer_action else {
@@ -71,6 +103,7 @@ impl WmlEngine {
     }
 
     pub(crate) fn advance_time_ms_internal(&mut self, delta_ms: u32) -> Result<(), String> {
+        self.debug_advance_time(delta_ms);
         let Some(timer_card_idx) = self.active_timer.as_ref().map(|timer| timer.card_idx) else {
             return Ok(());
         };

--- a/engine-wasm/engine/src/engine_tests/debug_recorder.rs
+++ b/engine-wasm/engine/src/engine_tests/debug_recorder.rs
@@ -1,0 +1,379 @@
+use super::*;
+use crate::{
+    EngineDebugErrorCode, EngineDebugEventKind, EngineDebugEventPayload,
+    EngineDebugPostfieldResolutionSource, EngineDebugRedactionReason, EngineDebugValue,
+    ENGINE_DEBUG_EVENT_BUFFER_CAPACITY, ENGINE_DEBUG_MAX_TEXT_BYTES,
+};
+
+const DEBUG_FLOW: &str = r##"
+<wml>
+  <card id="home">
+    <input name="user"/>
+    <a href="#next">Next</a>
+  </card>
+  <card id="next">
+    <timer name="tick" value="1"/>
+    <p>Next</p>
+  </card>
+</wml>
+"##;
+
+fn run_debug_flow() -> WmlEngine {
+    let mut engine = WmlEngine::new();
+    engine.set_debug_recording_enabled(true);
+    engine.load_deck(DEBUG_FLOW).expect("deck should load");
+    assert!(engine
+        .begin_focused_input_edit()
+        .expect("input edit should start"));
+    assert!(engine.set_focused_input_edit_draft("alice".to_string()));
+    assert!(engine
+        .commit_focused_input_edit()
+        .expect("input edit should commit"));
+    engine
+        .handle_key("down".to_string())
+        .expect("focus should move");
+    engine
+        .handle_key("enter".to_string())
+        .expect("link should navigate");
+    engine
+        .advance_time_ms(100)
+        .expect("timer should deterministically fire");
+    engine
+}
+
+#[test]
+fn debug_event_order_and_logical_time_are_deterministic() {
+    let first = run_debug_flow();
+    let second = run_debug_flow();
+    let first_batch = first
+        .poll_debug_events("0", 256)
+        .expect("events should poll");
+    let second_batch = second
+        .poll_debug_events("0", 256)
+        .expect("events should poll");
+
+    assert_eq!(
+        serde_json::to_value(&first_batch.events).unwrap(),
+        serde_json::to_value(&second_batch.events).unwrap()
+    );
+    assert_eq!(
+        first_batch
+            .events
+            .iter()
+            .map(|event| &event.kind)
+            .collect::<Vec<_>>(),
+        [
+            &EngineDebugEventKind::DeckLoad,
+            &EngineDebugEventKind::CardEnter,
+            &EngineDebugEventKind::InputEditStart,
+            &EngineDebugEventKind::InputEditDraft,
+            &EngineDebugEventKind::InputEditCommit,
+            &EngineDebugEventKind::FocusChange,
+            &EngineDebugEventKind::NavigationIntent,
+            &EngineDebugEventKind::CardExit,
+            &EngineDebugEventKind::FocusChange,
+            &EngineDebugEventKind::CardEnter,
+            &EngineDebugEventKind::TimerSchedule,
+            &EngineDebugEventKind::TimerFire,
+        ]
+    );
+    assert_eq!(
+        first_batch
+            .events
+            .iter()
+            .map(|event| event.seq.as_str())
+            .collect::<Vec<_>>(),
+        (1..=12).map(|seq| seq.to_string()).collect::<Vec<_>>()
+    );
+    assert!(first_batch.events[..11]
+        .iter()
+        .all(|event| event.monotonic_time_ms == 0));
+    assert_eq!(first_batch.events[11].monotonic_time_ms, 100);
+    assert_eq!(first.debug_event_cursor().as_deref(), Ok("12"));
+}
+
+#[test]
+fn public_recorder_drops_oldest_and_reports_cursor_gap_exactly() {
+    let mut engine = WmlEngine::new();
+    engine.set_debug_recording_enabled(true);
+    engine
+        .load_deck("<wml><card id=\"home\"><input name=\"field\"/></card></wml>")
+        .expect("deck should load");
+    assert!(engine
+        .begin_focused_input_edit()
+        .expect("input edit should start"));
+    for index in 0..ENGINE_DEBUG_EVENT_BUFFER_CAPACITY + 2 {
+        assert!(engine.set_focused_input_edit_draft(index.to_string()));
+    }
+
+    let batch = engine
+        .poll_debug_events("0", 256)
+        .expect("old cursor should resume at retained window");
+    assert_eq!(batch.dropped_count, 5);
+    assert_eq!(
+        batch.events.first().map(|event| event.seq.as_str()),
+        Some("6")
+    );
+    assert_eq!(batch.events.len(), 256);
+    assert!(batch.has_more);
+    let snapshot = engine.debug_snapshot().expect("snapshot should succeed");
+    assert_eq!(snapshot.buffer.dropped_count, 5);
+    assert_eq!(snapshot.buffer.oldest_seq.as_deref(), Some("6"));
+    assert_eq!(snapshot.buffer.latest_seq.as_deref(), Some("2053"));
+}
+
+#[test]
+fn secrets_are_masked_before_events_and_snapshots_enter_debug_dtos() {
+    const CANARY: &str = "D0_02_SECRET_CANARY_7f4a";
+    let mut engine = WmlEngine::new();
+    engine.set_debug_recording_enabled(true);
+    engine
+        .load_deck_context(
+            r##"
+            <wml><card id="login">
+              <do type="accept"><go href="/submit?token=D0_02_SECRET_CANARY_7f4a" method="post">
+                <postfield name="account" value="$(account)"/>
+                <postfield name="$(account)" value="visible"/>
+                <setvar name="copied" value="$(account)"/>
+                <setvar name="$(account)" value="derived"/>
+              </go></do>
+              <input name="account" type="password"/>
+            </card></wml>
+            "##,
+            "https://user:D0_02_SECRET_CANARY_7f4a@example.test/login.wml",
+            "text/vnd.wap.wml",
+            None,
+        )
+        .expect("secret fixture should load");
+    assert!(engine
+        .begin_focused_input_edit()
+        .expect("password edit should start"));
+    assert!(engine.set_focused_input_edit_draft(CANARY.to_string()));
+    assert!(engine
+        .commit_focused_input_edit()
+        .expect("password edit should commit"));
+    assert!(engine.set_var("authToken".to_string(), CANARY.to_string()));
+    assert!(engine.set_var(
+        "oversized".to_string(),
+        "x".repeat(ENGINE_DEBUG_MAX_TEXT_BYTES as usize + 1)
+    ));
+    engine
+        .handle_key("enter".to_string())
+        .expect("accept action should resolve external request");
+    assert!(engine
+        .begin_focused_input_edit()
+        .expect("password edit should restart"));
+    assert!(engine.set_focused_input_edit_draft(CANARY.to_string()));
+
+    let events = engine
+        .poll_debug_events("0", 256)
+        .expect("events should poll");
+    let snapshot = engine.debug_snapshot().expect("snapshot should succeed");
+    let serialized_events = serde_json::to_string(&events).unwrap();
+    let serialized_snapshot = serde_json::to_string(&snapshot).unwrap();
+    assert!(!serialized_events.contains(CANARY));
+    assert!(!serialized_snapshot.contains(CANARY));
+
+    let account = snapshot
+        .runtime_vars
+        .iter()
+        .find(|entry| entry.name == "account")
+        .expect("account variable should be present");
+    assert_eq!(
+        account.value,
+        EngineDebugValue::Masked {
+            reason: EngineDebugRedactionReason::PasswordInput
+        }
+    );
+    let copied = snapshot
+        .runtime_vars
+        .iter()
+        .find(|entry| entry.name == "copied")
+        .expect("derived variable should be present");
+    assert!(matches!(copied.value, EngineDebugValue::Masked { .. }));
+    let token = snapshot
+        .runtime_vars
+        .iter()
+        .find(|entry| entry.name == "authToken")
+        .expect("sensitive-name variable should be present");
+    assert_eq!(
+        token.value,
+        EngineDebugValue::Masked {
+            reason: EngineDebugRedactionReason::SensitiveName
+        }
+    );
+    let oversized = snapshot
+        .runtime_vars
+        .iter()
+        .find(|entry| entry.name == "oversized")
+        .expect("oversized variable should be present");
+    assert_eq!(
+        oversized.value,
+        EngineDebugValue::Omitted {
+            reason: EngineDebugRedactionReason::BoundedOutput
+        }
+    );
+    assert!(matches!(
+        snapshot.base_url,
+        EngineDebugValue::Masked {
+            reason: EngineDebugRedactionReason::CredentialBearingUrl
+        }
+    ));
+    let pending = snapshot
+        .pending_external_navigation
+        .expect("external navigation should be pending");
+    assert!(matches!(
+        pending.target,
+        EngineDebugValue::Masked {
+            reason: EngineDebugRedactionReason::CredentialBearingUrl
+        }
+    ));
+    assert!(matches!(
+        pending.post_body,
+        Some(EngineDebugValue::Masked {
+            reason: EngineDebugRedactionReason::TransportSecret
+        })
+    ));
+    let postfield_event = events
+        .events
+        .iter()
+        .find_map(|event| match &event.payload {
+            EngineDebugEventPayload::PostfieldResolve { fields } => Some(fields),
+            _ => None,
+        })
+        .expect("postfield event should be present");
+    assert_eq!(
+        postfield_event[0].source,
+        EngineDebugPostfieldResolutionSource::Variable
+    );
+    assert!(matches!(
+        postfield_event[0].value,
+        EngineDebugValue::Masked { .. }
+    ));
+    assert_eq!(postfield_event[1].name, "<masked>");
+}
+
+#[test]
+fn snapshots_sort_and_bound_runtime_variables() {
+    let mut engine = WmlEngine::new();
+    engine.set_debug_recording_enabled(true);
+    for index in (0..257).rev() {
+        assert!(engine.set_var(format!("value{index:03}"), index.to_string()));
+    }
+
+    let snapshot = engine.debug_snapshot().expect("snapshot should succeed");
+    assert_eq!(snapshot.runtime_vars.len(), 256);
+    assert_eq!(snapshot.runtime_vars_summary.total_count, 257);
+    assert_eq!(snapshot.runtime_vars_summary.returned_count, 256);
+    assert!(snapshot.runtime_vars_summary.truncated);
+    assert_eq!(snapshot.runtime_vars[0].name, "value000");
+    assert_eq!(snapshot.runtime_vars[255].name, "value255");
+}
+
+#[test]
+fn cancel_script_trap_and_timer_cancel_boundaries_emit_without_secret_detail() {
+    const CANARY: &str = "D0_02_SCRIPT_SECRET_CANARY";
+    let mut engine = WmlEngine::new();
+    engine.set_debug_recording_enabled(true);
+    engine
+        .load_deck(
+            r##"<wml>
+              <card id="home">
+                <timer name="session" value="10"/>
+                <input name="field"/>
+                <a href="#next">Next</a>
+              </card>
+              <card id="next"><p>Next</p></card>
+            </wml>"##,
+        )
+        .expect("deck should load");
+    assert!(engine
+        .begin_focused_input_edit()
+        .expect("input edit should start"));
+    assert!(engine.cancel_focused_input_edit());
+    let outcome = engine.execute_script_ref_function(
+        format!("https://user:{CANARY}@example.test/unit.wmlsc"),
+        CANARY.to_string(),
+    );
+    assert!(!outcome.ok);
+    engine
+        .handle_key("down".to_string())
+        .expect("focus should move to link");
+    engine
+        .handle_key("enter".to_string())
+        .expect("link should navigate and cancel the timer");
+
+    let events = engine
+        .poll_debug_events("0", 256)
+        .expect("events should poll");
+    for expected in [
+        EngineDebugEventKind::InputEditCancel,
+        EngineDebugEventKind::ScriptInvoke,
+        EngineDebugEventKind::ScriptTrap,
+        EngineDebugEventKind::TimerCancel,
+    ] {
+        assert!(
+            events.events.iter().any(|event| event.kind == expected),
+            "missing {expected:?} boundary"
+        );
+    }
+    assert!(!serde_json::to_string(&events).unwrap().contains(CANARY));
+}
+
+#[test]
+fn disabled_debug_source_is_inert_and_unavailable() {
+    let mut baseline = WmlEngine::new();
+    let mut disabled = WmlEngine::new();
+    disabled.set_debug_recording_enabled(false);
+    for engine in [&mut baseline, &mut disabled] {
+        engine.load_deck(DEBUG_FLOW).expect("deck should load");
+        engine
+            .handle_key("down".to_string())
+            .expect("focus should move");
+        engine
+            .handle_key("enter".to_string())
+            .expect("link should navigate");
+    }
+
+    assert_eq!(
+        render_snapshot_lines(&baseline),
+        render_snapshot_lines(&disabled)
+    );
+    assert_eq!(baseline.active_card_id(), disabled.active_card_id());
+    assert_eq!(baseline.focused_link_index(), disabled.focused_link_index());
+    assert_eq!(
+        serde_json::to_value(baseline.trace_entries()).unwrap(),
+        serde_json::to_value(disabled.trace_entries()).unwrap()
+    );
+    let error = disabled
+        .poll_debug_events("0", 1)
+        .expect_err("disabled recorder should be unavailable");
+    assert_eq!(error.code, EngineDebugErrorCode::DebugSourceUnavailable);
+    assert!(error.retryable);
+}
+
+#[test]
+fn recorder_activation_is_idempotent_and_reactivation_starts_fresh() {
+    let mut engine = WmlEngine::new();
+    assert!(!engine.debug_recording_enabled());
+    engine.set_debug_recording_enabled(true);
+    engine
+        .load_deck("<wml><card id=\"home\"><p>Home</p></card></wml>")
+        .expect("deck should load");
+    assert_eq!(engine.debug_event_cursor().as_deref(), Ok("2"));
+
+    engine.set_debug_recording_enabled(true);
+    assert_eq!(engine.debug_event_cursor().as_deref(), Ok("2"));
+    engine.set_debug_recording_enabled(false);
+    assert!(!engine.debug_recording_enabled());
+    assert_eq!(
+        engine
+            .debug_event_cursor()
+            .expect_err("disabled recorder should be unavailable")
+            .code,
+        EngineDebugErrorCode::DebugSourceUnavailable
+    );
+
+    engine.set_debug_recording_enabled(true);
+    assert_eq!(engine.debug_event_cursor().as_deref(), Ok("0"));
+}

--- a/engine-wasm/engine/src/engine_tests/mod.rs
+++ b/engine-wasm/engine/src/engine_tests/mod.rs
@@ -145,6 +145,7 @@ fn assert_trace_kinds_subsequence(engine: &WmlEngine, expected: &[&str]) {
 }
 
 mod actions_timers;
+mod debug_recorder;
 mod navigation_metadata;
 mod panic_containment;
 mod script_runtime;

--- a/engine-wasm/engine/src/engine_wasm_bindings_tests.rs
+++ b/engine-wasm/engine/src/engine_wasm_bindings_tests.rs
@@ -1742,3 +1742,49 @@ fn wasm_wml_304_request_intent_matches_native_serialization() {
         Some("no-cache")
     );
 }
+
+#[wasm_bindgen_test]
+fn wasm_debug_events_and_snapshot_match_native_dtos_and_mask_before_serialization() {
+    const CANARY: &str = "WASM_D0_02_SECRET_CANARY";
+    let mut engine = WmlEngine::wasm_new();
+    engine.set_debug_recording_enabled(true);
+    engine
+        .load_deck_context_wasm(
+            r#"<wml><card id="login"><input name="password" type="password"/></card></wml>"#,
+            "https://user:WASM_D0_02_SECRET_CANARY@example.test/login.wml",
+            "text/vnd.wap.wml",
+            None,
+            None,
+        )
+        .expect("debug fixture should load through WASM");
+    assert!(engine
+        .begin_focused_input_edit_wasm()
+        .expect("password edit should start through WASM"));
+    assert!(engine.set_focused_input_edit_draft_wasm(CANARY.to_string()));
+
+    let events = engine
+        .poll_debug_events("0", 32)
+        .expect("native DTO source should poll on WASM");
+    let snapshot = engine
+        .debug_snapshot()
+        .expect("native snapshot DTO should build on WASM");
+    assert_eq!(events.events[0].kind, EngineDebugEventKind::DeckLoad);
+    assert_eq!(events.events[1].kind, EngineDebugEventKind::CardEnter);
+    assert_eq!(events.events[2].kind, EngineDebugEventKind::InputEditStart);
+    assert_eq!(events.events[3].kind, EngineDebugEventKind::InputEditDraft);
+
+    let events_js = to_js_value(&events).expect("events should serialize through wasm serde");
+    let snapshot_js = to_js_value(&snapshot).expect("snapshot should serialize through wasm serde");
+    let events_json = js_sys::JSON::stringify(&events_js)
+        .expect("events JSON should stringify")
+        .as_string()
+        .expect("events JSON should be a string");
+    let snapshot_json = js_sys::JSON::stringify(&snapshot_js)
+        .expect("snapshot JSON should stringify")
+        .as_string()
+        .expect("snapshot JSON should be a string");
+    assert!(!events_json.contains(CANARY));
+    assert!(!snapshot_json.contains(CANARY));
+    assert!(events_json.contains("password-input"));
+    assert!(snapshot_json.contains("password-input"));
+}

--- a/engine-wasm/engine/src/lib.rs
+++ b/engine-wasm/engine/src/lib.rs
@@ -12,6 +12,7 @@ use wasm_bindgen::prelude::*;
 #[cfg(feature = "contract-codegen")]
 pub mod contract_codegen;
 mod engine_debug_contract;
+mod engine_debug_recorder;
 mod engine_public_api;
 mod engine_runtime_internal;
 mod engine_script_types;
@@ -265,6 +266,7 @@ pub struct WmlEngine {
     last_back_navigation_handled: bool,
     last_wml_load_diagnostics: Vec<WmlLoadDiagnostic>,
     browser_context_epoch: u32,
+    debug_recorder: Option<engine_debug_recorder::EngineDebugRecorder>,
 }
 
 impl Default for WmlEngine {


### PR DESCRIPTION
## Summary

- add an optional engine-owned, fixed-capacity drop-oldest debug recorder
- emit the D0-01 event set at deterministic WaveNav runtime boundaries with stable sequence, cursor, and drop accounting
- build bounded read-only snapshots and sanitize secrets before values enter debug DTOs
- preserve disabled-debug behavior and native/WASM-facing parity

## Scope

This implements D0-02 in `engine-wasm` and updates only the directly owned D0-02 status/evidence documentation. D0-03 host attach/poll/close IPC and D0-04 browser UI/export remain out of scope.

## Validation

- `cargo fmt --all -- --check`
- `cargo test` — 410 passed
- `cargo clippy --all-targets --all-features -- -D warnings`
- `wasm-pack test --node` — 37 passed
- `make coverage-rust-engine` — 94.88% line, 93.04% function
- Rust contract regeneration — no DTO drift
- repository pre-push hook suite — passed
- `git diff --check`
