### PR TITLE
fix(browser): preserve truthful navigation error state

### DIFF
--- a/browser/frontend/src/app/browser-controller.behavior.test.ts
+++ b/browser/frontend/src/app/browser-controller.behavior.test.ts
@@ -223,6 +223,30 @@ describe('BrowserController behavior coverage', () => {
     expect(hostClient.engineSetViewportCols).toHaveBeenCalledWith({ cols: 20 });
   });
 
+  it('reports an unrelated action failure without corrupting committed navigation state', async () => {
+    const refs = createRefs();
+    const presenter = new BrowserPresenter(refs, initialSession, 20);
+    const hostClient = createHostClient();
+    const controller = new BrowserController(hostClient as never, presenter, refs);
+
+    await controller.init('<wml><card id="seed"/></wml>');
+    const committedSession = presenter.getSessionState();
+    refs.viewportColsInput.value = '0';
+
+    document.querySelector<HTMLButtonElement>('#btn-load-context')?.click();
+    await flushAsyncWork();
+
+    expect(hostClient.engineLoadDeckContextFrame).toHaveBeenCalledTimes(1);
+    expect(presenter.getSessionState()).toEqual(committedSession);
+    expect(presenter.getSessionState().navigationStatus).toBe('loaded');
+    expect(presenter.getSessionState().lastError).toBeUndefined();
+    expect(refs.statusMessages.at(-1)).toBe(
+      WAVES_COPY.status.error('viewport cols must be an integer from 1 through 4294967295')
+    );
+
+    controller.dispose();
+  });
+
   it('leaves application shortcuts to the shared command registry', () => {
     const refs = createRefs();
     const presenter = new BrowserPresenter(refs, initialSession, 20);

--- a/browser/frontend/src/app/browser-controller.behavior.test.ts
+++ b/browser/frontend/src/app/browser-controller.behavior.test.ts
@@ -849,6 +849,31 @@ describe('BrowserController behavior coverage', () => {
     expect(refs.statusMessages.at(-1)).toBe(expectedMessage);
   });
 
+  it('surfaces a WBXML decode failure as a deck parse error', async () => {
+    const refs = createRefs();
+    const presenter = new BrowserPresenter(refs, initialSession, 20);
+    const hostClient = createHostClient();
+    const targetUrl = 'http://example.test/deck.wmlc';
+    vi.mocked(hostClient.fetchDeck).mockResolvedValue(
+      wbxmlDecodeFailureResponse(targetUrl) as never
+    );
+    const controller = new BrowserController(hostClient as never, presenter, refs);
+    await controller.init('<wml><card id="seed"/></wml>');
+    await controllerPrivates(controller).setRunMode('network', { loadLocalOnEnter: false });
+
+    refs.fetchUrlInput.value = targetUrl;
+    document.querySelector<HTMLButtonElement>('#btn-fetch-url')?.click();
+    await flushAsyncWork();
+
+    const expectedMessage = WAVES_COPY.status.deckParseFailed('WML public ID mismatch');
+    expect(refs.toastEl.textContent).toBe(expectedMessage);
+    expect(refs.statusMessages.at(-1)).toBe(expectedMessage);
+    expect(presenter.getSessionState()).toMatchObject({
+      navigationStatus: 'error',
+      lastError: 'WML public ID mismatch'
+    });
+  });
+
   it('shows a delayed in-progress hint for a slow network navigation but not for the enabling mode-switch load', async () => {
     // U1: repeat navigations (not just the very first render) get an
     // in-progress indicator once they run past the short delay threshold.

--- a/browser/frontend/src/app/browser-controller.behavior.test.ts
+++ b/browser/frontend/src/app/browser-controller.behavior.test.ts
@@ -247,6 +247,36 @@ describe('BrowserController behavior coverage', () => {
     controller.dispose();
   });
 
+  it('reports a current engine navigation failure without changing the committed frame', async () => {
+    const refs = createRefs();
+    const presenter = new BrowserPresenter(refs, initialSession, 20);
+    const hostClient = createHostClient();
+    const controller = new BrowserController(hostClient as never, presenter, refs);
+
+    await controller.init('<wml><card id="seed"/></wml>');
+    controllerPrivates(controller).timerRuntime.stop();
+    const committedSession = presenter.getSessionState();
+    const committedSnapshot = presenter.getSnapshot();
+    const committedViewport = refs.viewportEl.innerHTML;
+    vi.mocked(hostClient.engineHandleKeyFrame).mockRejectedValueOnce(
+      new Error('Card id not found')
+    );
+
+    document.querySelector<HTMLButtonElement>('#btn-enter')?.click();
+    await flushAsyncWork();
+
+    expect(presenter.getSessionState()).toEqual({
+      ...committedSession,
+      navigationStatus: 'error',
+      lastError: 'Card id not found'
+    });
+    expect(presenter.getSnapshot()).toEqual(committedSnapshot);
+    expect(refs.viewportEl.innerHTML).toBe(committedViewport);
+    expect(refs.statusMessages.at(-1)).toBe(WAVES_COPY.status.error('Card id not found'));
+
+    controller.dispose();
+  });
+
   it('leaves application shortcuts to the shared command registry', () => {
     const refs = createRefs();
     const presenter = new BrowserPresenter(refs, initialSession, 20);
@@ -697,6 +727,40 @@ describe('BrowserController behavior coverage', () => {
     expect(presenter.getSnapshot()?.activeCardId).not.toBe('stale-key');
     expect(refs.fetchUrlInput.value).not.toBe('http://example.test/stale-intent.wml');
     expect(applyTimerSnapshot).not.toHaveBeenCalled();
+  });
+
+  it('discards an engine key failure after its starting run mode changes', async () => {
+    const refs = createRefs();
+    const presenter = new BrowserPresenter(refs, initialSession, 20);
+    const hostClient = createHostClient();
+    const controller = new BrowserController(hostClient as never, presenter, refs);
+
+    await controller.init('<wml><card id="seed"/></wml>');
+    controllerPrivates(controller).timerRuntime.stop();
+    await controllerPrivates(controller).setRunMode('network', { loadLocalOnEnter: false });
+    await flushAsyncWork();
+
+    let rejectKey: ((reason: Error) => void) | undefined;
+    vi.mocked(hostClient.engineHandleKeyFrame).mockImplementationOnce(
+      () =>
+        new Promise((_resolve, reject) => {
+          rejectKey = reject;
+        })
+    );
+    const pendingKey = controllerPrivates(controller).applyEngineKey('enter');
+    await Promise.resolve();
+    expect(hostClient.engineHandleKeyFrame).toHaveBeenCalledTimes(1);
+
+    await controllerPrivates(controller).setRunMode('local', { loadLocalOnEnter: false });
+    const committedSession = presenter.getSessionState();
+    rejectKey?.(new Error('stale navigation failure'));
+    await expect(pendingKey).resolves.toBeUndefined();
+
+    expect(presenter.getSessionState()).toEqual(committedSession);
+    expect(presenter.getSessionState().navigationStatus).toBe('loaded');
+    expect(presenter.getSessionState().lastError).toBeUndefined();
+
+    controller.dispose();
   });
 
   it('clears the frozen skeleton placeholder when the very first deck load fails', async () => {

--- a/browser/frontend/src/app/browser-controller.ts
+++ b/browser/frontend/src/app/browser-controller.ts
@@ -37,6 +37,13 @@ export type RunMode = 'local' | 'network';
 
 const WAP_ACCEPT_HEADER = 'text/vnd.wap.wml, application/vnd.wap.wmlc, application/vnd.wap.wml+xml';
 
+class NavigationActionFailure extends Error {
+  constructor(error: unknown) {
+    super(error instanceof Error ? error.message : String(error));
+    this.name = 'NavigationActionFailure';
+  }
+}
+
 export class BrowserController {
   private readonly hostClient: TauriHostClient;
 
@@ -715,6 +722,12 @@ export class BrowserController {
         this.presenter.recordTimeline(actionName, 'ok');
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
+        if (error instanceof NavigationActionFailure) {
+          this.presenter.patchSessionState({
+            navigationStatus: 'error',
+            lastError: message
+          });
+        }
         this.presenter.setStatus(WAVES_COPY.status.error(message));
         this.presenter.recordTimeline(actionName, 'error', { message });
       }
@@ -727,9 +740,22 @@ export class BrowserController {
     const startingRunMode = this.runMode;
     const startingGeneration = this.navigation.captureNavigationGeneration();
     const previousActiveCardId = this.presenter.getSessionState().activeCardId;
-    const localFrame =
-      startingRunMode === 'local' ? await this.hostClient.engineHandleKeyFrame({ key }) : null;
-    const snapshot = localFrame ? localFrame.snapshot : await this.navigation.applyEngineKey(key);
+    let localFrame: EngineFrame | null;
+    let snapshot: EngineRuntimeSnapshot | null;
+    try {
+      localFrame =
+        startingRunMode === 'local' ? await this.hostClient.engineHandleKeyFrame({ key }) : null;
+      snapshot = localFrame ? localFrame.snapshot : await this.navigation.applyEngineKey(key);
+    } catch (error) {
+      if (
+        this.runMode !== startingRunMode ||
+        !this.navigation.isCurrentNavigation(startingGeneration) ||
+        this.navigation.isNavigationInFlight()
+      ) {
+        return;
+      }
+      throw new NavigationActionFailure(error);
+    }
     if (
       !snapshot ||
       this.runMode !== startingRunMode ||

--- a/browser/frontend/src/app/browser-controller.ts
+++ b/browser/frontend/src/app/browser-controller.ts
@@ -715,7 +715,6 @@ export class BrowserController {
         this.presenter.recordTimeline(actionName, 'ok');
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
-        this.presenter.patchSessionState({ navigationStatus: 'error', lastError: message });
         this.presenter.setStatus(WAVES_COPY.status.error(message));
         this.presenter.recordTimeline(actionName, 'error', { message });
       }

--- a/browser/frontend/src/app/navigation-state.load.test.ts
+++ b/browser/frontend/src/app/navigation-state.load.test.ts
@@ -212,6 +212,55 @@ describe('navigation-state load behavior', () => {
     expect(navigationErrors).toEqual([{ message: 'gateway timed out', kind: 'network' }]);
   });
 
+  it.each([
+    ['WBXML_DECODE_FAILED', 'application/vnd.wap.wmlc', 'WML public ID mismatch'],
+    ['UNSUPPORTED_CONTENT_TYPE', 'image/png', 'unsupported deck content type']
+  ] as const)(
+    'reports %s transport failures as the "parse" error kind',
+    async (code, contentType, message) => {
+      let engineLoads = 0;
+      const publishedCards: string[] = [];
+      const navigationErrors: Array<{ message: string; kind: string }> = [];
+      const host = createHostClientMock({
+        fetchDeck: async () =>
+          fetchOk({
+            ok: false,
+            status: 502,
+            contentType,
+            error: { code, message },
+            engineDeckInput: undefined,
+            wml: undefined
+          }),
+        engineLoadDeckContextFrame: async () => {
+          engineLoads += 1;
+          return frame({ activeCardId: 'unexpected' });
+        }
+      });
+      const machine = createNavigationStateMachine(host, 'http://seed.test', {
+        onFrame: (committedFrame) =>
+          publishedCards.push(committedFrame.snapshot.activeCardId ?? ''),
+        onNavigationError: (errorMessage, kind) => {
+          navigationErrors.push({ message: errorMessage, kind });
+        }
+      });
+
+      const result = await machine.loadTransportUrl({
+        url: 'http://example.test/deck.wmlc',
+        source: 'user',
+        followExternalIntent: true
+      });
+
+      expect(result).toBeNull();
+      expect(machine.getSessionState()).toMatchObject({
+        navigationStatus: 'error',
+        lastError: message
+      });
+      expect(navigationErrors).toEqual([{ message, kind: 'parse' }]);
+      expect(engineLoads).toBe(0);
+      expect(publishedCards).toEqual([]);
+    }
+  );
+
   it('fires onNavigationError when the fetch succeeds but returns no WML payload', async () => {
     const navigationErrors: string[] = [];
     const host = createHostClientMock({

--- a/browser/frontend/src/app/navigation-state.ts
+++ b/browser/frontend/src/app/navigation-state.ts
@@ -35,8 +35,15 @@ export type BackNavigationMode = 'engine' | 'host' | 'none';
 // failed" for every case (see U2 in USABILITY_RESILIENCE_BACKLOG.md):
 // 'network' covers transport-layer failures (timeout, non-200, protocol
 // error, TRANSPORT_UNAVAILABLE, external-intent hop limit); 'parse' covers a
-// transport response that succeeded but carried no usable WML payload.
+// transport response that carried no usable WML payload, including unsupported
+// content types and WBXML decode failures.
 export type NavigationErrorKind = 'network' | 'parse';
+
+const navigationErrorKindForFetchFailure = (response: FetchResponse): NavigationErrorKind =>
+  response.error?.code === 'UNSUPPORTED_CONTENT_TYPE' ||
+  response.error?.code === 'WBXML_DECODE_FAILED'
+    ? 'parse'
+    : 'network';
 
 export interface NavigationHostClient {
   fetchDeck(request: FetchRequest): Promise<FetchResponse>;
@@ -409,7 +416,7 @@ export const createNavigationStateMachine = (
       if (options.source === 'external-intent') {
         quarantineExternalIntentRequest(requestedUrl, method, requestPolicy, generation);
       }
-      hooks.onNavigationError?.(errorMessage, 'network');
+      hooks.onNavigationError?.(errorMessage, navigationErrorKindForFetchFailure(transport));
       return null;
     }
 


### PR DESCRIPTION
## Summary

- stop the generic action-error wrapper from overwriting the last committed navigation state
- mark only failures from a current engine key navigation as navigation errors; stale or superseded failures are discarded
- classify `WBXML_DECODE_FAILED` and `UNSUPPORTED_CONTENT_TYPE` fetch responses as parse failures
- preserve existing network classification for timeout, availability, protocol, payload, invalid-request, and cancellation errors
- retain F1-03 committed-frame sequencing: failed navigation keeps the committed frame and rejected content never reaches engine load or frame publication

## Root cause

`BrowserController.withAction` treated every caught action exception as a navigation failure, so validation and utility-action errors could replace a valid `navigationStatus` and `lastError`. Removing that blanket mutation exposed a legacy Waves story whose current engine task failure still needs an explicit host-visible navigation error.

The correction uses provenance at the engine navigation boundary rather than action names: `applyEngineKey` wraps only a genuine, still-current engine failure, while run-mode changes, generation changes, and in-flight replacement navigation discard the stale result. The generic wrapper reports that marker to session state and continues to report unrelated failures only through status and timeline.

Separately, `navigation-state` sent every non-ok `FetchDeckResponse` through the `network` error hook even when transport had returned content that could not be interpreted as WML.

## User impact

Unrelated action failures remain visible without corrupting the committed deck session. Genuine current engine navigation failures set `navigationStatus=error` while preserving the committed frame and history. WBXML decode and unsupported-content failures use the truthful “Deck parse failed” presentation instead of “Fetch failed.”

## Validation

- browser frontend: 340 tests passed
- Waves executable stories: 20 passed, including `missingFragment--waves-network-missing-fragment-error`
- frontend lint and formatting check
- frontend TypeScript typecheck
- frontend production build
- Rust-backed browser contract regeneration/drift check
- repository pre-push gate, including engine/host/transport fmt and clippy plus 414 engine tests

Closes #466.
Closes #467.
