### PR TITLE
fix(browser): redact diagnostic and timeline exports

### DIFF
--- a/browser/README.md
+++ b/browser/README.md
@@ -233,7 +233,8 @@ group and Docker services. This pilot is scheduled/manual until the promotion cr
 - [x] Add deterministic URL load and runtime status model
 - [x] Implement transport fetch -> engine loadDeckContext handoff
 - [x] Add integration fixtures for load/nav/external-intent loops
-- [x] Add event timeline export parity and chronology validation checks
+- [x] Add versioned, allowlisted event timeline exports with chronology validation and secret-safe
+  diagnostic projections (`APP-PRIV-01` / `RSL-06`)
 - [x] Ship browser-style shell with hidden developer drawer
 - [x] Add global keyboard navigation when not in text-entry fields
 - [x] Add hybrid back behavior (engine card-history + host URL fallback)

--- a/browser/frontend/src/app/browser-presenter.test.ts
+++ b/browser/frontend/src/app/browser-presenter.test.ts
@@ -183,7 +183,7 @@ describe('BrowserPresenter', () => {
     refs.devDrawerEl.dispatchEvent(new Event('toggle'));
 
     expect(refs.sessionStateEl.textContent).toContain('"navigationStatus": "loaded"');
-    expect(refs.snapshotEl.textContent).toContain('"activeCardId": "home"');
+    expect(refs.snapshotEl.textContent).toContain('"hasActiveCard": true');
     expect(refs.transportResponseEl.textContent).toContain('"status": 200');
     expect(refs.activeUrlLabelEl.textContent).toBe('http://local.test/start.wml');
   });
@@ -581,5 +581,106 @@ describe('BrowserPresenter', () => {
     expect(revokeObjectUrlSpy).toHaveBeenCalledWith('blob:test');
 
     clickSpy.mockRestore();
+  });
+
+  it('uses the same secret-safe projection for drawer, detached, and export state', async () => {
+    const refs = createRefs();
+    const presenter = new BrowserPresenter(
+      refs,
+      {
+        runMode: 'network',
+        navigationStatus: 'error',
+        requestedUrl: 'https://alice:userinfo-secret@example.test/?pin=pin-0000',
+        lastError: 'internal-error-secret',
+        historyIndex: 0,
+        history: [
+          {
+            url: 'https://example.test/login',
+            method: 'POST',
+            headers: { Authorization: 'authorization-secret', Cookie: 'cookie-secret' },
+            requestPolicy: {
+              postContext: { payload: 'legacy-payload-secret' },
+              requestIntent: {
+                method: 'post',
+                enctype: 'application/x-www-form-urlencoded',
+                sendReferer: false,
+                sameDeck: false,
+                postFields: [{ name: 'pin', value: 'typed-post-secret' }]
+              }
+            }
+          }
+        ]
+      },
+      20
+    );
+    refs.devDrawerEl.open = true;
+    refs.wmlInput.value = '<wml>raw-source-secret</wml>';
+    presenter.setTransportResponse({
+      ok: false,
+      status: 502,
+      finalUrl: 'https://example.test/?password=password-hunter2',
+      contentType: 'text/vnd.wap.wml',
+      wml: '<wml>raw-wml-secret</wml>',
+      error: {
+        code: 'PROTOCOL_ERROR',
+        message: 'internal-error-secret',
+        details: { cause: 'internal-error-secret' }
+      },
+      timingMs: { encode: 1, udpRtt: 2, decode: 3 }
+    });
+    presenter.setSnapshot({
+      activeCardId: 'login',
+      focusedLinkIndex: 0,
+      focusedInputEditName: 'pin',
+      focusedInputEditValue: 'pin-0000',
+      baseUrl: 'https://alice:userinfo-secret@example.test/',
+      contentType: 'text/vnd.wap.wml',
+      lastBackNavigationHandled: false,
+      lastScriptExecutionOk: false,
+      lastScriptExecutionTrap: 'internal-error-secret',
+      lastScriptDialogRequests: [{ type: 'alert', message: 'dialog-secret' }],
+      lastScriptTimerRequests: [{ type: 'cancel', token: 'timer-token-secret' }]
+    });
+    presenter.recordTimeline('load-transport-url', 'state', {
+      requestedUrl: 'https://example.test/?token=typed-post-secret',
+      method: 'POST',
+      headers: { 'Proxy-Authorization': 'proxy-authorization-secret' }
+    });
+
+    refs.devDrawerEl.dispatchEvent(new Event('toggle'));
+    const detachedState = JSON.stringify(presenter.getDeveloperToolsState());
+    const drawerState = [
+      refs.sessionStateEl.textContent,
+      refs.transportResponseEl.textContent,
+      refs.snapshotEl.textContent,
+      refs.timelineEl.textContent
+    ].join('\n');
+
+    presenter.recordTimeline('render', 'ok');
+    presenter.exportTimeline();
+    const exportBlob = createObjectUrlSpy.mock.calls.at(-1)?.[0];
+    const exportState = exportBlob instanceof Blob ? await exportBlob.text() : '';
+
+    for (const serialized of [detachedState, drawerState, exportState]) {
+      for (const secret of [
+        'userinfo-secret',
+        'pin-0000',
+        'internal-error-secret',
+        'authorization-secret',
+        'cookie-secret',
+        'legacy-payload-secret',
+        'typed-post-secret',
+        'password-hunter2',
+        'raw-wml-secret',
+        'raw-source-secret',
+        'dialog-secret',
+        'timer-token-secret',
+        'proxy-authorization-secret'
+      ]) {
+        expect(serialized).not.toContain(secret);
+      }
+    }
+    expect(presenter.getDeveloperToolsState()).not.toHaveProperty('source');
+    expect(exportState).toContain('"redactionPolicy": "allowlist-v1"');
   });
 });

--- a/browser/frontend/src/app/browser-presenter.ts
+++ b/browser/frontend/src/app/browser-presenter.ts
@@ -25,6 +25,11 @@ import {
   CanvasViewportRenderer,
   ensureCanvasViewportElements
 } from './canvas-viewport-renderer';
+import {
+  projectRuntimeSnapshot,
+  projectSessionState,
+  projectTransportResponse
+} from './diagnostic-projection';
 
 export type BootPhase = 'booting' | 'shell-ready' | 'engine-ready' | 'deck-ready';
 
@@ -133,10 +138,10 @@ export class BrowserPresenter {
 
   getDeveloperToolsState(): DeveloperToolsState {
     return {
-      hostStatus: this.statusText || WAVES_COPY.status.ready,
-      sessionState: { ...this.hostSessionState },
-      transportResponse: this.latestTransportResponse ? { ...this.latestTransportResponse } : null,
-      runtimeSnapshot: this.latestSnapshot ? { ...this.latestSnapshot } : null,
+      hostStatus: `Navigation: ${this.hostSessionState.navigationStatus}`,
+      sessionState: projectSessionState(this.hostSessionState),
+      transportResponse: projectTransportResponse(this.latestTransportResponse),
+      runtimeSnapshot: projectRuntimeSnapshot(this.latestSnapshot),
       timeline: this.timelineState.entries.map((entry) => ({
         ...entry,
         session: { ...entry.session },
@@ -150,10 +155,6 @@ export class BrowserPresenter {
           this.refs.localExampleTestingAcEl.querySelectorAll('li'),
           (item) => item.textContent ?? ''
         )
-      },
-      source: {
-        baseUrl: this.refs.baseUrlInput.value,
-        wml: this.refs.wmlInput.value
       }
     };
   }
@@ -470,7 +471,7 @@ export class BrowserPresenter {
       this.sessionStateText = this.writeTextIfChanged(
         this.refs.sessionStateEl,
         this.sessionStateText,
-        JSON.stringify(this.hostSessionState, null, 2)
+        JSON.stringify(state.sessionState, null, 2)
       );
       this.sessionStateDirty = false;
     }
@@ -486,7 +487,7 @@ export class BrowserPresenter {
       this.snapshotText = this.writeTextIfChanged(
         this.refs.snapshotEl,
         this.snapshotText,
-        this.latestSnapshot ? JSON.stringify(this.latestSnapshot, null, 2) : ''
+        state.runtimeSnapshot ? JSON.stringify(state.runtimeSnapshot, null, 2) : ''
       );
       this.snapshotDirty = false;
     }
@@ -494,7 +495,7 @@ export class BrowserPresenter {
       this.transportResponseText = this.writeTextIfChanged(
         this.refs.transportResponseEl,
         this.transportResponseText,
-        this.latestTransportResponse ? JSON.stringify(this.latestTransportResponse, null, 2) : ''
+        state.transportResponse ? JSON.stringify(state.transportResponse, null, 2) : ''
       );
       this.transportResponseDirty = false;
     }

--- a/browser/frontend/src/app/browser-presenter.ts
+++ b/browser/frontend/src/app/browser-presenter.ts
@@ -26,6 +26,7 @@ import {
   ensureCanvasViewportElements
 } from './canvas-viewport-renderer';
 import {
+  projectHostStatus,
   projectRuntimeSnapshot,
   projectSessionState,
   projectTransportResponse
@@ -138,7 +139,7 @@ export class BrowserPresenter {
 
   getDeveloperToolsState(): DeveloperToolsState {
     return {
-      hostStatus: `Navigation: ${this.hostSessionState.navigationStatus}`,
+      hostStatus: projectHostStatus(this.statusText, this.hostSessionState.navigationStatus),
       sessionState: projectSessionState(this.hostSessionState),
       transportResponse: projectTransportResponse(this.latestTransportResponse),
       runtimeSnapshot: projectRuntimeSnapshot(this.latestSnapshot),

--- a/browser/frontend/src/app/developer-tools-bridge.test.ts
+++ b/browser/frontend/src/app/developer-tools-bridge.test.ts
@@ -28,12 +28,18 @@ class TestBroadcastChannel extends EventTarget {
 
 const state: DeveloperToolsState = {
   hostStatus: 'Ready.',
-  sessionState: { runMode: 'local', navigationStatus: 'idle', requestedUrl: '' },
+  sessionState: {
+    runMode: 'local',
+    navigationStatus: 'idle',
+    requestedUrl: '',
+    hasActiveCard: false,
+    hasError: false,
+    historyLength: 0
+  },
   transportResponse: null,
   runtimeSnapshot: null,
   timeline: [],
-  document: { coverage: '', description: '', goal: '', testingAcceptance: [] },
-  source: { baseUrl: 'http://local.test/', wml: '<wml />' }
+  document: { coverage: '', description: '', goal: '', testingAcceptance: [] }
 };
 
 describe('Developer Tools browser bridge', () => {

--- a/browser/frontend/src/app/developer-tools-workspace.test.ts
+++ b/browser/frontend/src/app/developer-tools-workspace.test.ts
@@ -13,7 +13,9 @@ const state: DeveloperToolsState = {
     navigationStatus: 'loaded',
     requestedUrl: 'http://local.test/examples/basic.wml',
     finalUrl: 'http://local.test/examples/basic.wml',
-    activeCardId: 'home'
+    hasActiveCard: true,
+    hasError: false,
+    historyLength: 0
   },
   transportResponse: {
     ok: true,
@@ -23,14 +25,16 @@ const state: DeveloperToolsState = {
     timingMs: { encode: 1, udpRtt: 4, decode: 2 }
   },
   runtimeSnapshot: {
-    activeCardId: 'home',
+    hasActiveCard: true,
     focusedLinkIndex: 0,
     nextTimerWakeupMs: 250,
     baseUrl: 'http://local.test/examples/basic.wml',
     contentType: 'text/vnd.wap.wml',
+    editingInput: false,
+    editingSelect: false,
     lastBackNavigationHandled: false,
-    lastScriptDialogRequests: [],
-    lastScriptTimerRequests: []
+    scriptDialogRequestCount: 0,
+    scriptTimerRequestCount: 0
   },
   timeline: [
     {
@@ -40,7 +44,10 @@ const state: DeveloperToolsState = {
       session: {
         runMode: 'local',
         navigationStatus: 'loaded',
-        requestedUrl: 'http://local.test/examples/basic.wml'
+        requestedUrl: 'http://local.test/examples/basic.wml',
+        hasActiveCard: false,
+        hasError: false,
+        historyLength: 0
       }
     }
   ],
@@ -49,10 +56,6 @@ const state: DeveloperToolsState = {
     description: 'Description: Basic navigation',
     goal: 'Goal: Exercise card navigation',
     testingAcceptance: ['Select advances to the next card.']
-  },
-  source: {
-    baseUrl: 'http://local.test/examples/basic.wml',
-    wml: '<wml><card id="home" /></wml>'
   }
 };
 
@@ -93,7 +96,7 @@ describe('Developer Tools workspace', () => {
     dispose();
   });
 
-  it('renders structured summaries while retaining exact raw diagnostics', () => {
+  it('renders structured summaries from allowlisted diagnostics', () => {
     renderDeveloperToolsState(root, state);
 
     expect(root.querySelector('#developer-tools-host-status')?.textContent).toBe('Health: ok');
@@ -108,7 +111,7 @@ describe('Developer Tools workspace', () => {
       '"navigationStatus": "loaded"'
     );
     expect(root.querySelector('#transport-response')?.textContent).toContain('"status": 200');
-    expect(root.querySelector('#snapshot')?.textContent).toContain('"activeCardId": "home"');
+    expect(root.querySelector('#snapshot')?.textContent).toContain('"hasActiveCard": true');
     expect(root.querySelector('#timeline')?.textContent).toContain('"load-local-example"');
     expect(root.querySelector('#local-example-testing-ac li')?.textContent).toContain(
       'Select advances'

--- a/browser/frontend/src/app/developer-tools-workspace.ts
+++ b/browser/frontend/src/app/developer-tools-workspace.ts
@@ -1,5 +1,8 @@
-import type { EngineRuntimeSnapshot } from '../../../contracts/engine';
-import type { FetchResponse, HostSessionState } from '../../../contracts/transport';
+import type {
+  DiagnosticRuntimeSnapshot,
+  DiagnosticSessionState,
+  DiagnosticTransportResponse
+} from './diagnostic-projection';
 import type { TimelineEntry } from './timeline';
 
 export interface DeveloperToolsDocumentState {
@@ -9,19 +12,13 @@ export interface DeveloperToolsDocumentState {
   testingAcceptance: string[];
 }
 
-export interface DeveloperToolsSourceState {
-  baseUrl: string;
-  wml: string;
-}
-
 export interface DeveloperToolsState {
   hostStatus: string;
-  sessionState: HostSessionState;
-  transportResponse: FetchResponse | null;
-  runtimeSnapshot: EngineRuntimeSnapshot | null;
+  sessionState: DiagnosticSessionState;
+  transportResponse: DiagnosticTransportResponse | null;
+  runtimeSnapshot: DiagnosticRuntimeSnapshot | null;
   timeline: TimelineEntry[];
   document: DeveloperToolsDocumentState;
-  source: DeveloperToolsSourceState;
 }
 
 const EMPTY_VALUE = '—';
@@ -44,7 +41,7 @@ const displayValue = (value: unknown): string => {
   return String(value);
 };
 
-const transportDuration = (response: FetchResponse | null): string => {
+const transportDuration = (response: DiagnosticTransportResponse | null): string => {
   if (!response) {
     return EMPTY_VALUE;
   }
@@ -62,7 +59,11 @@ export const renderDeveloperToolsSummary = (root: ParentNode, state: DeveloperTo
   );
   setText(root, '[data-devtools-value="run-mode"]', sessionState.runMode);
   setText(root, '[data-devtools-value="navigation-status"]', sessionState.navigationStatus);
-  setText(root, '[data-devtools-value="active-card"]', displayValue(sessionState.activeCardId));
+  setText(
+    root,
+    '[data-devtools-value="active-card"]',
+    sessionState.hasActiveCard ? 'Present' : EMPTY_VALUE
+  );
   setText(root, '[data-devtools-value="event-count"]', String(timeline.length));
   setText(
     root,
@@ -88,7 +89,7 @@ export const renderDeveloperToolsSummary = (root: ParentNode, state: DeveloperTo
   setText(
     root,
     '[data-devtools-value="runtime-card"]',
-    displayValue(runtimeSnapshot?.activeCardId)
+    runtimeSnapshot?.hasActiveCard ? 'Present' : EMPTY_VALUE
   );
   setText(
     root,
@@ -116,8 +117,6 @@ export const renderDeveloperToolsState = (root: ParentNode, state: DeveloperTool
   const descriptionEl = root.querySelector<HTMLElement>('#local-example-description');
   const goalEl = root.querySelector<HTMLElement>('#local-example-goal');
   const acceptanceEl = root.querySelector<HTMLUListElement>('#local-example-testing-ac');
-  const baseUrlEl = root.querySelector<HTMLInputElement>('#base-url');
-  const wmlEl = root.querySelector<HTMLTextAreaElement>('#wml-input');
 
   if (coverageEl) coverageEl.textContent = state.document.coverage;
   if (descriptionEl) descriptionEl.textContent = state.document.description;
@@ -131,8 +130,6 @@ export const renderDeveloperToolsState = (root: ParentNode, state: DeveloperTool
       })
     );
   }
-  if (baseUrlEl && document.activeElement !== baseUrlEl) baseUrlEl.value = state.source.baseUrl;
-  if (wmlEl && document.activeElement !== wmlEl) wmlEl.value = state.source.wml;
 };
 
 const selectTab = (root: HTMLElement, nextTab: HTMLButtonElement): void => {

--- a/browser/frontend/src/app/diagnostic-projection.test.ts
+++ b/browser/frontend/src/app/diagnostic-projection.test.ts
@@ -1,0 +1,204 @@
+import { describe, expect, it } from 'vitest';
+import type { EngineRuntimeSnapshot } from '../../../contracts/engine';
+import type { FetchResponse, HostSessionState } from '../../../contracts/transport';
+import {
+  DIAGNOSTIC_PROJECTION_LIMITS,
+  projectDiagnosticUrl,
+  projectRuntimeSnapshot,
+  projectSessionState,
+  projectTimelineDetails,
+  projectTransportResponse
+} from './diagnostic-projection';
+
+const SECRET_VALUES = [
+  'userinfo-secret',
+  'pin-0000',
+  'password-hunter2',
+  'typed-post-secret',
+  'legacy-payload-secret',
+  'authorization-secret',
+  'cookie-secret',
+  'proxy-authorization-secret',
+  'raw-wml-secret',
+  'raw-bytes-secret',
+  'internal-error-secret',
+  'dialog-secret',
+  'timer-token-secret'
+] as const;
+
+const expectSecretsAbsent = (value: unknown): string => {
+  const serialized = JSON.stringify(value);
+  for (const secret of SECRET_VALUES) {
+    expect(serialized).not.toContain(secret);
+  }
+  return serialized;
+};
+
+describe('diagnostic projection', () => {
+  it('removes URL userinfo and sensitive query values without redacting near-miss names', () => {
+    const projected = projectDiagnosticUrl(
+      'https://alice:userinfo-secret@example.test/login?pin=pin-0000&password=password-hunter2&user[token]=typed-post-secret&pinboard=pinboard-safe&tokenizer=tokenizer-safe&passwordHint=hint-safe&author=author-safe&monkey=monkey-safe'
+    );
+
+    expect(projected).not.toContain('alice');
+    expect(projected).not.toContain('userinfo-secret');
+    expect(projected).not.toContain('pin-0000');
+    expect(projected).not.toContain('password-hunter2');
+    expect(projected).not.toContain('typed-post-secret');
+    expect(projected).toContain('pinboard=pinboard-safe');
+    expect(projected).toContain('tokenizer=tokenizer-safe');
+    expect(projected).toContain('passwordHint=hint-safe');
+    expect(projected).toContain('author=author-safe');
+    expect(projected).toContain('monkey=monkey-safe');
+  });
+
+  it('projects replay history to safe request metadata while omitting credentials and values', () => {
+    const session: HostSessionState = {
+      runMode: 'network',
+      navigationStatus: 'error',
+      requestedUrl:
+        'https://alice:userinfo-secret@example.test/form?pin=pin-0000&pinboard=pinboard-safe',
+      finalUrl: 'https://example.test/form?password=password-hunter2',
+      lastError: 'internal-error-secret',
+      historyIndex: 0,
+      history: [
+        {
+          url: 'https://example.test/form',
+          requestedUrl: 'https://example.test/form?token=typed-post-secret',
+          method: 'POST',
+          headers: {
+            Authorization: 'authorization-secret',
+            Cookie: 'cookie-secret',
+            'Proxy-Authorization': 'proxy-authorization-secret',
+            'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8'
+          },
+          requestPolicy: {
+            refererUrl: 'https://bob:password-hunter2@example.test/start',
+            postContext: {
+              contentType: 'application/x-www-form-urlencoded',
+              payload: 'legacy-payload-secret'
+            },
+            requestIntent: {
+              method: 'post',
+              enctype: 'application/x-www-form-urlencoded',
+              sendReferer: true,
+              sameDeck: false,
+              postFields: [{ name: 'pin', value: 'typed-post-secret' }]
+            }
+          },
+          activeCardId: 'login'
+        }
+      ]
+    };
+
+    const projected = projectSessionState(session);
+    const serialized = expectSecretsAbsent(projected);
+
+    expect(serialized).not.toContain('Authorization');
+    expect(serialized).not.toContain('Cookie');
+    expect(serialized).not.toContain('Proxy-Authorization');
+    expect(projected.hasError).toBe(true);
+    expect(projected.historyLength).toBe(1);
+    expect(projected.currentHistoryEntry?.headers).toEqual({
+      count: 4,
+      contentType: 'application/x-www-form-urlencoded'
+    });
+    expect(projected.currentHistoryEntry?.requestPolicy?.post).toEqual({
+      contentType: 'application/x-www-form-urlencoded',
+      payloadLength: 'legacy-payload-secret'.length,
+      postFieldCount: 1,
+      postFieldValueLength: 'typed-post-secret'.length
+    });
+    expect(projected.requestedUrl).toContain('pinboard=pinboard-safe');
+  });
+
+  it('omits transport bodies and arbitrary error internals while retaining failure metadata', () => {
+    const response: FetchResponse = {
+      ok: false,
+      status: 502,
+      finalUrl: 'https://example.test/deck?token=typed-post-secret',
+      contentType: 'text/vnd.wap.wml; charset=utf-8',
+      wml: '<wml>raw-wml-secret</wml>',
+      raw: { bytesBase64: 'raw-bytes-secret', contentType: 'application/vnd.wap.wmlc' },
+      error: {
+        code: 'WBXML_DECODE_FAILED',
+        message: 'internal-error-secret',
+        details: { cause: 'internal-error-secret' }
+      },
+      timingMs: { encode: 1, udpRtt: 2, decode: 3 }
+    };
+
+    const projected = projectTransportResponse(response);
+    expectSecretsAbsent(projected);
+    expect(projected).toEqual({
+      ok: false,
+      status: 502,
+      finalUrl: 'https://example.test/deck?token=%5Bredacted%5D',
+      contentType: 'text/vnd.wap.wml',
+      timingMs: { encode: 1, udpRtt: 2, decode: 3 },
+      error: { code: 'WBXML_DECODE_FAILED' },
+      body: {
+        decodedWmlLength: '<wml>raw-wml-secret</wml>'.length,
+        rawBase64Length: 'raw-bytes-secret'.length
+      }
+    });
+  });
+
+  it('omits runtime edit values, dialogs, timer tokens, traps, and post-field values', () => {
+    const snapshot: EngineRuntimeSnapshot = {
+      activeCardId: 'login',
+      focusedLinkIndex: 1,
+      focusedInputEditName: 'pin',
+      focusedInputEditValue: 'pin-0000',
+      baseUrl: 'https://alice:userinfo-secret@example.test/deck',
+      contentType: 'text/vnd.wap.wml',
+      lastBackNavigationHandled: false,
+      externalNavigationIntent: 'https://example.test/submit?password=password-hunter2',
+      externalNavigationRequestPolicy: {
+        postContext: { payload: 'legacy-payload-secret' },
+        requestIntent: {
+          method: 'post',
+          enctype: 'application/x-www-form-urlencoded',
+          sendReferer: false,
+          sameDeck: true,
+          postFields: [{ name: 'pin', value: 'typed-post-secret' }]
+        }
+      },
+      lastScriptExecutionOk: false,
+      lastScriptExecutionTrap: 'internal-error-secret',
+      lastScriptExecutionErrorClass: 'internal-error-secret',
+      lastScriptExecutionErrorCategory: 'resource',
+      lastScriptDialogRequests: [{ type: 'alert', message: 'dialog-secret' }],
+      lastScriptTimerRequests: [{ type: 'schedule', delayMs: 10, token: 'timer-token-secret' }]
+    };
+
+    const projected = projectRuntimeSnapshot(snapshot);
+    expectSecretsAbsent(projected);
+    expect(projected).toMatchObject({
+      hasActiveCard: true,
+      editingInput: true,
+      editingSelect: false,
+      lastScriptExecutionOk: false,
+      lastScriptExecutionErrorCategory: 'resource',
+      scriptDialogRequestCount: 1,
+      scriptTimerRequestCount: 1
+    });
+  });
+
+  it('drops unknown timeline details and bounds allowlisted correlation metadata', () => {
+    expect(
+      projectTimelineDetails('unknown-action', {
+        message: 'internal-error-secret',
+        payload: 'legacy-payload-secret'
+      })
+    ).toBeUndefined();
+
+    const projected = projectTimelineDetails('navigation-coalesced', {
+      requestedUrl: `https://example.test/${'a'.repeat(3_000)}?token=typed-post-secret`,
+      requestId: `waves-${'b'.repeat(300)}`
+    });
+    expectSecretsAbsent(projected);
+    expect(String(projected?.requestedUrl).length).toBe(DIAGNOSTIC_PROJECTION_LIMITS.urlLength);
+    expect(String(projected?.requestId).length).toBe(DIAGNOSTIC_PROJECTION_LIMITS.requestIdLength);
+  });
+});

--- a/browser/frontend/src/app/diagnostic-projection.test.ts
+++ b/browser/frontend/src/app/diagnostic-projection.test.ts
@@ -4,6 +4,7 @@ import type { FetchResponse, HostSessionState } from '../../../contracts/transpo
 import {
   DIAGNOSTIC_PROJECTION_LIMITS,
   projectDiagnosticUrl,
+  projectHostStatus,
   projectRuntimeSnapshot,
   projectSessionState,
   projectTimelineDetails,
@@ -35,6 +36,16 @@ const expectSecretsAbsent = (value: unknown): string => {
 };
 
 describe('diagnostic projection', () => {
+  it('preserves allowlisted command feedback without exposing variable status contents', () => {
+    expect(projectHostStatus('Health: internal-error-secret', 'loaded')).toBe('Health: completed.');
+    expect(projectHostStatus('Rendered current card.', 'loaded')).toBe('Rendered current card.');
+    expect(projectHostStatus('Rendered current card', 'loaded')).toBe('Navigation: loaded');
+    expect(projectHostStatus('Healthcheck: internal-error-secret', 'error')).toBe(
+      'Navigation: error'
+    );
+    expect(projectHostStatus('Error: internal-error-secret', 'error')).toBe('Navigation: error');
+  });
+
   it('removes URL userinfo and sensitive query values without redacting near-miss names', () => {
     const projected = projectDiagnosticUrl(
       'https://alice:userinfo-secret@example.test/login?pin=pin-0000&password=password-hunter2&user[token]=typed-post-secret&pinboard=pinboard-safe&tokenizer=tokenizer-safe&passwordHint=hint-safe&author=author-safe&monkey=monkey-safe'

--- a/browser/frontend/src/app/diagnostic-projection.ts
+++ b/browser/frontend/src/app/diagnostic-projection.ts
@@ -1,0 +1,556 @@
+import {
+  SCRIPT_ERROR_CATEGORY_LABELS,
+  type EngineRuntimeSnapshot
+} from '../../../contracts/engine';
+import { APPLICATION_STATE_SENSITIVE_QUERY_KEYS } from '../../../contracts/application-state';
+import type {
+  FetchRequestPolicy,
+  FetchResponse,
+  HostHistoryEntry,
+  HostNavigationSource,
+  HostSessionState,
+  RunMode
+} from '../../../contracts/transport';
+
+export const DIAGNOSTIC_REDACTION_POLICY = 'allowlist-v1' as const;
+
+export const DIAGNOSTIC_PROJECTION_LIMITS = {
+  urlLength: 2_048,
+  requestIdLength: 128
+} as const;
+
+const REDACTED_QUERY_VALUE = '[redacted]';
+const INVALID_URL = '[invalid-url]';
+
+const SENSITIVE_QUERY_NAMES = new Set<string>(APPLICATION_STATE_SENSITIVE_QUERY_KEYS);
+
+const RUN_MODES = new Set<RunMode>(['local', 'network']);
+const NAVIGATION_STATUSES = new Set<HostSessionState['navigationStatus']>([
+  'idle',
+  'loading',
+  'loaded',
+  'error'
+]);
+const NAVIGATION_SOURCES = new Set<HostNavigationSource>([
+  'user',
+  'external-intent',
+  'history-back',
+  'reload',
+  'engine-back',
+  'keyboard'
+]);
+
+export interface DiagnosticHeaderMetadata {
+  count: number;
+  contentType?: string;
+}
+
+export interface DiagnosticPostMetadata {
+  contentType?: string;
+  payloadLength?: number;
+  postFieldCount?: number;
+  postFieldValueLength?: number;
+}
+
+export interface DiagnosticRequestPolicy {
+  destinationPolicy?: FetchRequestPolicy['destinationPolicy'];
+  cacheControl?: FetchRequestPolicy['cacheControl'];
+  refererUrl?: string;
+  uaCapabilityProfile?: FetchRequestPolicy['uaCapabilityProfile'];
+  method?: string;
+  enctype?: string;
+  sendReferer?: boolean;
+  hasAcceptCharset?: boolean;
+  sameDeck?: boolean;
+  post?: DiagnosticPostMetadata;
+}
+
+export interface DiagnosticHistoryEntry {
+  url: string;
+  requestedUrl?: string;
+  method?: string;
+  headers?: DiagnosticHeaderMetadata;
+  requestPolicy?: DiagnosticRequestPolicy;
+  source?: HostNavigationSource;
+  hasActiveCard: boolean;
+}
+
+export interface DiagnosticSessionState {
+  runMode: RunMode;
+  navigationStatus: HostSessionState['navigationStatus'];
+  requestedUrl: string;
+  finalUrl?: string;
+  contentType?: string;
+  hasActiveCard: boolean;
+  focusedLinkIndex?: number;
+  externalNavigationIntent?: string;
+  hasError: boolean;
+  navigationSource?: HostNavigationSource;
+  historyIndex?: number;
+  historyLength: number;
+  currentHistoryEntry?: DiagnosticHistoryEntry;
+}
+
+export interface DiagnosticTransportResponse {
+  ok: boolean;
+  status: number;
+  finalUrl: string;
+  contentType?: string;
+  timingMs: {
+    encode: number;
+    udpRtt: number;
+    decode: number;
+  };
+  error?: {
+    code: NonNullable<FetchResponse['error']>['code'];
+  };
+  body?: {
+    decodedWmlLength?: number;
+    rawBase64Length?: number;
+  };
+}
+
+export interface DiagnosticRuntimeSnapshot {
+  hasActiveCard: boolean;
+  focusedLinkIndex: number;
+  nextTimerWakeupMs?: number;
+  editingInput: boolean;
+  editingSelect: boolean;
+  baseUrl: string;
+  contentType?: string;
+  browserContextEpoch?: number;
+  lastBackNavigationHandled: boolean;
+  externalNavigationIntent?: string;
+  externalNavigationRequestPolicy?: DiagnosticRequestPolicy;
+  lastScriptExecutionOk?: boolean;
+  lastScriptExecutionErrorCategory?: string;
+  lastScriptRequiresRefresh?: boolean;
+  scriptDialogRequestCount: number;
+  scriptTimerRequestCount: number;
+}
+
+const bounded = (value: string, limit: number): string =>
+  value.length <= limit ? value : `${value.slice(0, Math.max(0, limit - 1))}…`;
+
+const isSensitiveQueryToken = (value: string): boolean => {
+  if (SENSITIVE_QUERY_NAMES.has(value)) {
+    return true;
+  }
+  for (const sensitiveName of SENSITIVE_QUERY_NAMES) {
+    if (value.endsWith(`_${sensitiveName}`) || value.endsWith(`-${sensitiveName}`)) {
+      return true;
+    }
+  }
+  return false;
+};
+
+const isSensitiveQueryName = (name: string): boolean => {
+  const normalized = name.trim().toLowerCase();
+  if (isSensitiveQueryToken(normalized)) return true;
+  const bracketSegments = Array.from(normalized.matchAll(/\[([^\]]+)\]/g), (match) => match[1]);
+  if (bracketSegments.length > 0) {
+    return isSensitiveQueryToken(bracketSegments.at(-1) ?? '');
+  }
+  const dotSegments = normalized.split('.');
+  return dotSegments.length > 1 && isSensitiveQueryToken(dotSegments.at(-1) ?? '');
+};
+
+export const projectDiagnosticUrl = (value: string | undefined): string | undefined => {
+  if (value === undefined) {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return '';
+  }
+  try {
+    const absolute = /^[A-Za-z][A-Za-z\d+.-]*:/.test(trimmed);
+    const url = new URL(trimmed, 'http://waves.invalid');
+    url.username = '';
+    url.password = '';
+    const redactedQuery = new URLSearchParams();
+    for (const [name, queryValue] of url.searchParams) {
+      redactedQuery.append(name, isSensitiveQueryName(name) ? REDACTED_QUERY_VALUE : queryValue);
+    }
+    url.search = redactedQuery.toString();
+    const projected = absolute ? url.toString() : `${url.pathname}${url.search}${url.hash}`;
+    return bounded(projected, DIAGNOSTIC_PROJECTION_LIMITS.urlLength);
+  } catch {
+    return INVALID_URL;
+  }
+};
+
+const projectContentType = (value: unknown): string | undefined => {
+  const mediaType =
+    typeof value === 'string' ? value.split(';', 1)[0]?.trim().toLowerCase() : undefined;
+  return mediaType && /^[a-z0-9!#$&^_.+-]+\/[a-z0-9!#$&^_.+-]+$/.test(mediaType)
+    ? mediaType
+    : undefined;
+};
+
+const projectMethod = (value: string | undefined): string | undefined => {
+  const method = value?.trim().toUpperCase();
+  return method && /^[A-Z]{1,16}$/.test(method) ? method : undefined;
+};
+
+const projectHeaders = (
+  headers: Record<string, unknown> | undefined
+): DiagnosticHeaderMetadata | undefined => {
+  if (!headers) {
+    return undefined;
+  }
+  const contentType = Object.entries(headers).find(
+    ([name]) => name.trim().toLowerCase() === 'content-type'
+  )?.[1];
+  return {
+    count: Object.keys(headers).length,
+    ...(projectContentType(contentType) ? { contentType: projectContentType(contentType) } : {})
+  };
+};
+
+export const projectRequestPolicy = (
+  policy: FetchRequestPolicy | undefined
+): DiagnosticRequestPolicy | undefined => {
+  if (!policy) {
+    return undefined;
+  }
+  const postContext = policy.postContext;
+  const requestIntent = policy.requestIntent;
+  const post: DiagnosticPostMetadata = {
+    ...(projectContentType(postContext?.contentType ?? requestIntent?.sourceContentType)
+      ? {
+          contentType: projectContentType(
+            postContext?.contentType ?? requestIntent?.sourceContentType
+          )
+        }
+      : {}),
+    ...(postContext?.payload !== undefined ? { payloadLength: postContext.payload.length } : {}),
+    ...(requestIntent
+      ? {
+          postFieldCount: requestIntent.postFields.length,
+          postFieldValueLength: requestIntent.postFields.reduce(
+            (total, field) => total + field.value.length,
+            0
+          )
+        }
+      : {})
+  };
+  return {
+    ...(policy.destinationPolicy ? { destinationPolicy: policy.destinationPolicy } : {}),
+    ...(policy.cacheControl ? { cacheControl: policy.cacheControl } : {}),
+    ...(policy.refererUrl ? { refererUrl: projectDiagnosticUrl(policy.refererUrl) } : {}),
+    ...(policy.uaCapabilityProfile ? { uaCapabilityProfile: policy.uaCapabilityProfile } : {}),
+    ...(requestIntent?.method ? { method: projectMethod(requestIntent.method) } : {}),
+    ...(projectContentType(requestIntent?.enctype)
+      ? { enctype: projectContentType(requestIntent?.enctype) }
+      : {}),
+    ...(requestIntent ? { sendReferer: requestIntent.sendReferer } : {}),
+    ...(requestIntent ? { hasAcceptCharset: Boolean(requestIntent.acceptCharset) } : {}),
+    ...(requestIntent?.sameDeck !== undefined
+      ? { sameDeck: requestIntent.sameDeck }
+      : postContext?.sameDeck !== undefined
+        ? { sameDeck: postContext.sameDeck }
+        : {}),
+    ...(Object.keys(post).length > 0 ? { post } : {})
+  };
+};
+
+const projectHistoryEntry = (entry: HostHistoryEntry): DiagnosticHistoryEntry => ({
+  url: projectDiagnosticUrl(entry.url) ?? '',
+  ...(entry.requestedUrl ? { requestedUrl: projectDiagnosticUrl(entry.requestedUrl) } : {}),
+  ...(projectMethod(entry.method) ? { method: projectMethod(entry.method) } : {}),
+  ...(projectHeaders(entry.headers) ? { headers: projectHeaders(entry.headers) } : {}),
+  ...(projectRequestPolicy(entry.requestPolicy)
+    ? { requestPolicy: projectRequestPolicy(entry.requestPolicy) }
+    : {}),
+  ...(entry.source && NAVIGATION_SOURCES.has(entry.source) ? { source: entry.source } : {}),
+  hasActiveCard: Boolean(entry.activeCardId)
+});
+
+export const projectSessionState = (session: HostSessionState): DiagnosticSessionState => {
+  const historyLength = session.history?.length ?? 0;
+  const currentHistoryEntry =
+    session.history && session.historyIndex !== undefined && session.historyIndex >= 0
+      ? session.history[session.historyIndex]
+      : undefined;
+  return {
+    runMode: RUN_MODES.has(session.runMode) ? session.runMode : 'local',
+    navigationStatus: NAVIGATION_STATUSES.has(session.navigationStatus)
+      ? session.navigationStatus
+      : 'error',
+    requestedUrl: projectDiagnosticUrl(session.requestedUrl) ?? '',
+    ...(session.finalUrl ? { finalUrl: projectDiagnosticUrl(session.finalUrl) } : {}),
+    ...(projectContentType(session.contentType)
+      ? { contentType: projectContentType(session.contentType) }
+      : {}),
+    hasActiveCard: Boolean(session.activeCardId),
+    ...(Number.isSafeInteger(session.focusedLinkIndex)
+      ? { focusedLinkIndex: session.focusedLinkIndex }
+      : {}),
+    ...(session.externalNavigationIntent
+      ? { externalNavigationIntent: projectDiagnosticUrl(session.externalNavigationIntent) }
+      : {}),
+    hasError: Boolean(session.lastError),
+    ...(session.navigationSource && NAVIGATION_SOURCES.has(session.navigationSource)
+      ? { navigationSource: session.navigationSource }
+      : {}),
+    ...(Number.isSafeInteger(session.historyIndex) ? { historyIndex: session.historyIndex } : {}),
+    historyLength,
+    ...(currentHistoryEntry
+      ? { currentHistoryEntry: projectHistoryEntry(currentHistoryEntry) }
+      : {})
+  };
+};
+
+export const projectTransportResponse = (
+  response: FetchResponse | null
+): DiagnosticTransportResponse | null => {
+  if (!response) {
+    return null;
+  }
+  const decodedWmlLength = response.wml?.length ?? response.engineDeckInput?.wmlXml.length;
+  const rawBase64Length =
+    response.raw?.bytesBase64.length ?? response.engineDeckInput?.rawBytesBase64?.length;
+  return {
+    ok: response.ok,
+    status: response.status,
+    finalUrl: projectDiagnosticUrl(response.finalUrl) ?? '',
+    ...(projectContentType(response.contentType)
+      ? { contentType: projectContentType(response.contentType) }
+      : {}),
+    timingMs: { ...response.timingMs },
+    ...(response.error ? { error: { code: response.error.code } } : {}),
+    ...(decodedWmlLength !== undefined || rawBase64Length !== undefined
+      ? {
+          body: {
+            ...(decodedWmlLength !== undefined ? { decodedWmlLength } : {}),
+            ...(rawBase64Length !== undefined ? { rawBase64Length } : {})
+          }
+        }
+      : {})
+  };
+};
+
+export const projectRuntimeSnapshot = (
+  snapshot: EngineRuntimeSnapshot | null
+): DiagnosticRuntimeSnapshot | null => {
+  if (!snapshot) {
+    return null;
+  }
+  return {
+    hasActiveCard: Boolean(snapshot.activeCardId),
+    focusedLinkIndex: snapshot.focusedLinkIndex,
+    ...(snapshot.nextTimerWakeupMs !== undefined
+      ? { nextTimerWakeupMs: snapshot.nextTimerWakeupMs }
+      : {}),
+    editingInput: Boolean(snapshot.focusedInputEditName),
+    editingSelect: Boolean(snapshot.focusedSelectEditName),
+    baseUrl: projectDiagnosticUrl(snapshot.baseUrl) ?? '',
+    ...(projectContentType(snapshot.contentType)
+      ? { contentType: projectContentType(snapshot.contentType) }
+      : {}),
+    ...(snapshot.browserContextEpoch !== undefined
+      ? { browserContextEpoch: snapshot.browserContextEpoch }
+      : {}),
+    lastBackNavigationHandled: snapshot.lastBackNavigationHandled,
+    ...(snapshot.externalNavigationIntent
+      ? { externalNavigationIntent: projectDiagnosticUrl(snapshot.externalNavigationIntent) }
+      : {}),
+    ...(snapshot.externalNavigationRequestPolicy
+      ? {
+          externalNavigationRequestPolicy: projectRequestPolicy(
+            snapshot.externalNavigationRequestPolicy
+          )
+        }
+      : {}),
+    ...(snapshot.lastScriptExecutionOk !== undefined
+      ? { lastScriptExecutionOk: snapshot.lastScriptExecutionOk }
+      : {}),
+    ...(snapshot.lastScriptExecutionErrorCategory &&
+    snapshot.lastScriptExecutionErrorCategory in SCRIPT_ERROR_CATEGORY_LABELS
+      ? {
+          lastScriptExecutionErrorCategory: snapshot.lastScriptExecutionErrorCategory
+        }
+      : {}),
+    ...(snapshot.lastScriptRequiresRefresh !== undefined
+      ? { lastScriptRequiresRefresh: snapshot.lastScriptRequiresRefresh }
+      : {}),
+    scriptDialogRequestCount: snapshot.lastScriptDialogRequests.length,
+    scriptTimerRequestCount: snapshot.lastScriptTimerRequests.length
+  };
+};
+
+const asRecord = (value: unknown): Record<string, unknown> | undefined =>
+  typeof value === 'object' && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+
+const safeNumber = (value: unknown): number | undefined =>
+  typeof value === 'number' && Number.isSafeInteger(value) ? value : undefined;
+
+const safeBoolean = (value: unknown): boolean | undefined =>
+  typeof value === 'boolean' ? value : undefined;
+
+const addNumber = (target: Record<string, unknown>, key: string, value: unknown): void => {
+  const projected = safeNumber(value);
+  if (projected !== undefined) target[key] = projected;
+};
+
+const addBoolean = (target: Record<string, unknown>, key: string, value: unknown): void => {
+  const projected = safeBoolean(value);
+  if (projected !== undefined) target[key] = projected;
+};
+
+const addUrl = (target: Record<string, unknown>, key: string, value: unknown): void => {
+  if (typeof value === 'string') target[key] = projectDiagnosticUrl(value);
+};
+
+const projectSessionPatch = (patch: Record<string, unknown>): Record<string, unknown> => {
+  const projected: Record<string, unknown> = {};
+  if (typeof patch.runMode === 'string' && RUN_MODES.has(patch.runMode as RunMode)) {
+    projected.runMode = patch.runMode;
+  }
+  if (
+    typeof patch.navigationStatus === 'string' &&
+    NAVIGATION_STATUSES.has(patch.navigationStatus as HostSessionState['navigationStatus'])
+  ) {
+    projected.navigationStatus = patch.navigationStatus;
+  }
+  addUrl(projected, 'requestedUrl', patch.requestedUrl);
+  addUrl(projected, 'finalUrl', patch.finalUrl);
+  if (typeof patch.contentType === 'string') {
+    const contentType = projectContentType(patch.contentType);
+    if (contentType) projected.contentType = contentType;
+  }
+  if ('activeCardId' in patch) projected.hasActiveCard = Boolean(patch.activeCardId);
+  addNumber(projected, 'focusedLinkIndex', patch.focusedLinkIndex);
+  addUrl(projected, 'externalNavigationIntent', patch.externalNavigationIntent);
+  if ('lastError' in patch) projected.hasError = Boolean(patch.lastError);
+  if (
+    typeof patch.navigationSource === 'string' &&
+    NAVIGATION_SOURCES.has(patch.navigationSource as HostNavigationSource)
+  ) {
+    projected.navigationSource = patch.navigationSource;
+  }
+  addNumber(projected, 'historyIndex', patch.historyIndex);
+  if (Array.isArray(patch.history)) projected.historyLength = patch.history.length;
+  return projected;
+};
+
+export const projectTimelineDetails = (
+  action: string,
+  details: Record<string, unknown> | undefined
+): Record<string, unknown> | undefined => {
+  if (!details) return undefined;
+  const projected: Record<string, unknown> = {};
+
+  switch (action) {
+    case 'session-state': {
+      const patch = asRecord(details.patch);
+      if (patch) projected.patch = projectSessionPatch(patch);
+      break;
+    }
+    case 'startup-network-probe':
+      addNumber(projected, 'attempt', details.attempt);
+      addUrl(projected, 'targetUrl', details.targetUrl);
+      break;
+    case 'external-intent-quarantined':
+      addNumber(projected, 'generation', details.generation);
+      addUrl(projected, 'requestedUrl', details.requestedUrl);
+      projected.method = projectMethod(
+        typeof details.method === 'string' ? details.method : undefined
+      );
+      break;
+    case 'load-transport-url': {
+      if (
+        typeof details.source === 'string' &&
+        NAVIGATION_SOURCES.has(details.source as HostNavigationSource)
+      ) {
+        projected.source = details.source;
+      }
+      addUrl(projected, 'requestedUrl', details.requestedUrl);
+      projected.method = projectMethod(
+        typeof details.method === 'string' ? details.method : undefined
+      );
+      addBoolean(projected, 'followExternalIntent', details.followExternalIntent);
+      addBoolean(projected, 'pushHistory', details.pushHistory);
+      const headers = asRecord(details.headers);
+      if (headers) projected.headers = projectHeaders(headers);
+      const policy = asRecord(details.requestPolicy) as FetchRequestPolicy | undefined;
+      if (policy) projected.requestPolicy = projectRequestPolicy(policy);
+      break;
+    }
+    case 'fetch-deck-response':
+      addBoolean(projected, 'ok', details.ok);
+      addNumber(projected, 'status', details.status);
+      addUrl(projected, 'finalUrl', details.finalUrl);
+      if (typeof details.contentType === 'string') {
+        const contentType = projectContentType(details.contentType);
+        if (contentType) projected.contentType = contentType;
+      }
+      break;
+    case 'browser-context-reset':
+      addNumber(projected, 'browserContextEpoch', details.browserContextEpoch);
+      break;
+    case 'engine-load-deck-context':
+      projected.hasActiveCard = Boolean(details.activeCardId);
+      addNumber(projected, 'focusedLinkIndex', details.focusedLinkIndex);
+      addUrl(projected, 'externalNavigationIntent', details.externalNavigationIntent);
+      break;
+    case 'navigation-coalesced':
+      addUrl(projected, 'requestedUrl', details.requestedUrl);
+      if (typeof details.requestId === 'string') {
+        projected.requestId = bounded(
+          details.requestId,
+          DIAGNOSTIC_PROJECTION_LIMITS.requestIdLength
+        );
+      }
+      break;
+    case 'host-history-back':
+      addNumber(projected, 'historyIndex', details.historyIndex);
+      addUrl(projected, 'url', details.url);
+      projected.hasRestoredCard = Boolean(details.restoredCardId);
+      break;
+    case 'boot-phase':
+      if (
+        ['booting', 'shell-ready', 'engine-ready', 'deck-ready'].includes(String(details.phase))
+      ) {
+        projected.phase = details.phase;
+      }
+      break;
+    case 'keyboard-input-edit-state':
+    case 'keyboard-select-edit-state':
+      if (['ArrowUp', 'ArrowDown', 'Enter', 'Escape', 'Backspace'].includes(String(details.key))) {
+        projected.key = details.key;
+      }
+      addBoolean(projected, 'handled', details.handled);
+      projected.hasFocusedControl = Boolean(
+        details.focusedInputEditName ?? details.focusedSelectEditName
+      );
+      break;
+    case 'script-timer-schedule':
+      addNumber(projected, 'delayMs', details.delayMs);
+      addNumber(projected, 'dueMs', details.dueMs);
+      break;
+    case 'script-timer-cancel':
+      addNumber(projected, 'nowMs', details.nowMs);
+      break;
+    case 'script-timer-expire':
+      addNumber(projected, 'dueMs', details.dueMs);
+      break;
+    case 'engine-timer-transition':
+      projected.cardChanged = Boolean(details.from !== details.to);
+      break;
+    case 'cancel-fetch-failed':
+    case 'engine-timer-tick':
+      projected.error = true;
+      break;
+    default:
+      break;
+  }
+
+  for (const key of Object.keys(projected)) {
+    if (projected[key] === undefined) delete projected[key];
+  }
+  return Object.keys(projected).length > 0 ? projected : undefined;
+};

--- a/browser/frontend/src/app/diagnostic-projection.ts
+++ b/browser/frontend/src/app/diagnostic-projection.ts
@@ -39,6 +39,26 @@ const NAVIGATION_SOURCES = new Set<HostNavigationSource>([
   'engine-back',
   'keyboard'
 ]);
+const SAFE_HOST_STATUS_MESSAGES = new Set([
+  'Rendered current card.',
+  'Snapshot refreshed.',
+  'Cleared external navigation intent.',
+  'Exported timeline JSON.',
+  'Cleared event timeline.'
+]);
+
+export const projectHostStatus = (
+  message: string,
+  navigationStatus: HostSessionState['navigationStatus']
+): string => {
+  if (message.startsWith('Health:')) {
+    return 'Health: completed.';
+  }
+  if (SAFE_HOST_STATUS_MESSAGES.has(message)) {
+    return message;
+  }
+  return `Navigation: ${NAVIGATION_STATUSES.has(navigationStatus) ? navigationStatus : 'error'}`;
+};
 
 export interface DiagnosticHeaderMetadata {
   count: number;

--- a/browser/frontend/src/app/timeline.test.ts
+++ b/browser/frontend/src/app/timeline.test.ts
@@ -52,6 +52,70 @@ describe('app/timeline', () => {
     expect(state.nextSeq).toBe(4);
   });
 
+  it('stores only the allowlisted projection at the producer boundary', () => {
+    const next = appendTimelineEntry(
+      createTimelineState(),
+      200,
+      'load-transport-url',
+      'state',
+      {
+        runMode: 'network',
+        navigationStatus: 'loading',
+        requestedUrl: 'https://alice:userinfo-secret@example.test/?pin=pin-0000',
+        lastError: 'internal-error-secret',
+        historyIndex: 0,
+        history: [
+          {
+            url: 'https://example.test/',
+            method: 'POST',
+            headers: { Authorization: 'authorization-secret' },
+            requestPolicy: { postContext: { payload: 'legacy-payload-secret' } }
+          }
+        ]
+      },
+      {
+        requestedUrl: 'https://example.test/?password=password-hunter2',
+        method: 'POST',
+        headers: { Cookie: 'cookie-secret' },
+        requestPolicy: {
+          requestIntent: {
+            method: 'post',
+            enctype: 'application/x-www-form-urlencoded',
+            sendReferer: false,
+            sameDeck: false,
+            postFields: [{ name: 'pin', value: 'typed-post-secret' }]
+          }
+        }
+      }
+    );
+
+    const serialized = JSON.stringify(next.entries);
+    for (const secret of [
+      'userinfo-secret',
+      'pin-0000',
+      'internal-error-secret',
+      'authorization-secret',
+      'legacy-payload-secret',
+      'password-hunter2',
+      'cookie-secret',
+      'typed-post-secret'
+    ]) {
+      expect(serialized).not.toContain(secret);
+    }
+    expect(next.entries[0]?.session).toMatchObject({
+      navigationStatus: 'loading',
+      hasError: true,
+      historyLength: 1
+    });
+    expect(next.entries[0]?.details).toMatchObject({
+      method: 'POST',
+      headers: { count: 1 },
+      requestPolicy: {
+        post: { postFieldCount: 1, postFieldValueLength: 'typed-post-secret'.length }
+      }
+    });
+  });
+
   it('builds and validates timeline export payload', () => {
     const state = appendTimelineEntry(
       appendTimelineEntry(createTimelineState(), 200, 'bootstrap', 'state', {
@@ -71,7 +135,8 @@ describe('app/timeline', () => {
       requestedUrl: 'http://local.test'
     });
     expect(payload.timelineLength).toBe(2);
-    expect(payload.schemaVersion).toBe(1);
+    expect(payload.schemaVersion).toBe(2);
+    expect(payload.redactionPolicy).toBe('allowlist-v1');
     expect(() =>
       validateTimelineExport(payload as unknown as Record<string, unknown>)
     ).not.toThrow();

--- a/browser/frontend/src/app/timeline.ts
+++ b/browser/frontend/src/app/timeline.ts
@@ -1,4 +1,10 @@
 import type { HostSessionState } from '../../../contracts/transport';
+import {
+  DIAGNOSTIC_REDACTION_POLICY,
+  projectSessionState,
+  projectTimelineDetails,
+  type DiagnosticSessionState
+} from './diagnostic-projection';
 import { WAVES_CONFIG } from './waves-config';
 import { WAVES_COPY } from './waves-copy';
 
@@ -6,7 +12,7 @@ export interface TimelineEntry {
   seq: number;
   action: string;
   phase: 'start' | 'ok' | 'error' | 'state';
-  session: HostSessionState;
+  session: DiagnosticSessionState;
   details?: Record<string, unknown>;
 }
 
@@ -17,13 +23,14 @@ export interface TimelineState {
 
 export interface TimelineExportPayload {
   schemaVersion: number;
+  redactionPolicy: typeof DIAGNOSTIC_REDACTION_POLICY;
   timelineLength: number;
-  latestSessionState: HostSessionState;
+  latestSessionState: DiagnosticSessionState;
   timeline: Array<{
     seq: number;
     action: string;
     phase: TimelineEntry['phase'];
-    session: HostSessionState;
+    session: DiagnosticSessionState;
     details?: Record<string, unknown>;
   }>;
 }
@@ -41,12 +48,13 @@ export const appendTimelineEntry = (
   session: HostSessionState,
   details?: Record<string, unknown>
 ): TimelineState => {
+  const projectedDetails = projectTimelineDetails(action, details);
   const entry: TimelineEntry = {
     seq: state.nextSeq,
     action,
     phase,
-    session,
-    ...(details ? { details } : {})
+    session: projectSessionState(session),
+    ...(projectedDetails ? { details: projectedDetails } : {})
   };
   const entries = [...state.entries, entry];
   const trimmed =
@@ -64,8 +72,9 @@ export const buildTimelineExport = (
   latestSessionState: HostSessionState
 ): TimelineExportPayload => ({
   schemaVersion: WAVES_CONFIG.timelineSchemaVersion,
+  redactionPolicy: DIAGNOSTIC_REDACTION_POLICY,
   timelineLength: entries.length,
-  latestSessionState,
+  latestSessionState: projectSessionState(latestSessionState),
   timeline: entries.map((entry) => ({
     seq: entry.seq,
     action: entry.action,

--- a/browser/frontend/src/app/waves-config.ts
+++ b/browser/frontend/src/app/waves-config.ts
@@ -12,7 +12,7 @@ export const WAVES_CONFIG = {
   defaultDebugBaseUrl: 'http://local.test/start.wml',
   defaultViewportCols: 20,
   maxTimelineEvents: 200,
-  timelineSchemaVersion: 1,
+  timelineSchemaVersion: 2,
   timelineExportFilename: 'waves-event-timeline.json',
   timelineExportJsonIndent: 2,
   maxExternalIntentHops: 3,

--- a/browser/frontend/src/session-history.test.ts
+++ b/browser/frontend/src/session-history.test.ts
@@ -131,6 +131,55 @@ describe('session-history', () => {
     expect(state.entries[1]?.requestPolicy?.postContext?.payload).toBe('foo=1');
   });
 
+  it('preserves byte-exact replay credentials inside history', () => {
+    const state = createHostHistoryState();
+    const payload = 'username=alice&pin=%30%30%30%30&note=a+b';
+    pushHostHistoryEntry(state, 'http://local.test/login', 'result', 'user', {
+      requestedUrl: 'http://local.test/login',
+      method: 'POST',
+      headers: {
+        Authorization: 'Basic YWxpY2U6c2VjcmV0',
+        Cookie: 'sid=replay-secret'
+      },
+      requestPolicy: {
+        postContext: {
+          contentType: 'application/x-www-form-urlencoded',
+          payload
+        },
+        requestIntent: {
+          method: 'post',
+          enctype: 'application/x-www-form-urlencoded',
+          sendReferer: true,
+          sameDeck: false,
+          postFields: [
+            { name: 'username', value: 'alice' },
+            { name: 'pin', value: '0000' }
+          ]
+        }
+      }
+    });
+
+    const replay = peekHistoryBack({
+      entries: [
+        ...state.entries,
+        {
+          url: 'http://local.test/next',
+          method: 'GET'
+        }
+      ],
+      index: 1
+    });
+    expect(replay?.headers).toEqual({
+      authorization: 'Basic YWxpY2U6c2VjcmV0',
+      cookie: 'sid=replay-secret'
+    });
+    expect(replay?.requestPolicy?.postContext?.payload).toBe(payload);
+    expect(replay?.requestPolicy?.requestIntent?.postFields).toEqual([
+      { name: 'username', value: 'alice' },
+      { name: 'pin', value: '0000' }
+    ]);
+  });
+
   it('keeps separate entries when request headers differ', () => {
     const state = createHostHistoryState();
     pushHostHistoryEntry(state, 'http://local.test/a', 'home', 'user', {

--- a/docs/waves/PRD-WAVES-DESKTOP-APPLICATION-COMPLETION.md
+++ b/docs/waves/PRD-WAVES-DESKTOP-APPLICATION-COMPLETION.md
@@ -736,6 +736,10 @@ WBP-10 --> WBP-11 --> safe-session integration and release matrix
 6. `Validation`: automated secret-canary suite plus review of five representative bundles.
 7. `Suggested branch`: `codex/browser-state-redaction`.
 8. `Suggested PR title`: `fix(browser): sanitize persisted and exported state`.
+9. `Implementation note`: `RSL-06` / issue `#506` supplies the versioned allowlisted projection
+   for the existing session, transport, runtime, timeline, detached-diagnostic, and timeline-export
+   surfaces. Raw/source opt-in support remains excluded until its separate consent and byte-bound
+   decision is implemented.
 
 #### APP-FAV-01 Favorites and first-party service-catalog domain
 

--- a/docs/waves/RESILIENCE_WORK_ITEMS.md
+++ b/docs/waves/RESILIENCE_WORK_ITEMS.md
@@ -223,7 +223,7 @@ WBXML trigger, but current main will still replay an equivalent terminal externa
 ### RSL-06 Redacted developer and timeline projections
 
 1. `Issue`: [#506](https://github.com/dills122/wap-labs/issues/506)
-2. `Status`: `todo`
+2. `Status`: `done`
 3. `Priority`: `P2` security
 4. `Depends On`: none
 5. `Files`:
@@ -242,6 +242,16 @@ WBXML trigger, but current main will still replay an equivalent terminal externa
 - Internal Back still replays the byte-exact original POST.
 8. `Accept`:
 - Diagnostic artifacts are useful without disclosing replay credentials.
+9. `Resolution`:
+- Timeline entries are projected into a fixed allowlisted DTO when produced, while host history
+  continues to retain the exact request identity needed for standards-compatible Back replay.
+- Drawer, detached diagnostic, and version 2 timeline-export serialization all consume the same
+  projection. URL userinfo and credential-like query values are removed, request bodies and typed
+  post-field values become count/length metadata, secret header values and arbitrary error details
+  are omitted, and decoded/source payloads do not enter diagnostic state.
+- Focused frontend coverage exercises secret canaries, near-miss query names, raw transport/runtime
+  failures, producer-boundary projection, deterministic metadata, and byte-exact internal POST
+  history preservation.
 
 ### RSL-07 Bounded toast and host-history state
 


### PR DESCRIPTION
## Summary

- add one fixed-shape, allowlisted projection for session, transport, runtime, and timeline diagnostics
- project timeline state and details at append time, then reuse the same DTOs for drawer, detached developer tools, and version 2 timeline exports
- preserve exact internal request identity for Back/history replay while exposing only safe method, status, content-type, count, length, route, correlation, and timing metadata
- remove raw WML/source mirroring from serialized developer-tool state and document the APP-PRIV-01 / RSL-06 behavior

## Root cause

Replay-capable host history was intentionally credential-complete, but timeline entries and developer/export surfaces copied the live session, transport response, runtime snapshot, and arbitrary details without a serialization boundary.

## Security invariants

- URL userinfo and credential-like query values are removed
- Authorization, Cookie, Proxy-Authorization, raw POST payloads, and typed post-field values never enter diagnostics or exports
- decoded/source WML, raw response bytes, dialog text, timer tokens, script traps, and arbitrary error messages/details are omitted by default
- safe near-miss query fields remain visible
- projection output is fixed-shape and deterministically bounded; RSL-07 queue/history retention is unchanged
- internal history retains byte-exact replay headers, legacy payload, and typed post fields

## Verification

- `pnpm --dir browser/frontend test` — 49 files / 342 tests passed
- `pnpm --dir browser/frontend lint`
- `pnpm --dir browser/frontend typecheck`
- `pnpm --dir browser/frontend format:check`
- `pnpm --dir browser/frontend build`
- `pnpm --dir browser contracts:check`
- `cargo test --manifest-path browser/src-tauri/Cargo.toml --locked` — 93 library + 4 generator tests passed; external Kannel smokes ignored
- pre-push repository hooks — engine tests (414), Rust fmt/clippy, transport checks, Go fmt/vet/tests, and infrastructure validation passed

Closes #506
