### PR TITLE
feat(engine): add deterministic viewport scrolling

### DIFF
--- a/browser/README.md
+++ b/browser/README.md
@@ -82,8 +82,8 @@ Implemented now:
 
 Not implemented yet:
 
-- Remaining F2 scroll and unified softkey/input work plus the F3/F4 internal split and legacy-path
-  removal
+- Remaining F2 unified softkey/input work plus the F3/F4 internal split and legacy-path removal;
+  deterministic engine-owned scrolling is complete
 - Phase-aware recovery and safe session persistence (`WBP-11..12`); true navigation cancellation
   is already implemented
 - Production packaging/signing/notarization
@@ -225,8 +225,8 @@ group and Docker services. This pilot is scheduled/manual until the promotion cr
    concurrency hardening; do not reopen completed tickets.
 2. Preserve completed WBP-06/F0 frame, input, drift, and WML-309 evidence. Keep `EngineDebug*`
    separate and retain the legacy render/key compatibility paths until the declared cutover gate.
-3. Fix issue `#450` before persisted/searchable history, then continue F2-02 scrolling and F2-03
-   unified softkey/input routing on the completed F2-01 hit-region foundation.
+3. Preserve the completed issue `#450` history correction and F2-02 scrolling, then continue F2-03
+   unified softkey/input routing on the frame-bound hit-region foundation.
 4. Sequence `WBP-11` recovery presentation and `APP-SHELL-01` Library/Preferences around their
    shared presenter and shell ownership.
 5. Keep the remaining `M1-09` (`F2-F4` frame migration) dependency-gated and `M1-03` as a

--- a/browser/contracts/generated/engine-host.ts
+++ b/browser/contracts/generated/engine-host.ts
@@ -43,7 +43,7 @@ export type ExternalNavigationRequestPolicySnapshot = { cacheControl?: ExternalN
 
 export type EngineRuntimeSnapshot = { activeCardId?: string, focusedLinkIndex: number, nextTimerWakeupMs?: number, focusedInputEditName?: string, focusedInputEditValue?: string, focusedSelectEditName?: string, focusedSelectEditValue?: string, baseUrl: string, contentType: string, browserContextEpoch?: number, historyPushSequence?: number, deckLanguage?: string, activeCardLanguage?: string, lastBackNavigationHandled: boolean, externalNavigationIntent?: string, externalNavigationRequestPolicy?: ExternalNavigationRequestPolicySnapshot, lastScriptExecutionOk?: boolean, lastScriptExecutionTrap?: string, lastScriptExecutionErrorClass?: string, lastScriptExecutionErrorCategory?: string, lastScriptRequiresRefresh?: boolean, lastScriptDialogRequests: Array<ScriptDialogRequestSnapshot>, lastScriptTimerRequests: Array<ScriptTimerRequestSnapshot>, };
 
-export type EngineViewport = { cols: number, };
+export type EngineViewport = { cols: number, rows: number, offsetRow: number, contentRows: number, };
 
 export type EngineViewportError = { "type": "invalid-viewport", requestedCols: string, minCols: number, maxCols: number, message: string, };
 
@@ -89,7 +89,7 @@ export type EnginePresentationFrame = { contractVersion: number, frameId: string
 
 export type EngineInputKey = "up" | "down" | "enter";
 
-export type EngineInputEvent = { "type": "key", key: EngineInputKey, } | { "type": "activate-action", frameId: string, actionId: string, } | { "type": "click", frameId: string, x: number, y: number, };
+export type EngineInputEvent = { "type": "key", key: EngineInputKey, } | { "type": "activate-action", frameId: string, actionId: string, } | { "type": "click", frameId: string, x: number, y: number, } | { "type": "scroll", frameId: string, deltaRows: number, };
 
 export type EngineFrame = { snapshot: EngineRuntimeSnapshot, render: RenderList, presentation: EnginePresentationFrame, };
 

--- a/browser/contracts/generated/tauri-host-client.ts
+++ b/browser/contracts/generated/tauri-host-client.ts
@@ -1439,10 +1439,22 @@ const RUNTIME_SCHEMAS: Record<string, RuntimeSchema> = {
   "EngineViewport": {
     "kind": "object",
     "required": [
-      "cols"
+      "cols",
+      "rows",
+      "offsetRow",
+      "contentRows"
     ],
     "properties": {
       "cols": {
+        "kind": "number"
+      },
+      "rows": {
+        "kind": "number"
+      },
+      "offsetRow": {
+        "kind": "number"
+      },
+      "contentRows": {
         "kind": "number"
       }
     }

--- a/browser/frontend/src/app/browser-controller.behavior.test.ts
+++ b/browser/frontend/src/app/browser-controller.behavior.test.ts
@@ -455,6 +455,35 @@ describe('BrowserController behavior coverage', () => {
     controller.dispose();
   });
 
+  it('routes a Canvas wheel step through the frame-bound scroll input path', async () => {
+    const refs = createRefs();
+    const presenter = new BrowserPresenter(refs, initialSession, 20);
+    const hostClient = createHostClient();
+    const controller = new BrowserController(hostClient as never, presenter, refs);
+
+    await controller.init('<wml><card id="seed"/></wml>');
+    const canvas = refs.viewportEl.querySelector<HTMLCanvasElement>('.viewport-canvas');
+    expect(canvas).not.toBeNull();
+    if (!canvas) {
+      return;
+    }
+    vi.mocked(hostClient.engineHandleInputFrame).mockClear();
+
+    const event = new WheelEvent('wheel', { bubbles: true, cancelable: true, deltaY: 120 });
+    canvas.dispatchEvent(event);
+    await flushAsyncWork();
+
+    expect(event.defaultPrevented).toBe(true);
+    expect(hostClient.engineHandleInputFrame).toHaveBeenCalledWith({
+      event: {
+        type: 'scroll',
+        frameId: 'test-frame',
+        deltaRows: 1
+      }
+    });
+    controller.dispose();
+  });
+
   it('uses the local back flow when back is triggered in local mode', async () => {
     const refs = createRefs();
     const presenter = new BrowserPresenter(refs, initialSession, 20);

--- a/browser/frontend/src/app/browser-controller.ts
+++ b/browser/frontend/src/app/browser-controller.ts
@@ -306,6 +306,7 @@ export class BrowserController {
     this.renderActiveLocalExampleNotes();
     this.shellEventBindings.bind();
     this.viewportCanvas.addEventListener('click', this.handleViewportClick);
+    this.viewportCanvas.addEventListener('wheel', this.handleViewportWheel, { passive: false });
     this.timerRuntime.start();
     this.presenter.setBootPhase('engine-ready');
     const selectedMode = this.refs.runModeSelectEl.value === 'network' ? 'network' : 'local';
@@ -318,6 +319,7 @@ export class BrowserController {
     this.timerRuntime.stop();
     this.shellEventBindings.unbind();
     this.viewportCanvas.removeEventListener('click', this.handleViewportClick);
+    this.viewportCanvas.removeEventListener('wheel', this.handleViewportWheel);
     this.presenter.dispose();
   }
 
@@ -499,6 +501,28 @@ export class BrowserController {
       return;
     }
     void this.withAction('viewport-click', async () => this.applyEngineClick(event))();
+  };
+
+  private readonly handleViewportWheel = (event: WheelEvent): void => {
+    if (event.ctrlKey || !Number.isFinite(event.deltaY) || event.deltaY === 0) {
+      return;
+    }
+    const committedFrame = this.committedFrame;
+    if (!committedFrame) {
+      return;
+    }
+    event.preventDefault();
+    const input: EngineInputEvent = {
+      type: 'scroll',
+      frameId: committedFrame.presentation.frameId,
+      deltaRows: event.deltaY > 0 ? 1 : -1
+    };
+    void this.withAction('viewport-scroll', async () => {
+      await this.applyEngineMutation(
+        () => this.hostClient.engineHandleInputFrame({ event: input }),
+        () => this.navigation.applyEngineInput(input)
+      );
+    })();
   };
 
   // ---------------------------------------------------------------------

--- a/browser/frontend/src/app/navigation-state.test-helpers.ts
+++ b/browser/frontend/src/app/navigation-state.test-helpers.ts
@@ -12,10 +12,10 @@ export const renderStub: RenderList = {
 };
 
 export const presentationStub: EnginePresentationFrame = {
-  contractVersion: 2,
+  contractVersion: 3,
   frameId: 'test-frame',
   profileId: 'class-c-reference',
-  viewport: { cols: 20 },
+  viewport: { cols: 20, rows: 20, offsetRow: 0, contentRows: 1 },
   deck: {
     baseUrl: 'http://example.test/start.wml',
     contentType: 'text/vnd.wap.wml'

--- a/browser/src-tauri/src/tests/tauri_commands.rs
+++ b/browser/src-tauri/src/tests/tauri_commands.rs
@@ -75,7 +75,7 @@ fn tauri_frame_command_wrappers_return_snapshot_and_render_together() {
     )
     .expect("frame load should succeed");
     assert_eq!(loaded.snapshot.active_card_id.as_deref(), Some("home"));
-    assert_eq!(loaded.presentation.contract_version, 2);
+    assert_eq!(loaded.presentation.contract_version, 3);
     assert_eq!(loaded.presentation.card.id, "home");
     assert_eq!(loaded.presentation.frame_id.len(), 16);
     assert_eq!(

--- a/docs/waves/ENGINE_HOST_FRAME_MIGRATION_PLAN.md
+++ b/docs/waves/ENGINE_HOST_FRAME_MIGRATION_PLAN.md
@@ -32,8 +32,8 @@ Out of scope:
 1. Engine already emits structured draw commands (`RenderList`, `DrawCmd::Text|Link`).
 2. WASM host sample already consumes draw commands and paints to Canvas2D.
 3. Tauri frontend currently converts draw commands into HTML string lines (`innerHTML`) for viewport presentation.
-4. Input flow supports keys, frame-bound actions, and frame-bound logical clicks; scroll remains a
-   later event-boundary slice.
+4. Input flow supports keys, frame-bound actions, frame-bound logical clicks, and deterministic
+   signed-row scrolling over an engine-owned visible window.
 5. Type contracts are partly centralized:
    - generated host contracts from Rust (`ts-rs`) in `browser/contracts/generated/*`
    - handwritten engine wasm contract in `engine-wasm/contracts/wml-engine.ts`
@@ -117,7 +117,7 @@ Contract guardrails:
 ### Phase F2: Input Event Surface Expansion
 
 - keep the completed click routing and deterministic engine hit testing stable
-- add scroll routing from hosts to engine
+- preserve scroll routing from hosts to the engine-owned clamped row window
 - keep keyboard path behavior identical
 
 ### Phase F3: Internal Engine Boundary Cleanup

--- a/docs/waves/ENGINE_HOST_FRAME_WORK_ITEMS.md
+++ b/docs/waves/ENGINE_HOST_FRAME_WORK_ITEMS.md
@@ -284,7 +284,7 @@ Archive:
 
 ### F2-02 Add scroll event path and viewport offset semantics
 
-1. `Status`: `todo`
+1. `Status`: `done`
 2. `Depends On`: `F2-01`
 3. `Files`:
 
@@ -304,6 +304,16 @@ Archive:
 6. `Accept`:
 
 - identical event traces produce identical visible frame windows.
+
+8. `Notes`:
+
+- Frame contract version 3 adds a neutral 20-row Class C reference window with `offsetRow` and
+  `contentRows`; presentation rows and hit regions are projected relative to the visible window.
+- `EngineInputEvent::Scroll { frameId, deltaRows }` is stale-frame protected and clamps signed row
+  deltas to the content bounds. Browser and host-sample wheel adapters normalize each physical
+  wheel event to one row without inspecting deck content.
+- Native boundary, repeatability, click-after-scroll, browser integration, and the `F2-02`
+  executable story cover the acceptance path.
 
 ### F2-03 Softkey/input abstraction alignment
 

--- a/engine-wasm/README.md
+++ b/engine-wasm/README.md
@@ -85,7 +85,8 @@ cargo test
 - See the canonical presentation-frame canvas renderer in `engine-wasm/host-sample/renderer.ts`.
   The sample viewport consumes `renderFrame()` rows and segments directly; it does not use the
   legacy `RenderList` compatibility path. Pointer activation sends only the current `frameId` and
-  logical column/row coordinates back through `handleInput()`; target lookup stays in the engine.
+  logical column/row coordinates back through `handleInput()`; wheel input sends a signed row
+  delta. Target lookup, viewport offset, and scroll clamping stay in the engine.
 
 ### 8) Quick local harness (no Electron)
 

--- a/engine-wasm/contracts/README.md
+++ b/engine-wasm/contracts/README.md
@@ -24,14 +24,15 @@ serialization. Optional Rust values use the existing `serde_wasm_bindgen` bounda
 numbers stay JavaScript `number` values because the boundary uses the default safe-integer
 serializer rather than BigInt mode.
 
-`EnginePresentationFrame` is the authoritative engine-to-host display contract. Version 2 carries
-a content-derived `frameId`, profile and viewport identity, deck/card display metadata, ordered
+`EnginePresentationFrame` is the authoritative engine-to-host display contract. Version 3 carries
+a content-derived `frameId`, profile and viewport-window identity, deck/card display metadata, ordered
 rows and segments, engine-owned focus hit regions, focus and non-secret selection state, ordered
 actionable affordances, and Back availability. Hit rectangles use unsigned logical
 column/row coordinates with half-open bounds: left/top are included and right/bottom are excluded.
 Wrapped focusables expose one ordered rectangle per visible row chunk with the same action ID.
-`EngineInputEvent` accepts key input, frame-bound logical clicks, and frame-bound action
-activation. Hosts return the current `frameId` and click coordinates or an advertised `actionId`;
+`EngineInputEvent` accepts key input, frame-bound logical clicks, frame-bound action activation,
+and frame-bound signed row scrolling. Hosts return the current `frameId` with click coordinates,
+an advertised `actionId`, or a row delta;
 stale input and unavailable actions are rejected before runtime mutation, while empty-space clicks
 are deterministic no-ops. `primary`, `task`, and `back` are logical control associations, not
 vendor-specific physical key claims.
@@ -39,9 +40,10 @@ vendor-specific physical key claims.
 The legacy `render()`/`RenderList` and `handleKey()` methods remain additive compatibility paths.
 `renderFrame()` and `handleInput()` use the same runtime/layout/action implementation, and the
 native/WASM parity suites pin their output, trace, serialization, and stale-frame behavior.
-`EngineDebug*` remains a separate diagnostics namespace and is not a render or input API. Scroll
-semantics, editor event expansion, renderer cutover, and physical softkey placement remain later
-frame-migration work.
+`EngineDebug*` remains a separate diagnostics namespace and is not a render or input API. The
+neutral Class C reference window exposes 20 rows plus `offsetRow` and `contentRows`. Scroll clamps
+to `0..contentRows-rows`, and visible frame rows and hit regions are viewport-relative. Editor
+event expansion and physical softkey placement remain later frame-migration work.
 
 `ENGINE_RENDER_LIMITS` is generated from the Rust-owned render contract: 4,096 layout rows,
 segments, and legacy draw commands, plus 2 MiB for the combined legacy/presentation JSON

--- a/engine-wasm/contracts/generated/runtime-dtos.ts
+++ b/engine-wasm/contracts/generated/runtime-dtos.ts
@@ -123,7 +123,7 @@ export interface EngineDebugConnector {
   closeDebugSession(request: EngineDebugCloseSessionRequest): Promise<EngineDebugCloseSessionOutcome>;
 }
 
-export type EngineViewport = { cols: number, };
+export type EngineViewport = { cols: number, rows: number, offsetRow: number, contentRows: number, };
 
 export type EngineViewportError = { "type": "invalid-viewport", requestedCols: string, minCols: number, maxCols: number, message: string, };
 
@@ -169,7 +169,7 @@ export type EnginePresentationFrame = { contractVersion: number, frameId: string
 
 export type EngineInputKey = "up" | "down" | "enter";
 
-export type EngineInputEvent = { "type": "key", key: EngineInputKey, } | { "type": "activate-action", frameId: string, actionId: string, } | { "type": "click", frameId: string, x: number, y: number, };
+export type EngineInputEvent = { "type": "key", key: EngineInputKey, } | { "type": "activate-action", frameId: string, actionId: string, } | { "type": "click", frameId: string, x: number, y: number, } | { "type": "scroll", frameId: string, deltaRows: number, };
 
 export type DrawCmd = { "type": "text", x: number, y: number, text: string, } | { "type": "link", x: number, y: number, text: string, focused: boolean, href: string, };
 

--- a/engine-wasm/contracts/wml-engine.ts
+++ b/engine-wasm/contracts/wml-engine.ts
@@ -192,8 +192,8 @@ export interface WmlEngineCommon {
   // available until the F1/F4 host cutover is complete.
   renderFrame(): EnginePresentationFrame;
   handleKey(key: EngineKey): void;
-  // Typed key, frame-bound logical click, and stable action dispatch. Wheel
-  // and editor events remain outside F2-01.
+  // Typed key, frame-bound logical click/action dispatch, and signed row
+  // scrolling. Hosts normalize physical wheel input without inspecting WML.
   handleInput(event: EngineInputEvent): void;
   advanceTimeMs(deltaMs: number): void;
   // Delay until the active native WML timer expires; absent when no timer is running.

--- a/engine-wasm/engine/src/engine_public_api.rs
+++ b/engine-wasm/engine/src/engine_public_api.rs
@@ -10,6 +10,7 @@ impl WmlEngine {
             external_nav_intent: None,
             external_nav_request_policy: None,
             viewport_cols: DEFAULT_VIEWPORT_COLS,
+            viewport_offset_row: 0,
             base_url: String::new(),
             content_type: String::new(),
             raw_bytes_base64: None,
@@ -227,6 +228,7 @@ impl WmlEngine {
             .map(|edit| edit.input_name.clone());
         let mut next = WmlEngine::new();
         next.viewport_cols = self.viewport_cols;
+        next.viewport_offset_row = 0;
         next.debug_recorder = self.debug_recorder.clone();
         if navigation.kind == DeckNavigationKind::Independent {
             next.browser_context_epoch = previous_context_epoch.saturating_add(1);
@@ -419,11 +421,27 @@ impl WmlEngine {
             ))
         };
 
+        let content_rows = layout
+            .segments
+            .last()
+            .map_or(0, |segment| segment.y.saturating_add(1));
+        let viewport_rows = ENGINE_VIEWPORT_ROWS;
+        let max_offset_row = content_rows.saturating_sub(viewport_rows);
+        let offset_row = u32::try_from(self.viewport_offset_row)
+            .unwrap_or(u32::MAX)
+            .min(max_offset_row);
+        let visible_end = offset_row.saturating_add(viewport_rows);
+
         let mut rows: Vec<EngineFrameRow> = Vec::new();
-        for segment in &layout.segments {
-            if rows.last().is_none_or(|row| row.index != segment.y) {
+        for segment in layout
+            .segments
+            .iter()
+            .filter(|segment| segment.y >= offset_row && segment.y < visible_end)
+        {
+            let visible_row = segment.y - offset_row;
+            if rows.last().is_none_or(|row| row.index != visible_row) {
                 rows.push(EngineFrameRow {
-                    index: segment.y,
+                    index: visible_row,
                     segments: Vec::new(),
                 });
             }
@@ -458,13 +476,14 @@ impl WmlEngine {
         let hit_regions = layout
             .segments
             .iter()
+            .filter(|segment| segment.y >= offset_row && segment.y < visible_end)
             .filter_map(|segment| {
                 segment.focus_index.map(|index| {
                     let width = u32::try_from(segment.text.chars().count())
                         .map_err(|_| "Frame hit-region width exceeds contract range".to_string())?;
                     Ok(EngineHitRegion {
                         x: segment.x,
-                        y: segment.y,
+                        y: segment.y - offset_row,
                         width,
                         height: 1,
                         action_id: format!("focus:{index}"),
@@ -591,6 +610,9 @@ impl WmlEngine {
             viewport: EngineViewport {
                 cols: u32::try_from(self.viewport_cols)
                     .expect("viewport range is validated before engine state mutation"),
+                rows: viewport_rows,
+                offset_row,
+                content_rows,
             },
             deck: EngineDeckDisplayMetadata {
                 base_url: self.base_url.clone(),
@@ -667,6 +689,21 @@ impl WmlEngine {
                 };
                 self.focus_action_for_click(&action_id)?;
                 self.activate_frame_action(&action_id)
+            }
+            EngineInputEvent::Scroll {
+                frame_id,
+                delta_rows,
+            } => {
+                let frame = self.input_frame(&frame_id)?;
+                let max_offset = frame
+                    .viewport
+                    .content_rows
+                    .saturating_sub(frame.viewport.rows);
+                let next_offset = (i64::from(frame.viewport.offset_row) + i64::from(delta_rows))
+                    .clamp(0, i64::from(max_offset));
+                self.viewport_offset_row = usize::try_from(next_offset)
+                    .expect("clamped viewport offset fits the target pointer width");
+                Ok(())
             }
         }
     }
@@ -782,6 +819,7 @@ impl WmlEngine {
             return Err(EngineViewportError::invalid(cols));
         }
         self.viewport_cols = cols as usize;
+        self.viewport_offset_row = 0;
         Ok(())
     }
 

--- a/engine-wasm/engine/src/engine_runtime_internal/navigation.rs
+++ b/engine-wasm/engine/src/engine_runtime_internal/navigation.rs
@@ -123,6 +123,7 @@ impl WmlEngine {
             nav.engine.nav_stack.push(previous_idx);
         }
         nav.engine.active_card_idx = next_idx;
+        nav.engine.viewport_offset_row = 0;
         nav.engine.set_focused_link_idx_with_debug(0);
         nav.engine.debug_emit(EngineDebugEventPayload::CardEnter);
         nav.engine.initialize_controls_on_active_card()?;
@@ -201,6 +202,7 @@ impl WmlEngine {
         nav.engine.cancel_active_input_edit_with_debug();
         nav.engine.active_select_edit = None;
         nav.engine.active_card_idx = back_target_idx;
+        nav.engine.viewport_offset_row = 0;
         nav.engine.set_focused_link_idx_with_debug(0);
         nav.engine.debug_emit(EngineDebugEventPayload::CardEnter);
         if let Err(err) = nav.engine.apply_set_var_assignments(assignments) {
@@ -618,6 +620,7 @@ struct NavRollbackGuard<'a> {
 struct NavStateRollback {
     active_card_idx: usize,
     focused_link_idx: usize,
+    viewport_offset_row: usize,
     nav_stack: Vec<usize>,
     active_timer: Option<CardTimerState>,
     vars: HashMap<String, String>,
@@ -638,6 +641,7 @@ impl NavStateRollback {
         Self {
             active_card_idx: engine.active_card_idx,
             focused_link_idx: engine.focused_link_idx,
+            viewport_offset_row: engine.viewport_offset_row,
             nav_stack: engine.nav_stack.clone(),
             active_timer: engine.active_timer.clone(),
             vars: engine.vars.clone(),
@@ -657,6 +661,7 @@ impl NavStateRollback {
     fn restore(self, engine: &mut WmlEngine) {
         engine.active_card_idx = self.active_card_idx;
         engine.focused_link_idx = self.focused_link_idx;
+        engine.viewport_offset_row = self.viewport_offset_row;
         engine.nav_stack = self.nav_stack;
         engine.active_timer = self.active_timer;
         engine.vars = self.vars;

--- a/engine-wasm/engine/src/engine_tests/f2_02_scroll.rs
+++ b/engine-wasm/engine/src/engine_tests/f2_02_scroll.rs
@@ -1,0 +1,137 @@
+use crate::{EngineInputEvent, WmlEngine, ENGINE_VIEWPORT_ROWS};
+
+fn scroll_deck(row_count: usize) -> String {
+    let paragraphs = (0..row_count)
+        .map(|index| format!("<p>Row {index:02}</p>"))
+        .collect::<String>();
+    format!(r#"<wml><card id="home">{paragraphs}</card></wml>"#)
+}
+
+fn scroll(engine: &mut WmlEngine, delta_rows: i32) -> Result<(), String> {
+    let frame = engine.render_frame().expect("frame should render");
+    engine.handle_input(EngineInputEvent::Scroll {
+        frame_id: frame.frame_id,
+        delta_rows,
+    })
+}
+
+fn visible_text(engine: &WmlEngine) -> Vec<String> {
+    engine
+        .render_frame()
+        .expect("frame should render")
+        .rows
+        .iter()
+        .flat_map(|row| row.segments.iter())
+        .map(|segment| match segment {
+            crate::EngineFrameSegment::Text { text, .. }
+            | crate::EngineFrameSegment::Focusable { text, .. } => text.clone(),
+        })
+        .collect()
+}
+
+#[test]
+fn f2_02_scroll_clamps_to_content_boundaries_and_projects_viewport_rows() {
+    let mut engine = WmlEngine::new();
+    engine
+        .load_deck(&scroll_deck(ENGINE_VIEWPORT_ROWS as usize + 5))
+        .expect("scroll deck should load");
+
+    let initial = engine.render_frame().expect("initial frame");
+    assert_eq!(initial.viewport.rows, ENGINE_VIEWPORT_ROWS);
+    assert_eq!(initial.viewport.offset_row, 0);
+    assert_eq!(initial.viewport.content_rows, ENGINE_VIEWPORT_ROWS + 5);
+    assert_eq!(initial.rows.first().map(|row| row.index), Some(0));
+    assert_eq!(initial.rows.last().map(|row| row.index), Some(19));
+
+    scroll(&mut engine, 3).expect("forward scroll should succeed");
+    let advanced = engine.render_frame().expect("advanced frame");
+    assert_eq!(advanced.viewport.offset_row, 3);
+    assert_eq!(advanced.rows.first().map(|row| row.index), Some(0));
+    assert_eq!(advanced.rows.last().map(|row| row.index), Some(19));
+    assert_eq!(
+        visible_text(&engine).first().map(String::as_str),
+        Some("Row 03")
+    );
+
+    scroll(&mut engine, i32::MAX).expect("bottom clamp should succeed");
+    let bottom = engine.render_frame().expect("bottom frame");
+    assert_eq!(bottom.viewport.offset_row, 5);
+    assert_eq!(
+        visible_text(&engine).first().map(String::as_str),
+        Some("Row 05")
+    );
+
+    scroll(&mut engine, i32::MIN).expect("top clamp should succeed");
+    assert_eq!(
+        engine
+            .render_frame()
+            .expect("top frame")
+            .viewport
+            .offset_row,
+        0
+    );
+}
+
+#[test]
+fn f2_02_identical_scroll_traces_produce_identical_visible_windows() {
+    let mut first = WmlEngine::new();
+    first
+        .load_deck(&scroll_deck(ENGINE_VIEWPORT_ROWS as usize + 12))
+        .expect("scroll deck should load");
+    let mut second = first.clone();
+
+    for delta in [1, 4, -2, 99, -3] {
+        scroll(&mut first, delta).expect("first trace step");
+        scroll(&mut second, delta).expect("second trace step");
+        assert_eq!(
+            first.render_frame().expect("first frame"),
+            second.render_frame().expect("second frame")
+        );
+    }
+}
+
+#[test]
+fn f2_02_scroll_rejects_stale_frames_without_mutation() {
+    let mut engine = WmlEngine::new();
+    engine
+        .load_deck(&scroll_deck(ENGINE_VIEWPORT_ROWS as usize + 2))
+        .expect("scroll deck should load");
+    let initial = engine.render_frame().expect("initial frame");
+
+    let error = engine
+        .handle_input(EngineInputEvent::Scroll {
+            frame_id: "stale-frame".to_string(),
+            delta_rows: 1,
+        })
+        .expect_err("stale scroll must reject");
+
+    assert_eq!(error, "Engine input references a stale frame");
+    assert_eq!(engine.render_frame().expect("unchanged frame"), initial);
+}
+
+#[test]
+fn f2_02_visible_hit_regions_are_viewport_relative() {
+    let paragraphs = (0..ENGINE_VIEWPORT_ROWS)
+        .map(|index| format!("<p>Row {index:02}</p>"))
+        .collect::<String>();
+    let deck = format!(
+        r##"<wml><card id="home">{paragraphs}<p><a href="#next">Next</a></p></card><card id="next"><p>Done</p></card></wml>"##
+    );
+    let mut engine = WmlEngine::new();
+    engine.load_deck(&deck).expect("link deck should load");
+
+    scroll(&mut engine, 1).expect("scroll should expose link");
+    let frame = engine.render_frame().expect("scrolled frame");
+    assert_eq!(frame.viewport.offset_row, 1);
+    assert_eq!(frame.hit_regions.len(), 1);
+    assert_eq!(frame.hit_regions[0].y, ENGINE_VIEWPORT_ROWS - 1);
+
+    engine
+        .handle_input(EngineInputEvent::Click {
+            frame_id: frame.frame_id,
+            x: 0,
+            y: ENGINE_VIEWPORT_ROWS - 1,
+        })
+        .expect("viewport-relative click should activate");
+    assert_eq!(engine.active_card_id().as_deref(), Ok("next"));
+}

--- a/engine-wasm/engine/src/engine_tests/mod.rs
+++ b/engine-wasm/engine/src/engine_tests/mod.rs
@@ -147,6 +147,7 @@ fn assert_trace_kinds_subsequence(engine: &WmlEngine, expected: &[&str]) {
 mod actions_timers;
 mod debug_recorder;
 mod f2_01_click;
+mod f2_02_scroll;
 mod navigation_metadata;
 mod panic_containment;
 mod render_limits;

--- a/engine-wasm/engine/src/engine_tests/render_limits.rs
+++ b/engine-wasm/engine/src/engine_tests/render_limits.rs
@@ -1,6 +1,9 @@
 use super::*;
 use crate::render::frame::{EngineRenderError, EngineRenderLimits, EngineRenderResource};
-use crate::{ENGINE_MAX_DRAW_COMMANDS, ENGINE_MAX_LAYOUT_ROWS, ENGINE_MAX_LAYOUT_SEGMENTS};
+use crate::{
+    ENGINE_MAX_DRAW_COMMANDS, ENGINE_MAX_LAYOUT_ROWS, ENGINE_MAX_LAYOUT_SEGMENTS,
+    ENGINE_VIEWPORT_ROWS,
+};
 
 fn deck_with_text_rows(count: usize) -> String {
     format!(
@@ -45,7 +48,14 @@ fn production_structural_limits_accept_exact_output_and_reject_one_more_row() {
     let output = exact
         .render_output()
         .expect("exact production output limits should render");
-    assert_eq!(output.presentation.rows.len(), ENGINE_MAX_LAYOUT_ROWS);
+    assert_eq!(
+        output.presentation.rows.len(),
+        ENGINE_VIEWPORT_ROWS as usize
+    );
+    assert_eq!(
+        output.presentation.viewport.content_rows,
+        ENGINE_MAX_LAYOUT_ROWS as u32
+    );
     assert_eq!(output.render.draw.len(), ENGINE_MAX_DRAW_COMMANDS);
     assert_eq!(
         output
@@ -54,7 +64,7 @@ fn production_structural_limits_accept_exact_output_and_reject_one_more_row() {
             .iter()
             .map(|row| row.segments.len())
             .sum::<usize>(),
-        ENGINE_MAX_LAYOUT_SEGMENTS
+        ENGINE_VIEWPORT_ROWS as usize
     );
 
     let one_over = loaded_engine(&deck_with_text_rows(ENGINE_MAX_LAYOUT_ROWS + 1));

--- a/engine-wasm/engine/src/engine_tests/serialized_contracts.rs
+++ b/engine-wasm/engine/src/engine_tests/serialized_contracts.rs
@@ -22,10 +22,15 @@ fn wml_309_frame_and_input_contracts_keep_stable_serialized_shapes() {
     assert_eq!(
         serde_json::to_value(&frame).expect("frame should serialize"),
         json!({
-            "contractVersion": 2,
+            "contractVersion": 3,
             "frameId": frame.frame_id,
             "profileId": "class-c-reference",
-            "viewport": { "cols": 20 },
+            "viewport": {
+                "cols": 20,
+                "rows": 20,
+                "offsetRow": 0,
+                "contentRows": 1
+            },
             "deck": {
                 "baseUrl": "http://example.test/frame.wml",
                 "contentType": "text/vnd.wap.wml",
@@ -82,6 +87,18 @@ fn wml_309_frame_and_input_contracts_keep_stable_serialized_shapes() {
             "frameId": "0123456789abcdef",
             "x": 7,
             "y": 3
+        })
+    );
+    assert_eq!(
+        serde_json::to_value(EngineInputEvent::Scroll {
+            frame_id: "0123456789abcdef".to_string(),
+            delta_rows: -3
+        })
+        .expect("scroll input should serialize"),
+        json!({
+            "type": "scroll",
+            "frameId": "0123456789abcdef",
+            "deltaRows": -3
         })
     );
 }

--- a/engine-wasm/engine/src/engine_tests/wml_309_frame.rs
+++ b/engine-wasm/engine/src/engine_tests/wml_309_frame.rs
@@ -44,7 +44,7 @@ fn wml_309_frame_exposes_ordered_unique_active_do_affordances_with_labels() {
     let engine = frame_engine();
     let frame = engine.render_frame().expect("frame should render");
 
-    assert_eq!(frame.contract_version, 2);
+    assert_eq!(frame.contract_version, 3);
     assert_eq!(frame.profile_id, "class-c-reference");
     assert_eq!(frame.viewport.cols, 20);
     assert_eq!(frame.card.id, "home");

--- a/engine-wasm/engine/src/engine_wasm_bindings_tests.rs
+++ b/engine-wasm/engine/src/engine_wasm_bindings_tests.rs
@@ -980,6 +980,54 @@ fn wasm_f2_01_click_resolution_matches_native_for_the_same_frame_and_coordinate(
 }
 
 #[wasm_bindgen_test]
+fn wasm_f2_02_scroll_window_matches_native_for_the_same_event_trace() {
+    let paragraphs = (0..25)
+        .map(|index| format!("<p>Row {index:02}</p>"))
+        .collect::<String>();
+    let deck = format!(r#"<wml><card id="home">{paragraphs}</card></wml>"#);
+
+    let mut native = WmlEngine::new();
+    native.load_deck(&deck).expect("native deck should load");
+    let mut wasm = WmlEngine::wasm_new();
+    wasm.load_deck_wasm(&deck).expect("WASM deck should load");
+
+    for delta_rows in [3, i32::MAX, -2] {
+        let native_frame = native.render_frame().expect("native frame should render");
+        let input = EngineInputEvent::Scroll {
+            frame_id: native_frame.frame_id,
+            delta_rows,
+        };
+        native
+            .handle_input(input.clone())
+            .expect("native scroll should dispatch");
+        wasm.handle_input_wasm(
+            serde_wasm_bindgen::to_value(&input).expect("scroll input should serialize"),
+        )
+        .expect("WASM scroll should dispatch");
+
+        let expected = native.render_frame().expect("native result frame");
+        let actual = wasm
+            .render_frame_wasm()
+            .expect("WASM result frame should serialize");
+        assert_eq!(
+            Reflect::get(&actual, &JsValue::from_str("frameId"))
+                .expect("frameId")
+                .as_string()
+                .as_deref(),
+            Some(expected.frame_id.as_str())
+        );
+        let viewport = Reflect::get(&actual, &JsValue::from_str("viewport"))
+            .expect("viewport should be present");
+        assert_eq!(
+            Reflect::get(&viewport, &JsValue::from_str("offsetRow"))
+                .expect("offsetRow")
+                .as_f64(),
+            Some(f64::from(expected.viewport.offset_row))
+        );
+    }
+}
+
+#[wasm_bindgen_test]
 fn wasm_wml_303_back_override_reports_handled_without_snapshot_change() {
     let mut engine = WmlEngine::wasm_new();
     engine

--- a/engine-wasm/engine/src/lib.rs
+++ b/engine-wasm/engine/src/lib.rs
@@ -87,6 +87,7 @@ pub use render::frame::{
     EngineViewport, EngineViewportError, ENGINE_FRAME_CONTRACT_VERSION, ENGINE_FRAME_PROFILE_ID,
     ENGINE_MAX_DRAW_COMMANDS, ENGINE_MAX_LAYOUT_ROWS, ENGINE_MAX_LAYOUT_SEGMENTS,
     ENGINE_MAX_SERIALIZED_RENDER_BYTES, ENGINE_VIEWPORT_MAX_COLS, ENGINE_VIEWPORT_MIN_COLS,
+    ENGINE_VIEWPORT_ROWS,
 };
 
 #[cfg(feature = "render-test-instrumentation")]
@@ -254,6 +255,7 @@ pub struct WmlEngine {
     external_nav_intent: Option<String>,
     external_nav_request_policy: Option<ScriptNavigationRequestPolicyLiteral>,
     viewport_cols: usize,
+    viewport_offset_row: usize,
     base_url: String,
     content_type: String,
     raw_bytes_base64: Option<String>,

--- a/engine-wasm/engine/src/render/frame.rs
+++ b/engine-wasm/engine/src/render/frame.rs
@@ -4,8 +4,9 @@ use serde::{Deserialize, Serialize};
 
 use super::render_list::RenderList;
 
-pub const ENGINE_FRAME_CONTRACT_VERSION: u16 = 2;
+pub const ENGINE_FRAME_CONTRACT_VERSION: u16 = 3;
 pub const ENGINE_FRAME_PROFILE_ID: &str = "class-c-reference";
+pub const ENGINE_VIEWPORT_ROWS: u32 = 20;
 pub const ENGINE_VIEWPORT_MIN_COLS: u32 = 1;
 pub const ENGINE_VIEWPORT_MAX_COLS: u32 = u32::MAX;
 pub const ENGINE_MAX_LAYOUT_ROWS: usize = 4_096;
@@ -297,6 +298,9 @@ impl EnginePresentationFrame {
 #[serde(rename_all = "camelCase")]
 pub struct EngineViewport {
     pub cols: u32,
+    pub rows: u32,
+    pub offset_row: u32,
+    pub content_rows: u32,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize)]
@@ -477,5 +481,11 @@ pub enum EngineInputEvent {
         frame_id: String,
         x: u32,
         y: u32,
+    },
+    Scroll {
+        #[serde(rename = "frameId")]
+        frame_id: String,
+        #[serde(rename = "deltaRows")]
+        delta_rows: i32,
     },
 }

--- a/engine-wasm/examples/generated/examples.ts
+++ b/engine-wasm/examples/generated/examples.ts
@@ -56,6 +56,7 @@ export interface StoryExpectation {
     contractVersion: number;
     profileId: string;
     cardId: string;
+    viewport?: { cols: number; rows: number; offsetRow: number; contentRows: number };
     affordances: Array<{
       actionId: string;
       label: string;
@@ -80,6 +81,7 @@ export type StoryAction =
   | { type: 'type-text'; text: string }
   | { type: 'activate-action'; actionId: string }
   | { type: 'click'; x: number; y: number }
+  | { type: 'scroll'; deltaRows: number }
   | { type: 'back' }
   | { type: 'tick'; ms: 100 | 1000 }
   | { type: 'clear-intent' };
@@ -1329,7 +1331,7 @@ export const EXAMPLES: HostExample[] = [
             "focusedLinkIndex": 0
           },
           "frame": {
-            "contractVersion": 2,
+            "contractVersion": 3,
             "profileId": "class-c-reference",
             "cardId": "home",
             "hitRegions": [
@@ -1375,6 +1377,105 @@ export const EXAMPLES: HostExample[] = [
       }
     ],
     "wml": "<?xml version=\"1.0\"?>\n<!DOCTYPE wml PUBLIC \"-//WAPFORUM//DTD WML 1.3//EN\"\n  \"http://www.wapforum.org/DTD/wml13.dtd\">\n<wml>\n  <card id=\"home\">\n    <p><a href=\"#next\">Open</a></p>\n  </card>\n  <card id=\"next\">\n    <p>Pointer activation reached the next card.</p>\n  </card>\n</wml>\n"
+  },
+  {
+    "key": "f202DeterministicScroll",
+    "label": "Deterministic Viewport Scroll",
+    "description": "Exercises engine-owned row windows and frame-bound scrolling across content longer than the Class C reference viewport.",
+    "goal": "Verify that signed row deltas clamp deterministically and publish viewport-relative rows without host-side content interpretation.",
+    "workItems": [
+      "F2-02"
+    ],
+    "specItems": [
+      "WBP-08"
+    ],
+    "testingAc": [
+      "The initial frame exposes a 20-row viewport over 25 content rows.",
+      "Scrolling by three rows publishes offsetRow 3 with the same fixed visible-row window.",
+      "A large negative delta clamps the viewport back to offsetRow 0."
+    ],
+    "flows": [
+      {
+        "id": "scroll-window-clamps-and-replays",
+        "title": "Engine-owned visible row window follows frame-bound scroll input",
+        "target": "host-sample",
+        "workItems": [
+          "F2-02"
+        ],
+        "specItems": [
+          "WBP-08"
+        ],
+        "initial": {
+          "state": {
+            "activeCardId": "home",
+            "focusedLinkIndex": 0
+          },
+          "frame": {
+            "contractVersion": 3,
+            "profileId": "class-c-reference",
+            "cardId": "home",
+            "viewport": {
+              "cols": 20,
+              "rows": 20,
+              "offsetRow": 0,
+              "contentRows": 25
+            },
+            "affordances": []
+          }
+        },
+        "steps": [
+          {
+            "action": {
+              "type": "scroll",
+              "deltaRows": 3
+            },
+            "expect": {
+              "state": {
+                "activeCardId": "home",
+                "focusedLinkIndex": 0
+              },
+              "frame": {
+                "contractVersion": 3,
+                "profileId": "class-c-reference",
+                "cardId": "home",
+                "viewport": {
+                  "cols": 20,
+                  "rows": 20,
+                  "offsetRow": 3,
+                  "contentRows": 25
+                },
+                "affordances": []
+              }
+            }
+          },
+          {
+            "action": {
+              "type": "scroll",
+              "deltaRows": -99
+            },
+            "expect": {
+              "state": {
+                "activeCardId": "home",
+                "focusedLinkIndex": 0
+              },
+              "frame": {
+                "contractVersion": 3,
+                "profileId": "class-c-reference",
+                "cardId": "home",
+                "viewport": {
+                  "cols": 20,
+                  "rows": 20,
+                  "offsetRow": 0,
+                  "contentRows": 25
+                },
+                "affordances": []
+              }
+            }
+          }
+        ]
+      }
+    ],
+    "wml": "<?xml version=\"1.0\"?>\n<!DOCTYPE wml PUBLIC \"-//WAPFORUM//DTD WML 1.3//EN\"\n  \"http://www.wapforum.org/DTD/wml13.dtd\">\n<wml>\n  <card id=\"home\">\n    <p>Row 00</p>\n    <p>Row 01</p>\n    <p>Row 02</p>\n    <p>Row 03</p>\n    <p>Row 04</p>\n    <p>Row 05</p>\n    <p>Row 06</p>\n    <p>Row 07</p>\n    <p>Row 08</p>\n    <p>Row 09</p>\n    <p>Row 10</p>\n    <p>Row 11</p>\n    <p>Row 12</p>\n    <p>Row 13</p>\n    <p>Row 14</p>\n    <p>Row 15</p>\n    <p>Row 16</p>\n    <p>Row 17</p>\n    <p>Row 18</p>\n    <p>Row 19</p>\n    <p>Row 20</p>\n    <p>Row 21</p>\n    <p>Row 22</p>\n    <p>Row 23</p>\n    <p>Row 24</p>\n  </card>\n</wml>\n"
   },
   {
     "key": "fieldOpenwave2011Navigation",
@@ -5494,7 +5595,7 @@ export const EXAMPLES: HostExample[] = [
             "focusedLinkIndex": 0
           },
           "frame": {
-            "contractVersion": 2,
+            "contractVersion": 3,
             "profileId": "class-c-reference",
             "cardId": "home",
             "affordances": [
@@ -5538,7 +5639,7 @@ export const EXAMPLES: HostExample[] = [
                 "ACTION_FRAGMENT"
               ],
               "frame": {
-                "contractVersion": 2,
+                "contractVersion": 3,
                 "profileId": "class-c-reference",
                 "cardId": "second",
                 "affordances": [

--- a/engine-wasm/examples/source/f2-01-deterministic-click-input.flow.json
+++ b/engine-wasm/examples/source/f2-01-deterministic-click-input.flow.json
@@ -10,7 +10,7 @@
       "initial": {
         "state": { "activeCardId": "home", "focusedLinkIndex": 0 },
         "frame": {
-          "contractVersion": 2,
+          "contractVersion": 3,
           "profileId": "class-c-reference",
           "cardId": "home",
           "hitRegions": [

--- a/engine-wasm/examples/source/f2-02-deterministic-scroll.flow.json
+++ b/engine-wasm/examples/source/f2-02-deterministic-scroll.flow.json
@@ -1,0 +1,50 @@
+{
+  "version": 1,
+  "example": "f202DeterministicScroll",
+  "flows": [
+    {
+      "id": "scroll-window-clamps-and-replays",
+      "title": "Engine-owned visible row window follows frame-bound scroll input",
+      "workItems": ["F2-02"],
+      "specItems": ["WBP-08"],
+      "initial": {
+        "state": { "activeCardId": "home", "focusedLinkIndex": 0 },
+        "frame": {
+          "contractVersion": 3,
+          "profileId": "class-c-reference",
+          "cardId": "home",
+          "viewport": { "cols": 20, "rows": 20, "offsetRow": 0, "contentRows": 25 },
+          "affordances": []
+        }
+      },
+      "steps": [
+        {
+          "action": { "type": "scroll", "deltaRows": 3 },
+          "expect": {
+            "state": { "activeCardId": "home", "focusedLinkIndex": 0 },
+            "frame": {
+              "contractVersion": 3,
+              "profileId": "class-c-reference",
+              "cardId": "home",
+              "viewport": { "cols": 20, "rows": 20, "offsetRow": 3, "contentRows": 25 },
+              "affordances": []
+            }
+          }
+        },
+        {
+          "action": { "type": "scroll", "deltaRows": -99 },
+          "expect": {
+            "state": { "activeCardId": "home", "focusedLinkIndex": 0 },
+            "frame": {
+              "contractVersion": 3,
+              "profileId": "class-c-reference",
+              "cardId": "home",
+              "viewport": { "cols": 20, "rows": 20, "offsetRow": 0, "contentRows": 25 },
+              "affordances": []
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/engine-wasm/examples/source/f2-02-deterministic-scroll.wml
+++ b/engine-wasm/examples/source/f2-02-deterministic-scroll.wml
@@ -1,0 +1,43 @@
+<!--
+label: Deterministic Viewport Scroll
+work-items: F2-02
+spec-items: WBP-08
+description: Exercises engine-owned row windows and frame-bound scrolling across content longer than the Class C reference viewport.
+goal: Verify that signed row deltas clamp deterministically and publish viewport-relative rows without host-side content interpretation.
+testing-ac:
+- The initial frame exposes a 20-row viewport over 25 content rows.
+- Scrolling by three rows publishes offsetRow 3 with the same fixed visible-row window.
+- A large negative delta clamps the viewport back to offsetRow 0.
+-->
+<?xml version="1.0"?>
+<!DOCTYPE wml PUBLIC "-//WAPFORUM//DTD WML 1.3//EN"
+  "http://www.wapforum.org/DTD/wml13.dtd">
+<wml>
+  <card id="home">
+    <p>Row 00</p>
+    <p>Row 01</p>
+    <p>Row 02</p>
+    <p>Row 03</p>
+    <p>Row 04</p>
+    <p>Row 05</p>
+    <p>Row 06</p>
+    <p>Row 07</p>
+    <p>Row 08</p>
+    <p>Row 09</p>
+    <p>Row 10</p>
+    <p>Row 11</p>
+    <p>Row 12</p>
+    <p>Row 13</p>
+    <p>Row 14</p>
+    <p>Row 15</p>
+    <p>Row 16</p>
+    <p>Row 17</p>
+    <p>Row 18</p>
+    <p>Row 19</p>
+    <p>Row 20</p>
+    <p>Row 21</p>
+    <p>Row 22</p>
+    <p>Row 23</p>
+    <p>Row 24</p>
+  </card>
+</wml>

--- a/engine-wasm/examples/source/wml-309-frame-affordances.flow.json
+++ b/engine-wasm/examples/source/wml-309-frame-affordances.flow.json
@@ -16,7 +16,7 @@
       "initial": {
         "state": { "activeCardId": "home", "focusedLinkIndex": 0 },
         "frame": {
-          "contractVersion": 2,
+          "contractVersion": 3,
           "profileId": "class-c-reference",
           "cardId": "home",
           "affordances": [
@@ -51,7 +51,7 @@
             "state": { "activeCardId": "second", "focusedLinkIndex": 0 },
             "traceKinds": ["ACTION_AFFORDANCE", "ACTION_FRAGMENT"],
             "frame": {
-              "contractVersion": 2,
+              "contractVersion": 3,
               "profileId": "class-c-reference",
               "cardId": "second",
               "affordances": [

--- a/engine-wasm/host-sample/main.ts
+++ b/engine-wasm/host-sample/main.ts
@@ -1,4 +1,4 @@
-import { bootWmlEngine, canvasClickInput } from './renderer';
+import { bootWmlEngine, canvasClickInput, wheelScrollInput } from './renderer';
 import { EXAMPLES } from '../examples/generated/examples';
 import type { EngineSnapshot } from './renderer';
 import { mapKeyboardKey } from './utils/keyboard';
@@ -26,6 +26,7 @@ declare global {
       collect(): StoryEvidence;
       activateAction(actionId: string): void;
       click(x: number, y: number): void;
+      scroll(deltaRows: number): void;
     };
   }
 }
@@ -222,6 +223,13 @@ async function main() {
       const snapshot = updateRuntimeState();
       status.textContent = `Clicked (${x}, ${y}). Active card: ${snapshot.activeCardId}`;
       appendEvent(`CLICK (${x},${y})`, snapshot);
+    },
+    scroll: (deltaRows) => {
+      const frame = host.renderFrame();
+      host.handleInput({ type: 'scroll', frameId: frame.frameId, deltaRows });
+      const snapshot = updateRuntimeState();
+      status.textContent = `Scrolled ${deltaRows} row(s).`;
+      appendEvent(`SCROLL (${deltaRows})`, snapshot);
     }
   };
 
@@ -333,6 +341,27 @@ async function main() {
       appendEvent(`POINTER_ERROR ${String(error)}`, snapshot);
     }
   });
+  canvas.addEventListener(
+    'wheel',
+    (event) => {
+      try {
+        const input = wheelScrollInput(host.renderFrame(), event.deltaY);
+        if (!input) {
+          return;
+        }
+        event.preventDefault();
+        host.handleInput(input);
+        const snapshot = updateRuntimeState();
+        status.textContent = `Scrolled ${input.deltaRows} row(s).`;
+        appendEvent(`SCROLL (${input.deltaRows})`, snapshot);
+      } catch (error) {
+        const snapshot = updateRuntimeState();
+        status.textContent = `Scroll error: ${String(error)}`;
+        appendEvent(`SCROLL_ERROR ${String(error)}`, snapshot);
+      }
+    },
+    { passive: false }
+  );
   const tickTime = (deltaMs: number, source: 'manual' | 'auto' = 'manual') => {
     try {
       const beforeCardId = host.snapshot().activeCardId;

--- a/engine-wasm/host-sample/renderer.ts
+++ b/engine-wasm/host-sample/renderer.ts
@@ -116,6 +116,20 @@ export const canvasClickInput = (
   };
 };
 
+export const wheelScrollInput = (
+  frame: EnginePresentationFrame,
+  deltaY: number
+): Extract<EngineInputEvent, { type: 'scroll' }> | null => {
+  if (!Number.isFinite(deltaY) || deltaY === 0) {
+    return null;
+  }
+  return {
+    type: 'scroll',
+    frameId: frame.frameId,
+    deltaRows: deltaY > 0 ? 1 : -1
+  };
+};
+
 export async function bootWmlEngine(canvas: HTMLCanvasElement, xml: string): Promise<EngineHost> {
   await init();
 

--- a/engine-wasm/host-sample/runtime-dto-fixtures.ts
+++ b/engine-wasm/host-sample/runtime-dto-fixtures.ts
@@ -5,10 +5,10 @@ import type {
 } from '../contracts/wml-engine';
 
 export const representativeFrameFixture = {
-  contractVersion: 2,
+  contractVersion: 3,
   frameId: 'fixture-frame',
   profileId: 'class-c-reference',
-  viewport: { cols: 20 },
+  viewport: { cols: 20, rows: 20, offsetRow: 0, contentRows: 2 },
   deck: {
     baseUrl: 'http://local.test/deck.wml',
     contentType: 'text/vnd.wap.wml'

--- a/engine-wasm/host-sample/scripts/generate-example-manifest.mjs
+++ b/engine-wasm/host-sample/scripts/generate-example-manifest.mjs
@@ -42,6 +42,7 @@ const ACTION_TYPES = new Set([
   'type-text',
   'activate-action',
   'click',
+  'scroll',
   'back',
   'tick',
   'clear-intent'
@@ -370,7 +371,7 @@ function parseFrameExpectation(value, filename, location) {
   const frame = requireRecord(value, filename, location);
   validateKeys(
     frame,
-    new Set(['contractVersion', 'profileId', 'cardId', 'hitRegions', 'affordances']),
+    new Set(['contractVersion', 'profileId', 'cardId', 'viewport', 'hitRegions', 'affordances']),
     filename,
     location
   );
@@ -379,6 +380,21 @@ function parseFrameExpectation(value, filename, location) {
   }
   const profileId = requireString(frame.profileId, filename, `${location}.profileId`);
   const cardId = requireString(frame.cardId, filename, `${location}.cardId`);
+  let viewport;
+  if (frame.viewport !== undefined) {
+    viewport = requireRecord(frame.viewport, filename, `${location}.viewport`);
+    validateKeys(
+      viewport,
+      new Set(['cols', 'rows', 'offsetRow', 'contentRows']),
+      filename,
+      `${location}.viewport`
+    );
+    for (const key of ['cols', 'rows', 'offsetRow', 'contentRows']) {
+      if (!Number.isInteger(viewport[key]) || viewport[key] < 0) {
+        throw new Error(`${filename}: ${location}.viewport.${key} must be a non-negative integer`);
+      }
+    }
+  }
   if (!Array.isArray(frame.affordances)) {
     throw new Error(`${filename}: ${location}.affordances must be an array`);
   }
@@ -456,7 +472,14 @@ function parseFrameExpectation(value, filename, location) {
             )
           };
         });
-  return { contractVersion: frame.contractVersion, profileId, cardId, hitRegions, affordances };
+  return {
+    contractVersion: frame.contractVersion,
+    profileId,
+    cardId,
+    viewport,
+    hitRegions,
+    affordances
+  };
 }
 
 function parseExpectation(value, filename, location) {
@@ -504,7 +527,7 @@ function parseAction(value, filename, location) {
   const action = requireRecord(value, filename, location);
   validateKeys(
     action,
-    new Set(['type', 'key', 'ms', 'text', 'actionId', 'x', 'y']),
+    new Set(['type', 'key', 'ms', 'text', 'actionId', 'x', 'y', 'deltaRows']),
     filename,
     location
   );
@@ -560,6 +583,21 @@ function parseAction(value, filename, location) {
       throw new Error(`${filename}: ${location} click requires non-negative integer x and y`);
     }
     return { type: action.type, x: action.x, y: action.y };
+  }
+
+  if (action.type === 'scroll') {
+    if (
+      !Number.isInteger(action.deltaRows) ||
+      action.key !== undefined ||
+      action.ms !== undefined ||
+      action.text !== undefined ||
+      action.actionId !== undefined ||
+      action.x !== undefined ||
+      action.y !== undefined
+    ) {
+      throw new Error(`${filename}: ${location} scroll requires an integer deltaRows`);
+    }
+    return { type: action.type, deltaRows: action.deltaRows };
   }
 
   if (
@@ -798,6 +836,7 @@ export interface StoryExpectation {
     contractVersion: number;
     profileId: string;
     cardId: string;
+    viewport?: { cols: number; rows: number; offsetRow: number; contentRows: number };
     affordances: Array<{
       actionId: string;
       label: string;
@@ -822,6 +861,7 @@ export type StoryAction =
   | { type: 'type-text'; text: string }
   | { type: 'activate-action'; actionId: string }
   | { type: 'click'; x: number; y: number }
+  | { type: 'scroll'; deltaRows: number }
   | { type: 'back' }
   | { type: 'tick'; ms: 100 | 1000 }
   | { type: 'clear-intent' };

--- a/engine-wasm/host-sample/scripts/story-runner-lib.mjs
+++ b/engine-wasm/host-sample/scripts/story-runner-lib.mjs
@@ -111,6 +111,13 @@ export function assertStoryExpectation(evidence, expectation, label) {
       `${label}: frame.profileId`
     );
     assert.equal(evidence.frame.card.id, expectation.frame.cardId, `${label}: frame.card.id`);
+    if (expectation.frame.viewport) {
+      assert.deepEqual(
+        evidence.frame.viewport,
+        expectation.frame.viewport,
+        `${label}: frame.viewport`
+      );
+    }
     const actualAffordances = evidence.frame.affordances.map(
       ({ actionId, label: actionLabel, source, control, enabled }) => ({
         actionId,

--- a/engine-wasm/host-sample/scripts/test-story.mjs
+++ b/engine-wasm/host-sample/scripts/test-story.mjs
@@ -121,6 +121,19 @@ async function applyAction(page, action, target) {
     );
     return;
   }
+  if (action.type === 'scroll') {
+    if (target !== 'host-sample') {
+      throw new Error('scroll is currently supported by the host-sample story target');
+    }
+    await page.evaluate((deltaRows) => {
+      const bridge = window.__WAVENAV_STORY_EVIDENCE__;
+      if (!bridge?.scroll) {
+        throw new Error('WaveNav story scroll bridge is unavailable');
+      }
+      bridge.scroll(deltaRows);
+    }, action.deltaRows);
+    return;
+  }
   if (action.type === 'key') {
     const selector =
       target === 'waves-browser'

--- a/engine-wasm/host-sample/scripts/tests/story-runner-lib.test.mjs
+++ b/engine-wasm/host-sample/scripts/tests/story-runner-lib.test.mjs
@@ -141,7 +141,7 @@ test('asserts Waves host session, status, and semantic render evidence', () => {
 
 test('asserts the canonical frame contract and ordered affordances', () => {
   const frame = {
-    contractVersion: 2,
+    contractVersion: 3,
     frameId: 'cafef00d',
     profileId: 'class-c-reference',
     card: { id: 'home' },
@@ -160,7 +160,7 @@ test('asserts the canonical frame contract and ordered affordances', () => {
   const expectation = {
     state: { activeCardId: 'home' },
     frame: {
-      contractVersion: 2,
+      contractVersion: 3,
       profileId: 'class-c-reference',
       cardId: 'home',
       affordances: [


### PR DESCRIPTION
## Summary

- add frame-bound signed-row scroll input with deterministic engine-owned clamping
- publish a 20-row Class C viewport window with relative rows and hit regions in frame contract v3
- route browser and host-sample wheel input without host-side WML inspection
- add native/WASM parity, browser integration, contract drift, and executable F2-02 story coverage

## Verification

- `cargo test --manifest-path engine-wasm/engine/Cargo.toml --lib` (424 passed)
- `fnm exec --using=22.22.1 -- wasm-pack test --node` (42 passed)
- `pnpm --dir browser/frontend test` (374 passed)
- `cargo test --manifest-path browser/src-tauri/Cargo.toml` (101 passed, 6 external-stack tests ignored)
- `pnpm test:story F2-02` (1 passed)
- engine/browser contract checks, example-manifest check, typechecks, lints, builds, rustfmt, clippy
- repository pre-push checks
