### PR TITLE
fix(browser): bound toast and host-history state

### DIFF
--- a/browser/frontend/src/app/browser-presenter.test.ts
+++ b/browser/frontend/src/app/browser-presenter.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { HostSessionState } from '../../../contracts/transport';
 import { ENGINE_RENDER_LIMITS, type RenderList } from '../../../contracts/engine';
 import type { BrowserShellRefs } from './browser-shell-template';
-import { BrowserPresenter } from './browser-presenter';
+import { BrowserPresenter, TOAST_NOTIFICATION_CAPACITY } from './browser-presenter';
 import { WAVES_COPY } from './waves-copy';
 
 const createRefs = (): BrowserShellRefs => {
@@ -286,15 +286,102 @@ describe('BrowserPresenter', () => {
       expect(refs.liveAnnouncerEl.textContent).toBe('first message');
 
       // Fired before the first toast's TTL elapses -- must not clobber it.
-      presenter.showToast('second message', 'ok', 1000);
+      presenter.showToast('second message', 'error', 1000);
       expect(refs.toastEl.textContent).toBe('first message');
 
       vi.advanceTimersByTime(1000);
       expect(refs.toastEl.textContent).toBe('second message');
-      expect(refs.toastEl.className).toBe('toast toast-ok');
+      expect(refs.toastEl.className).toBe('toast toast-error');
       expect(refs.liveAnnouncerEl.textContent).toBe('second message');
 
       vi.advanceTimersByTime(1000);
+      expect(refs.toastEl.className).toBe('toast toast-hidden');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('coalesces 97 identical failures into one accessible bounded notification', async () => {
+    vi.useFakeTimers();
+    try {
+      const refs = createRefs();
+      const presenter = new BrowserPresenter(refs, initialSession, 20);
+      const records: MutationRecord[] = [];
+      const observer = new MutationObserver((mutations) => records.push(...mutations));
+      observer.observe(refs.liveAnnouncerEl, { childList: true });
+
+      for (let failure = 0; failure < 97; failure += 1) {
+        presenter.showToast('gateway timed out', 'error', 1000);
+      }
+      await Promise.resolve();
+
+      const toastState = presenter as unknown as {
+        activeToast?: unknown;
+        toastQueue: unknown[];
+      };
+      expect(
+        Number(toastState.activeToast !== undefined) + toastState.toastQueue.length
+      ).toBeLessThanOrEqual(TOAST_NOTIFICATION_CAPACITY);
+      expect(toastState.toastQueue).toHaveLength(0);
+      expect(records).toHaveLength(1);
+      expect(refs.liveAnnouncerEl.textContent).toBe('gateway timed out');
+
+      vi.advanceTimersByTime(1000);
+      expect(refs.toastEl.className).toBe('toast toast-hidden');
+      observer.disconnect();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('keeps a 10,000-notification burst within total toast capacity', () => {
+    vi.useFakeTimers();
+    try {
+      const refs = createRefs();
+      const presenter = new BrowserPresenter(refs, initialSession, 20);
+
+      for (let failure = 0; failure < 10_000; failure += 1) {
+        presenter.showToast(`failure-${failure}`, 'error', 1000, false);
+      }
+
+      const toastState = presenter as unknown as {
+        activeToast?: { message: string };
+        toastQueue: Array<{ message: string }>;
+      };
+      expect(toastState.activeToast?.message).toBe('failure-0');
+      expect(toastState.toastQueue.map(({ message }) => message)).toEqual([
+        'failure-9997',
+        'failure-9998',
+        'failure-9999'
+      ]);
+      expect(1 + toastState.toastQueue.length).toBe(TOAST_NOTIFICATION_CAPACITY);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('makes successful recovery visible immediately and discards stale failures', () => {
+    vi.useFakeTimers();
+    try {
+      const refs = createRefs();
+      const presenter = new BrowserPresenter(refs, initialSession, 20);
+      const success = WAVES_COPY.status.fetchedAndLoadedDeck('http://local.test/recovered.wml');
+
+      presenter.showToast('first failure', 'error', 1000);
+      presenter.showToast('second failure', 'error', 1000);
+      presenter.showToast('third failure', 'error', 1000);
+      presenter.setStatus(success);
+
+      const toastState = presenter as unknown as {
+        activeToast?: unknown;
+        toastQueue: unknown[];
+      };
+      expect(refs.toastEl.className).toBe('toast toast-hidden');
+      expect(toastState.activeToast).toBeUndefined();
+      expect(toastState.toastQueue).toEqual([]);
+      expect(refs.liveAnnouncerEl.textContent).toBe(success);
+
+      vi.advanceTimersByTime(10_000);
       expect(refs.toastEl.className).toBe('toast toast-hidden');
     } finally {
       vi.useRealTimers();

--- a/browser/frontend/src/app/browser-presenter.ts
+++ b/browser/frontend/src/app/browser-presenter.ts
@@ -35,6 +35,19 @@ import {
 export type BootPhase = 'booting' | 'shell-ready' | 'engine-ready' | 'deck-ready';
 
 const REPEAT_NAV_HINT_CLASS = 'viewport-navigation-hint';
+// One visible toast plus three pending notifications bounds the existing
+// six-second TTL backlog at 24 seconds. Identical notifications share a slot,
+// and recovery signals bypass the backlog entirely.
+export const TOAST_NOTIFICATION_CAPACITY = 4;
+const MAX_QUEUED_TOASTS = TOAST_NOTIFICATION_CAPACITY - 1;
+
+interface ToastNotification {
+  message: string;
+  tone: 'error' | 'ok';
+  ttlMs: number;
+  announce: boolean;
+}
+
 const SKELETON_LINE_CLASSES = [
   'skeleton-line',
   'skeleton-line skeleton-line-wide',
@@ -56,12 +69,8 @@ export class BrowserPresenter {
 
   private toastTimer: ReturnType<typeof setTimeout> | undefined;
   private toastShowing = false;
-  private toastQueue: Array<{
-    message: string;
-    tone: 'error' | 'ok';
-    ttlMs: number;
-    announce: boolean;
-  }> = [];
+  private activeToast: ToastNotification | undefined;
+  private toastQueue: ToastNotification[] = [];
   private hasRenderedContent = false;
   private announcedDialogRequests: readonly ScriptDialogRequestSnapshot[] = [];
   private announcedScriptFailure: {
@@ -208,6 +217,9 @@ export class BrowserPresenter {
   setStatus(message: string): void {
     this.statusText = message;
     const tone = inferStatusTone(message);
+    if (statusSignalsSuccessfulRecovery(message, tone)) {
+      this.supersedeFailureToasts();
+    }
     this.refs.statusEl.setStatus(message, tone);
     this.announce(message);
     uiEvents.emit('status', { message, tone });
@@ -332,44 +344,86 @@ export class BrowserPresenter {
     ttlMs: number = WAVES_CONFIG.toastTtlMs,
     announce = true
   ): void {
-    if (this.toastShowing) {
-      this.toastQueue.push({ message, tone, ttlMs, announce });
+    const notification = { message, tone, ttlMs, announce };
+    if (tone === 'ok') {
+      this.supersedeFailureToasts(notification);
       return;
     }
-    this.presentToast(message, tone, ttlMs, announce);
+    if (this.isDuplicateToast(notification)) {
+      return;
+    }
+    if (this.toastShowing) {
+      if (this.toastQueue.length >= MAX_QUEUED_TOASTS) {
+        this.toastQueue.shift();
+      }
+      this.toastQueue.push(notification);
+      return;
+    }
+    this.presentToast(notification);
   }
 
-  private presentToast(
-    message: string,
-    tone: 'error' | 'ok',
-    ttlMs: number,
-    announce: boolean
-  ): void {
+  private presentToast(notification: ToastNotification): void {
     this.toastShowing = true;
-    this.refs.toastEl.textContent = message;
-    this.refs.toastEl.className = `toast toast-${tone}`;
-    if (announce) {
-      this.announce(message);
+    this.activeToast = notification;
+    this.refs.toastEl.textContent = notification.message;
+    this.refs.toastEl.className = `toast toast-${notification.tone}`;
+    if (notification.announce) {
+      this.announce(notification.message);
     }
     if (this.toastTimer) {
       clearTimeout(this.toastTimer);
     }
     this.toastTimer = setTimeout(() => {
       this.dismissToastAndShowNext();
-    }, ttlMs);
+    }, notification.ttlMs);
   }
 
   private dismissToastAndShowNext(): void {
     this.refs.toastEl.className = 'toast toast-hidden';
     this.toastShowing = false;
+    this.activeToast = undefined;
     this.toastTimer = undefined;
     const next = this.toastQueue.shift();
     if (next) {
-      this.presentToast(next.message, next.tone, next.ttlMs, next.announce);
+      this.presentToast(next);
+    }
+  }
+
+  private isDuplicateToast(notification: ToastNotification): boolean {
+    return [this.activeToast, ...this.toastQueue].some(
+      (candidate) =>
+        candidate?.message === notification.message && candidate.tone === notification.tone
+    );
+  }
+
+  private supersedeFailureToasts(success?: ToastNotification): void {
+    this.toastQueue = this.toastQueue.filter((notification) => notification.tone !== 'error');
+    if (this.activeToast?.tone === 'error') {
+      if (this.toastTimer) {
+        clearTimeout(this.toastTimer);
+        this.toastTimer = undefined;
+      }
+      this.refs.toastEl.className = 'toast toast-hidden';
+      this.toastShowing = false;
+      this.activeToast = undefined;
+    }
+    if (success) {
+      this.toastQueue = [];
+      this.presentToast(success);
+      return;
+    }
+    if (!this.toastShowing) {
+      const next = this.toastQueue.shift();
+      if (next) {
+        this.presentToast(next);
+      }
     }
   }
 
   private announce(message: string): void {
+    if (this.refs.liveAnnouncerEl.textContent === message) {
+      return;
+    }
     this.refs.liveAnnouncerEl.textContent = message;
   }
 
@@ -626,6 +680,15 @@ const dialogRequestListsEqual = (
 
 const describeScriptErrorCategory = (category: string | undefined): string =>
   (category && SCRIPT_ERROR_CATEGORY_LABELS[category]) || 'script error';
+
+const statusSignalsSuccessfulRecovery = (
+  message: string,
+  tone: ReturnType<typeof inferStatusTone>
+): boolean =>
+  tone === 'ok' ||
+  message === WAVES_COPY.status.bootDeckReady ||
+  message === WAVES_COPY.status.rawWmlLoaded ||
+  message.startsWith(WAVES_COPY.status.loadedLocalDeck(''));
 
 // Mirrors the engine's deterministic dialog resolution
 // (engine-wasm/engine/src/wavescript/stdlib/dialogs.rs): confirm() always

--- a/browser/frontend/src/app/timeline.test.ts
+++ b/browser/frontend/src/app/timeline.test.ts
@@ -4,6 +4,7 @@ import {
   buildTimelineExport,
   clearTimelineState,
   createTimelineState,
+  TIMELINE_ENTRY_CAPACITY,
   validateTimelineExport
 } from './timeline';
 
@@ -50,6 +51,37 @@ describe('app/timeline', () => {
     expect(state.entries).toHaveLength(2);
     expect(state.entries.map((entry) => entry.action)).toEqual(['b', 'c']);
     expect(state.nextSeq).toBe(4);
+  });
+
+  it('hard-caps a 10,000-event timeline and its export', () => {
+    let state = createTimelineState();
+    for (let navigation = 0; navigation < 10_000; navigation += 1) {
+      state = appendTimelineEntry(
+        state,
+        10_000,
+        `navigation-${navigation}`,
+        navigation % 2 === 0 ? 'state' : 'ok',
+        {
+          runMode: 'network',
+          navigationStatus: 'loaded',
+          requestedUrl: `http://local.test/${navigation}`
+        }
+      );
+    }
+
+    expect(state.entries).toHaveLength(TIMELINE_ENTRY_CAPACITY);
+    expect(state.entries[0]?.seq).toBe(10_000 - TIMELINE_ENTRY_CAPACITY + 1);
+    expect(state.entries.at(-1)?.seq).toBe(10_000);
+    expect(state.nextSeq).toBe(10_001);
+
+    const payload = buildTimelineExport(state.entries, {
+      runMode: 'network',
+      navigationStatus: 'loaded',
+      requestedUrl: 'http://local.test/9999'
+    });
+    expect(payload.timelineLength).toBe(TIMELINE_ENTRY_CAPACITY);
+    expect(payload.timeline).toHaveLength(TIMELINE_ENTRY_CAPACITY);
+    expect(JSON.stringify(payload).length).toBeLessThan(100_000);
   });
 
   it('stores only the allowlisted projection at the producer boundary', () => {

--- a/browser/frontend/src/app/timeline.ts
+++ b/browser/frontend/src/app/timeline.ts
@@ -35,6 +35,11 @@ export interface TimelineExportPayload {
   }>;
 }
 
+// Diagnostic chronology is intentionally a rolling window. Two hundred
+// projected events retain enough context for a navigation failure while
+// keeping the drawer, detached tools state, and JSON export predictably small.
+export const TIMELINE_ENTRY_CAPACITY = WAVES_CONFIG.maxTimelineEvents;
+
 export const createTimelineState = (): TimelineState => ({
   entries: [],
   nextSeq: 1
@@ -48,6 +53,10 @@ export const appendTimelineEntry = (
   session: HostSessionState,
   details?: Record<string, unknown>
 ): TimelineState => {
+  const requestedEntries = Number.isFinite(maxEntries)
+    ? Math.trunc(maxEntries)
+    : TIMELINE_ENTRY_CAPACITY;
+  const retainedEntries = Math.max(1, Math.min(requestedEntries, TIMELINE_ENTRY_CAPACITY));
   const projectedDetails = projectTimelineDetails(action, details);
   const entry: TimelineEntry = {
     seq: state.nextSeq,
@@ -58,7 +67,7 @@ export const appendTimelineEntry = (
   };
   const entries = [...state.entries, entry];
   const trimmed =
-    entries.length > maxEntries ? entries.slice(entries.length - maxEntries) : entries;
+    entries.length > retainedEntries ? entries.slice(entries.length - retainedEntries) : entries;
   return {
     entries: trimmed,
     nextSeq: state.nextSeq + 1

--- a/browser/frontend/src/session-history.test.ts
+++ b/browser/frontend/src/session-history.test.ts
@@ -3,8 +3,10 @@ import {
   canHistoryBack,
   commitHistoryBack,
   createHostHistoryState,
+  HOST_HISTORY_ENTRY_CAPACITY,
   peekHistoryBack,
   pushHostHistoryEntry,
+  RETAINED_WML_BACK_DEPTH,
   resetHostHistoryState,
   updateCurrentHistoryCard
 } from './session-history';
@@ -250,6 +252,85 @@ describe('session-history', () => {
       'http://local.test/a',
       'http://local.test/b',
       'http://local.test/d'
+    ]);
+  });
+
+  it('evicts the oldest entry and retains a deterministic WML Back window', () => {
+    const state = createHostHistoryState();
+    for (let navigation = 0; navigation < 10_000; navigation += 1) {
+      pushHostHistoryEntry(state, `http://local.test/${navigation}`, `card-${navigation}`, 'user');
+    }
+
+    expect(state.entries).toHaveLength(HOST_HISTORY_ENTRY_CAPACITY);
+    expect(state.index).toBe(HOST_HISTORY_ENTRY_CAPACITY - 1);
+    expect(state.entries[0]?.url).toBe('http://local.test/9968');
+    expect(state.entries.at(-1)?.url).toBe('http://local.test/9999');
+
+    const traversed: string[] = [];
+    while (canHistoryBack(state)) {
+      const entry = commitHistoryBack(state);
+      if (entry) {
+        traversed.push(entry.url);
+      }
+    }
+    expect(traversed).toHaveLength(RETAINED_WML_BACK_DEPTH);
+    expect(traversed.at(-1)).toBe('http://local.test/9968');
+    expect(state.index).toBe(0);
+  });
+
+  it('truncates forward entries before applying oldest-entry eviction', () => {
+    const state = createHostHistoryState();
+    for (let navigation = 0; navigation < HOST_HISTORY_ENTRY_CAPACITY; navigation += 1) {
+      pushHostHistoryEntry(state, `http://local.test/${navigation}`);
+    }
+    commitHistoryBack(state);
+    commitHistoryBack(state);
+
+    pushHostHistoryEntry(state, 'http://local.test/replacement');
+
+    expect(state.entries).toHaveLength(HOST_HISTORY_ENTRY_CAPACITY - 1);
+    expect(state.index).toBe(HOST_HISTORY_ENTRY_CAPACITY - 2);
+    expect(state.entries[0]?.url).toBe('http://local.test/0');
+    expect(state.entries.at(-2)?.url).toBe('http://local.test/29');
+    expect(state.entries.at(-1)?.url).toBe('http://local.test/replacement');
+
+    pushHostHistoryEntry(state, 'http://local.test/newest');
+    pushHostHistoryEntry(state, 'http://local.test/evicts-oldest');
+    expect(state.entries).toHaveLength(HOST_HISTORY_ENTRY_CAPACITY);
+    expect(state.entries[0]?.url).toBe('http://local.test/1');
+    expect(state.entries.at(-1)?.url).toBe('http://local.test/evicts-oldest');
+    expect(state.index).toBe(HOST_HISTORY_ENTRY_CAPACITY - 1);
+  });
+
+  it('clones retained POST replay identity independently from caller mutation', () => {
+    const state = createHostHistoryState();
+    const requestIdentity = {
+      method: 'POST',
+      headers: { Authorization: 'Basic byte-exact' },
+      requestPolicy: {
+        postContext: {
+          contentType: 'application/x-www-form-urlencoded',
+          payload: 'pin=%30%30%30%30'
+        },
+        requestIntent: {
+          method: 'post' as const,
+          enctype: 'application/x-www-form-urlencoded',
+          sendReferer: true,
+          sameDeck: false,
+          postFields: [{ name: 'pin', value: '0000' }]
+        }
+      }
+    };
+
+    pushHostHistoryEntry(state, 'http://local.test/login', 'result', 'user', requestIdentity);
+    requestIdentity.headers.Authorization = 'changed';
+    requestIdentity.requestPolicy.postContext.payload = 'changed';
+    requestIdentity.requestPolicy.requestIntent.postFields[0].value = 'changed';
+
+    expect(state.entries[0]?.headers).toEqual({ authorization: 'Basic byte-exact' });
+    expect(state.entries[0]?.requestPolicy?.postContext?.payload).toBe('pin=%30%30%30%30');
+    expect(state.entries[0]?.requestPolicy?.requestIntent?.postFields).toEqual([
+      { name: 'pin', value: '0000' }
     ]);
   });
 

--- a/browser/frontend/src/session-history.ts
+++ b/browser/frontend/src/session-history.ts
@@ -10,6 +10,12 @@ export interface HostHistoryState {
   index: number;
 }
 
+// A 32-entry host window preserves the current deck plus 31 deterministic WML
+// Back steps. That is useful constrained-device history without allowing exact
+// POST replay credentials to accumulate for the lifetime of the application.
+export const HOST_HISTORY_ENTRY_CAPACITY = 32;
+export const RETAINED_WML_BACK_DEPTH = HOST_HISTORY_ENTRY_CAPACITY - 1;
+
 export const createHostHistoryState = (): HostHistoryState => ({
   entries: [],
   index: -1
@@ -39,6 +45,10 @@ export const pushHostHistoryEntry = (
     activeCardId,
     source
   });
+  const overflow = state.entries.length - HOST_HISTORY_ENTRY_CAPACITY;
+  if (overflow > 0) {
+    state.entries.splice(0, overflow);
+  }
   state.index = state.entries.length - 1;
 };
 
@@ -110,6 +120,12 @@ const cloneRequestPolicy = (policy?: FetchRequestPolicy): FetchRequestPolicy | u
   }
   return {
     ...policy,
-    postContext: policy.postContext ? { ...policy.postContext } : undefined
+    postContext: policy.postContext ? { ...policy.postContext } : undefined,
+    requestIntent: policy.requestIntent
+      ? {
+          ...policy.requestIntent,
+          postFields: policy.requestIntent.postFields.map((field) => ({ ...field }))
+        }
+      : undefined
   };
 };

--- a/docs/waves/PRD-WAVES-DESKTOP-APPLICATION-COMPLETION.md
+++ b/docs/waves/PRD-WAVES-DESKTOP-APPLICATION-COMPLETION.md
@@ -99,7 +99,8 @@ At the synchronized `6cf1682a` baseline:
   open/draft PR queue is empty at this checkpoint.
 - Issue `#450` blocks persistent/searchable history because same-card entries can be lost across a
   deck boundary.
-- Issue `#504` remains the active resilience baton for bounded presenter/history state.
+- Issue `#504` is resolved by bounded presenter/history state. The 32-entry host window does not
+  fix `#450`; persistent/searchable history remains blocked on that separate identity correction.
 
 Independent streams retain their own responsibilities:
 

--- a/docs/waves/RESILIENCE_WORK_ITEMS.md
+++ b/docs/waves/RESILIENCE_WORK_ITEMS.md
@@ -37,8 +37,8 @@ error, preserve usable state where appropriate, and leave an explicit recovery p
 The P1 containment gate is closed: `RSL-01` quarantines terminal external-intent failures,
 `RSL-02` bounds and cancels navigation work, `RSL-03` makes mutating frame commands transactional,
 and `RSL-04` bounds single-pass render output. `RSL-05` closes malformed IPC admission and typed
-host failures, and `RSL-06` closes diagnostic/export redaction. The active resilience baton is
-`RSL-07` on the shared presenter/history surface.
+host failures, `RSL-06` closes diagnostic/export redaction, and `RSL-07` closes bounded
+presenter/history state.
 
 ## Lane A: Navigation Containment
 
@@ -319,7 +319,7 @@ host failures, and `RSL-06` closes diagnostic/export redaction. The active resil
 ### RSL-07 Bounded toast and host-history state
 
 1. `Issue`: [#504](https://github.com/dills122/wap-labs/issues/504)
-2. `Status`: `todo`
+2. `Status`: `done`
 3. `Priority`: `P2`
 4. `Depends On`: `RSL-06`
 5. `Files`:
@@ -346,6 +346,22 @@ host failures, and `RSL-06` closes diagnostic/export redaction. The active resil
 
 - UI and host-session collections remain bounded and preserve an obvious recovery signal.
 
+9. `Resolution`:
+
+- Toast state retains at most four notifications (one visible plus three queued), coalesces
+  identical message/tone pairs, and lets a successful recovery status or toast immediately remove
+  stale failures. Repeated identical failures write the accessible live region once.
+- Host history retains 32 entries: the current entry plus 31 deterministic WML Back steps. Forward
+  history is truncated before a push, then overflow evicts the oldest entry and re-bases the index
+  to the retained window. Retained POST request identities are independently cloned and remain
+  byte-exact for replay.
+- Timeline production and exported diagnostic state retain at most 200 already-redacted entries,
+  even if a caller requests a larger window. A 10,000-navigation simulation covers history,
+  timeline, toast, and export bounds.
+- Issue `#450` remains a separate follow-up: this eviction policy preserves every entry it receives
+  (including duplicates) but does not repair same-card history identity lost across deck
+  replacement. Persistent/searchable history must continue to wait for that identity fix.
+
 ## Dispatch Order and Conflict Map
 
 Completed containment and IPC batches:
@@ -356,12 +372,14 @@ Completed containment and IPC batches:
 4. `RSL-04` bounded single-pass render output
 5. `RSL-05` bounded ingress and typed host errors
 
-Recommended next resilience sequence:
+Completed diagnostic/UI-state sequence:
 
-1. `RSL-07` bounded toast/history state on the completed RSL-06 projection boundary.
-2. Issue `#450` history identity/cross-deck correctness before persisted or searchable history.
+1. `RSL-06` diagnostic and export redaction.
+2. `RSL-07` bounded toast/history state on the completed RSL-06 projection boundary.
+
+Issue `#450` history identity/cross-deck correctness remains required before persisted or searchable
+history.
 
 Likely conflicts:
 
-- `RSL-07` / WBP-11 / merged shell presentation: `browser-presenter.ts`
-- `RSL-07` / issue `#450`: host-history state and retention behavior
+- issue `#450` / WBP-11 / merged shell presentation: host-history and presenter surfaces

--- a/docs/waves/SPRINT_PLAN_2026-03_MASTER_PRIORITIZED.md
+++ b/docs/waves/SPRINT_PLAN_2026-03_MASTER_PRIORITIZED.md
@@ -266,11 +266,11 @@ and lanes may run concurrently subject to the noted file ownership.
 |        5 | Request A2 — replayable POST history                                               | Starts after A1 fixes the serialized request shape; shares navigation/history structures with C1, so land after C1 or coordinate one owner.                                                                    | Directly targets `WML-CL-HISTORY-POST-REPLAY` and the remaining partial WML-C-07/WML-C-38 boundary.                          | Makes form navigation/back behavior predictable in public-lab scenarios.                       |
 |        6 | Script B2 — bounded `WMLS-502` operator/conversion execution                       | Starts after B1 establishes stack dataflow; same files as B1, so it is sequential in lane B.                                                                                                                   | Begins converting the 32 partial / 9 missing WMLScript parents and 107 unassessed language clauses into executable evidence. | Expands the safe script behavior available to representative WAP decks.                        |
 
-Desktop dispatch checkpoint: F1-01 through F1-03, RSL-01 through RSL-06, APP-STATE-01,
-APP-FAV-01, APP-CMD-01, and D0-01 through D0-03 are complete. The next parallel-safe desktop batch
-is RSL-07 bounded presenter/history state, F2-01 deterministic click input, and D0-04 read-only
-Inspector consumption with explicit file ownership. Issue `#450`, WBP-11, and APP-SHELL-01 follow
-on their shared history/presenter/shell surfaces.
+Desktop dispatch checkpoint: F1-01 through F1-03, RSL-01 through RSL-07, APP-STATE-01,
+APP-FAV-01, APP-CMD-01, and D0-01 through D0-03 are complete. F2-01 and D0-04 remain independent
+parallel slices; WBP-11 and APP-SHELL-01 follow on shared presenter/shell surfaces. RSL-07 bounds
+retained history but leaves issue `#450`'s cross-deck same-card identity correction to its separate
+follow-up.
 
 Preserve completed WML, WBXML, WDP, WCMP, and WSP evidence; do not activate
 connection-oriented WSP/WTP to manufacture completion. `REN-4` and full

--- a/docs/waves/WORK_ITEMS.md
+++ b/docs/waves/WORK_ITEMS.md
@@ -179,22 +179,19 @@ Tailnet WAP smoke, sealed-firewall reboot persistence, and retained rollback. Pu
 cloud UDP rule, public firewall mode, and external probes remain incomplete. That lane neither
 blocks nor satisfies Class C evidence and is not dispatched from this board.
 
-The resilience board is also synchronized to current main: `RSL-01` through `RSL-06` are done in
-PRs `#515`, `#516`, `#521`, `#527`, `#528`, and `#532`. Navigation error classification is closed
-by PR `#530`, and D0-03 host debug sessions are closed by PR `#531`. The next containment baton is
-`RSL-07` on the presenter/history surface.
+The resilience board is also synchronized to current main: `RSL-01` through `RSL-07` are done.
+The final pair adds allowlisted diagnostic redaction followed by bounded toast, timeline, and
+host-history state on the shared presenter/history surface.
 
-The next parallel-safe desktop batch is:
+The remaining parallel-safe desktop slices are:
 
-1. `RSL-07` as the sole owner of `browser-presenter.ts`, `session-history.ts`, and `timeline.ts`
-   while bounding toast and host-history state (`#504`).
-2. `F2-01` deterministic click/hit-region input through the engine-owned frame contract.
-3. `D0-04` read-only Inspector polling and safe capture in new debug-consumer modules/components;
-   it must not edit the RSL-07 presenter/history files in this batch.
+1. `F2-01` deterministic click/hit-region input through the engine-owned frame contract.
+2. `D0-04` read-only Inspector polling and safe capture in new debug-consumer modules/components.
 
-After this batch, fix `#450` on the stabilized bounded-history foundation, continue F2-02/F2-03
-after F2-01, and sequence `WBP-11` plus `APP-SHELL-01` around the shared presenter/shell surfaces.
-Keep `#450` ahead of persisted/searchable history.
+After those slices, fix `#450` on the stabilized bounded-history foundation, continue F2-02/F2-03
+after F2-01, and integrate `WBP-11` phase-aware recovery plus `APP-SHELL-01` Library/Preferences
+without sharing an active presenter owner. Keep `#450` ahead of persisted/searchable history;
+RSL-07's deterministic eviction does not repair its cross-deck same-card identity loss.
 
 ### WML-203A Legacy local-example standalone-document migration
 


### PR DESCRIPTION
## Summary

- cap toast state at four notifications (one visible plus three queued), coalesce identical
  message/tone pairs, and let successful recovery immediately supersede stale failures
- retain a deterministic 32-entry host-history window (current entry plus 31 WML Back steps),
  truncating forward history before evicting the oldest entry
- hard-cap timeline and diagnostic exports at the existing 200-event window, even if a caller
  requests more
- keep exact retained POST replay identity while preserving the RSL-06 allowlisted, secret-safe
  diagnostic projection
- mark RSL-07 / issue #504 complete in active planning docs and keep issue #450 as the separate
  cross-deck same-card history-identity follow-up

## Why

Retry storms and long sessions could leave Waves with an unbounded toast queue and unbounded exact
host-history state. Timeline entries were caller-capped, but the timeline module did not enforce a
hard export window itself. This change makes every collection deterministic and bounded without
weakening Back replay or diagnostic redaction.

## Eviction and recovery semantics

- identical queued or visible toasts share one slot and one identical live-region write
- distinct pending toasts retain the newest three behind the currently visible toast
- an `ok` toast or successful deck-load status removes visible and queued stale failures immediately
- host history truncates entries after the current index before append; overflow then removes the
  oldest entries and re-bases the index to the retained window
- retained POST headers, payload, request intent, and post fields are independently cloned and
  replay byte-exactly
- diagnostic drawers, detached tools state, and exports continue to contain only the RSL-06
  allowlisted projections

## Validation

- focused presenter/history/timeline/accessibility tests: 56 passed
- full browser frontend tests: 358 passed
- frontend ESLint, TypeScript typecheck, Prettier check, and Vite production build
- active documentation links: 2,300 files / 226 links
- Waves executable stories: 20 passed
- repository pre-push suite, including OpenTofu validation, Go vet/tests, Rust fmt/Clippy, and 414
  WaveNav engine tests
- `git diff --check`

Closes #504
