### PR TITLE
feat(browser): add read-only engine inspector capture

### DIFF
--- a/browser/ENGINE_DEBUG_INSPECTOR.md
+++ b/browser/ENGINE_DEBUG_INSPECTOR.md
@@ -1,0 +1,85 @@
+# Waves Engine Inspector
+
+The D0-04 Engine Inspector is an optional, first-party, read-only consumer of the generated D0-03
+host commands. It is part of the existing docked and detached Developer Tools workspace. It does
+not add engine controls, a remote listener, replay, raw-source access, or a second debug session.
+
+## Host policy and lifecycle
+
+The Inspector reflects the host's default-disabled policy rather than presenting a frontend
+preference as enablement:
+
+1. Launch the native host with `WAVES_ENGINE_DEBUG_POLICY=enabled`.
+2. Open Developer Tools, select **Inspector**, and choose **Start Inspector**.
+3. The frontend requests one protocol-v1 session, takes an initial bounded snapshot, and polls from
+   the opaque cursor returned by the host.
+4. Polling runs only while at least one docked or detached Inspector surface is visible. Hiding the
+   panel pauses the consumer timer without changing engine ordering.
+5. **Stop** cancels frontend polling and closes the local host session. Session errors also stop
+   polling and make an idempotent close attempt. Application disposal/unmount performs the same
+   cleanup.
+6. Starting again opens a new host identity and clears the prior in-memory capture.
+
+`DEBUG_DISABLED`, `SESSION_LIMIT_REACHED`, cursor/session failures, and sanitized source failures
+remain typed, non-fatal Inspector states. Their host messages and thrown implementation details are
+not rendered or exported. Ordinary deck loading, navigation, focus, input, timers, scripts, and
+rendering do not depend on the Inspector lifecycle.
+
+## Consumer capacities
+
+The engine and host keep their generated contract limits. D0-04 adds smaller frontend presentation
+and artifact limits:
+
+| Surface                                  |                  Limit |
+| ---------------------------------------- | ---------------------: |
+| Events requested per poll                |                  `100` |
+| Events retained in frontend memory       |     `512`, drop oldest |
+| Event rows rendered after filtering      |  `200`, newest matches |
+| Filter query                             |        `80` characters |
+| Postfield resolutions retained per event |                   `64` |
+| Snapshot variables retained              |                  `128` |
+| Snapshot timers retained                 |                   `32` |
+| Snapshot variables/timers rendered       |            `32` / `16` |
+| Events considered for export             | `256`, newest retained |
+| Text units per exported field            |                  `512` |
+| Serialized JSON artifact                 |         `262144` bytes |
+
+Producer `droppedCount` values and frontend drop-oldest counts are tracked separately. The event
+sequence string is the only ordering key; polling cadence and monotonic time never reorder events.
+When an export would exceed the byte ceiling, the oldest candidate events are removed until the
+complete UTF-8 JSON document fits.
+
+## Versioned capture schema
+
+The file name is `waves-engine-debug-capture-v1.json`. Its explicit top-level allowlist is:
+
+- `schemaVersion`: `1`
+- `kind`: `waves-engine-debug-capture`
+- `protocolVersion`
+- `limits`
+- generated capability booleans and numeric bounds
+- `accounting`: producer gaps, frontend drops, retained/exported counts, retained sequence bounds,
+  and export truncation
+- optional bounded `snapshot`
+- bounded `events`
+
+Session identifiers, wall-clock timestamps, filters, host status, credentials, request bodies, raw
+WML/source, transport secrets, arbitrary error internals, and masked original values are not part
+of the schema. Events, payload variants, values, capabilities, snapshots, and collection summaries
+are reconstructed field by field before they enter frontend retention. `masked` and `omitted`
+values serialize only their state and reason.
+
+The exporter trusts the engine-owned D0-02 classification of `visible`, `masked`, and `omitted`
+values. It does not offer unmasking and does not attempt to recover or post-process original secret
+material.
+
+## Filters and accessibility
+
+Filtering is presentation-only. Operators can select a fixed event family and search the bounded
+retained projection by sequence, kind, card identifier, or projected summary. Filters never change
+the cursor, recorder, snapshot, or runtime.
+
+The Inspector uses the Developer Tools roving tab pattern, native buttons/select/search controls,
+labelled regions, a polite status output in the detached window, visible focus styling, and
+keyboard-operable disclosures. The docked application keeps its single global live-announcement
+channel.

--- a/browser/README.md
+++ b/browser/README.md
@@ -69,6 +69,8 @@ Implemented now:
   - `engine_clear_external_navigation_intent`
 - Default-disabled D0-03 engine debug session bridge with generated open/poll/snapshot/close Tauri
   commands, one process-local session, engine-owned bounded recording, and typed sanitized outcomes
+- Optional D0-04 Engine Inspector with visibility-aware polling, bounded filters/retention/snapshot
+  presentation, cursor-gap accounting, and a versioned 256 KiB allowlisted capture artifact
 - In-process Rust transport library under `../transport-rust/`:
   - `http://`/`https://` fetch
   - `wap://`/`waps://` gateway bridge mapping
@@ -187,8 +189,13 @@ generation gate.
 
 The D0-03 read-only engine debug command bridge is disabled by default. Start the native Tauri host
 with `WAVES_ENGINE_DEBUG_POLICY=enabled` to allow one process-local protocol-v1 session. No other
-value enables it, and the policy does not expose a sensitive-data override, remote listener,
-capture/export flow, or Inspector UI; those consumer concerns remain deferred to D0-04.
+value enables it, and the policy does not expose a sensitive-data override or remote listener.
+
+The D0-04 Inspector is available in the existing docked and detached Developer Tools workspace.
+It opens and closes the generated D0-03 session, pauses polling while hidden, retains and renders
+bounded projections, and exports only the versioned allowlist documented in
+[`ENGINE_DEBUG_INSPECTOR.md`](ENGINE_DEBUG_INSPECTOR.md). It does not add mutable debugger
+commands, raw source/secret access, replay, or multi-session behavior.
 
 ## Native Tauri/Kannel UI pilot
 
@@ -243,7 +250,7 @@ group and Docker services. This pilot is scheduled/manual until the promotion cr
 - [x] Implement transport fetch -> engine loadDeckContext handoff
 - [x] Add integration fixtures for load/nav/external-intent loops
 - [x] Add versioned, allowlisted event timeline exports with chronology validation and secret-safe
-  diagnostic projections (`APP-PRIV-01` / `RSL-06`)
+      diagnostic projections (`APP-PRIV-01` / `RSL-06`)
 - [x] Ship browser-style shell with hidden developer drawer
 - [x] Add global keyboard navigation when not in text-entry fields
 - [x] Add hybrid back behavior (engine card-history + host URL fallback)

--- a/browser/frontend/scripts/check-rendered-accessibility.mjs
+++ b/browser/frontend/scripts/check-rendered-accessibility.mjs
@@ -89,7 +89,7 @@ const assertDeveloperToolsPanelContainment = async (
       })
     : null;
   const evidence = [];
-  for (const tabId of ['overview', 'transport', 'runtime', 'timeline', 'source']) {
+  for (const tabId of ['overview', 'transport', 'runtime', 'inspector', 'timeline', 'source']) {
     await activateDeveloperToolsTab(page, tabId);
     const metrics = await page.locator(`#devtools-panel-${tabId}`).evaluate((panel) => {
       const panelRect = panel.getBoundingClientRect();

--- a/browser/frontend/src/app/browser-application.ts
+++ b/browser/frontend/src/app/browser-application.ts
@@ -10,6 +10,15 @@ import { WAVES_COPY } from './waves-copy';
 import { registerBrowserComponents } from '../components';
 import { bindDeveloperToolsHost } from './developer-tools-bridge';
 import { ApplicationCommandBridge } from './application-command-bridge';
+import { createEngineDebugSessionClient } from './engine-debug-client';
+import {
+  createEngineDebugSessionController,
+  type EngineDebugSessionController
+} from './engine-debug-session-controller';
+import {
+  bindEngineDebugInspector,
+  type EngineDebugInspectorBinding
+} from '../components/engine-debug-inspector';
 
 const SAMPLE_WML = `<?xml version="1.0"?>
 <!DOCTYPE wml PUBLIC "-//WAPFORUM//DTD WML 1.3//EN" "http://www.wapforum.org/DTD/wml13.dtd">
@@ -28,6 +37,11 @@ const SAMPLE_WML = `<?xml version="1.0"?>
 export interface BrowserApplication {
   commandBridge: ApplicationCommandBridge;
   controller: BrowserController;
+  debugInspector?: {
+    binding: EngineDebugInspectorBinding;
+    controller: EngineDebugSessionController;
+    unsubscribe: () => void;
+  };
   presenter: BrowserPresenter;
   refs: BrowserShellRefs;
 }
@@ -64,15 +78,31 @@ export const composeBrowserApplication = (
     requestedUrl: refs.fetchUrlInput.value
   };
   const presenter = new BrowserPresenter(refs, initialSession, WAVES_CONFIG.maxTimelineEvents);
+  let debugInspector: BrowserApplication['debugInspector'];
   if (refs.developerToolsRootEl) {
-    presenter.attachDeveloperToolsBridge(
-      bindDeveloperToolsHost({
-        root: refs.developerToolsRootEl,
-        getState: () => presenter.getDeveloperToolsState(),
-        onError: (message) =>
-          presenter.showToast(WAVES_COPY.status.developerToolsWindowFailed(message), 'error')
-      })
-    );
+    const debugInspectorController = createEngineDebugSessionController({
+      client: createEngineDebugSessionClient(hostClient)
+    });
+    const developerToolsBridge = bindDeveloperToolsHost({
+      root: refs.developerToolsRootEl,
+      getState: () => presenter.getDeveloperToolsState(),
+      onError: (message) =>
+        presenter.showToast(WAVES_COPY.status.developerToolsWindowFailed(message), 'error'),
+      onInspectorAction: (action) => debugInspectorController.dispatch(action)
+    });
+    presenter.attachDeveloperToolsBridge(developerToolsBridge);
+    const binding = bindEngineDebugInspector(refs.developerToolsRootEl, {
+      dispatch: (action) => debugInspectorController.dispatch(action)
+    });
+    const unsubscribe = debugInspectorController.subscribe((viewModel) => {
+      binding.render(viewModel);
+      developerToolsBridge.publishInspector(viewModel);
+    });
+    debugInspector = {
+      binding,
+      controller: debugInspectorController,
+      unsubscribe
+    };
   }
   const controller = new BrowserController(hostClient, presenter, refs);
   const commandBridge = new ApplicationCommandBridge({
@@ -81,7 +111,7 @@ export const composeBrowserApplication = (
     }
   });
 
-  return { commandBridge, controller, presenter, refs };
+  return { commandBridge, controller, debugInspector, presenter, refs };
 };
 
 export const initializeBrowserApplication = async (
@@ -97,5 +127,8 @@ export const initializeBrowserApplication = async (
 
 export const disposeBrowserApplication = (application: BrowserApplication): void => {
   application.commandBridge.dispose();
+  application.debugInspector?.binding.dispose();
+  application.debugInspector?.unsubscribe();
+  void application.debugInspector?.controller.dispose();
   application.controller.dispose();
 };

--- a/browser/frontend/src/app/browser-shell-template.test.ts
+++ b/browser/frontend/src/app/browser-shell-template.test.ts
@@ -66,7 +66,7 @@ describe('mountBrowserShell', () => {
     expect(utilityRail?.querySelector('#dev-drawer')).not.toBeNull();
     expect(devDrawerSection?.querySelector('#dev-drawer')).not.toBeNull();
     expect(devDrawerSection?.querySelector('[role="tablist"]')).not.toBeNull();
-    expect(devDrawerSection?.querySelectorAll('[role="tabpanel"]')).toHaveLength(5);
+    expect(devDrawerSection?.querySelectorAll('[role="tabpanel"]')).toHaveLength(6);
     expect(devDrawerSection?.querySelector('#btn-open-devtools-window')).not.toBeNull();
     expect(statusBar?.querySelector('#status')).not.toBeNull();
     expect(statusBar?.querySelector('#viewport-cols')).not.toBeNull();

--- a/browser/frontend/src/app/developer-tools-bridge.test.ts
+++ b/browser/frontend/src/app/developer-tools-bridge.test.ts
@@ -2,6 +2,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { bindDeveloperToolsHost } from './developer-tools-bridge';
 import type { DeveloperToolsState } from './developer-tools-workspace';
 import { developerDrawerTemplate } from './shell/developer-drawer-template';
+import { EngineDebugStore } from './engine-debug-store';
+import { buildEngineDebugInspectorViewModel } from './engine-debug-view-model';
 
 class TestBroadcastChannel extends EventTarget {
   static channels: TestBroadcastChannel[] = [];
@@ -87,6 +89,51 @@ describe('Developer Tools browser bridge', () => {
     detached.postMessage({ type: 'action', action: { action: 'health' } });
 
     expect(healthClick).toHaveBeenCalledOnce();
+    bridge.dispose();
+    detached.close();
+  });
+
+  it('publishes projected Inspector state and relays validated read-only actions', () => {
+    const root = document.querySelector<HTMLElement>('#developer-tools-workspace');
+    if (!root) throw new Error('missing workspace in test fixture');
+    const onInspectorAction = vi.fn();
+    const bridge = bindDeveloperToolsHost({
+      root,
+      getState: () => state,
+      onError: vi.fn(),
+      onInspectorAction
+    });
+    const detached = new TestBroadcastChannel('waves-developer-tools');
+    const received: unknown[] = [];
+    detached.addEventListener('message', (event) => received.push((event as MessageEvent).data));
+    const inspectorState = buildEngineDebugInspectorViewModel(new EngineDebugStore().getState());
+
+    detached.postMessage({ type: 'ready' });
+    bridge.publishInspector(inspectorState);
+    detached.postMessage({
+      type: 'inspector-action',
+      inspectorAction: { type: 'filter', group: 'script', query: 'invoke' }
+    });
+    detached.postMessage({
+      type: 'inspector-action',
+      inspectorAction: { type: 'visibility', surface: 'remote', visible: true }
+    });
+    detached.postMessage({ type: 'closed' });
+
+    expect(received).toContainEqual({
+      type: 'inspector-state',
+      inspectorState
+    });
+    expect(onInspectorAction).toHaveBeenNthCalledWith(1, {
+      type: 'filter',
+      group: 'script',
+      query: 'invoke'
+    });
+    expect(onInspectorAction).toHaveBeenNthCalledWith(2, {
+      type: 'visibility',
+      surface: 'window',
+      visible: false
+    });
     bridge.dispose();
     detached.close();
   });

--- a/browser/frontend/src/app/developer-tools-bridge.ts
+++ b/browser/frontend/src/app/developer-tools-bridge.ts
@@ -3,6 +3,13 @@ import {
   bindDeveloperToolsWorkspace,
   renderDeveloperToolsState
 } from './developer-tools-workspace';
+import {
+  bindEngineDebugInspector,
+  type EngineDebugInspectorBinding
+} from '../components/engine-debug-inspector';
+import type { EngineDebugInspectorAction } from './engine-debug-session-controller';
+import type { EngineDebugInspectorViewModel } from './engine-debug-view-model';
+import { WAVES_COPY } from './waves-copy';
 
 const DEVTOOLS_WINDOW_LABEL = 'developer-tools';
 const DEVTOOLS_CHANNEL = 'waves-developer-tools';
@@ -10,6 +17,8 @@ const DEVTOOLS_READY_EVENT = 'waves://developer-tools/ready';
 const DEVTOOLS_CLOSED_EVENT = 'waves://developer-tools/closed';
 const DEVTOOLS_STATE_EVENT = 'waves://developer-tools/state';
 const DEVTOOLS_ACTION_EVENT = 'waves://developer-tools/action';
+const DEVTOOLS_INSPECTOR_STATE_EVENT = 'waves://developer-tools/inspector-state';
+const DEVTOOLS_INSPECTOR_ACTION_EVENT = 'waves://developer-tools/inspector-action';
 
 type DeveloperToolsActionId =
   | 'health'
@@ -27,14 +36,17 @@ interface DeveloperToolsAction {
 }
 
 interface ChannelMessage {
-  type: 'ready' | 'closed' | 'state' | 'action';
+  type: 'ready' | 'closed' | 'state' | 'action' | 'inspector-state' | 'inspector-action';
   state?: DeveloperToolsState;
   action?: DeveloperToolsAction;
+  inspectorState?: EngineDebugInspectorViewModel;
+  inspectorAction?: EngineDebugInspectorAction;
 }
 
 export interface DeveloperToolsHostBridge {
   isConnected(): boolean;
   publish(state: DeveloperToolsState): void;
+  publishInspector(state: EngineDebugInspectorViewModel): void;
   dispose(): void;
 }
 
@@ -42,6 +54,7 @@ interface BindDeveloperToolsHostOptions {
   root: HTMLElement;
   getState: () => DeveloperToolsState;
   onError: (message: string) => void;
+  onInspectorAction?: (action: EngineDebugInspectorAction) => void;
 }
 
 const isTauriRuntime = (): boolean => Reflect.has(globalThis, '__TAURI_INTERNALS__');
@@ -57,6 +70,24 @@ const isDeveloperToolsAction = (value: unknown): value is DeveloperToolsAction =
     'clear-timeline',
     'load-source'
   ].includes(String(value.action));
+};
+
+const isEngineDebugInspectorAction = (value: unknown): value is EngineDebugInspectorAction => {
+  if (!value || typeof value !== 'object' || !('type' in value)) return false;
+  const action = value as Record<string, unknown>;
+  if (['start', 'stop', 'snapshot', 'export'].includes(String(action.type))) return true;
+  if (action.type === 'filter') {
+    return (
+      ['all', 'deck', 'navigation', 'input', 'action', 'script', 'timer'].includes(
+        String(action.group)
+      ) && typeof action.query === 'string'
+    );
+  }
+  return (
+    action.type === 'visibility' &&
+    ['docked', 'window'].includes(String(action.surface)) &&
+    typeof action.visible === 'boolean'
+  );
 };
 
 const dispatchDeveloperToolsAction = (action: DeveloperToolsAction): void => {
@@ -84,7 +115,8 @@ const dispatchDeveloperToolsAction = (action: DeveloperToolsAction): void => {
 export const bindDeveloperToolsHost = ({
   root,
   getState,
-  onError
+  onError,
+  onInspectorAction
 }: BindDeveloperToolsHostOptions): DeveloperToolsHostBridge => {
   let connected = false;
   let disposed = false;
@@ -92,6 +124,7 @@ export const bindDeveloperToolsHost = ({
   const openButton = root.querySelector<HTMLButtonElement>('#btn-open-devtools-window');
   const channel =
     typeof BroadcastChannel === 'undefined' ? null : new BroadcastChannel(DEVTOOLS_CHANNEL);
+  let inspectorState: EngineDebugInspectorViewModel | undefined;
 
   const publish = (state: DeveloperToolsState): void => {
     if (!connected || disposed) return;
@@ -104,16 +137,44 @@ export const bindDeveloperToolsHost = ({
     channel?.postMessage({ type: 'state', state } satisfies ChannelMessage);
   };
 
+  const publishInspector = (state: EngineDebugInspectorViewModel): void => {
+    inspectorState = state;
+    if (!connected || disposed) return;
+    if (isTauriRuntime()) {
+      void import('@tauri-apps/api/event')
+        .then(({ emitTo }) => emitTo(DEVTOOLS_WINDOW_LABEL, DEVTOOLS_INSPECTOR_STATE_EVENT, state))
+        .catch(() => onError(WAVES_COPY.status.developerToolsInspectorStateFailed));
+      return;
+    }
+    channel?.postMessage({
+      type: 'inspector-state',
+      inspectorState: state
+    } satisfies ChannelMessage);
+  };
+
   const markReady = (): void => {
     connected = true;
     publish(getState());
+    if (inspectorState) publishInspector(inspectorState);
+  };
+
+  const markClosed = (): void => {
+    connected = false;
+    onInspectorAction?.({ type: 'visibility', surface: 'window', visible: false });
   };
 
   const handleChannelMessage = (event: MessageEvent<ChannelMessage>): void => {
     if (event.data.type === 'ready') markReady();
-    if (event.data.type === 'closed') connected = false;
+    if (event.data.type === 'closed') markClosed();
     if (event.data.type === 'action' && event.data.action) {
       dispatchDeveloperToolsAction(event.data.action);
+    }
+    if (
+      event.data.type === 'inspector-action' &&
+      event.data.inspectorAction &&
+      isEngineDebugInspectorAction(event.data.inspectorAction)
+    ) {
+      onInspectorAction?.(event.data.inspectorAction);
     }
   };
   channel?.addEventListener('message', handleChannelMessage);
@@ -122,19 +183,26 @@ export const bindDeveloperToolsHost = ({
     ? import('@tauri-apps/api/event')
         .then(async ({ listen }) => {
           const stopReady = await listen(DEVTOOLS_READY_EVENT, markReady);
-          const stopClosed = await listen(DEVTOOLS_CLOSED_EVENT, () => {
-            connected = false;
-          });
+          const stopClosed = await listen(DEVTOOLS_CLOSED_EVENT, markClosed);
           const stopAction = await listen<DeveloperToolsAction>(DEVTOOLS_ACTION_EVENT, (event) => {
             if (isDeveloperToolsAction(event.payload)) dispatchDeveloperToolsAction(event.payload);
           });
+          const stopInspectorAction = await listen<EngineDebugInspectorAction>(
+            DEVTOOLS_INSPECTOR_ACTION_EVENT,
+            (event) => {
+              if (isEngineDebugInspectorAction(event.payload)) {
+                onInspectorAction?.(event.payload);
+              }
+            }
+          );
           if (disposed) {
             stopReady();
             stopClosed();
             stopAction();
+            stopInspectorAction();
             return;
           }
-          unlisteners.push(stopReady, stopClosed, stopAction);
+          unlisteners.push(stopReady, stopClosed, stopAction, stopInspectorAction);
         })
         .catch((error: unknown) => {
           onError(String(error));
@@ -168,9 +236,7 @@ export const bindDeveloperToolsHost = ({
           resizable: true
         });
         child.once('tauri://error', (event) => onError(String(event.payload)));
-        child.once('tauri://destroyed', () => {
-          connected = false;
-        });
+        child.once('tauri://destroyed', markClosed);
         return;
       }
 
@@ -197,6 +263,7 @@ export const bindDeveloperToolsHost = ({
   return {
     isConnected: () => connected,
     publish,
+    publishInspector,
     dispose: () => {
       disposed = true;
       openButton?.removeEventListener('click', handleOpenClick);
@@ -239,6 +306,22 @@ export const bindDeveloperToolsWindow = async (root: HTMLElement): Promise<() =>
     channel?.postMessage({ type: 'action', action } satisfies ChannelMessage);
   };
 
+  const sendInspectorAction = async (action: EngineDebugInspectorAction): Promise<void> => {
+    if (isTauriRuntime()) {
+      const { emitTo } = await import('@tauri-apps/api/event');
+      await emitTo('main', DEVTOOLS_INSPECTOR_ACTION_EVENT, action);
+      return;
+    }
+    channel?.postMessage({
+      type: 'inspector-action',
+      inspectorAction: action
+    } satisfies ChannelMessage);
+  };
+  const inspectorBinding: EngineDebugInspectorBinding = bindEngineDebugInspector(root, {
+    dispatch: (action) => void sendInspectorAction(action)
+  });
+  cleanups.push(() => inspectorBinding.dispose());
+
   for (const button of root.querySelectorAll<HTMLButtonElement>('[data-devtools-action]')) {
     const handleClick = (): void => {
       const action = actionFromButton(button, root);
@@ -253,12 +336,19 @@ export const bindDeveloperToolsWindow = async (root: HTMLElement): Promise<() =>
     const stopState = await listen<DeveloperToolsState>(DEVTOOLS_STATE_EVENT, (event) => {
       renderDeveloperToolsState(root, event.payload);
     });
-    cleanups.push(stopState);
+    const stopInspectorState = await listen<EngineDebugInspectorViewModel>(
+      DEVTOOLS_INSPECTOR_STATE_EVENT,
+      (event) => inspectorBinding.render(event.payload)
+    );
+    cleanups.push(stopState, stopInspectorState);
     await emitTo('main', DEVTOOLS_READY_EVENT);
   } else {
     const handleState = (event: MessageEvent<ChannelMessage>): void => {
       if (event.data.type === 'state' && event.data.state) {
         renderDeveloperToolsState(root, event.data.state);
+      }
+      if (event.data.type === 'inspector-state' && event.data.inspectorState) {
+        inspectorBinding.render(event.data.inspectorState);
       }
     };
     channel?.addEventListener('message', handleState);
@@ -267,6 +357,7 @@ export const bindDeveloperToolsWindow = async (root: HTMLElement): Promise<() =>
   }
 
   const handleBeforeUnload = (): void => {
+    void sendInspectorAction({ type: 'visibility', surface: 'window', visible: false });
     if (isTauriRuntime()) {
       void import('@tauri-apps/api/event').then(({ emitTo }) =>
         emitTo('main', DEVTOOLS_CLOSED_EVENT)

--- a/browser/frontend/src/app/engine-debug-capture.test.ts
+++ b/browser/frontend/src/app/engine-debug-capture.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, it } from 'vitest';
+import type {
+  EngineDebugCapabilities,
+  EngineDebugEvent,
+  EngineDebugSnapshot
+} from '../../../contracts/engine';
+import {
+  ENGINE_DEBUG_CAPTURE_KIND,
+  ENGINE_DEBUG_CAPTURE_SCHEMA_VERSION,
+  ENGINE_DEBUG_CONSUMER_LIMITS,
+  serializeEngineDebugCapture
+} from './engine-debug-capture';
+import { EngineDebugStore } from './engine-debug-store';
+import { buildEngineDebugInspectorViewModel } from './engine-debug-view-model';
+
+const capabilities: EngineDebugCapabilities = {
+  protocolVersion: 1,
+  supportsPolling: true,
+  supportsSnapshots: true,
+  supportsSensitiveUnmasking: false,
+  maskingPolicy: 'required',
+  timestampKind: 'monotonic',
+  sessionLimit: 1,
+  eventBufferCapacity: 2048,
+  defaultMaxEventsPerPoll: 100,
+  maxEventsPerPoll: 256,
+  maxSnapshotVariables: 256,
+  maxSnapshotTimers: 64,
+  maxTextBytes: 4096
+};
+
+const event = (seq: number, value = `value-${seq}`): EngineDebugEvent => ({
+  seq: String(seq),
+  kind: 'input.edit.draft',
+  monotonicTimeMs: seq,
+  cardId: 'form',
+  payload: {
+    type: 'input-edit-draft',
+    name: 'query',
+    value: { state: 'visible', value }
+  }
+});
+
+const snapshot = (canary?: string): EngineDebugSnapshot => {
+  const maskedValue = canary
+    ? { state: 'masked' as const, reason: 'password-input' as const, originalValue: canary }
+    : { state: 'masked' as const, reason: 'password-input' as const };
+  return {
+    protocolVersion: 1,
+    capturedSeq: '900',
+    activeCardId: 'form',
+    focusedLinkIndex: 0,
+    focusedInputEdit: {
+      name: 'password',
+      value: maskedValue
+    },
+    runtimeVars: Array.from({ length: 300 }, (_, index) => ({
+      name: `variable-${index}`,
+      value: { state: 'visible' as const, value: 'x'.repeat(4096) }
+    })),
+    runtimeVarsSummary: { totalCount: 300, returnedCount: 300, truncated: false },
+    timers: Array.from({ length: 90 }, (_, index) => ({
+      remainingMs: index,
+      token: { state: 'visible' as const, value: `timer-${index}` }
+    })),
+    timersSummary: { totalCount: 90, returnedCount: 90, truncated: false },
+    buffer: { oldestSeq: '1', latestSeq: '900', droppedCount: 3, capacity: 2048 },
+    viewportCols: 20,
+    baseUrl: { state: 'visible', value: 'http://local.test/form.wml' },
+    contentType: 'text/vnd.wap.wml'
+  };
+};
+
+describe('engine debug bounded capture and view projection', () => {
+  it('caps retained events, rendered rows, filters, and snapshot collections', () => {
+    const store = new EngineDebugStore();
+    store.markActive(capabilities);
+    store.appendEvents(
+      Array.from({ length: ENGINE_DEBUG_CONSUMER_LIMITS.retainedEvents + 88 }, (_, index) =>
+        event(index + 1)
+      ),
+      7
+    );
+    store.setSnapshot(snapshot());
+    store.setFilter('input', 'q'.repeat(ENGINE_DEBUG_CONSUMER_LIMITS.filterQueryLength + 20));
+
+    const state = store.getState();
+    const viewModel = buildEngineDebugInspectorViewModel(state);
+    const renderedSnapshot = JSON.parse(viewModel.snapshotText) as EngineDebugSnapshot;
+
+    expect(state.events).toHaveLength(ENGINE_DEBUG_CONSUMER_LIMITS.retainedEvents);
+    expect(state.frontendDroppedEvents).toBe(88);
+    expect(state.producerDroppedEvents).toBe(7);
+    expect(state.filter.query).toHaveLength(ENGINE_DEBUG_CONSUMER_LIMITS.filterQueryLength);
+    expect(viewModel.rows.length).toBeLessThanOrEqual(ENGINE_DEBUG_CONSUMER_LIMITS.renderedRows);
+    expect(state.snapshot?.runtimeVars).toHaveLength(
+      ENGINE_DEBUG_CONSUMER_LIMITS.snapshotVariables
+    );
+    expect(state.snapshot?.timers).toHaveLength(ENGINE_DEBUG_CONSUMER_LIMITS.snapshotTimers);
+    expect(renderedSnapshot.runtimeVars).toHaveLength(32);
+    expect(renderedSnapshot.timers).toHaveLength(16);
+  });
+
+  it('serializes only the versioned allowlist and never carries masked originals', () => {
+    const canary = 'CANARY-RAW-PASSWORD-74f1';
+    const unsafeEvent = {
+      ...event(1),
+      requestBody: canary,
+      rawWml: `<wml>${canary}</wml>`,
+      payload: {
+        type: 'input-edit-draft',
+        name: 'password',
+        value: {
+          state: 'masked',
+          reason: 'password-input',
+          originalValue: canary,
+          value: canary
+        }
+      }
+    } as unknown as EngineDebugEvent;
+    const capture = serializeEngineDebugCapture({
+      capabilities,
+      events: [unsafeEvent],
+      snapshot: snapshot(canary),
+      accounting: {
+        producerDroppedEvents: 0,
+        frontendDroppedEvents: 0,
+        retainedEvents: 1,
+        oldestSeq: '1',
+        latestSeq: '1'
+      }
+    });
+    const store = new EngineDebugStore();
+    store.appendEvents([unsafeEvent], 0);
+    store.setSnapshot(snapshot(canary));
+    const rendered = JSON.stringify(buildEngineDebugInspectorViewModel(store.getState()));
+
+    expect(capture.document.schemaVersion).toBe(ENGINE_DEBUG_CAPTURE_SCHEMA_VERSION);
+    expect(capture.document.kind).toBe(ENGINE_DEBUG_CAPTURE_KIND);
+    expect(capture.json).not.toContain(canary);
+    expect(capture.json).not.toContain('requestBody');
+    expect(capture.json).not.toContain('rawWml');
+    expect(capture.json).toContain('"reason": "password-input"');
+    expect(rendered).not.toContain(canary);
+  });
+
+  it('keeps export bytes bounded even after repeated maximum-size polling retention', () => {
+    const events = Array.from({ length: ENGINE_DEBUG_CONSUMER_LIMITS.retainedEvents }, (_, index) =>
+      event(index + 1, 'x'.repeat(ENGINE_DEBUG_CONSUMER_LIMITS.storedTextLength))
+    );
+    const capture = serializeEngineDebugCapture({
+      capabilities,
+      events,
+      snapshot: snapshot(),
+      accounting: {
+        producerDroppedEvents: 999,
+        frontendDroppedEvents: 10_000,
+        retainedEvents: events.length,
+        oldestSeq: events[0]?.seq,
+        latestSeq: events.at(-1)?.seq
+      }
+    });
+
+    expect(capture.byteLength).toBeLessThanOrEqual(ENGINE_DEBUG_CONSUMER_LIMITS.exportBytes);
+    expect(capture.document.events.length).toBeLessThanOrEqual(
+      ENGINE_DEBUG_CONSUMER_LIMITS.exportEvents
+    );
+    expect(capture.document.accounting.exportTruncated).toBe(true);
+    expect(capture.document.accounting.retainedEvents).toBe(
+      ENGINE_DEBUG_CONSUMER_LIMITS.retainedEvents
+    );
+  });
+});

--- a/browser/frontend/src/app/engine-debug-capture.ts
+++ b/browser/frontend/src/app/engine-debug-capture.ts
@@ -1,0 +1,446 @@
+import type {
+  EngineDebugCapabilities,
+  EngineDebugCollectionSummary,
+  EngineDebugEvent,
+  EngineDebugEventKind,
+  EngineDebugEventPayload,
+  EngineDebugRedactionReason,
+  EngineDebugSnapshot,
+  EngineDebugValue
+} from '../../../contracts/engine';
+
+export const ENGINE_DEBUG_CAPTURE_SCHEMA_VERSION = 1 as const;
+export const ENGINE_DEBUG_CAPTURE_KIND = 'waves-engine-debug-capture' as const;
+
+export const ENGINE_DEBUG_CONSUMER_LIMITS = {
+  retainedEvents: 512,
+  renderedRows: 200,
+  filterQueryLength: 80,
+  snapshotVariables: 128,
+  snapshotTimers: 32,
+  postfieldsPerEvent: 64,
+  storedTextLength: 4_096,
+  exportTextLength: 512,
+  exportEvents: 256,
+  exportBytes: 256 * 1_024
+} as const;
+
+export interface EngineDebugCaptureAccounting {
+  producerDroppedEvents: number;
+  frontendDroppedEvents: number;
+  retainedEvents: number;
+  oldestSeq?: string;
+  latestSeq?: string;
+}
+
+export interface EngineDebugCaptureInput {
+  capabilities?: EngineDebugCapabilities;
+  events: readonly EngineDebugEvent[];
+  snapshot?: EngineDebugSnapshot;
+  accounting: EngineDebugCaptureAccounting;
+}
+
+export interface EngineDebugCaptureDocument {
+  schemaVersion: typeof ENGINE_DEBUG_CAPTURE_SCHEMA_VERSION;
+  kind: typeof ENGINE_DEBUG_CAPTURE_KIND;
+  protocolVersion: number;
+  limits: {
+    retainedEvents: number;
+    renderedRows: number;
+    snapshotVariables: number;
+    snapshotTimers: number;
+    exportBytes: number;
+  };
+  capabilities?: EngineDebugCapabilities;
+  accounting: EngineDebugCaptureAccounting & {
+    exportedEvents: number;
+    exportTruncated: boolean;
+  };
+  snapshot?: EngineDebugSnapshot;
+  events: EngineDebugEvent[];
+}
+
+export interface SerializedEngineDebugCapture {
+  document: EngineDebugCaptureDocument;
+  json: string;
+  byteLength: number;
+}
+
+const REDACTION_REASONS = new Set<EngineDebugRedactionReason>([
+  'password-input',
+  'sensitive-name',
+  'credential-bearing-url',
+  'transport-secret',
+  'policy',
+  'bounded-output'
+] satisfies EngineDebugRedactionReason[]);
+
+const boundedText = (
+  value: unknown,
+  limit: number = ENGINE_DEBUG_CONSUMER_LIMITS.storedTextLength
+): string => String(value ?? '').slice(0, limit);
+
+const boundedCount = (value: unknown): number => {
+  const count = typeof value === 'number' && Number.isFinite(value) ? Math.trunc(value) : 0;
+  return Math.max(0, count);
+};
+
+const boundedDecimal = (value: unknown): string => {
+  const candidate = String(value ?? '');
+  return /^\d{1,40}$/.test(candidate) ? candidate : '0';
+};
+
+const projectRedactionReason = (value: EngineDebugRedactionReason): EngineDebugRedactionReason =>
+  REDACTION_REASONS.has(value) ? value : 'policy';
+
+export const projectEngineDebugValue = (
+  value: EngineDebugValue,
+  textLimit: number = ENGINE_DEBUG_CONSUMER_LIMITS.storedTextLength
+): EngineDebugValue => {
+  if (value.state === 'visible') {
+    return { state: 'visible', value: boundedText(value.value, textLimit) };
+  }
+  if (value.state === 'masked') {
+    return { state: 'masked', reason: projectRedactionReason(value.reason) };
+  }
+  return { state: 'omitted', reason: projectRedactionReason(value.reason) };
+};
+
+const projectCollectionSummary = (
+  summary: EngineDebugCollectionSummary,
+  returnedCount: number
+): EngineDebugCollectionSummary => ({
+  totalCount: boundedCount(summary.totalCount),
+  returnedCount,
+  truncated: Boolean(summary.truncated) || boundedCount(summary.totalCount) > returnedCount
+});
+
+const projectPayload = (
+  payload: EngineDebugEventPayload,
+  textLimit: number = ENGINE_DEBUG_CONSUMER_LIMITS.storedTextLength
+): { kind: EngineDebugEventKind; payload: EngineDebugEventPayload } => {
+  switch (payload.type) {
+    case 'deck-load':
+      return {
+        kind: 'deck.load',
+        payload: {
+          type: 'deck-load',
+          baseUrl: projectEngineDebugValue(payload.baseUrl, textLimit),
+          contentType: boundedText(payload.contentType, textLimit),
+          cardCount: boundedCount(payload.cardCount)
+        }
+      };
+    case 'card-enter':
+      return { kind: 'card.enter', payload: { type: 'card-enter' } };
+    case 'card-exit':
+      return { kind: 'card.exit', payload: { type: 'card-exit' } };
+    case 'focus-change':
+      return {
+        kind: 'focus.change',
+        payload: {
+          type: 'focus-change',
+          ...(payload.previousIndex === undefined
+            ? {}
+            : { previousIndex: boundedCount(payload.previousIndex) }),
+          ...(payload.currentIndex === undefined
+            ? {}
+            : { currentIndex: boundedCount(payload.currentIndex) })
+        }
+      };
+    case 'input-edit-start':
+      return {
+        kind: 'input.edit.start',
+        payload: { type: 'input-edit-start', name: boundedText(payload.name, textLimit) }
+      };
+    case 'input-edit-draft':
+      return {
+        kind: 'input.edit.draft',
+        payload: {
+          type: 'input-edit-draft',
+          name: boundedText(payload.name, textLimit),
+          value: projectEngineDebugValue(payload.value, textLimit)
+        }
+      };
+    case 'input-edit-commit':
+      return {
+        kind: 'input.edit.commit',
+        payload: {
+          type: 'input-edit-commit',
+          name: boundedText(payload.name, textLimit),
+          value: projectEngineDebugValue(payload.value, textLimit)
+        }
+      };
+    case 'input-edit-cancel':
+      return {
+        kind: 'input.edit.cancel',
+        payload: { type: 'input-edit-cancel', name: boundedText(payload.name, textLimit) }
+      };
+    case 'action-accept':
+      return {
+        kind: 'action.accept',
+        payload: {
+          type: 'action-accept',
+          actionType: boundedText(payload.actionType, textLimit),
+          ...(payload.name === undefined ? {} : { name: boundedText(payload.name, textLimit) })
+        }
+      };
+    case 'action-external':
+      return {
+        kind: 'action.external',
+        payload: {
+          type: 'action-external',
+          target: projectEngineDebugValue(payload.target, textLimit)
+        }
+      };
+    case 'navigation-intent':
+      return {
+        kind: 'nav.intent',
+        payload: {
+          type: 'navigation-intent',
+          target: projectEngineDebugValue(payload.target, textLimit)
+        }
+      };
+    case 'postfield-resolve':
+      return {
+        kind: 'postfield.resolve',
+        payload: {
+          type: 'postfield-resolve',
+          fields: payload.fields
+            .slice(0, ENGINE_DEBUG_CONSUMER_LIMITS.postfieldsPerEvent)
+            .map((field) => ({
+              name: boundedText(field.name, textLimit),
+              value: projectEngineDebugValue(field.value, textLimit),
+              source: field.source
+            }))
+        }
+      };
+    case 'script-invoke':
+      return {
+        kind: 'script.invoke',
+        payload: {
+          type: 'script-invoke',
+          source: projectEngineDebugValue(payload.source, textLimit),
+          functionName: boundedText(payload.functionName, textLimit)
+        }
+      };
+    case 'script-trap':
+      return {
+        kind: 'script.trap',
+        payload: {
+          type: 'script-trap',
+          source: projectEngineDebugValue(payload.source, textLimit),
+          functionName: boundedText(payload.functionName, textLimit),
+          detail: projectEngineDebugValue(payload.detail, textLimit)
+        }
+      };
+    case 'timer-schedule':
+      return {
+        kind: 'timer.schedule',
+        payload: {
+          type: 'timer-schedule',
+          delayMs: boundedCount(payload.delayMs),
+          token: projectEngineDebugValue(payload.token, textLimit)
+        }
+      };
+    case 'timer-fire':
+      return {
+        kind: 'timer.fire',
+        payload: {
+          type: 'timer-fire',
+          token: projectEngineDebugValue(payload.token, textLimit)
+        }
+      };
+    case 'timer-cancel':
+      return {
+        kind: 'timer.cancel',
+        payload: {
+          type: 'timer-cancel',
+          token: projectEngineDebugValue(payload.token, textLimit)
+        }
+      };
+  }
+};
+
+export const projectEngineDebugEvent = (
+  event: EngineDebugEvent,
+  textLimit: number = ENGINE_DEBUG_CONSUMER_LIMITS.storedTextLength
+): EngineDebugEvent => {
+  const projected = projectPayload(event.payload, textLimit);
+  return {
+    seq: boundedDecimal(event.seq),
+    kind: projected.kind,
+    monotonicTimeMs: boundedCount(event.monotonicTimeMs),
+    ...(event.cardId === undefined ? {} : { cardId: boundedText(event.cardId, textLimit) }),
+    payload: projected.payload
+  };
+};
+
+export const projectEngineDebugSnapshot = (
+  snapshot: EngineDebugSnapshot,
+  options: {
+    textLimit?: number;
+    variableLimit?: number;
+    timerLimit?: number;
+  } = {}
+): EngineDebugSnapshot => {
+  const textLimit = options.textLimit ?? ENGINE_DEBUG_CONSUMER_LIMITS.storedTextLength;
+  const variableLimit = options.variableLimit ?? ENGINE_DEBUG_CONSUMER_LIMITS.snapshotVariables;
+  const timerLimit = options.timerLimit ?? ENGINE_DEBUG_CONSUMER_LIMITS.snapshotTimers;
+  const runtimeVars = snapshot.runtimeVars.slice(0, variableLimit).map((entry) => ({
+    name: boundedText(entry.name, textLimit),
+    value: projectEngineDebugValue(entry.value, textLimit)
+  }));
+  const timers = snapshot.timers.slice(0, timerLimit).map((timer) => ({
+    remainingMs: boundedCount(timer.remainingMs),
+    token: projectEngineDebugValue(timer.token, textLimit)
+  }));
+  return {
+    protocolVersion: boundedCount(snapshot.protocolVersion),
+    capturedSeq: boundedDecimal(snapshot.capturedSeq),
+    ...(snapshot.activeCardId === undefined
+      ? {}
+      : { activeCardId: boundedText(snapshot.activeCardId, textLimit) }),
+    focusedLinkIndex: boundedCount(snapshot.focusedLinkIndex),
+    ...(snapshot.focusedInputEdit === undefined
+      ? {}
+      : {
+          focusedInputEdit: {
+            name: boundedText(snapshot.focusedInputEdit.name, textLimit),
+            value: projectEngineDebugValue(snapshot.focusedInputEdit.value, textLimit)
+          }
+        }),
+    runtimeVars,
+    runtimeVarsSummary: projectCollectionSummary(snapshot.runtimeVarsSummary, runtimeVars.length),
+    ...(snapshot.pendingExternalNavigation === undefined
+      ? {}
+      : {
+          pendingExternalNavigation: {
+            target: projectEngineDebugValue(snapshot.pendingExternalNavigation.target, textLimit),
+            ...(snapshot.pendingExternalNavigation.method === undefined
+              ? {}
+              : { method: boundedText(snapshot.pendingExternalNavigation.method, textLimit) }),
+            ...(snapshot.pendingExternalNavigation.refererUrl === undefined
+              ? {}
+              : {
+                  refererUrl: projectEngineDebugValue(
+                    snapshot.pendingExternalNavigation.refererUrl,
+                    textLimit
+                  )
+                }),
+            ...(snapshot.pendingExternalNavigation.postBody === undefined
+              ? {}
+              : {
+                  postBody: projectEngineDebugValue(
+                    snapshot.pendingExternalNavigation.postBody,
+                    textLimit
+                  )
+                })
+          }
+        }),
+    timers,
+    timersSummary: projectCollectionSummary(snapshot.timersSummary, timers.length),
+    buffer: {
+      ...(snapshot.buffer.oldestSeq === undefined
+        ? {}
+        : { oldestSeq: boundedDecimal(snapshot.buffer.oldestSeq) }),
+      ...(snapshot.buffer.latestSeq === undefined
+        ? {}
+        : { latestSeq: boundedDecimal(snapshot.buffer.latestSeq) }),
+      droppedCount: boundedCount(snapshot.buffer.droppedCount),
+      capacity: boundedCount(snapshot.buffer.capacity)
+    },
+    viewportCols: boundedCount(snapshot.viewportCols),
+    baseUrl: projectEngineDebugValue(snapshot.baseUrl, textLimit),
+    contentType: boundedText(snapshot.contentType, textLimit)
+  };
+};
+
+export const projectEngineDebugCapabilities = (
+  capabilities: EngineDebugCapabilities
+): EngineDebugCapabilities => ({
+  protocolVersion: boundedCount(capabilities.protocolVersion),
+  supportsPolling: Boolean(capabilities.supportsPolling),
+  supportsSnapshots: Boolean(capabilities.supportsSnapshots),
+  supportsSensitiveUnmasking: false,
+  maskingPolicy: 'required',
+  timestampKind: 'monotonic',
+  sessionLimit: boundedCount(capabilities.sessionLimit),
+  eventBufferCapacity: boundedCount(capabilities.eventBufferCapacity),
+  defaultMaxEventsPerPoll: boundedCount(capabilities.defaultMaxEventsPerPoll),
+  maxEventsPerPoll: boundedCount(capabilities.maxEventsPerPoll),
+  maxSnapshotVariables: boundedCount(capabilities.maxSnapshotVariables),
+  maxSnapshotTimers: boundedCount(capabilities.maxSnapshotTimers),
+  maxTextBytes: boundedCount(capabilities.maxTextBytes)
+});
+
+const projectAccounting = (
+  accounting: EngineDebugCaptureAccounting,
+  retainedEvents: number
+): EngineDebugCaptureAccounting => ({
+  producerDroppedEvents: boundedCount(accounting.producerDroppedEvents),
+  frontendDroppedEvents: boundedCount(accounting.frontendDroppedEvents),
+  retainedEvents,
+  ...(accounting.oldestSeq === undefined
+    ? {}
+    : { oldestSeq: boundedDecimal(accounting.oldestSeq) }),
+  ...(accounting.latestSeq === undefined ? {} : { latestSeq: boundedDecimal(accounting.latestSeq) })
+});
+
+const encodeCapture = (
+  input: EngineDebugCaptureInput,
+  events: EngineDebugEvent[]
+): EngineDebugCaptureDocument => {
+  const snapshot = input.snapshot
+    ? projectEngineDebugSnapshot(input.snapshot, {
+        textLimit: ENGINE_DEBUG_CONSUMER_LIMITS.exportTextLength,
+        variableLimit: 64,
+        timerLimit: ENGINE_DEBUG_CONSUMER_LIMITS.snapshotTimers
+      })
+    : undefined;
+  const accounting = projectAccounting(input.accounting, input.events.length);
+  return {
+    schemaVersion: ENGINE_DEBUG_CAPTURE_SCHEMA_VERSION,
+    kind: ENGINE_DEBUG_CAPTURE_KIND,
+    protocolVersion: input.capabilities?.protocolVersion ?? snapshot?.protocolVersion ?? 1,
+    limits: {
+      retainedEvents: ENGINE_DEBUG_CONSUMER_LIMITS.retainedEvents,
+      renderedRows: ENGINE_DEBUG_CONSUMER_LIMITS.renderedRows,
+      snapshotVariables: ENGINE_DEBUG_CONSUMER_LIMITS.snapshotVariables,
+      snapshotTimers: ENGINE_DEBUG_CONSUMER_LIMITS.snapshotTimers,
+      exportBytes: ENGINE_DEBUG_CONSUMER_LIMITS.exportBytes
+    },
+    ...(input.capabilities
+      ? { capabilities: projectEngineDebugCapabilities(input.capabilities) }
+      : {}),
+    accounting: {
+      ...accounting,
+      exportedEvents: events.length,
+      exportTruncated: events.length < input.events.length
+    },
+    ...(snapshot ? { snapshot } : {}),
+    events
+  };
+};
+
+export const serializeEngineDebugCapture = (
+  input: EngineDebugCaptureInput
+): SerializedEngineDebugCapture => {
+  const encoder = new TextEncoder();
+  const candidates = input.events
+    .slice(-ENGINE_DEBUG_CONSUMER_LIMITS.exportEvents)
+    .map((event) => projectEngineDebugEvent(event, ENGINE_DEBUG_CONSUMER_LIMITS.exportTextLength));
+  let events = candidates;
+  let document = encodeCapture(input, events);
+  let json = JSON.stringify(document, null, 2);
+
+  while (encoder.encode(json).byteLength > ENGINE_DEBUG_CONSUMER_LIMITS.exportBytes) {
+    if (events.length === 0) {
+      throw new RangeError('Engine debug capture metadata exceeds the export byte limit.');
+    }
+    events = events.slice(1);
+    document = encodeCapture(input, events);
+    json = JSON.stringify(document, null, 2);
+  }
+
+  return { document, json, byteLength: encoder.encode(json).byteLength };
+};

--- a/browser/frontend/src/app/engine-debug-client.ts
+++ b/browser/frontend/src/app/engine-debug-client.ts
@@ -1,0 +1,32 @@
+import type {
+  EngineDebugCloseSessionOutcome,
+  EngineDebugOpenSessionOutcome,
+  EngineDebugPollEventsOutcome,
+  EngineDebugSnapshotOutcome
+} from '../../../contracts/engine';
+import type { TauriHostClient } from '../../../contracts/generated/tauri-host-client';
+
+export interface EngineDebugSessionClient {
+  open(): Promise<EngineDebugOpenSessionOutcome>;
+  poll(sessionId: string, cursor: string, maxEvents: number): Promise<EngineDebugPollEventsOutcome>;
+  snapshot(sessionId: string): Promise<EngineDebugSnapshotOutcome>;
+  close(sessionId: string): Promise<EngineDebugCloseSessionOutcome>;
+}
+
+type EngineDebugHostClient = Pick<
+  TauriHostClient,
+  | 'engineDebugOpenSession'
+  | 'engineDebugPollEvents'
+  | 'engineDebugGetSnapshot'
+  | 'engineDebugCloseSession'
+>;
+
+export const createEngineDebugSessionClient = (
+  hostClient: EngineDebugHostClient
+): EngineDebugSessionClient => ({
+  open: () => hostClient.engineDebugOpenSession({ protocolVersion: 1 }),
+  poll: (sessionId, cursor, maxEvents) =>
+    hostClient.engineDebugPollEvents({ sessionId, cursor, maxEvents }),
+  snapshot: (sessionId) => hostClient.engineDebugGetSnapshot({ sessionId }),
+  close: (sessionId) => hostClient.engineDebugCloseSession({ sessionId })
+});

--- a/browser/frontend/src/app/engine-debug-session-controller.test.ts
+++ b/browser/frontend/src/app/engine-debug-session-controller.test.ts
@@ -1,0 +1,235 @@
+import { describe, expect, it, vi } from 'vitest';
+import type {
+  EngineDebugCapabilities,
+  EngineDebugErrorCode,
+  EngineDebugEvent,
+  EngineDebugOpenSessionOutcome,
+  EngineDebugSnapshot
+} from '../../../contracts/engine';
+import type { EngineDebugSessionClient } from './engine-debug-client';
+import { EngineDebugStore } from './engine-debug-store';
+import {
+  createEngineDebugSessionController,
+  type EngineDebugSessionController
+} from './engine-debug-session-controller';
+import type { EngineDebugInspectorViewModel } from './engine-debug-view-model';
+
+const capabilities: EngineDebugCapabilities = {
+  protocolVersion: 1,
+  supportsPolling: true,
+  supportsSnapshots: true,
+  supportsSensitiveUnmasking: false,
+  maskingPolicy: 'required',
+  timestampKind: 'monotonic',
+  sessionLimit: 1,
+  eventBufferCapacity: 2048,
+  defaultMaxEventsPerPoll: 100,
+  maxEventsPerPoll: 256,
+  maxSnapshotVariables: 256,
+  maxSnapshotTimers: 64,
+  maxTextBytes: 4096
+};
+
+const snapshot: EngineDebugSnapshot = {
+  protocolVersion: 1,
+  capturedSeq: '3',
+  activeCardId: 'home',
+  focusedLinkIndex: 0,
+  runtimeVars: [],
+  runtimeVarsSummary: { totalCount: 0, returnedCount: 0, truncated: false },
+  timers: [],
+  timersSummary: { totalCount: 0, returnedCount: 0, truncated: false },
+  buffer: { oldestSeq: '1', latestSeq: '3', droppedCount: 0, capacity: 2048 },
+  viewportCols: 20,
+  baseUrl: { state: 'visible', value: 'http://local.test/start.wml' },
+  contentType: 'text/vnd.wap.wml'
+};
+
+const event: EngineDebugEvent = {
+  seq: '3',
+  kind: 'card.enter',
+  monotonicTimeMs: 15,
+  cardId: 'home',
+  payload: { type: 'card-enter' }
+};
+
+const openSuccess = (sessionId: string): EngineDebugOpenSessionOutcome => ({
+  status: 'success',
+  session: { sessionId, cursor: '0', capabilities }
+});
+
+const failure = (code: EngineDebugErrorCode) =>
+  ({
+    status: 'failure',
+    error: { code, message: 'ignored host message', retryable: false }
+  }) as const;
+
+class TestScheduler {
+  private nextId = 1;
+  readonly callbacks = new Map<number, () => void>();
+
+  setTimeout(callback: () => void): ReturnType<typeof setTimeout> {
+    const id = this.nextId++;
+    this.callbacks.set(id, callback);
+    return id;
+  }
+
+  clearTimeout(timer: ReturnType<typeof setTimeout>): void {
+    this.callbacks.delete(timer);
+  }
+}
+
+const createClient = (): EngineDebugSessionClient => ({
+  open: vi.fn(async () => openSuccess('session-1')),
+  poll: vi.fn(async () => ({
+    status: 'success' as const,
+    batch: { events: [event], nextCursor: '3', droppedCount: 0, hasMore: false }
+  })),
+  snapshot: vi.fn(async () => ({ status: 'success' as const, snapshot })),
+  close: vi.fn(async () => ({ status: 'success' as const, result: { closed: true } }))
+});
+
+const observe = (
+  controller: EngineDebugSessionController
+): { latest: () => EngineDebugInspectorViewModel; dispose: () => void } => {
+  let viewModel: EngineDebugInspectorViewModel | undefined;
+  const dispose = controller.subscribe((next) => {
+    viewModel = next;
+  });
+  return {
+    latest: () => {
+      if (!viewModel) throw new Error('missing Inspector view-model');
+      return viewModel;
+    },
+    dispose
+  };
+};
+
+describe('engine debug session controller lifecycle', () => {
+  it('reports the default-disabled policy without opening a runtime control path', async () => {
+    const client = createClient();
+    vi.mocked(client.open).mockResolvedValueOnce(failure('DEBUG_DISABLED'));
+    const controller = createEngineDebugSessionController({ client, onCapture: vi.fn() });
+    const observation = observe(controller);
+
+    expect(observation.latest().policyLabel).toBe('Disabled by default');
+    await controller.start();
+
+    expect(observation.latest().phase).toBe('unavailable');
+    expect(observation.latest().policyLabel).toBe('Local policy disabled');
+    expect(observation.latest().statusDetail).toContain('WAVES_ENGINE_DEBUG_POLICY=enabled');
+    expect(client.poll).not.toHaveBeenCalled();
+    expect(client.snapshot).not.toHaveBeenCalled();
+    expect(client.close).not.toHaveBeenCalled();
+  });
+
+  it('opens, snapshots, polls by cursor, accounts for gaps, and closes one session', async () => {
+    const client = createClient();
+    vi.mocked(client.poll).mockResolvedValueOnce({
+      status: 'success',
+      batch: { events: [event], nextCursor: '3', droppedCount: 9, hasMore: false }
+    });
+    const store = new EngineDebugStore();
+    const controller = createEngineDebugSessionController({
+      client,
+      store,
+      scheduler: new TestScheduler(),
+      onCapture: vi.fn()
+    });
+    const observation = observe(controller);
+    controller.dispatch({ type: 'visibility', surface: 'docked', visible: true });
+
+    await controller.start();
+
+    expect(client.open).toHaveBeenCalledOnce();
+    expect(client.snapshot).toHaveBeenCalledWith('session-1');
+    expect(client.poll).toHaveBeenCalledWith('session-1', '0', 100);
+    expect(observation.latest().phase).toBe('active');
+    expect(observation.latest().retainedEventCount).toBe(1);
+    expect(observation.latest().producerDroppedEvents).toBe(9);
+    expect(observation.latest().snapshotSummary).toContain('Sequence 3');
+
+    await controller.stop();
+
+    expect(client.close).toHaveBeenCalledWith('session-1');
+    expect(observation.latest().phase).toBe('idle');
+  });
+
+  it('surfaces the single-session host limit without retrying or mutating engine state', async () => {
+    const client = createClient();
+    vi.mocked(client.open).mockResolvedValueOnce(failure('SESSION_LIMIT_REACHED'));
+    const controller = createEngineDebugSessionController({ client, onCapture: vi.fn() });
+    const observation = observe(controller);
+
+    await controller.start();
+
+    expect(observation.latest().phase).toBe('error');
+    expect(observation.latest().statusDetail).toContain('Another local Inspector session');
+    expect(client.poll).not.toHaveBeenCalled();
+    expect(client.close).not.toHaveBeenCalled();
+  });
+
+  it('closes after a poll error and discards arbitrary error internals', async () => {
+    const client = createClient();
+    const canary = 'CANARY-ARBITRARY-ERROR-INTERNALS';
+    vi.mocked(client.poll).mockResolvedValueOnce({
+      status: 'failure',
+      error: { code: 'INVALID_CURSOR', message: canary, retryable: false }
+    });
+    const controller = createEngineDebugSessionController({ client, onCapture: vi.fn() });
+    const observation = observe(controller);
+    controller.dispatch({ type: 'visibility', surface: 'docked', visible: true });
+
+    await controller.start();
+
+    expect(observation.latest().phase).toBe('error');
+    expect(observation.latest().statusDetail).toContain('cursor was rejected');
+    expect(JSON.stringify(observation.latest())).not.toContain(canary);
+    expect(client.close).toHaveBeenCalledWith('session-1');
+  });
+
+  it('rotates identity on close/reopen and cleans up the active session on unmount', async () => {
+    const client = createClient();
+    vi.mocked(client.open)
+      .mockResolvedValueOnce(openSuccess('session-first'))
+      .mockResolvedValueOnce(openSuccess('session-second'));
+    const scheduler = new TestScheduler();
+    const controller = createEngineDebugSessionController({
+      client,
+      scheduler,
+      onCapture: vi.fn()
+    });
+    controller.dispatch({ type: 'visibility', surface: 'docked', visible: true });
+
+    await controller.start();
+    await controller.stop();
+    await controller.start();
+    expect(scheduler.callbacks.size).toBe(1);
+
+    await controller.dispose();
+
+    expect(client.close).toHaveBeenNthCalledWith(1, 'session-first');
+    expect(client.close).toHaveBeenNthCalledWith(2, 'session-second');
+    expect(scheduler.callbacks.size).toBe(0);
+  });
+
+  it('pauses scheduled polling when every Inspector surface is hidden', async () => {
+    const client = createClient();
+    const scheduler = new TestScheduler();
+    const controller = createEngineDebugSessionController({
+      client,
+      scheduler,
+      onCapture: vi.fn()
+    });
+    controller.dispatch({ type: 'visibility', surface: 'docked', visible: true });
+    await controller.start();
+    expect(scheduler.callbacks.size).toBe(1);
+
+    controller.dispatch({ type: 'visibility', surface: 'docked', visible: false });
+    expect(scheduler.callbacks.size).toBe(0);
+
+    controller.dispatch({ type: 'visibility', surface: 'window', visible: true });
+    expect(scheduler.callbacks.size).toBe(1);
+    await controller.dispose();
+  });
+});

--- a/browser/frontend/src/app/engine-debug-session-controller.ts
+++ b/browser/frontend/src/app/engine-debug-session-controller.ts
@@ -1,0 +1,329 @@
+import type { EngineDebugErrorCode, EngineDebugSession } from '../../../contracts/engine';
+import {
+  ENGINE_DEBUG_CONSUMER_LIMITS,
+  serializeEngineDebugCapture,
+  type SerializedEngineDebugCapture
+} from './engine-debug-capture';
+import type { EngineDebugSessionClient } from './engine-debug-client';
+import { EngineDebugStore, type EngineDebugEventGroup } from './engine-debug-store';
+import {
+  buildEngineDebugInspectorViewModel,
+  type EngineDebugInspectorViewModel
+} from './engine-debug-view-model';
+
+export const ENGINE_DEBUG_POLL_INTERVAL_MS = 750;
+export const ENGINE_DEBUG_POLL_BATCH_SIZE = 100;
+export const ENGINE_DEBUG_CAPTURE_FILENAME = 'waves-engine-debug-capture-v1.json';
+
+export type EngineDebugInspectorSurface = 'docked' | 'window';
+
+export type EngineDebugInspectorAction =
+  | { type: 'start' }
+  | { type: 'stop' }
+  | { type: 'snapshot' }
+  | { type: 'export' }
+  | { type: 'filter'; group: EngineDebugEventGroup; query: string }
+  | { type: 'visibility'; surface: EngineDebugInspectorSurface; visible: boolean };
+
+interface EngineDebugScheduler {
+  setTimeout(callback: () => void, delayMs: number): ReturnType<typeof setTimeout>;
+  clearTimeout(timer: ReturnType<typeof setTimeout>): void;
+}
+
+export interface EngineDebugSessionControllerOptions {
+  client: EngineDebugSessionClient;
+  store?: EngineDebugStore;
+  scheduler?: EngineDebugScheduler;
+  pollIntervalMs?: number;
+  onCapture?: (capture: SerializedEngineDebugCapture) => void;
+}
+
+export interface EngineDebugSessionController {
+  subscribe(listener: (viewModel: EngineDebugInspectorViewModel) => void): () => void;
+  dispatch(action: EngineDebugInspectorAction): void;
+  start(): Promise<void>;
+  stop(): Promise<void>;
+  refreshSnapshot(): Promise<void>;
+  exportCapture(): SerializedEngineDebugCapture;
+  dispose(): Promise<void>;
+}
+
+const browserScheduler: EngineDebugScheduler = {
+  setTimeout: (callback, delayMs) => setTimeout(callback, delayMs),
+  clearTimeout: (timer) => clearTimeout(timer)
+};
+
+const downloadCapture = (capture: SerializedEngineDebugCapture): void => {
+  const blob = new Blob([capture.json], { type: 'application/json' });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = ENGINE_DEBUG_CAPTURE_FILENAME;
+  link.click();
+  URL.revokeObjectURL(url);
+};
+
+export const createEngineDebugSessionController = ({
+  client,
+  store = new EngineDebugStore(),
+  scheduler = browserScheduler,
+  pollIntervalMs = ENGINE_DEBUG_POLL_INTERVAL_MS,
+  onCapture = downloadCapture
+}: EngineDebugSessionControllerOptions): EngineDebugSessionController => {
+  const listeners = new Set<(viewModel: EngineDebugInspectorViewModel) => void>();
+  const visibleSurfaces: Record<EngineDebugInspectorSurface, boolean> = {
+    docked: false,
+    window: false
+  };
+  let session: EngineDebugSession | undefined;
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  let generation = 0;
+  let pollInFlight = false;
+  let disposed = false;
+
+  const emit = (): void => {
+    const viewModel = buildEngineDebugInspectorViewModel(store.getState());
+    for (const listener of listeners) listener(viewModel);
+  };
+
+  const isVisible = (): boolean => visibleSurfaces.docked || visibleSurfaces.window;
+
+  const clearPollTimer = (): void => {
+    if (timer !== undefined) {
+      scheduler.clearTimeout(timer);
+      timer = undefined;
+    }
+  };
+
+  const pollLimit = (): number => {
+    const capabilities = session?.capabilities;
+    if (!capabilities) return ENGINE_DEBUG_POLL_BATCH_SIZE;
+    return Math.max(
+      1,
+      Math.min(
+        ENGINE_DEBUG_POLL_BATCH_SIZE,
+        capabilities.defaultMaxEventsPerPoll,
+        capabilities.maxEventsPerPoll
+      )
+    );
+  };
+
+  const schedulePoll = (delayMs: number): void => {
+    clearPollTimer();
+    if (disposed || !session || !isVisible() || store.getState().phase !== 'active') return;
+    const expectedGeneration = generation;
+    timer = scheduler.setTimeout(
+      () => {
+        timer = undefined;
+        void poll(expectedGeneration);
+      },
+      Math.max(0, delayMs)
+    );
+  };
+
+  const closeQuietly = async (sessionId: string): Promise<void> => {
+    try {
+      await client.close(sessionId);
+    } catch {
+      // Teardown deliberately ignores host internals and never retries without a new user action.
+    }
+  };
+
+  const failSession = async (
+    code: EngineDebugErrorCode,
+    expectedGeneration: number
+  ): Promise<void> => {
+    if (expectedGeneration !== generation) return;
+    clearPollTimer();
+    const failedSession = session;
+    session = undefined;
+    generation += 1;
+    store.markFailure(code);
+    emit();
+    if (failedSession) await closeQuietly(failedSession.sessionId);
+  };
+
+  const snapshot = async (expectedGeneration: number): Promise<boolean> => {
+    const activeSession = session;
+    if (!activeSession || expectedGeneration !== generation) return false;
+    try {
+      const outcome = await client.snapshot(activeSession.sessionId);
+      if (expectedGeneration !== generation) return false;
+      if (outcome.status === 'failure') {
+        await failSession(outcome.error.code, expectedGeneration);
+        return false;
+      }
+      store.setSnapshot(outcome.snapshot);
+      emit();
+      return true;
+    } catch {
+      await failSession('INTERNAL_ERROR', expectedGeneration);
+      return false;
+    }
+  };
+
+  const poll = async (expectedGeneration: number): Promise<void> => {
+    const activeSession = session;
+    if (
+      pollInFlight ||
+      !activeSession ||
+      expectedGeneration !== generation ||
+      !isVisible() ||
+      store.getState().phase !== 'active'
+    ) {
+      return;
+    }
+    pollInFlight = true;
+    const previousCursor = activeSession.cursor;
+    try {
+      const outcome = await client.poll(activeSession.sessionId, previousCursor, pollLimit());
+      if (expectedGeneration !== generation) return;
+      if (outcome.status === 'failure') {
+        await failSession(outcome.error.code, expectedGeneration);
+        return;
+      }
+      activeSession.cursor = outcome.batch.nextCursor;
+      store.appendEvents(outcome.batch.events, outcome.batch.droppedCount);
+      emit();
+      const madeProgress = outcome.batch.nextCursor !== previousCursor;
+      schedulePoll(outcome.batch.hasMore && madeProgress ? 0 : pollIntervalMs);
+    } catch {
+      await failSession('INTERNAL_ERROR', expectedGeneration);
+    } finally {
+      pollInFlight = false;
+    }
+  };
+
+  const start = async (): Promise<void> => {
+    if (disposed || ['opening', 'active', 'closing'].includes(store.getState().phase)) return;
+    clearPollTimer();
+    const expectedGeneration = ++generation;
+    store.beginOpen();
+    emit();
+    try {
+      const outcome = await client.open();
+      if (expectedGeneration !== generation || disposed) {
+        if (outcome.status === 'success') await closeQuietly(outcome.session.sessionId);
+        return;
+      }
+      if (outcome.status === 'failure') {
+        store.markFailure(outcome.error.code);
+        emit();
+        return;
+      }
+      session = {
+        sessionId: outcome.session.sessionId,
+        cursor: outcome.session.cursor,
+        capabilities: outcome.session.capabilities
+      };
+      store.markActive(outcome.session.capabilities);
+      emit();
+      if (!(await snapshot(expectedGeneration))) return;
+      if (isVisible()) await poll(expectedGeneration);
+    } catch {
+      await failSession('INTERNAL_ERROR', expectedGeneration);
+    }
+  };
+
+  const stop = async (): Promise<void> => {
+    if (store.getState().phase === 'idle' && !session) return;
+    const activeSession = session;
+    session = undefined;
+    generation += 1;
+    clearPollTimer();
+    store.beginClose();
+    emit();
+    if (!activeSession) {
+      store.markStopped();
+      emit();
+      return;
+    }
+    try {
+      const outcome = await client.close(activeSession.sessionId);
+      if (outcome.status === 'failure') {
+        store.markFailure(outcome.error.code);
+      } else {
+        store.markStopped();
+      }
+    } catch {
+      store.markFailure('INTERNAL_ERROR');
+    }
+    emit();
+  };
+
+  const refreshSnapshot = async (): Promise<void> => {
+    if (!session || store.getState().phase !== 'active') return;
+    await snapshot(generation);
+  };
+
+  const exportCapture = (): SerializedEngineDebugCapture => {
+    const state = store.getState();
+    const events = [...state.events];
+    const capture = serializeEngineDebugCapture({
+      capabilities: state.capabilities,
+      events,
+      snapshot: state.snapshot,
+      accounting: {
+        producerDroppedEvents: state.producerDroppedEvents,
+        frontendDroppedEvents: state.frontendDroppedEvents,
+        retainedEvents: events.length,
+        ...(events.at(0) ? { oldestSeq: events[0]?.seq } : {}),
+        ...(events.at(-1) ? { latestSeq: events.at(-1)?.seq } : {})
+      }
+    });
+    onCapture(capture);
+    return capture;
+  };
+
+  const dispatch = (action: EngineDebugInspectorAction): void => {
+    switch (action.type) {
+      case 'start':
+        void start();
+        break;
+      case 'stop':
+        void stop();
+        break;
+      case 'snapshot':
+        void refreshSnapshot();
+        break;
+      case 'export':
+        exportCapture();
+        break;
+      case 'filter':
+        store.setFilter(action.group, action.query);
+        emit();
+        break;
+      case 'visibility': {
+        const wasVisible = isVisible();
+        visibleSurfaces[action.surface] = action.visible;
+        const nowVisible = isVisible();
+        if (wasVisible && !nowVisible) clearPollTimer();
+        if (!wasVisible && nowVisible) schedulePoll(0);
+        break;
+      }
+    }
+  };
+
+  return {
+    subscribe: (listener) => {
+      listeners.add(listener);
+      listener(buildEngineDebugInspectorViewModel(store.getState()));
+      return () => listeners.delete(listener);
+    },
+    dispatch,
+    start,
+    stop,
+    refreshSnapshot,
+    exportCapture,
+    dispose: async () => {
+      if (disposed) return;
+      disposed = true;
+      visibleSurfaces.docked = false;
+      visibleSurfaces.window = false;
+      listeners.clear();
+      await stop();
+    }
+  };
+};
+
+export const engineDebugExportCapacity = ENGINE_DEBUG_CONSUMER_LIMITS.exportBytes;

--- a/browser/frontend/src/app/engine-debug-store.ts
+++ b/browser/frontend/src/app/engine-debug-store.ts
@@ -1,0 +1,142 @@
+import type {
+  EngineDebugCapabilities,
+  EngineDebugErrorCode,
+  EngineDebugEvent,
+  EngineDebugSnapshot
+} from '../../../contracts/engine';
+import {
+  ENGINE_DEBUG_CONSUMER_LIMITS,
+  projectEngineDebugCapabilities,
+  projectEngineDebugEvent,
+  projectEngineDebugSnapshot
+} from './engine-debug-capture';
+
+export type EngineDebugInspectorPhase =
+  'idle' | 'opening' | 'active' | 'closing' | 'unavailable' | 'error';
+
+export type EngineDebugPolicyState = 'default-disabled' | 'enabled' | 'disabled' | 'unknown';
+
+export type EngineDebugEventGroup =
+  'all' | 'deck' | 'navigation' | 'input' | 'action' | 'script' | 'timer';
+
+export interface EngineDebugFilter {
+  group: EngineDebugEventGroup;
+  query: string;
+}
+
+export interface EngineDebugStoreState {
+  phase: EngineDebugInspectorPhase;
+  policy: EngineDebugPolicyState;
+  capabilities?: EngineDebugCapabilities;
+  events: readonly EngineDebugEvent[];
+  snapshot?: EngineDebugSnapshot;
+  producerDroppedEvents: number;
+  frontendDroppedEvents: number;
+  errorCode?: EngineDebugErrorCode;
+  filter: EngineDebugFilter;
+}
+
+const EVENT_GROUPS = new Set<EngineDebugEventGroup>([
+  'all',
+  'deck',
+  'navigation',
+  'input',
+  'action',
+  'script',
+  'timer'
+]);
+
+const boundedCounter = (value: number): number =>
+  Number.isFinite(value) ? Math.max(0, Math.trunc(value)) : 0;
+
+export class EngineDebugStore {
+  private state: EngineDebugStoreState = {
+    phase: 'idle',
+    policy: 'default-disabled',
+    events: [],
+    producerDroppedEvents: 0,
+    frontendDroppedEvents: 0,
+    filter: { group: 'all', query: '' }
+  };
+
+  getState(): EngineDebugStoreState {
+    return this.state;
+  }
+
+  beginOpen(): void {
+    this.state = {
+      phase: 'opening',
+      policy: this.state.policy === 'disabled' ? 'unknown' : this.state.policy,
+      events: [],
+      producerDroppedEvents: 0,
+      frontendDroppedEvents: 0,
+      filter: this.state.filter
+    };
+  }
+
+  markActive(capabilities: EngineDebugCapabilities): void {
+    this.state = {
+      ...this.state,
+      phase: 'active',
+      policy: 'enabled',
+      capabilities: projectEngineDebugCapabilities(capabilities),
+      errorCode: undefined
+    };
+  }
+
+  beginClose(): void {
+    this.state = { ...this.state, phase: 'closing', errorCode: undefined };
+  }
+
+  markStopped(): void {
+    this.state = {
+      ...this.state,
+      phase: 'idle',
+      errorCode: undefined
+    };
+  }
+
+  markFailure(code: EngineDebugErrorCode): void {
+    this.state = {
+      ...this.state,
+      phase: code === 'DEBUG_DISABLED' ? 'unavailable' : 'error',
+      policy:
+        code === 'DEBUG_DISABLED'
+          ? 'disabled'
+          : this.state.policy === 'enabled'
+            ? 'unknown'
+            : this.state.policy,
+      errorCode: code
+    };
+  }
+
+  appendEvents(events: readonly EngineDebugEvent[], producerDroppedEvents: number): void {
+    const projected = events.map((event) => projectEngineDebugEvent(event));
+    const combined = [...this.state.events, ...projected];
+    const overflow = Math.max(0, combined.length - ENGINE_DEBUG_CONSUMER_LIMITS.retainedEvents);
+    this.state = {
+      ...this.state,
+      events: overflow > 0 ? combined.slice(overflow) : combined,
+      producerDroppedEvents:
+        this.state.producerDroppedEvents + boundedCounter(producerDroppedEvents),
+      frontendDroppedEvents: this.state.frontendDroppedEvents + overflow
+    };
+  }
+
+  setSnapshot(snapshot: EngineDebugSnapshot): void {
+    this.state = {
+      ...this.state,
+      snapshot: projectEngineDebugSnapshot(snapshot)
+    };
+  }
+
+  setFilter(group: EngineDebugEventGroup, query: string): void {
+    this.state = {
+      ...this.state,
+      filter: {
+        group: EVENT_GROUPS.has(group) ? group : 'all',
+        query: query.slice(0, ENGINE_DEBUG_CONSUMER_LIMITS.filterQueryLength)
+      }
+    };
+  }
+}

--- a/browser/frontend/src/app/engine-debug-view-model.ts
+++ b/browser/frontend/src/app/engine-debug-view-model.ts
@@ -1,0 +1,222 @@
+import type {
+  EngineDebugErrorCode,
+  EngineDebugEvent,
+  EngineDebugEventKind,
+  EngineDebugEventPayload,
+  EngineDebugValue
+} from '../../../contracts/engine';
+import { ENGINE_DEBUG_CONSUMER_LIMITS, projectEngineDebugSnapshot } from './engine-debug-capture';
+import type {
+  EngineDebugEventGroup,
+  EngineDebugInspectorPhase,
+  EngineDebugStoreState
+} from './engine-debug-store';
+
+export interface EngineDebugEventRow {
+  seq: string;
+  kind: EngineDebugEventKind;
+  monotonicTime: string;
+  cardId?: string;
+  summary: string;
+}
+
+export interface EngineDebugInspectorViewModel {
+  phase: EngineDebugInspectorPhase;
+  statusLabel: string;
+  statusDetail: string;
+  policyLabel: string;
+  canStart: boolean;
+  canStop: boolean;
+  canSnapshot: boolean;
+  canExport: boolean;
+  busy: boolean;
+  filter: {
+    group: EngineDebugEventGroup;
+    query: string;
+  };
+  retainedEventCount: number;
+  matchingEventCount: number;
+  renderedEventCount: number;
+  producerDroppedEvents: number;
+  frontendDroppedEvents: number;
+  rows: EngineDebugEventRow[];
+  snapshotText: string;
+  snapshotSummary: string;
+  capacitySummary: string;
+}
+
+export const ENGINE_DEBUG_EVENT_GROUPS: ReadonlyArray<{
+  value: EngineDebugEventGroup;
+  label: string;
+}> = [
+  { value: 'all', label: 'All events' },
+  { value: 'deck', label: 'Deck and card' },
+  { value: 'navigation', label: 'Navigation and focus' },
+  { value: 'input', label: 'Input editing' },
+  { value: 'action', label: 'Actions and fields' },
+  { value: 'script', label: 'Scripts' },
+  { value: 'timer', label: 'Timers' }
+];
+
+const ERROR_MESSAGES: Record<EngineDebugErrorCode, string> = {
+  DEBUG_DISABLED:
+    'The local host policy is disabled. Set WAVES_ENGINE_DEBUG_POLICY=enabled before launch.',
+  UNSUPPORTED_PROTOCOL_VERSION: 'The host does not support Inspector protocol version 1.',
+  SESSION_LIMIT_REACHED: 'Another local Inspector session is already open. Close it and try again.',
+  SESSION_NOT_FOUND: 'The Inspector session expired. Start a new local session.',
+  INVALID_CURSOR: 'The event cursor was rejected. Start a new local session.',
+  INVALID_REQUEST: 'The bounded Inspector request was rejected.',
+  DEBUG_SOURCE_UNAVAILABLE: 'The engine diagnostic source is temporarily unavailable.',
+  INTERNAL_ERROR: 'The Inspector stopped after a sanitized host error.'
+};
+
+const phaseStatus = (
+  phase: EngineDebugInspectorPhase,
+  errorCode: EngineDebugErrorCode | undefined
+): { label: string; detail: string } => {
+  switch (phase) {
+    case 'idle':
+      return {
+        label: 'Off',
+        detail:
+          'Read-only and disabled by default. Starting requires the local host policy at launch.'
+      };
+    case 'opening':
+      return { label: 'Starting', detail: 'Opening one bounded local debug session.' };
+    case 'active':
+      return {
+        label: 'Capturing',
+        detail: 'Read-only polling is active while an Inspector surface is visible.'
+      };
+    case 'closing':
+      return { label: 'Stopping', detail: 'Polling is stopped and the local session is closing.' };
+    case 'unavailable':
+    case 'error':
+      return {
+        label: phase === 'unavailable' ? 'Policy disabled' : 'Stopped after error',
+        detail: errorCode ? ERROR_MESSAGES[errorCode] : ERROR_MESSAGES.INTERNAL_ERROR
+      };
+  }
+};
+
+const displayValue = (value: EngineDebugValue): string => {
+  if (value.state === 'visible') {
+    return value.value.slice(0, 160);
+  }
+  return `[${value.state}: ${value.reason}]`;
+};
+
+const describePayload = (payload: EngineDebugEventPayload): string => {
+  switch (payload.type) {
+    case 'deck-load':
+      return `${payload.cardCount} cards · ${payload.contentType} · ${displayValue(payload.baseUrl)}`;
+    case 'card-enter':
+      return 'Entered card';
+    case 'card-exit':
+      return 'Exited card';
+    case 'focus-change':
+      return `${payload.previousIndex ?? 'none'} → ${payload.currentIndex ?? 'none'}`;
+    case 'input-edit-start':
+      return `Started ${payload.name}`;
+    case 'input-edit-draft':
+      return `${payload.name} = ${displayValue(payload.value)}`;
+    case 'input-edit-commit':
+      return `${payload.name} committed as ${displayValue(payload.value)}`;
+    case 'input-edit-cancel':
+      return `Cancelled ${payload.name}`;
+    case 'action-accept':
+      return `${payload.actionType}${payload.name ? ` · ${payload.name}` : ''}`;
+    case 'action-external':
+      return `External target ${displayValue(payload.target)}`;
+    case 'navigation-intent':
+      return `Target ${displayValue(payload.target)}`;
+    case 'postfield-resolve':
+      return `${payload.fields.length} bounded field${payload.fields.length === 1 ? '' : 's'}`;
+    case 'script-invoke':
+      return `${displayValue(payload.source)} · ${payload.functionName}`;
+    case 'script-trap':
+      return `${payload.functionName} · ${displayValue(payload.detail)}`;
+    case 'timer-schedule':
+      return `${payload.delayMs} ms · ${displayValue(payload.token)}`;
+    case 'timer-fire':
+    case 'timer-cancel':
+      return displayValue(payload.token);
+  }
+};
+
+const groupForKind = (kind: EngineDebugEventKind): EngineDebugEventGroup => {
+  if (kind.startsWith('deck.') || kind.startsWith('card.')) return 'deck';
+  if (kind.startsWith('nav.') || kind.startsWith('focus.')) return 'navigation';
+  if (kind.startsWith('input.')) return 'input';
+  if (kind.startsWith('action.') || kind.startsWith('postfield.')) return 'action';
+  if (kind.startsWith('script.')) return 'script';
+  return 'timer';
+};
+
+const rowFromEvent = (event: EngineDebugEvent): EngineDebugEventRow => ({
+  seq: event.seq,
+  kind: event.kind,
+  monotonicTime: `${event.monotonicTimeMs} ms`,
+  ...(event.cardId === undefined ? {} : { cardId: event.cardId }),
+  summary: describePayload(event.payload)
+});
+
+const matchesFilter = (
+  event: EngineDebugEvent,
+  group: EngineDebugEventGroup,
+  query: string
+): boolean => {
+  if (group !== 'all' && groupForKind(event.kind) !== group) return false;
+  if (!query) return true;
+  const row = rowFromEvent(event);
+  return `${row.seq} ${row.kind} ${row.cardId ?? ''} ${row.summary}`
+    .toLowerCase()
+    .includes(query.toLowerCase());
+};
+
+export const buildEngineDebugInspectorViewModel = (
+  state: EngineDebugStoreState
+): EngineDebugInspectorViewModel => {
+  const matchingEvents = state.events.filter((event) =>
+    matchesFilter(event, state.filter.group, state.filter.query)
+  );
+  const renderedEvents = matchingEvents.slice(-ENGINE_DEBUG_CONSUMER_LIMITS.renderedRows);
+  const status = phaseStatus(state.phase, state.errorCode);
+  const snapshotForView = state.snapshot
+    ? projectEngineDebugSnapshot(state.snapshot, {
+        textLimit: 256,
+        variableLimit: 32,
+        timerLimit: 16
+      })
+    : undefined;
+  return {
+    phase: state.phase,
+    statusLabel: status.label,
+    statusDetail: status.detail,
+    policyLabel:
+      state.policy === 'enabled'
+        ? 'Local policy enabled'
+        : state.policy === 'disabled'
+          ? 'Local policy disabled'
+          : state.policy === 'unknown'
+            ? 'Local policy unknown'
+            : 'Disabled by default',
+    canStart: ['idle', 'unavailable', 'error'].includes(state.phase),
+    canStop: state.phase === 'active',
+    canSnapshot: state.phase === 'active' && Boolean(state.capabilities?.supportsSnapshots),
+    canExport: state.events.length > 0 || state.snapshot !== undefined,
+    busy: state.phase === 'opening' || state.phase === 'closing',
+    filter: state.filter,
+    retainedEventCount: state.events.length,
+    matchingEventCount: matchingEvents.length,
+    renderedEventCount: renderedEvents.length,
+    producerDroppedEvents: state.producerDroppedEvents,
+    frontendDroppedEvents: state.frontendDroppedEvents,
+    rows: renderedEvents.map(rowFromEvent),
+    snapshotText: snapshotForView ? JSON.stringify(snapshotForView, null, 2) : '',
+    snapshotSummary: snapshotForView
+      ? `Sequence ${snapshotForView.capturedSeq} · ${snapshotForView.runtimeVars.length}/${snapshotForView.runtimeVarsSummary.totalCount} variables · ${snapshotForView.timers.length}/${snapshotForView.timersSummary.totalCount} timers`
+      : 'No snapshot captured',
+    capacitySummary: `${state.events.length}/${ENGINE_DEBUG_CONSUMER_LIMITS.retainedEvents} retained · ${renderedEvents.length}/${ENGINE_DEBUG_CONSUMER_LIMITS.renderedRows} rendered`
+  };
+};

--- a/browser/frontend/src/app/shell/developer-drawer-template.ts
+++ b/browser/frontend/src/app/shell/developer-drawer-template.ts
@@ -1,4 +1,5 @@
 import { WAVES_COPY } from '../waves-copy';
+import { engineDebugInspectorTemplate } from '../../components/engine-debug-inspector';
 
 export type DeveloperToolsSurface = 'docked' | 'window';
 
@@ -61,6 +62,7 @@ export const developerDrawerTemplate = (surface: DeveloperToolsSurface = 'docked
           <button id="devtools-tab-overview" class="developer-tools-tab" type="button" role="tab" aria-selected="true" aria-controls="devtools-panel-overview" tabindex="0">${WAVES_COPY.shell.overview}</button>
           <button id="devtools-tab-transport" class="developer-tools-tab" type="button" role="tab" aria-selected="false" aria-controls="devtools-panel-transport" tabindex="-1">${WAVES_COPY.shell.transport}</button>
           <button id="devtools-tab-runtime" class="developer-tools-tab" type="button" role="tab" aria-selected="false" aria-controls="devtools-panel-runtime" tabindex="-1">${WAVES_COPY.shell.runtime}</button>
+          <button id="devtools-tab-inspector" class="developer-tools-tab" type="button" role="tab" aria-selected="false" aria-controls="devtools-panel-inspector" tabindex="-1">${WAVES_COPY.inspector.tab}</button>
           <button id="devtools-tab-timeline" class="developer-tools-tab" type="button" role="tab" aria-selected="false" aria-controls="devtools-panel-timeline" tabindex="-1">${WAVES_COPY.shell.timeline}</button>
           <button id="devtools-tab-source" class="developer-tools-tab" type="button" role="tab" aria-selected="false" aria-controls="devtools-panel-source" tabindex="-1">${WAVES_COPY.shell.source}</button>
         </div>
@@ -121,6 +123,10 @@ export const developerDrawerTemplate = (surface: DeveloperToolsSurface = 'docked
             <div class="developer-tools-inline-actions">
               ${actionButton('btn-clear-intent', 'clear-intent', WAVES_COPY.shell.clearExternalIntent)}
             </div>
+          </section>
+
+          <section id="devtools-panel-inspector" class="developer-tools-panel" role="tabpanel" aria-labelledby="devtools-tab-inspector" tabindex="0" hidden>
+            ${engineDebugInspectorTemplate()}
           </section>
 
           <section id="devtools-panel-timeline" class="developer-tools-panel" role="tabpanel" aria-labelledby="devtools-tab-timeline" tabindex="0" hidden>

--- a/browser/frontend/src/app/waves-copy.ts
+++ b/browser/frontend/src/app/waves-copy.ts
@@ -109,6 +109,38 @@ const locale = {
     nextCard: 'You are on the next card.',
     home: 'Go home'
   },
+  inspector: {
+    tab: 'Inspector',
+    title: 'Engine Inspector',
+    description: 'Bounded, local, read-only engine events and snapshots.',
+    start: 'Start Inspector',
+    stop: 'Stop',
+    hostPolicy: 'Host policy',
+    disabledByDefault: 'Disabled by default',
+    session: 'Session',
+    off: 'Off',
+    defaultDisabledDetail:
+      'Read-only and disabled by default. Starting requires the local host policy at launch.',
+    captureControls: 'Inspector capture controls',
+    eventGroup: 'Event group',
+    filter: 'Filter retained events',
+    filterPlaceholder: 'Sequence, kind, card, or value',
+    refreshSnapshot: 'Refresh Snapshot',
+    exportCapture: 'Export Capture',
+    inspectorOff: 'Inspector off.',
+    accounting: 'Inspector capacity and gap accounting',
+    matching: 'matching',
+    producerGaps: 'producer gaps',
+    frontendDrops: 'frontend drops',
+    eventStream: 'Event stream',
+    eventDescription:
+      'Ordered only by the engine sequence cursor; newest bounded rows remain visible.',
+    noEvents: 'No retained events.',
+    noMatchingEvents: 'No retained events match the current filter.',
+    engineDebugEvents: 'Engine debug events',
+    boundedSnapshot: 'Bounded snapshot',
+    noSnapshot: 'No snapshot captured'
+  },
   statusPrefix: {
     error: 'Error:',
     fetchFailed: 'Fetch failed:',
@@ -157,6 +189,7 @@ const locale = {
     developerToolsHidden: 'Developer tools hidden.',
     developerToolsWindowFailed: (message: string) =>
       `Developer tools window could not open. ${message}`,
+    developerToolsInspectorStateFailed: 'Inspector state could not be sent to the detached window.',
     keyboard: (key: string) => `Keyboard: ${key}`,
     keyboardBackEngine: 'Keyboard: back (engine history)',
     keyboardBackBrowser: 'Keyboard: back (browser history)',

--- a/browser/frontend/src/components/engine-debug-inspector.test.ts
+++ b/browser/frontend/src/components/engine-debug-inspector.test.ts
@@ -1,0 +1,88 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { developerDrawerTemplate } from '../app/shell/developer-drawer-template';
+import { EngineDebugStore } from '../app/engine-debug-store';
+import { buildEngineDebugInspectorViewModel } from '../app/engine-debug-view-model';
+import { bindDeveloperToolsWorkspace } from '../app/developer-tools-workspace';
+import { bindEngineDebugInspector } from './engine-debug-inspector';
+
+describe('engine debug Inspector component', () => {
+  let root: HTMLElement;
+
+  beforeEach(() => {
+    document.body.innerHTML = `<main>${developerDrawerTemplate('window')}</main>`;
+    const workspace = document.querySelector<HTMLElement>('#developer-tools-workspace');
+    if (!workspace) throw new Error('missing Developer Tools workspace');
+    root = workspace;
+  });
+
+  it('uses semantic controls and exposes the Inspector through roving keyboard tabs', async () => {
+    const dispatch = vi.fn();
+    const disposeWorkspace = bindDeveloperToolsWorkspace(root);
+    const binding = bindEngineDebugInspector(root, { dispatch });
+    const runtimeTab = root.querySelector<HTMLButtonElement>('#devtools-tab-runtime');
+    const inspectorTab = root.querySelector<HTMLButtonElement>('#devtools-tab-inspector');
+
+    runtimeTab?.click();
+    runtimeTab?.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }));
+    await Promise.resolve();
+
+    expect(inspectorTab?.getAttribute('aria-selected')).toBe('true');
+    expect(document.activeElement).toBe(inspectorTab);
+    expect(root.querySelector('#btn-engine-debug-start')?.tagName).toBe('BUTTON');
+    expect(root.querySelector('#engine-debug-query')?.getAttribute('maxlength')).toBe('80');
+    expect(root.querySelector('[data-engine-debug-value="live"]')?.getAttribute('role')).toBe(
+      'status'
+    );
+    expect(dispatch).toHaveBeenCalledWith({
+      type: 'visibility',
+      surface: 'window',
+      visible: true
+    });
+
+    binding.dispose();
+    disposeWorkspace();
+  });
+
+  it('renders projected text with textContent and relays read-only capture actions', () => {
+    const canary = 'CANARY-MASKED-ORIGINAL';
+    const unsafeMaskedValue = {
+      state: 'masked' as const,
+      reason: 'password-input' as const,
+      originalValue: canary
+    };
+    const store = new EngineDebugStore();
+    store.appendEvents(
+      [
+        {
+          seq: '1',
+          kind: 'input.edit.draft',
+          monotonicTimeMs: 1,
+          payload: {
+            type: 'input-edit-draft',
+            name: 'password',
+            value: unsafeMaskedValue
+          }
+        }
+      ],
+      0
+    );
+    const dispatch = vi.fn();
+    const binding = bindEngineDebugInspector(root, { dispatch });
+    binding.render(buildEngineDebugInspectorViewModel(store.getState()));
+
+    expect(root.textContent).toContain('[masked: password-input]');
+    expect(root.textContent).not.toContain(canary);
+    expect(root.querySelector('[data-engine-debug-events] script')).toBeNull();
+
+    root.querySelector<HTMLButtonElement>('#btn-engine-debug-start')?.click();
+    const query = root.querySelector<HTMLInputElement>('#engine-debug-query');
+    if (query) {
+      query.value = 'input';
+      query.dispatchEvent(new Event('input', { bubbles: true }));
+    }
+
+    expect(dispatch).toHaveBeenCalledWith({ type: 'start' });
+    expect(dispatch).toHaveBeenCalledWith({ type: 'filter', group: 'all', query: 'input' });
+    binding.dispose();
+  });
+});

--- a/browser/frontend/src/components/engine-debug-inspector.ts
+++ b/browser/frontend/src/components/engine-debug-inspector.ts
@@ -1,0 +1,284 @@
+import { ENGINE_DEBUG_CONSUMER_LIMITS } from '../app/engine-debug-capture';
+import type {
+  EngineDebugInspectorAction,
+  EngineDebugInspectorSurface
+} from '../app/engine-debug-session-controller';
+import {
+  ENGINE_DEBUG_EVENT_GROUPS,
+  type EngineDebugInspectorViewModel
+} from '../app/engine-debug-view-model';
+import { WAVES_COPY } from '../app/waves-copy';
+
+const COPY = WAVES_COPY.inspector;
+
+const options = ENGINE_DEBUG_EVENT_GROUPS.map(
+  ({ value, label }) => `<option value="${value}">${label}</option>`
+).join('');
+
+export const engineDebugInspectorTemplate = (): string => `
+  <div class="engine-debug-inspector" data-engine-debug-inspector>
+    <div class="developer-tools-panel-heading engine-debug-heading">
+      <div>
+        <h3>${COPY.title}</h3>
+        <p>${COPY.description}</p>
+      </div>
+      <div class="developer-tools-inline-actions">
+        <button id="btn-engine-debug-start" class="btn developer-tools-action primary" type="button">
+          ${COPY.start}
+        </button>
+        <button id="btn-engine-debug-stop" class="btn developer-tools-action" type="button" disabled>
+          ${COPY.stop}
+        </button>
+      </div>
+    </div>
+
+    <section class="engine-debug-policy" aria-labelledby="engine-debug-policy-title">
+      <div>
+        <span id="engine-debug-policy-title">${COPY.hostPolicy}</span>
+        <strong data-engine-debug-value="policy">${COPY.disabledByDefault}</strong>
+      </div>
+      <div>
+        <span>${COPY.session}</span>
+        <strong data-engine-debug-value="status">${COPY.off}</strong>
+      </div>
+      <p data-engine-debug-value="detail">
+        ${COPY.defaultDisabledDetail}
+      </p>
+    </section>
+
+    <div class="engine-debug-toolbar" aria-label="${COPY.captureControls}">
+      <label class="developer-tools-field engine-debug-filter" for="engine-debug-group">
+        <span>${COPY.eventGroup}</span>
+        <select id="engine-debug-group" class="host-control">${options}</select>
+      </label>
+      <label class="developer-tools-field engine-debug-filter" for="engine-debug-query">
+        <span>${COPY.filter}</span>
+        <input
+          id="engine-debug-query"
+          class="host-control"
+          type="search"
+          maxlength="${ENGINE_DEBUG_CONSUMER_LIMITS.filterQueryLength}"
+          autocomplete="off"
+          placeholder="${COPY.filterPlaceholder}"
+        />
+      </label>
+      <div class="developer-tools-inline-actions engine-debug-capture-actions">
+        <button id="btn-engine-debug-snapshot" class="btn developer-tools-action" type="button" disabled>
+          ${COPY.refreshSnapshot}
+        </button>
+        <button id="btn-engine-debug-export" class="btn developer-tools-action" type="button" disabled>
+          ${COPY.exportCapture}
+        </button>
+      </div>
+    </div>
+
+    <output
+      class="engine-debug-live-status"
+      data-engine-debug-value="live"
+    >${COPY.inspectorOff}</output>
+
+    <div class="engine-debug-accounting" aria-label="${COPY.accounting}">
+      <span data-engine-debug-value="capacity">0/${ENGINE_DEBUG_CONSUMER_LIMITS.retainedEvents} retained</span>
+      <span data-engine-debug-value="matches">0 ${COPY.matching}</span>
+      <span data-engine-debug-value="producer-drops">0 ${COPY.producerGaps}</span>
+      <span data-engine-debug-value="frontend-drops">0 ${COPY.frontendDrops}</span>
+    </div>
+
+    <section class="engine-debug-events" aria-labelledby="engine-debug-events-title">
+      <div class="developer-tools-panel-heading">
+        <div>
+          <h3 id="engine-debug-events-title">${COPY.eventStream}</h3>
+          <p>${COPY.eventDescription}</p>
+        </div>
+      </div>
+      <ol class="engine-debug-event-list" data-engine-debug-events aria-label="${COPY.engineDebugEvents}">
+        <li class="engine-debug-empty">${COPY.noEvents}</li>
+      </ol>
+    </section>
+
+    <details class="developer-tools-disclosure engine-debug-snapshot">
+      <summary>
+        <span>${COPY.boundedSnapshot}</span>
+        <span data-engine-debug-value="snapshot-summary">${COPY.noSnapshot}</span>
+      </summary>
+      <pre data-engine-debug-snapshot tabindex="0"></pre>
+    </details>
+  </div>
+`;
+
+export interface BindEngineDebugInspectorOptions {
+  dispatch(action: EngineDebugInspectorAction): void;
+}
+
+export interface EngineDebugInspectorBinding {
+  render(viewModel: EngineDebugInspectorViewModel): void;
+  dispose(): void;
+}
+
+const setText = (root: ParentNode, selector: string, value: string): void => {
+  const element = root.querySelector<HTMLElement>(selector);
+  if (element && element.textContent !== value) element.textContent = value;
+};
+
+const inspectorSurface = (root: HTMLElement): EngineDebugInspectorSurface =>
+  root.closest<HTMLElement>('[data-developer-tools-surface]')?.dataset.developerToolsSurface ===
+  'window'
+    ? 'window'
+    : 'docked';
+
+export const bindEngineDebugInspector = (
+  root: HTMLElement,
+  { dispatch }: BindEngineDebugInspectorOptions
+): EngineDebugInspectorBinding => {
+  const inspector = root.querySelector<HTMLElement>('[data-engine-debug-inspector]');
+  const panel = root.querySelector<HTMLElement>('#devtools-panel-inspector');
+  const drawer = root
+    .closest<HTMLElement>('[data-developer-tools-surface]')
+    ?.querySelector<HTMLDetailsElement>('#dev-drawer');
+  if (!inspector || !panel) throw new Error('missing engine Inspector workspace');
+
+  const surface = inspectorSurface(root);
+  const liveStatus = inspector.querySelector<HTMLOutputElement>('[data-engine-debug-value="live"]');
+  if (surface === 'window' && liveStatus) {
+    liveStatus.setAttribute('role', 'status');
+    liveStatus.setAttribute('aria-live', 'polite');
+    liveStatus.setAttribute('aria-atomic', 'true');
+  }
+  const cleanups: Array<() => void> = [];
+  const startButton = inspector.querySelector<HTMLButtonElement>('#btn-engine-debug-start');
+  const stopButton = inspector.querySelector<HTMLButtonElement>('#btn-engine-debug-stop');
+  const snapshotButton = inspector.querySelector<HTMLButtonElement>('#btn-engine-debug-snapshot');
+  const exportButton = inspector.querySelector<HTMLButtonElement>('#btn-engine-debug-export');
+  const groupSelect = inspector.querySelector<HTMLSelectElement>('#engine-debug-group');
+  const queryInput = inspector.querySelector<HTMLInputElement>('#engine-debug-query');
+  const eventList = inspector.querySelector<HTMLOListElement>('[data-engine-debug-events]');
+
+  if (
+    !startButton ||
+    !stopButton ||
+    !snapshotButton ||
+    !exportButton ||
+    !groupSelect ||
+    !queryInput ||
+    !eventList
+  ) {
+    throw new Error('missing engine Inspector controls');
+  }
+
+  const listen = <Target extends EventTarget>(
+    target: Target,
+    type: string,
+    listener: EventListener
+  ): void => {
+    target.addEventListener(type, listener);
+    cleanups.push(() => target.removeEventListener(type, listener));
+  };
+
+  listen(startButton, 'click', () => dispatch({ type: 'start' }));
+  listen(stopButton, 'click', () => dispatch({ type: 'stop' }));
+  listen(snapshotButton, 'click', () => dispatch({ type: 'snapshot' }));
+  listen(exportButton, 'click', () => dispatch({ type: 'export' }));
+
+  const dispatchFilter = (): void => {
+    dispatch({
+      type: 'filter',
+      group: groupSelect.value as EngineDebugInspectorViewModel['filter']['group'],
+      query: queryInput.value
+    });
+  };
+  listen(groupSelect, 'change', dispatchFilter);
+  listen(queryInput, 'input', dispatchFilter);
+
+  let lastVisibility: boolean | undefined;
+  const reportVisibility = (): void => {
+    const visible =
+      !panel.hidden &&
+      (drawer?.open ?? true) &&
+      (document.visibilityState === undefined || document.visibilityState === 'visible');
+    if (visible === lastVisibility) return;
+    lastVisibility = visible;
+    dispatch({ type: 'visibility', surface, visible });
+  };
+  const reportAfterTabChange = (): void => queueMicrotask(reportVisibility);
+  for (const tab of root.querySelectorAll<HTMLButtonElement>('[role="tab"]')) {
+    listen(tab, 'click', reportAfterTabChange);
+    listen(tab, 'keydown', reportAfterTabChange);
+  }
+  if (drawer) listen(drawer, 'toggle', reportVisibility);
+  listen(document, 'visibilitychange', reportVisibility);
+  reportVisibility();
+
+  const render = (viewModel: EngineDebugInspectorViewModel): void => {
+    inspector.setAttribute('aria-busy', String(viewModel.busy));
+    startButton.disabled = !viewModel.canStart;
+    stopButton.disabled = !viewModel.canStop;
+    snapshotButton.disabled = !viewModel.canSnapshot;
+    exportButton.disabled = !viewModel.canExport;
+    if (groupSelect.value !== viewModel.filter.group) groupSelect.value = viewModel.filter.group;
+    if (queryInput.value !== viewModel.filter.query) queryInput.value = viewModel.filter.query;
+    setText(inspector, '[data-engine-debug-value="policy"]', viewModel.policyLabel);
+    setText(inspector, '[data-engine-debug-value="status"]', viewModel.statusLabel);
+    setText(inspector, '[data-engine-debug-value="detail"]', viewModel.statusDetail);
+    setText(
+      inspector,
+      '[data-engine-debug-value="live"]',
+      `${viewModel.statusLabel}. ${viewModel.renderedEventCount} event rows rendered.`
+    );
+    setText(inspector, '[data-engine-debug-value="capacity"]', viewModel.capacitySummary);
+    setText(
+      inspector,
+      '[data-engine-debug-value="matches"]',
+      `${viewModel.matchingEventCount} ${COPY.matching}`
+    );
+    setText(
+      inspector,
+      '[data-engine-debug-value="producer-drops"]',
+      `${viewModel.producerDroppedEvents} ${COPY.producerGaps}`
+    );
+    setText(
+      inspector,
+      '[data-engine-debug-value="frontend-drops"]',
+      `${viewModel.frontendDroppedEvents} ${COPY.frontendDrops}`
+    );
+    setText(inspector, '[data-engine-debug-value="snapshot-summary"]', viewModel.snapshotSummary);
+    setText(inspector, '[data-engine-debug-snapshot]', viewModel.snapshotText);
+
+    eventList.replaceChildren(
+      ...(viewModel.rows.length === 0
+        ? [
+            Object.assign(document.createElement('li'), {
+              className: 'engine-debug-empty',
+              textContent: COPY.noMatchingEvents
+            })
+          ]
+        : viewModel.rows.map((row) => {
+            const item = document.createElement('li');
+            item.className = 'engine-debug-event';
+            const sequence = document.createElement('span');
+            sequence.className = 'engine-debug-event-seq';
+            sequence.textContent = `#${row.seq}`;
+            const kind = document.createElement('strong');
+            kind.className = 'engine-debug-event-kind';
+            kind.textContent = row.kind;
+            const time = document.createElement('span');
+            time.className = 'engine-debug-event-time';
+            time.textContent = row.monotonicTime;
+            const summary = document.createElement('span');
+            summary.className = 'engine-debug-event-summary';
+            summary.textContent = row.cardId ? `${row.cardId} · ${row.summary}` : row.summary;
+            item.append(sequence, kind, time, summary);
+            return item;
+          }))
+    );
+  };
+
+  return {
+    render,
+    dispose: () => {
+      while (cleanups.length > 0) cleanups.pop()?.();
+      if (lastVisibility !== false) {
+        dispatch({ type: 'visibility', surface, visible: false });
+      }
+    }
+  };
+};

--- a/browser/frontend/src/developer-tools.css
+++ b/browser/frontend/src/developer-tools.css
@@ -150,7 +150,7 @@
 
 .developer-tools-tabs {
   display: grid;
-  grid-template-columns: repeat(5, minmax(0, 1fr));
+  grid-template-columns: repeat(6, minmax(0, 1fr));
   min-width: 0;
   border-bottom: var(--rule-hair) solid var(--host-border);
   background: var(--color-chrome-bottom);
@@ -436,6 +436,164 @@
   tab-size: 2;
 }
 
+.engine-debug-inspector {
+  display: grid;
+  min-width: 0;
+  gap: var(--space-sm);
+}
+
+.engine-debug-policy {
+  display: grid;
+  min-width: 0;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  border: var(--rule-hair) solid var(--host-border);
+  border-radius: var(--radius-control);
+  background: var(--color-surface);
+}
+
+.engine-debug-policy > div {
+  min-width: 0;
+  padding: var(--space-xs);
+}
+
+.engine-debug-policy > div + div {
+  border-left: var(--rule-hair) solid var(--host-border);
+}
+
+.engine-debug-policy span,
+.engine-debug-policy strong {
+  display: block;
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
+.engine-debug-policy span {
+  color: var(--host-muted);
+  font-size: var(--text-xs);
+}
+
+.engine-debug-policy strong {
+  margin-block-start: var(--space-3xs);
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+}
+
+.engine-debug-policy p {
+  grid-column: 1 / -1;
+  margin: 0;
+  padding: var(--space-xs);
+  border-top: var(--rule-hair) solid var(--host-border);
+  color: var(--host-muted);
+  font-size: var(--text-xs);
+  overflow-wrap: anywhere;
+}
+
+.engine-debug-toolbar {
+  display: grid;
+  min-width: 0;
+  grid-template-columns: minmax(9rem, 0.7fr) minmax(12rem, 1.3fr);
+  gap: var(--space-xs);
+  align-items: end;
+}
+
+.engine-debug-capture-actions {
+  grid-column: 1 / -1;
+  margin-block-start: 0;
+}
+
+.engine-debug-live-status {
+  min-width: 0;
+  margin: 0;
+  color: var(--host-muted);
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  overflow-wrap: anywhere;
+}
+
+.engine-debug-accounting {
+  display: flex;
+  min-width: 0;
+  flex-wrap: wrap;
+  gap: var(--space-2xs) var(--space-sm);
+  padding-block: var(--space-xs);
+  border-block: var(--rule-hair) solid var(--host-border);
+  color: var(--host-muted);
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+}
+
+.engine-debug-events {
+  min-width: 0;
+}
+
+.engine-debug-event-list {
+  display: grid;
+  min-width: 0;
+  margin: 0;
+  padding: 0;
+  border: var(--rule-hair) solid var(--host-border);
+  border-radius: var(--radius-control);
+  background: var(--color-surface);
+  list-style: none;
+}
+
+.engine-debug-event,
+.engine-debug-empty {
+  min-width: 0;
+  padding: var(--space-xs);
+  border-bottom: var(--rule-hair) solid var(--host-border);
+}
+
+.engine-debug-event:last-child,
+.engine-debug-empty:last-child {
+  border-bottom: 0;
+}
+
+.engine-debug-event {
+  display: grid;
+  grid-template-columns: minmax(3.5rem, auto) minmax(8rem, 0.7fr) minmax(4.5rem, auto);
+  gap: var(--space-3xs) var(--space-xs);
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+}
+
+.engine-debug-event-seq,
+.engine-debug-event-time {
+  color: var(--host-muted);
+  font-variant-numeric: tabular-nums;
+}
+
+.engine-debug-event-kind {
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
+.engine-debug-event-summary {
+  min-width: 0;
+  grid-column: 1 / -1;
+  overflow-wrap: anywhere;
+}
+
+.engine-debug-empty {
+  color: var(--host-muted);
+  font-size: var(--text-xs);
+}
+
+.engine-debug-snapshot {
+  margin-block-start: 0;
+}
+
+.engine-debug-snapshot > summary span:last-child {
+  min-width: 0;
+  overflow: hidden;
+  color: var(--host-muted);
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  font-weight: 400;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 body.developer-tools-window {
   height: 100dvh;
   min-height: 0;
@@ -584,6 +742,14 @@ body.developer-tools-window textarea {
 
   .developer-tools-window .developer-tools-summary > div:nth-child(even) {
     border-right: 0;
+  }
+
+  .engine-debug-toolbar {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .engine-debug-capture-actions {
+    grid-column: auto;
   }
 }
 

--- a/docs/waves/ENGINE_DEBUG_CONNECTOR_PLAN.md
+++ b/docs/waves/ENGINE_DEBUG_CONNECTOR_PLAN.md
@@ -1,6 +1,6 @@
 # Engine Debug Connector Plan
 
-Status: D0-01 through D0-03 done; consumer implementation deferred to D0-04
+Status: D0-01 through D0-04 done; later external and mutable capabilities remain deferred
 Owner lane: `engine-wasm` + `browser`
 
 Related reference:
@@ -16,7 +16,7 @@ core engine behavior.
 This is a diagnostics surface, not a transport/runtime control plane. D0-01 defines contracts and
 ownership, and D0-02 implements the bounded engine-owned recorder and sanitized snapshot source.
 Host sessions, Tauri commands, and activation policy are implemented by D0-03. Consumer polling
-cadence and UI remain D0-04 work.
+cadence, UI, and bounded capture are implemented by D0-04.
 
 ## D0-01 Decisions
 
@@ -254,9 +254,26 @@ consumer work.
   errors, snapshots, idempotent close, and close/reopen identity rotation. Generated frontend tests
   cover the four-command mapping and guarded outcome validation.
 
-### D0-04 and later
+### D0-04 (implemented)
 
-- browser debug panel, polling schedule, filtering, and JSON export
+- The existing docked/detached Developer Tools workspace includes an optional read-only Inspector.
+  It opens one generated D0-03 session, takes bounded snapshots, and polls cursor-ordered batches
+  only while an Inspector surface is visible.
+- Frontend memory retains at most 512 projected events and renders at most 200 matching rows.
+  Producer cursor gaps and frontend drop-oldest counts remain separate. Filters use one fixed event
+  family and an 80-character query.
+- Stop, session error, and application disposal cancel polling and close the process-local session;
+  a later start requests a fresh identity. Typed failures remain isolated from ordinary browsing.
+- `waves-engine-debug-capture-v1.json` has a 256 KiB UTF-8 ceiling and an explicit versioned
+  allowlist. It omits session ids, wall-clock time, credentials, request bodies, raw WML/source,
+  arbitrary errors, and masked originals. Full lifecycle, capacity, schema, and security details
+  are recorded in `browser/ENGINE_DEBUG_INSPECTOR.md`.
+- Frontend tests cover disabled policy, open/poll/snapshot/close, the one-session limit, cursor gaps,
+  sanitized errors, close/reopen, hidden polling pause, unmount cleanup, repeated capacity pressure,
+  secret canaries, and keyboard/accessibility semantics.
+
+### Later capabilities
+
 - external local tool bridge
 - optional multi-session capability
 - any remote transport, if separately designed and security-reviewed

--- a/docs/waves/PRD-WAVES-DESKTOP-APPLICATION-COMPLETION.md
+++ b/docs/waves/PRD-WAVES-DESKTOP-APPLICATION-COMPLETION.md
@@ -69,8 +69,8 @@ The foundations required for application-quality work now exist:
    hybrid history, stable navigation coordination, and a collapsed diagnostic drawer.
 4. A private first-party WAP preview deployment and deterministic origin exist, although public
    publication remains gated.
-5. The debug connector contract is generated and bounded, although its recorder, host lifecycle,
-   and UI remain unimplemented.
+5. The generated bounded debug connector, engine recorder, host lifecycle, and read-only Inspector
+   capture workflow are implemented; external tools and mutable debugger capabilities remain later.
 
 These foundations make it possible to add application features without inventing parallel WML or
 transport behavior in the frontend.
@@ -83,7 +83,7 @@ transport behavior in the frontend.
 | Browsing shell   | Back, Reload, location, Go/Stop lifecycle, Local/Network, route/profile readouts, Canvas handset stage, status, Welcome/Help, and local examples                             | Integrated Home/Favorites/Services Library, visible history, recent locations, and Preferences surface       |
 | Runtime path     | Transport-first engine load, deterministic session state, bounded single-pass frame output, Canvas rendering, cancellable navigation, and atomic committed-frame publication | F2 pointer/scroll/softkey cutover and final legacy-path removal                                              |
 | History          | In-memory engine card history plus request-shaped host deck history                                                                                                          | Persistence, search, retention policy, and duplicate same-card preservation across deck replacement (`#450`) |
-| Diagnostics      | Safe allowlisted timeline/export projection plus bounded, masked D0-02 engine events/snapshots and default-disabled D0-03 host sessions                                      | D0-04 Inspector consumption, filters, capture UX, and controlled replay                                      |
+| Diagnostics      | Safe timeline projection plus bounded, masked D0-02 events/snapshots, D0-03 host sessions, and the D0-04 read-only Inspector/capture workflow                                | External tooling and any separately designed controlled replay                                               |
 | Settings         | Versioned schema/store, native atomic backend, migration, reset/clear operations, and memory test adapter                                                                    | Integrated Preferences UI, complete window restore, and diagnostic/accessibility controls                    |
 | Onboarding       | Welcome/Help, tutorial deck, and migration of the isolated launch preference into versioned application state                                                                | Broader task progress and contextual onboarding remain later work                                            |
 | Public services  | Private exact-host deployment, deterministic first-party origin, safe Favorites/service-catalog domain, and publication-state model                                          | Public authorization, guided entry, external verification, and desktop release gates remain open             |
@@ -630,7 +630,8 @@ Before feature UI begins:
 3. Versioned application state is complete in PR `#522`; safe projection, integrated settings,
    window restore, and local/GET-safe recovery remain.
 4. The safe Favorites/service-catalog domain is complete in PR `#517`; WAP Home/Library UI remains.
-5. Safe timeline/export projection is complete in PR `#532`; add the D0-04 Inspector consumer.
+5. Safe timeline/export projection is complete in PR `#532`; the D0-04 Inspector consumer adds a
+   separately versioned bounded engine capture.
 6. Shared native commands and platform shortcuts are complete in PR `#523`.
 7. Complete public-lab desktop profile/resource separation and guided safety messaging only after
    its publication dependencies authorize them.
@@ -638,7 +639,8 @@ Before feature UI begins:
 
 ### 8.3 Phase B: next application-quality increment
 
-- complete `D0-04` on the landed D0-02/D0-03 source and host bridge for the WAP Inspector;
+- preserve the completed D0-02 through D0-04 read-only Inspector path while deferring external and
+  mutable debugger capabilities;
 - add visible searchable history with explicit retention after `#450`;
 - complete Favorites import/export UX;
 - add broader Developer/Diagnostic preferences and redaction controls;

--- a/docs/waves/SPRINT_PLAN_2026-03_MASTER_PRIORITIZED.md
+++ b/docs/waves/SPRINT_PLAN_2026-03_MASTER_PRIORITIZED.md
@@ -267,10 +267,11 @@ and lanes may run concurrently subject to the noted file ownership.
 |        6 | Script B2 — bounded `WMLS-502` operator/conversion execution                       | Starts after B1 establishes stack dataflow; same files as B1, so it is sequential in lane B.                                                                                                                   | Begins converting the 32 partial / 9 missing WMLScript parents and 107 unassessed language clauses into executable evidence. | Expands the safe script behavior available to representative WAP decks.                        |
 
 Desktop dispatch checkpoint: F1-01 through F1-03, RSL-01 through RSL-07, APP-STATE-01,
-APP-FAV-01, APP-CMD-01, and D0-01 through D0-03 are complete. F2-01 and D0-04 remain independent
-parallel slices; WBP-11 and APP-SHELL-01 follow on shared presenter/shell surfaces. RSL-07 bounds
-retained history but leaves issue `#450`'s cross-deck same-card identity correction to its separate
-follow-up.
+APP-FAV-01, APP-CMD-01, and D0-01 through D0-04 are complete. D0-04 implements read-only Inspector
+consumption in its exclusive consumer/component surfaces while F2-01 remains independent on
+engine-input ownership. WBP-11 and APP-SHELL-01 follow on shared presenter/shell surfaces. RSL-07
+bounds retained history but leaves issue `#450`'s cross-deck same-card identity correction to its
+separate follow-up.
 
 Preserve completed WML, WBXML, WDP, WCMP, and WSP evidence; do not activate
 connection-oriented WSP/WTP to manufacture completion. `REN-4` and full

--- a/docs/waves/WAVES_BROWSER_PRODUCT_IMPLEMENTATION_PLAN.md
+++ b/docs/waves/WAVES_BROWSER_PRODUCT_IMPLEMENTATION_PLAN.md
@@ -607,7 +607,7 @@ themselves claim WBP-07 through WBP-14 complete.
 
 The redesigned shell/Developer Tools workspace, pre-release marketing refresh, versioned
 application-state foundation, Favorites domain, native command registry, safe diagnostic
-projection, and D0-02/D0-03 debug source/host bridge are merged. The next parallel-safe browser
-batch is `RSL-07` bounded presenter/history state, F2-01 deterministic click input, and D0-04
-read-only Inspector consumption with explicit non-overlapping ownership. Issue `#450`, `WBP-11`,
-and `APP-SHELL-01` follow on shared history, presenter, and shell surfaces.
+projection, and D0-02/D0-03 debug source/host bridge are merged. The D0-04 branch adds read-only
+Inspector consumption with bounded safe capture without taking the parallel RSL-07 presenter or
+F2-01 engine-input surfaces. Issue `#450`, `WBP-11`, and `APP-SHELL-01` follow on shared history,
+presenter, and shell surfaces.

--- a/docs/waves/WORK_ITEMS.md
+++ b/docs/waves/WORK_ITEMS.md
@@ -2062,7 +2062,7 @@ Reference plan:
 
 ### D0-04 Browser debug panel and capture workflow
 
-1. `Status`: `todo`
+1. `Status`: `done`
 2. `Depends On`: `D0-03`
 3. `Owner`: `browser`
 4. `Files`:
@@ -2092,7 +2092,17 @@ Reference plan:
 
 9. `Notes`:
 
-- if UI scope threatens active lane capacity, ship as follow-up after `D0-03`
+- implemented as a read-only Inspector in the existing docked/detached Developer Tools workspace;
+  no presenter, host-history, engine input/layout, generated-contract, or runtime-control surface
+  changed
+- frontend retention is capped at 512 projected events, rendered results at 200 rows, snapshot
+  collections at 128 variables/32 timers, filter queries at 80 characters, and exports at 256 KiB
+- export reconstructs a versioned allowlist and excludes session ids, credentials, request bodies,
+  raw WML/source, arbitrary errors, and masked original values
+- lifecycle tests cover disabled policy, open/poll/snapshot/close, session limit, cursor gaps,
+  errors, close/reopen, hidden polling pause, unmount cleanup, capacity pressure, secret canaries,
+  keyboard interaction, and accessibility; operational details are in
+  `browser/ENGINE_DEBUG_INSPECTOR.md`
 
 ## Phase U: User Onboarding + Help Experience (Planning-Ready)
 


### PR DESCRIPTION
## Summary

- complete D0-04 with an optional read-only Engine Inspector in the existing docked and detached Developer Tools workspace
- consume only the generated D0-03 open/poll/snapshot/close commands and preserve default-disabled local host policy
- add bounded cursor polling, filtering, snapshots, retention, and a versioned secret-safe JSON capture

## What Changed

- add dedicated debug-session client, store, view-model, controller, capture projection, and Inspector component modules
- open one protocol-v1 session, take an initial snapshot, poll only while an Inspector surface is visible, and close on Stop, session error, or application disposal
- retain at most 512 projected events, render at most 200 filtered rows, bound filters to 80 characters, and retain snapshots at 128 variables / 32 timers
- export `waves-engine-debug-capture-v1.json` with a 256 KiB UTF-8 ceiling, at most 256 candidate events, adaptive oldest-event removal, and an explicit allowlisted schema
- relay projected Inspector state/actions to the least-privileged detached Developer Tools window without granting it host-command access
- mark D0-04 complete and document lifecycle, capacities, schema, filtering, and security invariants

## Validation

- `pnpm --dir browser/frontend test` — 52 files / 363 tests passed
- `pnpm --dir browser/frontend test:coverage` — thresholds passed (83.93% lines, 82.85% functions)
- `pnpm --dir browser/frontend lint`
- `pnpm --dir browser/frontend format:check`
- `pnpm --dir browser/frontend typecheck`
- `pnpm --dir browser/frontend build`
- `pnpm --dir browser/frontend test:accessibility:rendered`
- `pnpm --dir browser run contracts:check`
- `cargo test --manifest-path browser/src-tauri/Cargo.toml --locked --lib debug_` — 7 relevant host lifecycle tests passed
- `pnpm docs:check`
- `pnpm test:story waves` — 20 stories passed
- repository pre-push checks, including 414 engine tests and Rust format/clippy gates

## Scope Notes

- Inspector presentation and export reconstruct allowlisted DTOs; masked and omitted values never retain an original value
- captures exclude session ids, wall-clock timestamps, credentials, request bodies, raw WML/source, transport secrets, filters, and arbitrary error internals
- no mutable debugger commands, replay, runtime-control bypass, remote/network listener, multi-session support, or sensitive unmasking
- no changes to `browser-presenter.ts`, `session-history.ts`, `timeline.ts`, browser-controller/layout/input code, or generated contracts
