### PR TITLE
feat(browser): unify engine input routing

### DIFF
--- a/browser/README.md
+++ b/browser/README.md
@@ -82,8 +82,8 @@ Implemented now:
 
 Not implemented yet:
 
-- Remaining F2 unified softkey/input work plus the F3/F4 internal split and legacy-path removal;
-  deterministic engine-owned scrolling is complete
+- Remaining F3/F4 internal split and legacy-path removal; deterministic engine-owned scrolling and
+  primary keyboard/control-button routing through the unified typed input path are complete
 - Phase-aware recovery and safe session persistence (`WBP-11..12`); true navigation cancellation
   is already implemented
 - Production packaging/signing/notarization
@@ -225,8 +225,8 @@ group and Docker services. This pilot is scheduled/manual until the promotion cr
    concurrency hardening; do not reopen completed tickets.
 2. Preserve completed WBP-06/F0 frame, input, drift, and WML-309 evidence. Keep `EngineDebug*`
    separate and retain the legacy render/key compatibility paths until the declared cutover gate.
-3. Preserve the completed issue `#450` history correction and F2-02 scrolling, then continue F2-03
-   unified softkey/input routing on the frame-bound hit-region foundation.
+3. Preserve the completed issue `#450` history correction, F2-02 scrolling, and F2-03 unified input
+   routing on the frame-bound hit-region foundation, then continue the F3/F4 migration.
 4. Sequence `WBP-11` recovery presentation and `APP-SHELL-01` Library/Preferences around their
    shared presenter and shell ownership.
 5. Keep the remaining `M1-09` (`F2-F4` frame migration) dependency-gated and `M1-03` as a

--- a/browser/frontend/src/app/browser-controller.behavior.test.ts
+++ b/browser/frontend/src/app/browser-controller.behavior.test.ts
@@ -146,7 +146,9 @@ const createHostClient = () => {
     engineRenderFrame: vi.fn(async () => frame({ activeCardId: 'render-home' })),
     engineHandleKey: vi.fn(async () => snapshot({ activeCardId: 'key-home' })),
     engineHandleKeyFrame: vi.fn(async () => frame({ activeCardId: 'key-home' })),
-    engineHandleInputFrame: vi.fn(async () => frame({ activeCardId: 'click-home' })),
+    engineHandleInputFrame: vi.fn(async ({ event }: { event: { type: string } }) =>
+      frame({ activeCardId: event.type === 'key' ? 'key-home' : 'click-home' })
+    ),
     engineNavigateToCard: vi.fn(async () => snapshot({ activeCardId: 'card-home' })),
     engineNavigateToCardFrame: vi.fn(async () => frame({ activeCardId: 'card-home' })),
     engineNavigateBack: vi.fn(async () => snapshot({ activeCardId: 'back-home' })),
@@ -260,7 +262,7 @@ describe('BrowserController behavior coverage', () => {
     const committedSession = presenter.getSessionState();
     const committedSnapshot = presenter.getSnapshot();
     const committedViewport = refs.viewportEl.innerHTML;
-    vi.mocked(hostClient.engineHandleKeyFrame).mockRejectedValueOnce(
+    vi.mocked(hostClient.engineHandleInputFrame).mockRejectedValueOnce(
       new Error('Card id not found')
     );
 
@@ -388,7 +390,7 @@ describe('BrowserController behavior coverage', () => {
     );
   });
 
-  it('renders directly from the local engine-key frame without a fallback render call', async () => {
+  it('routes keyboard and control buttons through the unified typed input frame path', async () => {
     const refs = createRefs();
     const presenter = new BrowserPresenter(refs, initialSession, 20);
     const hostClient = createHostClient();
@@ -396,14 +398,24 @@ describe('BrowserController behavior coverage', () => {
 
     await controller.init('<wml><card id="seed"/></wml>');
     vi.mocked(hostClient.engineHandleKeyFrame).mockClear();
+    vi.mocked(hostClient.engineHandleInputFrame).mockClear();
     vi.mocked(hostClient.engineRenderFrame).mockClear();
 
     document.querySelector<HTMLButtonElement>('#btn-up')?.click();
     await flushAsyncWork();
 
-    expect(hostClient.engineHandleKeyFrame).toHaveBeenCalledTimes(1);
-    // applyEngineKey renders using the frame the key handler already
-    // returned; it must not fall back to a redundant engineRenderFrame call.
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', cancelable: true }));
+    await flushAsyncWork();
+
+    expect(hostClient.engineHandleInputFrame).toHaveBeenNthCalledWith(1, {
+      event: { type: 'key', key: 'up' }
+    });
+    expect(hostClient.engineHandleInputFrame).toHaveBeenNthCalledWith(2, {
+      event: { type: 'key', key: 'down' }
+    });
+    expect(hostClient.engineHandleKeyFrame).not.toHaveBeenCalled();
+    // Typed input returns the committed frame directly; neither source falls
+    // back to a redundant engineRenderFrame call.
     expect(hostClient.engineRenderFrame).not.toHaveBeenCalled();
     expect(presenter.getSessionState()).toMatchObject({ activeCardId: 'key-home' });
   });
@@ -656,7 +668,7 @@ describe('BrowserController behavior coverage', () => {
       }
       return frame({ activeCardId: 'invoking-card', focusedLinkIndex: 2, baseUrl: invokingUrl });
     });
-    vi.mocked(hostClient.engineHandleKeyFrame).mockResolvedValue(frame(invokingSnapshot));
+    vi.mocked(hostClient.engineHandleInputFrame).mockResolvedValue(frame(invokingSnapshot));
     vi.mocked(hostClient.engineAdvanceTimeMsFrame).mockImplementation(async () =>
       frame({
         activeCardId: timerIntent ? 'invoking-card' : 'recovered-card',
@@ -773,7 +785,7 @@ describe('BrowserController behavior coverage', () => {
     await flushAsyncWork();
 
     let resolveKey: ((value: ReturnType<typeof frame>) => void) | undefined;
-    vi.mocked(hostClient.engineHandleKeyFrame).mockImplementationOnce(
+    vi.mocked(hostClient.engineHandleInputFrame).mockImplementationOnce(
       () =>
         new Promise((resolve) => {
           resolveKey = resolve;
@@ -785,7 +797,9 @@ describe('BrowserController behavior coverage', () => {
     );
     const pendingKey = controllerPrivates(controller).applyEngineKey('up');
     await Promise.resolve();
-    expect(hostClient.engineHandleKeyFrame).toHaveBeenCalledTimes(1);
+    expect(hostClient.engineHandleInputFrame).toHaveBeenCalledWith({
+      event: { type: 'key', key: 'up' }
+    });
 
     await controllerPrivates(controller).setRunMode('local', { loadLocalOnEnter: false });
     const activeCardBeforeCompletion = presenter.getSessionState().activeCardId;
@@ -819,7 +833,7 @@ describe('BrowserController behavior coverage', () => {
     await flushAsyncWork();
 
     let rejectKey: ((reason: Error) => void) | undefined;
-    vi.mocked(hostClient.engineHandleKeyFrame).mockImplementationOnce(
+    vi.mocked(hostClient.engineHandleInputFrame).mockImplementationOnce(
       () =>
         new Promise((_resolve, reject) => {
           rejectKey = reject;
@@ -827,7 +841,9 @@ describe('BrowserController behavior coverage', () => {
     );
     const pendingKey = controllerPrivates(controller).applyEngineKey('enter');
     await Promise.resolve();
-    expect(hostClient.engineHandleKeyFrame).toHaveBeenCalledTimes(1);
+    expect(hostClient.engineHandleInputFrame).toHaveBeenCalledWith({
+      event: { type: 'key', key: 'enter' }
+    });
 
     await controllerPrivates(controller).setRunMode('local', { loadLocalOnEnter: false });
     const committedSession = presenter.getSessionState();
@@ -897,7 +913,7 @@ describe('BrowserController behavior coverage', () => {
 
     vi.mocked(hostClient.fetchDeck).mockClear();
     vi.mocked(hostClient.engineNavigateBackFrame).mockClear();
-    vi.mocked(hostClient.engineHandleKeyFrame).mockResolvedValueOnce(
+    vi.mocked(hostClient.engineHandleInputFrame).mockResolvedValueOnce(
       frame(
         {
           activeCardId: 'login',

--- a/browser/frontend/src/app/browser-controller.ts
+++ b/browser/frontend/src/app/browser-controller.ts
@@ -800,9 +800,10 @@ export class BrowserController {
     };
 
   private async applyEngineKey(key: EngineKey): Promise<void> {
+    const input: EngineInputEvent = { type: 'key', key };
     await this.applyEngineMutation(
-      () => this.hostClient.engineHandleKeyFrame({ key }),
-      () => this.navigation.applyEngineKey(key)
+      () => this.hostClient.engineHandleInputFrame({ event: input }),
+      () => this.navigation.applyEngineInput(input)
     );
   }
 

--- a/docs/waves/ENGINE_HOST_FRAME_WORK_ITEMS.md
+++ b/docs/waves/ENGINE_HOST_FRAME_WORK_ITEMS.md
@@ -317,7 +317,7 @@ Archive:
 
 ### F2-03 Softkey/input abstraction alignment
 
-1. `Status`: `todo`
+1. `Status`: `done`
 2. `Depends On`: `F2-01`
 3. `Files`:
 
@@ -337,6 +337,16 @@ Archive:
 6. `Accept`:
 
 - single input abstraction path is used in host application code.
+
+8. `Notes`:
+
+- Browser keyboard intents and the Up, Select, and Down controls now construct
+  `EngineInputEvent::Key` and use the same local/network `handleInput` frame path as pointer input.
+- The native/WASM `handleKey` methods and navigation-state key adapter remain compatibility
+  surfaces until F4; primary browser-controller code no longer calls them.
+- Browser integration coverage asserts physical keyboard and control-button parity, the absence of
+  legacy key-command calls, direct committed-frame publication, and existing failure/cancellation
+  behavior. The `F2-03` Waves executable story covers button and keyboard sources.
 
 ## Phase F3: Engine Internal Boundary Split
 

--- a/engine-wasm/contracts/README.md
+++ b/engine-wasm/contracts/README.md
@@ -38,12 +38,15 @@ are deterministic no-ops. `primary`, `task`, and `back` are logical control asso
 vendor-specific physical key claims.
 
 The legacy `render()`/`RenderList` and `handleKey()` methods remain additive compatibility paths.
-`renderFrame()` and `handleInput()` use the same runtime/layout/action implementation, and the
-native/WASM parity suites pin their output, trace, serialization, and stale-frame behavior.
+Primary browser keyboard and Up/Select/Down controls construct `EngineInputEvent::Key` and use
+`handleInput()` alongside frame-bound pointer/action input. `renderFrame()` and `handleInput()` use
+the same runtime/layout/action implementation, and the native/WASM parity suites pin their output,
+trace, serialization, and stale-frame behavior.
 `EngineDebug*` remains a separate diagnostics namespace and is not a render or input API. The
 neutral Class C reference window exposes 20 rows plus `offsetRow` and `contentRows`. Scroll clamps
 to `0..contentRows-rows`, and visible frame rows and hit regions are viewport-relative. Editor
-event expansion and physical softkey placement remain later frame-migration work.
+event expansion, renderer cutover, and physical softkey placement remain later frame-migration
+work.
 
 `ENGINE_RENDER_LIMITS` is generated from the Rust-owned render contract: 4,096 layout rows,
 segments, and legacy draw commands, plus 2 MiB for the combined legacy/presentation JSON

--- a/engine-wasm/contracts/wml-engine.ts
+++ b/engine-wasm/contracts/wml-engine.ts
@@ -191,9 +191,12 @@ export interface WmlEngineCommon {
   // Canonical engine-owned frame/affordance projection. Legacy render() remains
   // available until the F1/F4 host cutover is complete.
   renderFrame(): EnginePresentationFrame;
+  // Legacy compatibility surface retained until F4. Primary hosts translate
+  // keyboard/control input into EngineInputEvent::Key and call handleInput().
   handleKey(key: EngineKey): void;
-  // Typed key, frame-bound logical click/action dispatch, and signed row
-  // scrolling. Hosts normalize physical wheel input without inspecting WML.
+  // Primary typed input boundary for keys, frame-bound logical clicks/actions,
+  // and signed row scrolling. Hosts normalize physical wheel input without
+  // inspecting WML; editor events remain a later expansion.
   handleInput(event: EngineInputEvent): void;
   advanceTimeMs(deltaMs: number): void;
   // Delay until the active native WML timer expires; absent when no timer is running.

--- a/engine-wasm/examples/generated/examples.ts
+++ b/engine-wasm/examples/generated/examples.ts
@@ -918,7 +918,8 @@ export const EXAMPLES: HostExample[] = [
     "goal": "Verify fragment transitions mutate active card while external links only emit host intent.",
     "workItems": [
       "A2-01",
-      "A2-02"
+      "A2-02",
+      "F2-03"
     ],
     "specItems": [
       "WML-R-006",
@@ -937,7 +938,8 @@ export const EXAMPLES: HostExample[] = [
         "target": "host-sample",
         "workItems": [
           "A2-01",
-          "A2-02"
+          "A2-02",
+          "F2-03"
         ],
         "specItems": [
           "WML-R-006",
@@ -1021,7 +1023,8 @@ export const EXAMPLES: HostExample[] = [
         },
         "workItems": [
           "A2-01",
-          "A2-02"
+          "A2-02",
+          "F2-03"
         ],
         "specItems": [
           "WML-R-006",

--- a/engine-wasm/examples/source/basic.flow.json
+++ b/engine-wasm/examples/source/basic.flow.json
@@ -5,7 +5,7 @@
     {
       "id": "fragment-and-external-intent",
       "title": "Fragment navigation and external intent stay separate",
-      "workItems": ["A2-01", "A2-02"],
+      "workItems": ["A2-01", "A2-02", "F2-03"],
       "specItems": ["WML-R-006", "WML-R-007"],
       "initial": {
         "state": {
@@ -64,7 +64,7 @@
       "title": "Waves UI drives fragment navigation and captures external intent",
       "target": "waves-browser",
       "setup": { "runMode": "local" },
-      "workItems": ["A2-01", "A2-02"],
+      "workItems": ["A2-01", "A2-02", "F2-03"],
       "specItems": ["WML-R-006", "WML-R-007"],
       "initial": {
         "state": {

--- a/engine-wasm/examples/source/basic.wml
+++ b/engine-wasm/examples/source/basic.wml
@@ -1,6 +1,6 @@
 <!--
 label: Basic Navigation
-work-items: A2-01, A2-02
+work-items: A2-01, A2-02, F2-03
 spec-items: WML-R-006, WML-R-007
 description: Baseline navigation deck with one fragment link and one external link.
 goal: Verify fragment transitions mutate active card while external links only emit host intent.


### PR DESCRIPTION
## Summary

- route browser keyboard and control-button input through `EngineInputEvent::Key`
- use the same typed local/WASM and network/native mutation boundary as pointer input
- retain legacy key APIs as compatibility surfaces until the F4 cutover
- update active contracts, work-item status, and the canonical F2-03 example story

## Verification

- frontend typecheck, lint, format, and build
- frontend suite: 52 files / 373 tests
- `pnpm test:story F2-03`: 2 passed
- repository pre-push gate: passed
