### PR TITLE
feat(browser): complete deterministic frame navigation integration

### DIFF
--- a/browser/frontend/src/app/browser-controller.behavior.test.ts
+++ b/browser/frontend/src/app/browser-controller.behavior.test.ts
@@ -438,7 +438,7 @@ describe('BrowserController behavior coverage', () => {
     const controller = new BrowserController(hostClient as never, presenter, refs);
 
     await controller.init('<wml><card id="seed"/></wml>');
-    vi.mocked(hostClient.engineAdvanceTimeMs).mockClear();
+    vi.mocked(hostClient.engineAdvanceTimeMsFrame).mockClear();
 
     window.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowUp' }));
 
@@ -449,7 +449,7 @@ describe('BrowserController behavior coverage', () => {
     await (
       controller as unknown as { tickEngineTimerRuntime(): Promise<void> }
     ).tickEngineTimerRuntime();
-    expect(hostClient.engineAdvanceTimeMs).not.toHaveBeenCalled();
+    expect(hostClient.engineAdvanceTimeMsFrame).not.toHaveBeenCalled();
 
     await flushAsyncWork();
 
@@ -457,7 +457,7 @@ describe('BrowserController behavior coverage', () => {
     await (
       controller as unknown as { tickEngineTimerRuntime(): Promise<void> }
     ).tickEngineTimerRuntime();
-    expect(hostClient.engineAdvanceTimeMs).toHaveBeenCalledTimes(1);
+    expect(hostClient.engineAdvanceTimeMsFrame).toHaveBeenCalledTimes(1);
   });
 
   it('does not tick the network engine while a transport navigation is in flight', async () => {
@@ -470,7 +470,7 @@ describe('BrowserController behavior coverage', () => {
     controllerPrivates(controller).timerRuntime.stop();
     await controllerPrivates(controller).setRunMode('network', { loadLocalOnEnter: false });
     await flushAsyncWork();
-    vi.mocked(hostClient.engineAdvanceTimeMs).mockClear();
+    vi.mocked(hostClient.engineAdvanceTimeMsFrame).mockClear();
 
     let resolveFetch: ((response: FetchResponse) => void) | undefined;
     vi.mocked(hostClient.fetchDeck).mockImplementationOnce(
@@ -485,7 +485,7 @@ describe('BrowserController behavior coverage', () => {
     await Promise.resolve();
 
     await controllerPrivates(controller).tickEngineTimerRuntime();
-    expect(hostClient.engineAdvanceTimeMs).not.toHaveBeenCalled();
+    expect(hostClient.engineAdvanceTimeMsFrame).not.toHaveBeenCalled();
 
     resolveFetch?.({
       ok: true,
@@ -525,8 +525,8 @@ describe('BrowserController behavior coverage', () => {
       return frame({ activeCardId: 'invoking-card', focusedLinkIndex: 2, baseUrl: invokingUrl });
     });
     vi.mocked(hostClient.engineHandleKeyFrame).mockResolvedValue(frame(invokingSnapshot));
-    vi.mocked(hostClient.engineAdvanceTimeMs).mockImplementation(async () =>
-      snapshot({
+    vi.mocked(hostClient.engineAdvanceTimeMsFrame).mockImplementation(async () =>
+      frame({
         activeCardId: timerIntent ? 'invoking-card' : 'recovered-card',
         focusedLinkIndex: timerIntent ? 2 : 0,
         baseUrl: timerIntent ? invokingUrl : changedTargetUrl,
@@ -837,7 +837,7 @@ describe('BrowserController behavior coverage', () => {
 
       await controller.init('<wml><card id="seed"/></wml>');
       // The periodic engine timer tick is irrelevant to this test and its
-      // mocked engineAdvanceTimeMs response would otherwise trigger an
+      // mocked engineAdvanceTimeMsFrame response would otherwise trigger an
       // unrelated re-render mid-delay, incidentally canceling the pending
       // indicator this test is trying to observe.
       controllerPrivates(controller).timerRuntime.stop();

--- a/browser/frontend/src/app/browser-controller.timer.test.ts
+++ b/browser/frontend/src/app/browser-controller.timer.test.ts
@@ -81,18 +81,25 @@ const initialSession: HostSessionState = {
 };
 
 describe('BrowserController local timer behavior', () => {
-  it('skips redraw for no-op local timer ticks', async () => {
+  it('skips no-op redraws and publishes changed local timer frames atomically', async () => {
     const refs = createRefs();
     const presenter = new BrowserPresenter(refs, initialSession, 20);
 
     const engineRender = vi.fn(async () => renderStub);
+    const engineRenderFrame = vi.fn(async () => frame({ activeCardId: 'render-fallback' }));
+    const engineAdvanceTimeMs = vi.fn(async () =>
+      snapshot({ activeCardId: 'legacy-timer', focusedLinkIndex: 0 })
+    );
+    const engineAdvanceTimeMsFrame = vi.fn(async () =>
+      frame({ activeCardId: 'home', focusedLinkIndex: 0 })
+    );
     const hostClient = {
       health: vi.fn(async () => 'ok'),
       fetchDeck: vi.fn(),
       engineLoadDeck: vi.fn(),
       engineLoadDeckContext: vi.fn(),
       engineRender,
-      engineRenderFrame: vi.fn(async () => frame({ activeCardId: 'home', focusedLinkIndex: 0 })),
+      engineRenderFrame,
       engineHandleKey: vi.fn(),
       engineHandleKeyFrame: vi.fn(async () => frame({ activeCardId: 'home', focusedLinkIndex: 0 })),
       engineNavigateToCard: vi.fn(),
@@ -104,12 +111,8 @@ describe('BrowserController local timer behavior', () => {
         frame({ activeCardId: 'home', focusedLinkIndex: 0 })
       ),
       engineSetViewportCols: vi.fn(),
-      engineAdvanceTimeMs: vi.fn(async () =>
-        snapshot({ activeCardId: 'home', focusedLinkIndex: 0 })
-      ),
-      engineAdvanceTimeMsFrame: vi.fn(async () =>
-        frame({ activeCardId: 'home', focusedLinkIndex: 0 })
-      ),
+      engineAdvanceTimeMs,
+      engineAdvanceTimeMsFrame,
       engineSnapshot: vi.fn(async () => snapshot({ activeCardId: 'home', focusedLinkIndex: 0 })),
       engineClearExternalNavigationIntent: vi.fn(),
       engineClearExternalNavigationIntentFrame: vi.fn(async () =>
@@ -155,5 +158,21 @@ describe('BrowserController local timer behavior', () => {
     await controllerPrivates(controller).tickEngineTimerRuntime();
 
     expect(engineRender).not.toHaveBeenCalled();
+    expect(engineRenderFrame).not.toHaveBeenCalled();
+    expect(engineAdvanceTimeMs).not.toHaveBeenCalled();
+    expect(engineAdvanceTimeMsFrame).toHaveBeenCalledOnce();
+
+    const timerRender = {
+      draw: [{ type: 'text' as const, x: 0, y: 0, text: 'timer committed' }]
+    };
+    engineAdvanceTimeMsFrame.mockResolvedValueOnce(
+      frame({ activeCardId: 'after-timer', focusedLinkIndex: 0 }, timerRender)
+    );
+
+    await controllerPrivates(controller).tickEngineTimerRuntime();
+
+    expect(presenter.getSnapshot()?.activeCardId).toBe('after-timer');
+    expect(presenter.getRenderList()).toEqual(timerRender);
+    expect(engineRenderFrame).not.toHaveBeenCalled();
   });
 });

--- a/browser/frontend/src/app/browser-controller.ts
+++ b/browser/frontend/src/app/browser-controller.ts
@@ -12,7 +12,11 @@ import {
 import type { TauriHostClient } from '../../../contracts/generated/tauri-host-client';
 import { EngineTimerRuntime } from './engine-timer-runtime';
 import { FocusedControlEditController } from './focused-control-edit';
-import { createNavigationStateMachine, type NavigationErrorKind } from './navigation-state';
+import {
+  createNavigationStateMachine,
+  shouldRenderTimerSnapshot,
+  type NavigationErrorKind
+} from './navigation-state';
 import { canHistoryBack } from '../session-history';
 import { StartupNetworkProbeController } from './startup-network-probe';
 import { KeyboardIntentRouter } from './keyboard-intent-router';
@@ -68,6 +72,7 @@ export class BrowserController {
   // engine deck load (which always clears the engine's nav stack) and set
   // true whenever a forward card change is observed while in local mode.
   private localBackAvailable = false;
+  private pendingLocalTimerFrame: { generation: number; frame: EngineFrame } | undefined;
 
   constructor(hostClient: TauriHostClient, presenter: BrowserPresenter, refs: BrowserShellRefs) {
     this.hostClient = hostClient;
@@ -79,9 +84,8 @@ export class BrowserController {
       this.refs.fetchUrlInput.value,
       {
         onSessionState: (session) => this.presenter.setSessionState(session),
-        onSnapshot: (snapshot) => this.presenter.setSnapshot(snapshot),
-        onRender: (render) => {
-          this.presenter.drawRenderList(render);
+        onFrame: (frame) => {
+          this.applyFrame(frame);
           if (!this.bootDeckReadyEmitted) {
             this.bootDeckReadyEmitted = true;
             this.presenter.setBootPhase('deck-ready');
@@ -142,20 +146,40 @@ export class BrowserController {
         !this.keyboardIntentRouter.isActionInFlight() && !this.navigation.isNavigationInFlight(),
       getRunMode: () => this.runMode,
       advanceLocal: async (deltaMs) => {
+        this.pendingLocalTimerFrame = undefined;
         if (this.navigation.isNavigationInFlight()) {
           return null;
         }
         const generation = this.navigation.captureNavigationGeneration();
-        const snapshot = await this.hostClient.engineAdvanceTimeMs({ deltaMs });
-        return this.runMode === 'local' && this.navigation.isCurrentNavigation(generation)
-          ? snapshot
-          : null;
+        const frame = await this.hostClient.engineAdvanceTimeMsFrame({ deltaMs });
+        if (
+          this.runMode !== 'local' ||
+          !this.navigation.isCurrentNavigation(generation) ||
+          this.navigation.isNavigationInFlight()
+        ) {
+          return null;
+        }
+        if (shouldRenderTimerSnapshot(frame.snapshot, this.presenter.getSessionState())) {
+          this.pendingLocalTimerFrame = { generation, frame };
+        }
+        return frame.snapshot;
       },
       advanceNetwork: (deltaMs) => this.navigation.applyEngineTimerTick(deltaMs),
       getSessionState: () => this.presenter.getSessionState(),
       renderLocalSnapshot: async (snapshot) => {
+        const pending = this.pendingLocalTimerFrame;
+        this.pendingLocalTimerFrame = undefined;
+        if (
+          !pending ||
+          pending.frame.snapshot !== snapshot ||
+          this.runMode !== 'local' ||
+          !this.navigation.isCurrentNavigation(pending.generation) ||
+          this.navigation.isNavigationInFlight()
+        ) {
+          return;
+        }
         const previousActiveCardId = this.presenter.getSessionState().activeCardId;
-        this.applyFrame(await this.hostClient.engineRenderFrame(), snapshot);
+        this.applyFrame(pending.frame);
         this.syncLocalSessionFromSnapshot(snapshot);
         this.noteLocalForwardNavigation(previousActiveCardId, snapshot.activeCardId);
       },
@@ -412,8 +436,16 @@ export class BrowserController {
   };
 
   private readonly handleClearExternalIntentClick = async (): Promise<void> => {
-    const snapshot = await this.hostClient.engineClearExternalNavigationIntent();
-    this.presenter.setSnapshot(snapshot);
+    const generation = this.navigation.captureNavigationGeneration();
+    const frame = await this.hostClient.engineClearExternalNavigationIntentFrame();
+    if (
+      !this.navigation.isCurrentNavigation(generation) ||
+      this.navigation.isNavigationInFlight()
+    ) {
+      return;
+    }
+    const snapshot = frame.snapshot;
+    this.applyFrame(frame);
     this.presenter.patchSessionState({
       externalNavigationIntent: snapshot.externalNavigationIntent
     });
@@ -708,7 +740,7 @@ export class BrowserController {
       return;
     }
     if (startingRunMode === 'local' && localFrame) {
-      this.applyFrame(localFrame, snapshot);
+      this.applyFrame(localFrame);
       this.syncLocalSessionFromSnapshot(snapshot);
       this.noteLocalForwardNavigation(previousActiveCardId, snapshot.activeCardId);
     }
@@ -883,8 +915,8 @@ export class BrowserController {
     };
   }
 
-  private applyFrame(frame: EngineFrame, snapshot = frame.snapshot): void {
-    this.presenter.setSnapshot(snapshot);
+  private applyFrame(frame: EngineFrame): void {
+    this.presenter.setSnapshot(frame.snapshot);
     this.presenter.drawRenderList(frame.render);
   }
 }

--- a/browser/frontend/src/app/navigation-state.frame.test.ts
+++ b/browser/frontend/src/app/navigation-state.frame.test.ts
@@ -1,0 +1,235 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { FetchResponse } from '../../../contracts/transport';
+import type { EngineFrame } from '../../../contracts/engine';
+import { createNavigationStateMachine } from './navigation-state';
+import { createHostClientMock, fetchOk, frame } from './navigation-state.test-helpers';
+
+interface Deferred<T> {
+  promise: Promise<T>;
+  resolve(value: T): void;
+}
+
+const deferred = <T>(): Deferred<T> => {
+  let resolvePromise: ((value: T) => void) | undefined;
+  const promise = new Promise<T>((resolve) => {
+    resolvePromise = resolve;
+  });
+  return {
+    promise,
+    resolve: (value) => resolvePromise?.(value)
+  };
+};
+
+const load = (
+  machine: ReturnType<typeof createNavigationStateMachine>,
+  url: string,
+  followExternalIntent = false
+) =>
+  machine.loadTransportUrl({
+    url,
+    source: 'user',
+    followExternalIntent
+  });
+
+const fetchOkFor = (url: string): FetchResponse => {
+  const response = fetchOk({ finalUrl: url });
+  return {
+    ...response,
+    engineDeckInput: response.engineDeckInput
+      ? { ...response.engineDeckInput, baseUrl: url }
+      : undefined
+  };
+};
+
+describe('navigation-state frame sequencing', () => {
+  it('publishes each load and input frame only after its engine transition resolves', async () => {
+    const sequence: string[] = [];
+    const publishedCards: string[] = [];
+    const machine = createNavigationStateMachine(
+      createHostClientMock({
+        engineLoadDeckContextFrame: vi.fn(async () => {
+          sequence.push('engine-load');
+          return frame({ activeCardId: 'loaded' });
+        }),
+        engineHandleKeyFrame: vi.fn(async () => {
+          sequence.push('engine-input');
+          return frame({ activeCardId: 'after-input' });
+        })
+      }),
+      'http://seed.test',
+      {
+        onFrame: (committedFrame) => {
+          const cardId = committedFrame.snapshot.activeCardId ?? '';
+          sequence.push(`frame:${cardId}`);
+          publishedCards.push(cardId);
+        }
+      }
+    );
+
+    await load(machine, 'http://example.test/start.wml');
+    await machine.applyEngineKey('enter');
+
+    expect(sequence).toEqual(['engine-load', 'frame:loaded', 'engine-input', 'frame:after-input']);
+    expect(publishedCards).toEqual(['loaded', 'after-input']);
+  });
+
+  it('publishes the atomic timer frame without a follow-up render request', async () => {
+    const engineAdvanceTimeMs = vi.fn();
+    const engineRenderFrame = vi.fn();
+    const engineAdvanceTimeMsFrame = vi.fn(async () =>
+      frame({ activeCardId: 'after-timer', lastScriptRequiresRefresh: true })
+    );
+    const publishedCards: string[] = [];
+    const machine = createNavigationStateMachine(
+      createHostClientMock({
+        engineLoadDeckContextFrame: vi.fn(async () => frame({ activeCardId: 'before-timer' })),
+        engineAdvanceTimeMs,
+        engineRenderFrame,
+        engineAdvanceTimeMsFrame
+      }),
+      'http://seed.test',
+      {
+        onFrame: (committedFrame) => publishedCards.push(committedFrame.snapshot.activeCardId ?? '')
+      }
+    );
+
+    await load(machine, 'http://example.test/timer.wml');
+    publishedCards.length = 0;
+
+    await expect(machine.applyEngineTimerTick(100)).resolves.toMatchObject({
+      activeCardId: 'after-timer'
+    });
+
+    expect(engineAdvanceTimeMsFrame).toHaveBeenCalledWith({ deltaMs: 100 });
+    expect(engineAdvanceTimeMs).not.toHaveBeenCalled();
+    expect(engineRenderFrame).not.toHaveBeenCalled();
+    expect(publishedCards).toEqual(['after-timer']);
+  });
+
+  it('publishes only the restored card frame for host-history Back', async () => {
+    const publishedCards: string[] = [];
+    const transitions: string[] = [];
+    const machine = createNavigationStateMachine(
+      createHostClientMock({
+        fetchDeck: vi.fn(async (request) => fetchOkFor(request.url)),
+        engineLoadDeckContextFrame: vi.fn(async (request) => {
+          const cardId = request.baseUrl.includes('/a.wml') ? 'a-home' : 'b-home';
+          transitions.push(`load:${cardId}`);
+          return frame({ activeCardId: cardId, baseUrl: request.baseUrl });
+        }),
+        engineHandleKeyFrame: vi.fn(async () => {
+          transitions.push('input:a-details');
+          return frame({
+            activeCardId: 'a-details',
+            baseUrl: 'http://example.test/a.wml'
+          });
+        }),
+        engineNavigateBackFrame: vi.fn(async () => {
+          transitions.push('back:no-op');
+          return frame({ activeCardId: 'b-home', lastBackNavigationHandled: false });
+        }),
+        engineNavigateToCardFrame: vi.fn(async ({ cardId }) => {
+          transitions.push(`card:${cardId}`);
+          return frame({ activeCardId: cardId, baseUrl: 'http://example.test/a.wml' });
+        })
+      }),
+      'http://seed.test',
+      {
+        onFrame: (committedFrame) => publishedCards.push(committedFrame.snapshot.activeCardId ?? '')
+      }
+    );
+
+    await load(machine, 'http://example.test/a.wml');
+    await machine.applyEngineKey('enter');
+    await load(machine, 'http://example.test/b.wml');
+    publishedCards.length = 0;
+    transitions.length = 0;
+
+    await expect(machine.navigateBackWithFallback()).resolves.toBe('host');
+
+    expect(transitions).toEqual(['back:no-op', 'load:a-home', 'card:a-details']);
+    expect(publishedCards).toEqual(['a-details']);
+  });
+
+  it('does not publish a cancelled load frame that resolves after cancellation', async () => {
+    const pendingFrame = deferred<EngineFrame>();
+    const engineLoadDeckContextFrame = vi.fn(() => pendingFrame.promise);
+    const publishedCards: string[] = [];
+    const machine = createNavigationStateMachine(
+      createHostClientMock({ engineLoadDeckContextFrame }),
+      'http://seed.test',
+      {
+        onFrame: (committedFrame) => publishedCards.push(committedFrame.snapshot.activeCardId ?? '')
+      }
+    );
+
+    const pendingLoad = load(machine, 'http://example.test/cancelled.wml');
+    await vi.waitFor(() => expect(engineLoadDeckContextFrame).toHaveBeenCalledOnce());
+    await machine.cancelPendingNavigation();
+    pendingFrame.resolve(frame({ activeCardId: 'cancelled' }));
+
+    await expect(pendingLoad).resolves.toBeNull();
+    expect(publishedCards).toEqual([]);
+  });
+
+  it('publishes frames only from the generation that wins a superseding load race', async () => {
+    const staleFrame = deferred<EngineFrame>();
+    const publishedCards: string[] = [];
+    const machine = createNavigationStateMachine(
+      createHostClientMock({
+        fetchDeck: vi.fn(async (request): Promise<FetchResponse> => fetchOkFor(request.url)),
+        engineLoadDeckContextFrame: vi.fn((request) =>
+          request.baseUrl.includes('stale')
+            ? staleFrame.promise
+            : Promise.resolve(frame({ activeCardId: 'committed', baseUrl: request.baseUrl }))
+        )
+      }),
+      'http://seed.test',
+      {
+        onFrame: (committedFrame) => publishedCards.push(committedFrame.snapshot.activeCardId ?? '')
+      }
+    );
+
+    const staleLoad = load(machine, 'http://example.test/stale.wml');
+    await Promise.resolve();
+    const committedLoad = load(machine, 'http://example.test/committed.wml');
+    await expect(committedLoad).resolves.toMatchObject({ activeCardId: 'committed' });
+
+    staleFrame.resolve(frame({ activeCardId: 'stale' }));
+    await expect(staleLoad).resolves.toBeNull();
+
+    expect(publishedCards).toEqual(['committed']);
+  });
+
+  it('publishes one frame for each accepted external-intent transition', async () => {
+    const publishedCards: string[] = [];
+    let loadCount = 0;
+    const machine = createNavigationStateMachine(
+      createHostClientMock({
+        fetchDeck: vi.fn(async (request) => fetchOkFor(request.url)),
+        engineLoadDeckContextFrame: vi.fn(async (request) => {
+          loadCount += 1;
+          return loadCount === 1
+            ? frame({
+                activeCardId: 'source',
+                baseUrl: request.baseUrl,
+                externalNavigationIntent: 'http://example.test/target.wml'
+              })
+            : frame({ activeCardId: 'target', baseUrl: request.baseUrl });
+        })
+      }),
+      'http://seed.test',
+      {
+        onFrame: (committedFrame) => publishedCards.push(committedFrame.snapshot.activeCardId ?? '')
+      }
+    );
+
+    await load(machine, 'http://example.test/source.wml', true);
+
+    expect(publishedCards).toEqual(['source', 'target']);
+    expect(machine.getSessionState()).toMatchObject({
+      finalUrl: 'http://example.test/target.wml',
+      activeCardId: 'target'
+    });
+  });
+});

--- a/browser/frontend/src/app/navigation-state.load.test.ts
+++ b/browser/frontend/src/app/navigation-state.load.test.ts
@@ -638,18 +638,17 @@ describe('navigation-state load behavior', () => {
   });
 
   it('skips render and session-state churn for no-op timer ticks', async () => {
-    let renderCount = 0;
+    let publishedFrameCount = 0;
     const stateEvents: string[] = [];
     const machine = createNavigationStateMachine(
       createHostClientMock({
-        engineRender: async () => {
-          renderCount += 1;
-          return { draw: [{ type: 'text', x: 0, y: 0, text: 'ok' }] };
-        },
-        engineAdvanceTimeMs: async () => snapshot({ activeCardId: 'home', focusedLinkIndex: 0 })
+        engineAdvanceTimeMsFrame: async () => frame({ activeCardId: 'home', focusedLinkIndex: 0 })
       }),
       'http://seed.test',
       {
+        onFrame: () => {
+          publishedFrameCount += 1;
+        },
         onStateEvent: (action) => stateEvents.push(action)
       }
     );
@@ -659,12 +658,12 @@ describe('navigation-state load behavior', () => {
       source: 'user',
       followExternalIntent: false
     });
-    const renderCountAfterLoad = renderCount;
+    const publishedFramesAfterLoad = publishedFrameCount;
     const stateEventsAfterLoad = stateEvents.length;
 
     await machine.applyEngineTimerTick(50);
 
-    expect(renderCount).toBe(renderCountAfterLoad);
+    expect(publishedFrameCount).toBe(publishedFramesAfterLoad);
     expect(stateEvents.length).toBe(stateEventsAfterLoad);
   });
 

--- a/browser/frontend/src/app/navigation-state.ts
+++ b/browser/frontend/src/app/navigation-state.ts
@@ -60,6 +60,7 @@ export interface NavigationHostClient {
 
 export interface NavigationHooks {
   onSessionState?(session: HostSessionState): void;
+  onFrame?(frame: EngineFrame): void;
   onSnapshot?(snapshot: EngineRuntimeSnapshot): void;
   onRender?(render: RenderList): void;
   onTransportResponse?(response: FetchResponse | null): void;
@@ -179,7 +180,8 @@ export const createNavigationStateMachine = (
     });
   };
 
-  const applyFrame = (frame: EngineFrame): void => {
+  const publishFrame = (frame: EngineFrame): void => {
+    hooks.onFrame?.(frame);
     hooks.onSnapshot?.(frame.snapshot);
     hooks.onRender?.(frame.render);
     syncSessionFromSnapshot(frame.snapshot);
@@ -330,8 +332,9 @@ export const createNavigationStateMachine = (
   const loadTransportUrlForGeneration = async (
     options: LoadTransportOptions,
     generation: number,
-    requestId: string
-  ): Promise<EngineRuntimeSnapshot | null> => {
+    requestId: string,
+    publishLoadedFrame = true
+  ): Promise<EngineFrame | null> => {
     const requestedUrl = options.url.trim();
     const navigationUrl = options.navigationUrl?.trim() || requestedUrl;
     if (!requestedUrl) {
@@ -470,7 +473,9 @@ export const createNavigationStateMachine = (
       focusedLinkIndex: frame.snapshot.focusedLinkIndex,
       externalNavigationIntent: frame.snapshot.externalNavigationIntent
     });
-    applyFrame(frame);
+    if (publishLoadedFrame) {
+      publishFrame(frame);
+    }
     // A committed navigation establishes a fresh engine state, so a prior
     // terminal-intent quarantine no longer applies.
     quarantinedExternalIntent = undefined;
@@ -509,7 +514,7 @@ export const createNavigationStateMachine = (
       let nextUrl = frame.snapshot.externalNavigationIntent;
       let nextRequestPolicy = frame.snapshot.externalNavigationRequestPolicy;
       for (let hop = 1; hop <= maxExternalIntentHops; hop += 1) {
-        const nextSnapshot = await loadTransportUrlForGeneration(
+        const nextFrame = await loadTransportUrlForGeneration(
           {
             url: nextUrl,
             method: 'GET',
@@ -521,11 +526,11 @@ export const createNavigationStateMachine = (
           generation,
           requestId
         );
-        if (!nextSnapshot || !nextSnapshot.externalNavigationIntent) {
+        if (!nextFrame || !nextFrame.snapshot.externalNavigationIntent) {
           break;
         }
-        nextUrl = nextSnapshot.externalNavigationIntent;
-        nextRequestPolicy = nextSnapshot.externalNavigationRequestPolicy;
+        nextUrl = nextFrame.snapshot.externalNavigationIntent;
+        nextRequestPolicy = nextFrame.snapshot.externalNavigationRequestPolicy;
         if (hop === maxExternalIntentHops) {
           const message = `External intent hop limit reached (${maxExternalIntentHops}).`;
           mergeSessionState({ navigationStatus: 'error', lastError: message });
@@ -534,7 +539,7 @@ export const createNavigationStateMachine = (
       }
     }
 
-    return frame.snapshot;
+    return frame;
   };
 
   const loadTransportUrl = async (
@@ -570,7 +575,8 @@ export const createNavigationStateMachine = (
           resolveOperation(null);
           return;
         }
-        resolveOperation(await loadTransportUrlForGeneration(options, generation, requestId));
+        const frame = await loadTransportUrlForGeneration(options, generation, requestId);
+        resolveOperation(frame?.snapshot ?? null);
       } catch (error) {
         rejectOperation(error);
       } finally {
@@ -599,7 +605,7 @@ export const createNavigationStateMachine = (
     } else {
       updateCurrentHistoryCard(hostHistory, frame.snapshot.activeCardId);
     }
-    applyFrame(frame);
+    publishFrame(frame);
     return frame.snapshot;
   };
 
@@ -609,15 +615,12 @@ export const createNavigationStateMachine = (
     }
     const generation = activeNavigationGeneration;
     const previousCardId = hostSessionState.activeCardId;
-    const snapshot = await hostClient.engineAdvanceTimeMs({ deltaMs });
+    const frame = await hostClient.engineAdvanceTimeMsFrame({ deltaMs });
     if (!isCurrentNavigation(generation) || isNavigationInFlight()) {
       return null;
     }
+    const snapshot = frame.snapshot;
     const shouldRender = shouldRenderTimerSnapshot(snapshot, hostSessionState);
-    const renderFrame = shouldRender ? await hostClient.engineRenderFrame() : null;
-    if (!isCurrentNavigation(generation) || isNavigationInFlight()) {
-      return null;
-    }
     const browserContextChanged = observeBrowserContext(snapshot);
     if (browserContextChanged) {
       resetHistoryToCurrentCard(snapshot);
@@ -634,9 +637,7 @@ export const createNavigationStateMachine = (
     } else {
       updateCurrentHistoryCard(hostHistory, snapshot.activeCardId);
     }
-    if (renderFrame) {
-      applyFrame(renderFrame);
-    }
+    publishFrame(frame);
     return snapshot;
   };
 
@@ -674,14 +675,14 @@ export const createNavigationStateMachine = (
         } else {
           updateCurrentHistoryCard(hostHistory, after.activeCardId);
         }
-        applyFrame(afterFrame);
+        publishFrame(afterFrame);
         return 'engine';
       }
 
       if (canHistoryBack(hostHistory)) {
         const previous = peekHistoryBack(hostHistory);
         if (previous?.url) {
-          const prevSnapshot = await loadTransportUrlForGeneration(
+          const loadedFrame = await loadTransportUrlForGeneration(
             {
               url: previous.requestedUrl ?? previous.url,
               navigationUrl: historyNavigationUrl(previous.url, previous.activeCardId),
@@ -693,27 +694,28 @@ export const createNavigationStateMachine = (
               requestPolicy: previous.requestPolicy
             },
             generation,
-            `waves-navigation-${generation}-history`
+            `waves-navigation-${generation}-history`,
+            false
           );
-          if (prevSnapshot && isCurrentNavigation(generation)) {
-            let restoredSnapshot = prevSnapshot;
-            let restoredFrame: EngineFrame | undefined;
-            if (previous.activeCardId && previous.activeCardId !== prevSnapshot.activeCardId) {
+          if (loadedFrame && isCurrentNavigation(generation)) {
+            let restoredFrame = loadedFrame;
+            if (
+              previous.activeCardId &&
+              previous.activeCardId !== loadedFrame.snapshot.activeCardId
+            ) {
               restoredFrame = await hostClient.engineNavigateToCardFrame({
                 cardId: previous.activeCardId
               });
               if (!isCurrentNavigation(generation)) {
                 return 'none';
               }
-              restoredSnapshot = restoredFrame.snapshot;
             }
             const committed = commitHistoryBack(hostHistory);
             if (!committed) {
               return 'none';
             }
-            if (restoredFrame) {
-              applyFrame(restoredFrame);
-            }
+            publishFrame(restoredFrame);
+            const restoredSnapshot = restoredFrame.snapshot;
             updateCurrentHistoryCard(hostHistory, restoredSnapshot.activeCardId);
             mergeSessionState({
               historyIndex: hostHistory.index,

--- a/docs/waves/ENGINE_HOST_FRAME_WORK_ITEMS.md
+++ b/docs/waves/ENGINE_HOST_FRAME_WORK_ITEMS.md
@@ -156,7 +156,7 @@ Archive:
 
 ### F1-03 Navigation-state integration with frame rendering
 
-1. `Status`: `todo`
+1. `Status`: `done`
 2. `Depends On`: `F1-02`
 3. `Files`:
 - `browser/frontend/src/app/navigation-state.ts`
@@ -168,6 +168,16 @@ Archive:
 - navigation-state tests cover render-after-load and render-after-input ordering.
 6. `Accept`:
 - no regressions in load/fetch/back/external-intent flows.
+8. `Notes`:
+- `NavigationHooks.onFrame` is the single committed-frame publication boundary; snapshot and render
+  projections come from the same accepted `EngineFrame`.
+- Load, input, Back, timer, and clear-intent paths consume the existing atomic frame-returning host
+  APIs. Generation checks suppress cancelled and stale completions before publication.
+- Host-history Back stages its deck load and optional card restoration, then publishes only the
+  final restored frame.
+- Focused sequencing evidence is in `navigation-state.frame.test.ts` and
+  `browser-controller.timer.test.ts`; the existing navigation/controller suites retain local,
+  network, reload, same-deck, Back, cancellation, and external-intent coverage.
 
 ## Phase F2: Input Event Expansion
 


### PR DESCRIPTION
## Summary

- route navigation-state publications through one `NavigationHooks.onFrame` commit boundary so snapshot and render projections always come from the same accepted `EngineFrame`
- use the existing atomic frame-returning host APIs for timer and clear-intent effects, removing split mutation/render sequencing
- stage host-history Back deck/card restoration and publish only the final restored frame
- preserve generation checks so cancelled, superseded, and stale completions cannot publish frames
- mark only F1-03 complete with focused sequencing evidence

## Sequencing invariants

1. Engine load/input/Back/timer work resolves before its frame is published.
2. Each accepted state transition publishes exactly one coherent frame; no-op timer ticks publish none.
3. Only the current navigation generation may publish.
4. Host-history Back keeps the prior frame visible until the requested deck/card restoration is complete.
5. Existing local/network load, reload, same-deck history, external-intent, and cancellation behavior remains on the established engine and transport boundaries.

## Scope

No changes to browser presenter, Canvas renderer/styles, engine layout/render code, transport, Tauri contracts, invoke guards, application state, command registry, or marketing site. Generated contract drift remains clean.

## Validation

- `pnpm --dir browser/frontend test` — 319 passed
- `pnpm --dir browser/frontend lint`
- `pnpm --dir browser/frontend format:check`
- `pnpm --dir browser/frontend typecheck`
- `pnpm --dir browser/frontend build`
- `pnpm --dir browser run contracts:check`
- `pnpm test:story all` — 54 passed
- `git diff --check`
- repository pre-commit and pre-push hooks — all passed, including engine/Tauri/transport Rust checks and 410 engine tests
