### PR TITLE
docs(waves): sync browser and public-lab release status

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,9 @@ for the complete command surface.
 ![The current Waves Developer Tools workspace beside the handset view](marketing-site/public/waves-browser-inspector.webp)
 
 The implementation is substantial but deliberately does not claim full WAP Class C conformance.
-Current assessments, clause evidence, and remaining gaps live in
+At the current evidence checkpoint, 41/198 selected parent rows are implemented;
+317/762 clauses are directly assessed. Current assessments, clause evidence, and remaining gaps
+live in
 [Project Atlas](https://dills122.github.io/wap-labs/atlas/) and the
 [compliance program](docs/waves/WAP_1_2_1_COMPLIANCE_PROGRAM.md).
 
@@ -235,7 +237,7 @@ prerequisites, and checks that remain GitHub-hosted or environment-dependent.
 - [WAP 1.2.1 compliance program](docs/waves/WAP_1_2_1_COMPLIANCE_PROGRAM.md)
 - [Contributor guide](CONTRIBUTING.md)
 
-Last reviewed: 2026-08-01 against `origin/main` at `90db2e33`.
+Last reviewed: 2026-08-02 against `origin/main` at `0028946e`.
 
 ## Contributing and license
 

--- a/browser/README.md
+++ b/browser/README.md
@@ -12,8 +12,9 @@ Implemented now:
 - Rust-sourced engine host contract generation:
   - generator: `src-tauri/src/bin/generate_contracts.rs`
   - output: `contracts/generated/engine-host.ts`
-- Canonical engine-owned WBP-06 presentation frame and typed input projection, carried inside the
-  transitional host `EngineFrame` envelope alongside the legacy snapshot/render fields
+- Canonical engine-owned WBP-06 presentation frame and typed input projection, with completed F1
+  Canvas publication and F2-01 engine-resolved click/hit-region input while legacy wrappers remain
+  available for the declared later cutover
 - Rust-sourced transport host contract generation:
   - generator: `src-tauri/src/bin/generate_contracts.rs`
   - output: `contracts/generated/transport-host.ts`
@@ -81,9 +82,10 @@ Implemented now:
 
 Not implemented yet:
 
-- Frame renderer/input cutover (`F1`/`F2`): the current viewport and keyboard behavior continue to
-  use compatibility paths while every host frame also carries the canonical presentation payload
-- True transport cancellation, phase-aware recovery, and safe session persistence (`WBP-10..12`)
+- Remaining F2 scroll and unified softkey/input work plus the F3/F4 internal split and legacy-path
+  removal
+- Phase-aware recovery and safe session persistence (`WBP-11..12`); true navigation cancellation
+  is already implemented
 - Production packaging/signing/notarization
 
 ## Direction
@@ -223,11 +225,13 @@ group and Docker services. This pilot is scheduled/manual until the promotion cr
    concurrency hardening; do not reopen completed tickets.
 2. Preserve completed WBP-06/F0 frame, input, drift, and WML-309 evidence. Keep `EngineDebug*`
    separate and retain the legacy render/key compatibility paths until the declared cutover gate.
-3. Continue with `F1-01` renderer adoption, then the visual-owner-led Canvas migration and later
-   hit-region/input expansion. Do not infer physical softkey placement from logical associations.
-4. Keep the remaining `M1-09` (`F1-F4` frame migration) dependency-gated and `M1-03` as a non-priority generator
-   follow-up.
-5. Treat `WBP-15` as ready for evidence-bounded Nokia 7110 profile planning, not implementation;
+3. Fix issue `#450` before persisted/searchable history, then continue F2-02 scrolling and F2-03
+   unified softkey/input routing on the completed F2-01 hit-region foundation.
+4. Sequence `WBP-11` recovery presentation and `APP-SHELL-01` Library/Preferences around their
+   shared presenter and shell ownership.
+5. Keep the remaining `M1-09` (`F2-F4` frame migration) dependency-gated and `M1-03` as a
+   non-priority generator follow-up.
+6. Treat `WBP-15` as ready for evidence-bounded Nokia 7110 profile planning, not implementation;
    `WBP-16` may run independently as an Openwave handset/browser evidence-lock research task.
 
 ## Planning + Traceability

--- a/docs/waves/PRD-WAVES-DESKTOP-APPLICATION-COMPLETION.md
+++ b/docs/waves/PRD-WAVES-DESKTOP-APPLICATION-COMPLETION.md
@@ -77,7 +77,7 @@ transport behavior in the frontend.
 
 ### 3.3 Current-state inventory
 
-| Capability       | Implemented at the 2026-07-30 checkpoint                                                                                                                                     | Gap                                                                                                          |
+| Capability       | Implemented at the 2026-08-02 checkpoint                                                                                                                                     | Gap                                                                                                          |
 | ---------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
 | Desktop identity | Tauri identity and native menus plus one shared application-command registry and versioned native application-state store                                                    | Production packaging/updater, integrated window restore, and user-facing import/export workflows             |
 | Browsing shell   | Back, Reload, location, Go/Stop lifecycle, Local/Network, route/profile readouts, Canvas handset stage, status, Welcome/Help, and local examples                             | Integrated Home/Favorites/Services Library, visible history, recent locations, and Preferences surface       |
@@ -86,16 +86,17 @@ transport behavior in the frontend.
 | Diagnostics      | Safe timeline projection plus bounded, masked D0-02 events/snapshots, D0-03 host sessions, and the D0-04 read-only Inspector/capture workflow                                | External tooling and any separately designed controlled replay                                               |
 | Settings         | Versioned schema/store, native atomic backend, migration, reset/clear operations, and memory test adapter                                                                    | Integrated Preferences UI, complete window restore, and diagnostic/accessibility controls                    |
 | Onboarding       | Welcome/Help, tutorial deck, and migration of the isolated launch preference into versioned application state                                                                | Broader task progress and contextual onboarding remain later work                                            |
-| Public services  | Private exact-host deployment, deterministic first-party origin, safe Favorites/service-catalog domain, and publication-state model                                          | Public authorization, guided entry, external verification, and desktop release gates remain open             |
+| Public services  | Live exact-host public deployment, deterministic first-party origin, bounded positive probes, safe Favorites/service-catalog domain, and publication-state model             | Publication-governance reconciliation, guided entry, negative/operations evidence, and desktop release gates remain open |
 
 ### 3.4 Current overlap and blockers
 
-At the synchronized `6cf1682a` baseline:
+At the synchronized `0028946e` baseline:
 
-- PRs `#502` and `#517` through `#533` are merged. The redesigned shell, canonical Canvas/frame
+- PRs `#502`, `#517` through `#536`, and `#538` are merged. The redesigned shell, canonical Canvas/frame
   path, cancellation, bounded render/IPC surfaces, Favorites domain, application state, native
   command registry, safe diagnostic projection, truthful navigation errors, D0-03 debug host
-  bridge, and selective CI/docs maintenance gates are the current integration baseline. The
+  bridge, D0-04 Inspector, F2-01 click input, public-lab documentation, and selective CI/docs
+  maintenance gates are the current integration baseline. The
   open/draft PR queue is empty at this checkpoint.
 - Issue `#450` blocks persistent/searchable history because same-card entries can be lost across a
   deck boundary.
@@ -630,11 +631,11 @@ Before feature UI begins:
 3. Versioned application state is complete in PR `#522`; safe projection, integrated settings,
    window restore, and local/GET-safe recovery remain.
 4. The safe Favorites/service-catalog domain is complete in PR `#517`; WAP Home/Library UI remains.
-5. Safe timeline/export projection is complete in PR `#532`; the D0-04 Inspector consumer adds a
-   separately versioned bounded engine capture.
+5. Safe timeline/export projection is complete in PR `#532`; the D0-04 Inspector consumer and its
+   separately versioned bounded engine capture are complete in PR `#536`.
 6. Shared native commands and platform shortcuts are complete in PR `#523`.
-7. Complete public-lab desktop profile/resource separation and guided safety messaging only after
-   its publication dependencies authorize them.
+7. Reconcile the now-live public lab with its publication evidence, then complete desktop
+   profile/resource separation and guided safety messaging.
 8. Complete the packaged desktop success/failure matrix, signing, checksums, and install guidance.
 
 ### 8.3 Phase B: next application-quality increment

--- a/docs/waves/PUBLIC_WAP_LAB_PRERELEASE_PLAN.md
+++ b/docs/waves/PUBLIC_WAP_LAB_PRERELEASE_PLAN.md
@@ -1,10 +1,10 @@
 # Waves Public WAP Lab and Pre-release Plan
 
-Planning status: Sprint 1 private-deployment checkpoint; LAB-101, the restricted INF-101/INF-102
-host path, and the hardened GW-101 deployment are live behind sealed Tailnet-only ingress, while
-public exposure remains blocked on Sprint 0 decisions and publication-specific evidence
+Planning status: operational public-endpoint checkpoint; Home, Forms, and Interop are reachable
+over public connectionless WSP/WDP through the hardened deployment, while publication governance,
+negative exposure checks, measured operations evidence, and desktop release gates remain open
 
-Research checkpoint: 2026-07-30; audited at `6cf1682a`
+Research checkpoint: 2026-08-02; audited at `0028946e`
 
 Historical service-pattern research, first-party fixture expansion, and the separately gated
 archive/museum lane are planned in `docs/waves/ARCHIVAL_WAP_SERVICE_INCORPORATION_PLAN.md`. That
@@ -229,11 +229,10 @@ resources and does not prove live R2 locking, provider planning, or recovery aga
 accounts. `PRE-001` and `PRE-003` remain required before those access-backed checks can run and
 complete the remaining `INF-101` acceptance gates; see `infra/network-preview/README.md`.
 
-The staged `INF-102` root may be authored and locally planned while shared/public `PRE-003` is
-open. Its default must fail closed: no DNS records, no public UDP ingress, no public SSH ingress,
-Tailscale-only administration, and no
-application deployment. Enabling public UDP/DNS still depends on the production gateway,
-`PRE-003`, `PRE-004`, and a separately reviewed plan.
+The staged `INF-102` root was authored with a fail-closed default: no DNS records, no public UDP
+ingress, no public SSH ingress, Tailscale-only administration, and no application deployment. The
+now-live public DNS/UDP state must be reconciled into an exact reviewed publication plan and the
+remaining `PRE-003`/`PRE-004` evidence; reachability alone does not prove that governance closure.
 
 PR #476 installed the production Compose stack and persistent `DOCKER-USER` policy on the existing
 restricted host. The exact release passed Tailnet GET/POST and unknown-origin denial, retained the
@@ -242,10 +241,11 @@ the Kannel health probe use the configured status credentials, and PRs #485/#495
 service supervision and the static-example smoke path. Cloud-init changes still apply only to
 future replacement hosts because Droplet user data is lifecycle-ignored.
 
-This is direct private-deployment evidence for the staged `INF-102`/`GW-101` path, not completion of
-their public acceptance. No public DNS record or cloud UDP rule was enabled, the host firewall was
-not switched to public mode, and the required external positive/negative probes and kill-switch
-rehearsal remain open.
+PR #538 documents bounded public Lowband probes against the Home, Forms, and Interop hosts. Public
+DNS and UDP 9200 are therefore operational, but reachability does not by itself close the release
+gates below. The exact publication plan/apply evidence, repeated negative exposure checks, measured
+abuse limits, independent kill-switch rehearsal, and operations evidence still require explicit
+reconciliation before the endpoint is treated as release-ready.
 
 ## Security, abuse, and operations
 
@@ -301,7 +301,8 @@ Target: 1-2 days before implementation.
 | `PRE-004` | Preview threat model/data policy |        3 | this plan          | Accept UDP abuse, open-proxy, logging, test-data, kill-switch, and incident ownership controls                                                         |
 | `PRE-005` | Release-scope decision           |        2 | current-main audit | Fix supported OS/architectures, preview label, WTLS warning, Class C claim language, and go/no-go owner                                                |
 
-`PRE-003` and `PRE-004` block public exposure.
+`PRE-003` and `PRE-004` remain governance gaps that block declaring the current public exposure
+release-ready; they no longer describe whether the endpoint is reachable.
 
 ## Sprint 1: Network Preview Foundation
 
@@ -321,14 +322,14 @@ Capacity assumption: three parallel implementation lanes, 36 points gross, 29 co
 |        5 | `PERF-101` | 512 MiB memory soak and resize gate            |      2 | `INF-102`, `GW-101`, `LAB-101` | Record RSS, swap, restarts, latency; allow 1 GiB only if the published threshold fails                                                                                                        |
 |        6 | `OPS-101`  | External WSP probe and disable runbook         |      4 | `INF-102`, `LAB-101`           | Exact external WSP/WBXML fixture; failure alert; tested rate-limit/firewall kill; redacted logs                                                                                               |
 
-Current landed evidence at the 2026-07-30 checkpoint:
+Current landed evidence at the 2026-08-02 checkpoint:
 
 | Work                   | Evidence on `main`                                                                                                                                                                                                                  | Remaining gate                                                                                                                                                           |
 | ---------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `LAB-101`              | Bounded Go origin, deterministic route/session tests, and live private root/login/register/POST smoke are landed.                                                                                                                   | Keep fixture expansion separate from public exposure and the archival-content lane.                                                                                      |
-| `GW-101`               | Hardened non-root Kannel/Compose release, authenticated health, exact-host maps, unknown-origin denial, supervision tests, loopback-bound local ports, and retained rollback are landed; the deployed release is healthy privately. | `PRE-004`, public-mode review, external port/proxy negatives, and measured abuse limits remain open.                                                                     |
+| `LAB-101`              | Bounded Go origin, deterministic route/session tests, and public Home, Forms, and Interop Lowband probes are landed.                                                                                                                  | Keep fixture expansion separate from the archival-content lane and reconcile the public release evidence.                                                               |
+| `GW-101`               | Hardened non-root Kannel/Compose release, authenticated health, exact-host maps, unknown-origin denial, supervision tests, loopback-bound internal ports, retained rollback, and public positive probes are landed.                 | `PRE-004`, repeated external port/proxy negatives, measured abuse limits, and kill-switch evidence remain open.                                                          |
 | `INF-101`              | Pinned offline/protected workflow contracts plus encrypted owner-local R2 state, recovery copies, and a zero-change provider plan are evidenced.                                                                                    | Shared/public `PRE-003`, live protected-plan/apply, and two-maintainer recovery evidence remain open.                                                                    |
-| `INF-102`              | Restricted Droplet, Reserved IP, private administration, sealed firewall, monitoring, installed service, and reboot persistence are evidenced.                                                                                      | Exact publication plan/apply, DNS, public UDP 9200, and external verification remain open.                                                                               |
+| `INF-102`              | Droplet, Reserved IP, private administration, monitoring, installed service, reboot persistence, public DNS, and UDP 9200 reachability are evidenced.                                                                                | Exact publication plan/apply provenance, repeated negative verification, and release-gate reconciliation remain open.                                                    |
 | `PERF-101` / `OPS-101` | No completion claim. Existing private health and smoke are prerequisites only.                                                                                                                                                      | Memory soak, external synthetic probe, alerts, rate/amplification measurements, and independently tested kill switch remain to dispatch after the access/decision gates. |
 
 Stretch only after committed acceptance:

--- a/docs/waves/WAVES_BROWSER_PRODUCT_IMPLEMENTATION_PLAN.md
+++ b/docs/waves/WAVES_BROWSER_PRODUCT_IMPLEMENTATION_PLAN.md
@@ -607,7 +607,6 @@ themselves claim WBP-07 through WBP-14 complete.
 
 The redesigned shell/Developer Tools workspace, pre-release marketing refresh, versioned
 application-state foundation, Favorites domain, native command registry, safe diagnostic
-projection, and D0-02/D0-03 debug source/host bridge are merged. The D0-04 branch adds read-only
-Inspector consumption with bounded safe capture without taking the parallel RSL-07 presenter or
-F2-01 engine-input surfaces. Issue `#450`, `WBP-11`, and `APP-SHELL-01` follow on shared history,
-presenter, and shell surfaces.
+projection, D0-02/D0-03 debug source/host bridge, D0-04 read-only Inspector, and F2-01 deterministic
+click input are merged. Issue `#450` is the next shared-history correction; F2-02/F2-03, `WBP-11`,
+and `APP-SHELL-01` follow on engine-input, presenter, and shell surfaces.

--- a/docs/waves/WORK_ITEMS.md
+++ b/docs/waves/WORK_ITEMS.md
@@ -85,14 +85,15 @@ Canonical sprint priority rule:
 The public network-preview plan is a separate product/release lane. Its `PRE-*`, `INF-*`,
 `GW-*`, `LAB-*`, `PERF-*`, `OPS-*`, `DESK-*`, `QA-*`, and `REL-*` identifiers do not assert WAP
 compliance closure or change the dependency order in the machine-readable compliance program.
-Public exposure remains blocked on the plan's access, threat-model, and release gates.
+Public release-readiness remains gated by the plan's access, threat-model, operations, and release
+evidence even though the bounded endpoint is now reachable.
 
-## Next In Line (Post-Merge Checkpoint Sync - 2026-07-30)
+## Next In Line (Post-Merge Checkpoint Sync - 2026-08-02)
 
-Audit base: `origin/main` `6cf1682a`. The GitHub open/draft PR queue was empty at this checkpoint.
-The second-pass desktop visual refinement and redesigned shell/Developer Tools workspace are now
-landed. They preserve `WBP-02A`, do not implement `WBP-02B`, and do not replace frame/runtime
-evidence.
+Audit base: `origin/main` `0028946e`. The GitHub open/draft PR queue was empty at this checkpoint.
+The second-pass desktop visual refinement, redesigned shell/Developer Tools workspace, D0-04
+read-only Inspector, and F2-01 deterministic click input are now landed. They preserve `WBP-02A`,
+do not implement `WBP-02B`, and do not replace remaining frame/runtime evidence.
 
 The selected-profile source and planning lanes are complete. The active queue
 must now turn the 198 selected parent rows and 762 planned clauses into direct
@@ -122,8 +123,8 @@ Current priority order is:
    context/history/card-table evidence, WML-304's merged request-intent and native request
    application boundary, and WMLS-501's completed decoder/verifier, verified-unit routing, and
    stack-dataflow closure. Advance replayable POST history and WMLS-502 execution as separate
-   implementation lanes. Preserve the completed D0-01 through D0-03 debug foundation and completed
-   F0/F1 frame migration; keep F2-F4, generators, and maintenance non-preemptive
+   implementation lanes. Preserve the completed D0-01 through D0-04 debug path and completed
+   F0/F1/F2-01 frame migration; keep F2-02 through F4, generators, and maintenance non-preemptive
    unless separately authorized or needed to unblock a strict obligation.
 
 The schema-v2 WDP delivery -> fetch/WBXML decode -> native engine parity path,
@@ -170,28 +171,24 @@ serializer or treat the legacy pre-serialized `postContext` payload as the new i
 
 The dependency, overlap, and release-contribution matrix is canonical in
 `SPRINT_PLAN_2026-03_MASTER_PRIORITIZED.md`. `WML-306` remains next after this batch because its
-browser policy files conflict with A1/A2. `PERF-101`, `OPS-101`, and public publication remain
-decision/access-gated rather than ready implementation dispatches.
+browser policy files conflict with A1/A2. `PERF-101`, `OPS-101`, and public release-gate closure
+remain evidence-gated rather than ready implementation dispatches.
 
-The separately owned public-WAP-services lane may continue in parallel. Current main plus the
-merged live checkpoint proves a healthy hardened application deployment on the restricted host,
-Tailnet WAP smoke, sealed-firewall reboot persistence, and retained rollback. Public DNS, the
-cloud UDP rule, public firewall mode, and external probes remain incomplete. That lane neither
+The separately owned public-WAP-services lane may continue in parallel. Public DNS and UDP 9200
+now serve bounded Home, Forms, and Interop probes through the hardened deployment. Publication
+governance, negative exposure evidence, measured abuse limits, operations evidence, and desktop
+release gates still require reconciliation in `PUBLIC_WAP_LAB_PRERELEASE_PLAN.md`. That lane neither
 blocks nor satisfies Class C evidence and is not dispatched from this board.
 
 The resilience board is also synchronized to current main: `RSL-01` through `RSL-07` are done.
 The final pair adds allowlisted diagnostic redaction followed by bounded toast, timeline, and
 host-history state on the shared presenter/history surface.
 
-The remaining parallel-safe desktop slices are:
-
-1. `F2-01` deterministic click/hit-region input through the engine-owned frame contract.
-2. `D0-04` read-only Inspector polling and safe capture in new debug-consumer modules/components.
-
-After those slices, fix `#450` on the stabilized bounded-history foundation, continue F2-02/F2-03
-after F2-01, and integrate `WBP-11` phase-aware recovery plus `APP-SHELL-01` Library/Preferences
-without sharing an active presenter owner. Keep `#450` ahead of persisted/searchable history;
-RSL-07's deterministic eviction does not repair its cross-deck same-card identity loss.
+The next desktop slice is issue `#450` on the stabilized bounded-history foundation. It must remain
+ahead of persisted/searchable history because RSL-07's deterministic eviction does not repair its
+cross-deck same-card identity loss. After `#450`, continue F2-02/F2-03 and integrate `WBP-11`
+phase-aware recovery plus `APP-SHELL-01` Library/Preferences without sharing an active presenter or
+shell owner. `WMLS-502` remains parallel-safe in its separate script lane.
 
 ### WML-203A Legacy local-example standalone-document migration
 


### PR DESCRIPTION
## Summary

- restore the exact active compliance rollups required by the drift validator
- advance the desktop work pointers past landed D0-04 and F2-01 work to issue #450
- reconcile the active public-lab plan with the now-live bounded WSP/WDP endpoint without claiming the remaining publication, abuse, operations, or desktop release gates are complete
- align the browser README, product plan, and desktop-completion PRD to the 2026-08-02 main checkpoint

## Verification

- `pnpm verify`
- `pnpm wap-compliance:check`
- `pnpm docs:check`
- strict repository pre-push hooks

## Notes

This PR updates current planning state only. It preserves completed ticket history and makes no conformance or desktop-release completion claim.
