### PR TITLE
feat(browser): add phase-aware navigation recovery

### DIFF
--- a/browser/README.md
+++ b/browser/README.md
@@ -55,6 +55,10 @@ Implemented now:
   - frontend user-facing strings route through `frontend/src/app/waves-copy.ts`
 - Transport-first URL navigation flow (`fetch_deck` -> `engine_load_deck_context` -> render)
 - Deterministic host session state model (`idle/loading/loaded/error`)
+- Phase-aware network lifecycle presentation (`Preparing`, `Connecting`, route-supported `Gateway`,
+  `Decode`, `Deck`, and `Card`) with correlation IDs and categorized recovery actions
+- Go/Stop reflects actual cancellability; failed navigation preserves the previous committed frame
+  and offers exact-request Retry, Change route, Details, and Return without engine-authored error UI
 - External intent follow loop (`externalNavigationIntent` -> host fetch/load cycle)
 - Generation-scoped navigation coordination prevents overlapping startup, timer, and user loads
   from committing stale engine, history, status, or persistence state
@@ -88,8 +92,7 @@ Not implemented yet:
 
 - Remaining F3/F4 internal split and legacy-path removal; deterministic engine-owned scrolling and
   primary keyboard/control-button routing through the unified typed input path are complete
-- Phase-aware recovery and safe session persistence (`WBP-11..12`); true navigation cancellation
-  is already implemented
+- Safe session persistence and crash recovery (`WBP-12`)
 - Production packaging/signing/notarization
 
 ## Direction

--- a/browser/frontend/src/app/browser-controller.behavior.test.ts
+++ b/browser/frontend/src/app/browser-controller.behavior.test.ts
@@ -5,7 +5,7 @@ import { BrowserController } from './browser-controller';
 import { controllerPrivates } from './browser-controller.test-helpers';
 import { BrowserPresenter } from './browser-presenter';
 import { defaultLocalDeckExample } from './local-examples';
-import { frame, renderStub, snapshot } from './navigation-state.test-helpers';
+import { fetchOk, frame, renderStub, snapshot } from './navigation-state.test-helpers';
 import { WAVES_COPY } from './waves-copy';
 
 const flushAsyncWork = async (): Promise<void> => {
@@ -38,6 +38,23 @@ const createRefs = (): BrowserShellRefs & { statusMessages: string[] } => {
   createButton('btn-clear-intent');
   createButton('btn-export-timeline');
   createButton('btn-clear-timeline');
+  const navigationPhaseBarEl = document.createElement('section');
+  navigationPhaseBarEl.id = 'navigation-phase-bar';
+  navigationPhaseBarEl.hidden = true;
+  navigationPhaseBarEl.innerHTML = `
+    <strong id="navigation-phase-label"></strong>
+    <span id="navigation-phase-detail"></span>
+    <code id="navigation-correlation-id"></code>
+    <div id="navigation-recovery" hidden>
+      <strong id="navigation-error-title"></strong>
+      <span id="navigation-error-message"></span>
+      <button id="btn-navigation-retry"></button>
+      <button id="btn-navigation-change-route"></button>
+      <button id="btn-navigation-details"></button>
+      <button id="btn-navigation-return"></button>
+    </div>
+  `;
+  document.body.append(navigationPhaseBarEl);
 
   const viewportEl = document.createElement('div');
   viewportEl.tabIndex = -1;
@@ -104,6 +121,7 @@ const createRefs = (): BrowserShellRefs & { statusMessages: string[] } => {
     localExampleDescriptionEl,
     localExampleGoalEl,
     localExampleTestingAcEl,
+    navigationPhaseBarEl,
     statusMessages
   };
 };
@@ -1083,6 +1101,14 @@ describe('BrowserController behavior coverage', () => {
       // already been invoked and its delay timer scheduled.
       await vi.advanceTimersByTimeAsync(0);
 
+      expect(refs.navigationPhaseBarEl?.hidden).toBe(false);
+      expect(refs.navigationPhaseBarEl?.querySelector('#navigation-phase-label')?.textContent).toBe(
+        'Connecting'
+      );
+      expect(document.querySelector<HTMLButtonElement>('#btn-fetch-url')?.textContent).toBe(
+        WAVES_COPY.shell.stop
+      );
+
       // Still well under the delay threshold: no indicator yet.
       await vi.advanceTimersByTimeAsync(50);
       expect(refs.viewportEl.classList.contains('viewport-skeleton')).toBe(false);
@@ -1132,7 +1158,7 @@ describe('BrowserController behavior coverage', () => {
   });
 });
 
-it('admits one fetch for eight rapid identical URL actions', async () => {
+it('switches Go to Stop only while a network fetch is cancellable', async () => {
   const refs = createRefs();
   const presenter = new BrowserPresenter(refs, initialSession, 20);
   const hostClient = createHostClient();
@@ -1153,26 +1179,76 @@ it('admits one fetch for eight rapid identical URL actions', async () => {
   );
   refs.fetchUrlInput.value = 'http://example.test/coalesced.wml';
   const fetchButton = document.querySelector<HTMLButtonElement>('#btn-fetch-url');
-  for (let action = 0; action < 8; action += 1) {
-    fetchButton?.click();
-  }
+  fetchButton?.click();
   await flushAsyncWork();
 
   expect(hostClient.fetchDeck).toHaveBeenCalledTimes(1);
   expect(hostClient.cancelFetch).not.toHaveBeenCalled();
+  expect(fetchButton?.textContent).toBe(WAVES_COPY.shell.stop);
+  expect(fetchButton?.dataset.navigationAction).toBe('stop');
 
-  resolveFetch?.({
-    ok: true,
-    status: 200,
-    finalUrl: 'http://example.test/coalesced.wml',
-    contentType: 'text/vnd.wap.wml',
-    wml: '<wml><card id="coalesced"><p>ok</p></card></wml>',
-    timingMs: { encode: 0, udpRtt: 0, decode: 0 },
-    engineDeckInput: {
-      wmlXml: '<wml><card id="coalesced"><p>ok</p></card></wml>',
-      baseUrl: 'http://example.test/coalesced.wml',
-      contentType: 'text/vnd.wap.wml'
-    }
-  });
+  fetchButton?.click();
   await flushAsyncWork();
+
+  expect(hostClient.cancelFetch).toHaveBeenCalledTimes(1);
+  expect(fetchButton?.textContent).toBe(WAVES_COPY.shell.go);
+  expect(fetchButton?.dataset.navigationAction).toBe('go');
+
+  resolveFetch?.(fetchOk({ finalUrl: 'http://example.test/coalesced.wml' }));
+  await flushAsyncWork();
+});
+
+it('retries a categorized failure and keeps the committed frame visible', async () => {
+  const refs = createRefs();
+  const presenter = new BrowserPresenter(refs, initialSession, 20);
+  const hostClient = createHostClient();
+  const controller = new BrowserController(hostClient as never, presenter, refs);
+
+  await controller.init('<wml><card id="seed"><p>stable</p></card></wml>');
+  controllerPrivates(controller).timerRuntime.stop();
+  const committedRender = presenter.getRenderList();
+  await controllerPrivates(controller).setRunMode('network', { loadLocalOnEnter: false });
+  await flushAsyncWork();
+  vi.mocked(hostClient.fetchDeck).mockClear();
+  vi.mocked(hostClient.fetchDeck)
+    .mockResolvedValueOnce(
+      fetchOk({
+        ok: false,
+        status: 504,
+        finalUrl: 'wap://example.test/failing.wml',
+        contentType: 'text/plain',
+        error: { code: 'GATEWAY_TIMEOUT', message: 'gateway timed out' },
+        wml: undefined,
+        engineDeckInput: undefined
+      }) as Awaited<ReturnType<typeof hostClient.fetchDeck>>
+    )
+    .mockResolvedValueOnce(
+      fetchOk({
+        finalUrl: 'wap://example.test/failing.wml'
+      }) as Awaited<ReturnType<typeof hostClient.fetchDeck>>
+    );
+
+  refs.fetchUrlInput.value = 'wap://example.test/failing.wml';
+  document.querySelector<HTMLButtonElement>('#btn-fetch-url')?.click();
+  await flushAsyncWork();
+
+  expect(refs.navigationPhaseBarEl?.dataset.navigationState).toBe('error');
+  expect(refs.navigationPhaseBarEl?.querySelector('#navigation-error-title')?.textContent).toBe(
+    'gateway · GATEWAY_TIMEOUT'
+  );
+  expect(
+    refs.navigationPhaseBarEl?.querySelector('#navigation-correlation-id')?.textContent
+  ).toMatch(/^Request waves-navigation-\d+-1$/);
+  expect(presenter.getRenderList()).toEqual(committedRender);
+
+  document.querySelector<HTMLButtonElement>('#btn-navigation-retry')?.click();
+  await flushAsyncWork();
+
+  expect(hostClient.fetchDeck).toHaveBeenCalledTimes(2);
+  expect(vi.mocked(hostClient.fetchDeck).mock.calls[1]?.[0]).toMatchObject({
+    url: 'wap://example.test/failing.wml',
+    method: 'GET'
+  });
+  expect(refs.navigationPhaseBarEl?.hidden).toBe(true);
+  expect(presenter.getSessionState().navigationStatus).toBe('loaded');
 });

--- a/browser/frontend/src/app/browser-controller.ts
+++ b/browser/frontend/src/app/browser-controller.ts
@@ -87,6 +87,17 @@ export class BrowserController {
   private localBackAvailable = false;
   private pendingLocalTimerFrame: { generation: number; frame: EngineFrame } | undefined;
   private committedFrame: EngineFrame | undefined;
+  private networkNavigationCancellable = false;
+  private lastFailedNavigation:
+    | {
+        url: string;
+        source: HostNavigationSource;
+        followExternalIntent: boolean;
+        pushHistory: boolean;
+        requestPolicy?: FetchRequestPolicy;
+        headers?: Record<string, string>;
+      }
+    | undefined;
 
   constructor(hostClient: TauriHostClient, presenter: BrowserPresenter, refs: BrowserShellRefs) {
     this.hostClient = hostClient;
@@ -121,8 +132,9 @@ export class BrowserController {
             false
           );
         },
-        onNavigationError: (message, kind) => {
+        onNavigationError: (message, kind, context) => {
           this.lastNavigationErrorKind = kind;
+          this.presenter.showNavigationFailure(message, context, this.presenter.hasRenderedDeck());
           this.presenter.showToast(
             kind === 'parse'
               ? WAVES_COPY.status.deckParseFailed(message)
@@ -132,6 +144,9 @@ export class BrowserController {
             false
           );
         },
+        onNavigationPhase: (context) => this.presenter.showNavigationPhase(context),
+        onNavigationCancellableChange: (cancellable) =>
+          this.updateNavigationCancellable(cancellable),
         onStateEvent: (action, details) => {
           this.presenter.recordTimeline(action, 'state', details);
           if (action === 'engine-load-deck-context') {
@@ -278,6 +293,10 @@ export class BrowserController {
         fetchUrlEnter: this.handleFetchUrlClick,
         reload: this.handleReloadClick,
         stopNavigation: this.handleStopNavigationClick,
+        retryNavigation: this.handleRetryNavigationClick,
+        changeNavigationRoute: this.handleChangeNavigationRouteClick,
+        showNavigationDetails: this.handleShowNavigationDetailsClick,
+        returnFromNavigationError: this.handleReturnFromNavigationErrorClick,
         changeMode: this.handleChangeModeClick,
         selectLocalExample: this.handleSelectLocalExampleClick,
         loadLocalExample: this.handleLoadLocalExampleClick,
@@ -415,6 +434,10 @@ export class BrowserController {
   };
 
   private readonly handleFetchUrlClick = async (): Promise<void> => {
+    if (this.networkNavigationCancellable) {
+      await this.handleStopNavigationClick();
+      return;
+    }
     if (this.runMode === 'local') {
       await this.loadSelectedLocalDeck();
       return;
@@ -473,7 +496,47 @@ export class BrowserController {
     if (cancellation) {
       await cancellation;
     }
+    this.presenter.clearNavigationPresentation();
+    this.presenter.setStatus(WAVES_COPY.status.navigationStopped);
     this.updateBackButtonAvailability();
+  };
+
+  private readonly handleRetryNavigationClick = async (): Promise<void> => {
+    const failed = this.lastFailedNavigation;
+    if (!failed) {
+      if (this.navigation.getSessionState().navigationSource === 'history-back') {
+        this.presenter.clearNavigationPresentation();
+        await this.navigateBackWithFallback();
+      }
+      return;
+    }
+    this.presenter.clearNavigationPresentation();
+    await this.loadTransportUrl(
+      failed.url,
+      failed.source,
+      failed.followExternalIntent,
+      failed.pushHistory,
+      failed.requestPolicy,
+      failed.headers
+    );
+  };
+
+  private readonly handleChangeNavigationRouteClick = async (): Promise<void> => {
+    this.refs.fetchUrlInput.disabled = false;
+    this.refs.fetchUrlInput.focus();
+    this.refs.fetchUrlInput.select();
+    this.presenter.setStatus(WAVES_COPY.navigation.chooseAnotherRoute);
+  };
+
+  private readonly handleShowNavigationDetailsClick = async (): Promise<void> => {
+    document.querySelector<HTMLButtonElement>('#btn-inspector')?.click();
+  };
+
+  private readonly handleReturnFromNavigationErrorClick = async (): Promise<void> => {
+    this.navigation.recoverToCommittedState();
+    this.presenter.clearNavigationPresentation();
+    this.presenter.setStatus(WAVES_COPY.navigation.returnedToDeck);
+    this.refs.viewportEl.focus();
   };
 
   private readonly handleChangeModeClick = async (): Promise<void> => {
@@ -620,6 +683,20 @@ export class BrowserController {
         ? this.localBackAvailable
         : canHistoryBack(this.navigation.getHistoryState());
     this.shellEventBindings.setBackButtonAvailable(available);
+  }
+
+  private updateNavigationCancellable(cancellable: boolean): void {
+    this.networkNavigationCancellable = cancellable;
+    const fetchButton = document.querySelector<HTMLButtonElement>('#btn-fetch-url');
+    if (!fetchButton) {
+      return;
+    }
+    fetchButton.textContent = cancellable ? WAVES_COPY.shell.stop : WAVES_COPY.shell.go;
+    fetchButton.dataset.navigationAction = cancellable ? 'stop' : 'go';
+    fetchButton.setAttribute(
+      'aria-label',
+      cancellable ? WAVES_COPY.shell.stop : WAVES_COPY.shell.go
+    );
   }
 
   // See localBackAvailable above: a sequence advance means the engine's nav
@@ -1071,6 +1148,17 @@ export class BrowserController {
         this.lastNetworkUrl = requestedUrl;
       }
       if (state.navigationStatus === 'error') {
+        this.lastFailedNavigation = {
+          url: failedExternalIntent ?? requestedUrl,
+          source: failedExternalIntent ? 'external-intent' : source,
+          followExternalIntent,
+          pushHistory,
+          requestPolicy:
+            failedExternalIntent && currentSnapshot?.externalNavigationRequestPolicy
+              ? currentSnapshot.externalNavigationRequestPolicy
+              : requestPolicy,
+          headers
+        };
         const message = state.lastError ?? WAVES_COPY.errors.unknownTransportFailure;
         this.presenter.setStatus(
           this.lastNavigationErrorKind === 'parse'
@@ -1078,6 +1166,8 @@ export class BrowserController {
             : WAVES_COPY.status.fetchFailed(message)
         );
       } else if (state.navigationStatus === 'loaded' && state.finalUrl) {
+        this.lastFailedNavigation = undefined;
+        this.presenter.clearNavigationPresentation();
         this.presenter.setStatus(WAVES_COPY.status.fetchedAndLoadedDeck(state.finalUrl));
         if (source === 'user' || source === 'reload') {
           this.refs.viewportEl.focus();

--- a/browser/frontend/src/app/browser-presenter.test.ts
+++ b/browser/frontend/src/app/browser-presenter.test.ts
@@ -28,6 +28,18 @@ const createRefs = (): BrowserShellRefs => {
   const localExampleDescriptionEl = document.createElement('p');
   const localExampleGoalEl = document.createElement('p');
   const localExampleTestingAcEl = document.createElement('ul');
+  const navigationPhaseBarEl = document.createElement('section');
+  navigationPhaseBarEl.hidden = true;
+  navigationPhaseBarEl.innerHTML = `
+    <strong id="navigation-phase-label"></strong>
+    <span id="navigation-phase-detail"></span>
+    <code id="navigation-correlation-id"></code>
+    <div id="navigation-recovery" hidden>
+      <strong id="navigation-error-title"></strong>
+      <span id="navigation-error-message"></span>
+      <button id="btn-navigation-return"></button>
+    </div>
+  `;
   const statusEl = {
     setStatus: () => {
       // no-op
@@ -57,7 +69,8 @@ const createRefs = (): BrowserShellRefs => {
     localExampleCoverageEl,
     localExampleDescriptionEl,
     localExampleGoalEl,
-    localExampleTestingAcEl
+    localExampleTestingAcEl,
+    navigationPhaseBarEl
   };
 };
 
@@ -86,6 +99,51 @@ describe('BrowserPresenter', () => {
     const presenter = new BrowserPresenter(createRefs(), initialSession, 20);
     presenter.setBootPhase('engine-ready');
     expect(document.body.getAttribute('data-boot-phase')).toBe('engine-ready');
+  });
+
+  it('projects phase and categorized recovery state without replacing viewport content', () => {
+    const refs = createRefs();
+    refs.viewportEl.textContent = 'last committed card';
+    const presenter = new BrowserPresenter(refs, initialSession, 20);
+
+    presenter.showNavigationPhase({
+      phase: 'connecting',
+      requestId: 'waves-navigation-2-1',
+      requestedUrl: 'wap://example.test/start.wml'
+    });
+
+    expect(refs.navigationPhaseBarEl?.hidden).toBe(false);
+    expect(refs.navigationPhaseBarEl?.dataset.navigationState).toBe('loading');
+    expect(refs.navigationPhaseBarEl?.querySelector('#navigation-phase-label')?.textContent).toBe(
+      'Connecting'
+    );
+    expect(refs.viewportEl.textContent).toBe('last committed card');
+
+    presenter.showNavigationFailure(
+      'gateway timed out',
+      {
+        layer: 'gateway',
+        category: 'GATEWAY_TIMEOUT',
+        requestId: 'waves-navigation-2-1',
+        requestedUrl: 'wap://example.test/start.wml'
+      },
+      true
+    );
+
+    expect(refs.navigationPhaseBarEl?.dataset.navigationState).toBe('error');
+    expect(refs.navigationPhaseBarEl?.querySelector('#navigation-error-title')?.textContent).toBe(
+      'gateway · GATEWAY_TIMEOUT'
+    );
+    expect(refs.navigationPhaseBarEl?.querySelector('#navigation-error-message')?.textContent).toBe(
+      'gateway timed out'
+    );
+    expect(
+      refs.navigationPhaseBarEl?.querySelector<HTMLButtonElement>('#btn-navigation-return')?.hidden
+    ).toBe(false);
+    expect(refs.viewportEl.textContent).toBe('last committed card');
+
+    presenter.clearNavigationPresentation();
+    expect(refs.navigationPhaseBarEl?.hidden).toBe(true);
   });
 
   it('clears viewport skeleton after first render', () => {

--- a/browser/frontend/src/app/browser-presenter.ts
+++ b/browser/frontend/src/app/browser-presenter.ts
@@ -31,6 +31,7 @@ import {
   projectSessionState,
   projectTransportResponse
 } from './diagnostic-projection';
+import type { NavigationFailureContext, NavigationPhaseContext } from './navigation-state';
 
 export type BootPhase = 'booting' | 'shell-ready' | 'engine-ready' | 'deck-ready';
 
@@ -228,6 +229,77 @@ export class BrowserPresenter {
 
   getStatus(): string {
     return this.statusText;
+  }
+
+  showNavigationPhase(context: NavigationPhaseContext): void {
+    const bar = this.refs.navigationPhaseBarEl;
+    if (!bar) {
+      return;
+    }
+    bar.hidden = false;
+    bar.dataset.navigationState = 'loading';
+    this.setPhaseBarText('#navigation-phase-label', WAVES_COPY.navigation.phase[context.phase]);
+    this.setPhaseBarText('#navigation-phase-detail', context.requestedUrl);
+    this.setPhaseBarText(
+      '#navigation-correlation-id',
+      WAVES_COPY.navigation.correlation(context.requestId)
+    );
+    const recovery = bar.querySelector<HTMLElement>('#navigation-recovery');
+    if (recovery) {
+      recovery.hidden = true;
+    }
+  }
+
+  showNavigationFailure(
+    message: string,
+    context: NavigationFailureContext,
+    canReturn: boolean
+  ): void {
+    const bar = this.refs.navigationPhaseBarEl;
+    if (!bar) {
+      return;
+    }
+    bar.hidden = false;
+    bar.dataset.navigationState = 'error';
+    this.setPhaseBarText('#navigation-phase-label', WAVES_COPY.navigation.failed);
+    this.setPhaseBarText('#navigation-phase-detail', '');
+    this.setPhaseBarText(
+      '#navigation-correlation-id',
+      WAVES_COPY.navigation.correlation(context.requestId)
+    );
+    this.setPhaseBarText(
+      '#navigation-error-title',
+      WAVES_COPY.navigation.failureTitle(context.layer, context.category)
+    );
+    this.setPhaseBarText('#navigation-error-message', message);
+    const recovery = bar.querySelector<HTMLElement>('#navigation-recovery');
+    if (recovery) {
+      recovery.hidden = false;
+    }
+    const returnButton = bar.querySelector<HTMLButtonElement>('#btn-navigation-return');
+    if (returnButton) {
+      returnButton.hidden = !canReturn;
+    }
+  }
+
+  clearNavigationPresentation(): void {
+    const bar = this.refs.navigationPhaseBarEl;
+    if (!bar) {
+      return;
+    }
+    bar.hidden = true;
+    bar.dataset.navigationState = 'idle';
+    const recovery = bar.querySelector<HTMLElement>('#navigation-recovery');
+    if (recovery) {
+      recovery.hidden = true;
+    }
+  }
+
+  private setPhaseBarText(selector: string, value: string): void {
+    const element = this.refs.navigationPhaseBarEl?.querySelector<HTMLElement>(selector);
+    if (element) {
+      element.textContent = value;
+    }
   }
 
   setBootPhase(phase: BootPhase): void {

--- a/browser/frontend/src/app/browser-shell-template.ts
+++ b/browser/frontend/src/app/browser-shell-template.ts
@@ -6,6 +6,7 @@ import { WAVES_CONFIG } from './waves-config';
 import { bindDeveloperToolsWorkspace } from './developer-tools-workspace';
 import { handsetStageTemplate } from './shell/handset-stage-template';
 import { navigationToolbarTemplate } from './shell/navigation-toolbar-template';
+import { navigationPhaseBarTemplate } from './shell/navigation-phase-bar-template';
 import { statusBarTemplate } from './shell/status-bar-template';
 import { utilityRailTemplate } from './shell/utility-rail-template';
 import { ensureCanvasViewportElements } from './canvas-viewport-renderer';
@@ -24,7 +25,7 @@ const browserShellTemplate = () => `
 
     ${applicationSurfacesTemplate()}
 
-    <div class="phase-bar-slot" hidden aria-hidden="true"></div>
+    ${navigationPhaseBarTemplate()}
 
     ${statusBarTemplate()}
 
@@ -66,6 +67,7 @@ export interface BrowserShellRefs {
   localExampleDescriptionEl: HTMLParagraphElement;
   localExampleGoalEl: HTMLParagraphElement;
   localExampleTestingAcEl: HTMLUListElement;
+  navigationPhaseBarEl?: HTMLElement;
 }
 
 export const mountBrowserShell = (
@@ -107,6 +109,7 @@ export const mountBrowserShell = (
   const localExampleTestingAcEl = document.querySelector<HTMLUListElement>(
     '#local-example-testing-ac'
   );
+  const navigationPhaseBarEl = document.querySelector<HTMLElement>('#navigation-phase-bar');
 
   if (
     !wmlInput ||
@@ -258,6 +261,7 @@ export const mountBrowserShell = (
     localExampleCoverageEl,
     localExampleDescriptionEl,
     localExampleGoalEl,
-    localExampleTestingAcEl
+    localExampleTestingAcEl,
+    navigationPhaseBarEl: navigationPhaseBarEl ?? undefined
   };
 };

--- a/browser/frontend/src/app/navigation-state.concurrency.test.ts
+++ b/browser/frontend/src/app/navigation-state.concurrency.test.ts
@@ -38,6 +38,32 @@ const fetchOkFor = (url: string): FetchResponse => {
 };
 
 describe('NavigationStateMachine concurrency ownership', () => {
+  it('publishes deterministic WAP phases and exposes Stop only while the fetch is cancellable', async () => {
+    const pendingFetch = deferred<FetchResponse>();
+    const phases: string[] = [];
+    const cancellable: boolean[] = [];
+    const machine = createNavigationStateMachine(
+      createHostClientMock({ fetchDeck: vi.fn(() => pendingFetch.promise) }),
+      'wap://seed.test',
+      {
+        onNavigationPhase: ({ phase }) => phases.push(phase),
+        onNavigationCancellableChange: (available) => cancellable.push(available)
+      }
+    );
+
+    const pendingLoad = load(machine, 'wap://example.test/start.wml');
+    await Promise.resolve();
+
+    expect(phases).toEqual(['preparing', 'connecting', 'gateway']);
+    expect(cancellable).toEqual([true]);
+
+    pendingFetch.resolve(fetchOk({ finalUrl: 'wap://example.test/start.wml' }));
+    await pendingLoad;
+
+    expect(phases).toEqual(['preparing', 'connecting', 'gateway', 'decode', 'deck', 'card']);
+    expect(cancellable).toEqual([true, false]);
+  });
+
   it('coalesces eight rapid identical loads into one active fetch', async () => {
     const pendingFetch = deferred<FetchResponse>();
     const fetchDeck = vi.fn(() => pendingFetch.promise);

--- a/browser/frontend/src/app/navigation-state.load.test.ts
+++ b/browser/frontend/src/app/navigation-state.load.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { createNavigationStateMachine } from './navigation-state';
+import { createNavigationStateMachine, type NavigationFailureContext } from './navigation-state';
 import { createHostClientMock, fetchOk, frame, snapshot } from './navigation-state.test-helpers';
 
 describe('navigation-state load behavior', () => {
@@ -29,6 +29,7 @@ describe('navigation-state load behavior', () => {
 
   it('transitions to error on transport failure and emits network unavailable hook', async () => {
     let networkUnavailable = 0;
+    const failures: NavigationFailureContext[] = [];
     const host = createHostClientMock({
       fetchDeck: async () =>
         fetchOk({
@@ -43,7 +44,8 @@ describe('navigation-state load behavior', () => {
     const machine = createNavigationStateMachine(host, 'http://seed.test', {
       onNetworkUnavailable: () => {
         networkUnavailable += 1;
-      }
+      },
+      onNavigationError: (_message, _kind, context) => failures.push(context)
     });
 
     const result = await machine.loadTransportUrl({
@@ -56,6 +58,49 @@ describe('navigation-state load behavior', () => {
     expect(machine.getSessionState().navigationStatus).toBe('error');
     expect(machine.getSessionState().lastError).toBe('offline');
     expect(networkUnavailable).toBe(1);
+    expect(failures).toEqual([
+      {
+        layer: 'connection',
+        category: 'TRANSPORT_UNAVAILABLE',
+        requestId: 'waves-navigation-1-1',
+        requestedUrl: 'http://example.test/start.wml'
+      }
+    ]);
+  });
+
+  it('turns a rejected host transport command into a correlated recovery failure', async () => {
+    const failures: NavigationFailureContext[] = [];
+    const hostFailure = Object.assign(new Error('host fetch task unavailable'), {
+      code: 'HOST_FAILURE'
+    });
+    const machine = createNavigationStateMachine(
+      createHostClientMock({ fetchDeck: async () => Promise.reject(hostFailure) }),
+      'http://seed.test',
+      {
+        onNavigationError: (_message, _kind, context) => failures.push(context)
+      }
+    );
+
+    await expect(
+      machine.loadTransportUrl({
+        url: 'http://example.test/start.wml',
+        source: 'user',
+        followExternalIntent: false
+      })
+    ).resolves.toBeNull();
+
+    expect(machine.getSessionState()).toMatchObject({
+      navigationStatus: 'error',
+      lastError: 'host fetch task unavailable'
+    });
+    expect(failures).toEqual([
+      {
+        layer: 'connection',
+        category: 'HOST_FAILURE',
+        requestId: 'waves-navigation-1-1',
+        requestedUrl: 'http://example.test/start.wml'
+      }
+    ]);
   });
 
   it('keeps the committed deck session and history atomic when a later fetch fails', async () => {
@@ -116,6 +161,14 @@ describe('navigation-state load behavior', () => {
     expect(machine.getHistoryState().entries).toHaveLength(1);
     expect(machine.getHistoryState().entries[0]?.url).toBe('http://example.test/stable.wml');
     expect(navigationErrors).toEqual(['destination unavailable']);
+
+    machine.recoverToCommittedState();
+    expect(machine.getSessionState()).toMatchObject({
+      navigationStatus: 'loaded',
+      finalUrl: 'http://example.test/stable.wml',
+      activeCardId: 'stable'
+    });
+    expect(machine.getSessionState().lastError).toBeUndefined();
   });
 
   it('fires onNavigationError for transport failures, alongside onNetworkUnavailable', async () => {

--- a/browser/frontend/src/app/navigation-state.ts
+++ b/browser/frontend/src/app/navigation-state.ts
@@ -40,6 +40,23 @@ export type BackNavigationMode = 'engine' | 'host' | 'none';
 // content types and WBXML decode failures.
 export type NavigationErrorKind = 'network' | 'parse';
 
+export type NavigationPhase = 'preparing' | 'connecting' | 'gateway' | 'decode' | 'deck' | 'card';
+
+export type NavigationFailureLayer = 'request' | 'connection' | 'gateway' | 'decode' | 'deck';
+
+export interface NavigationPhaseContext {
+  phase: NavigationPhase;
+  requestId: string;
+  requestedUrl: string;
+}
+
+export interface NavigationFailureContext {
+  layer: NavigationFailureLayer;
+  category: string;
+  requestId: string;
+  requestedUrl: string;
+}
+
 const navigationErrorKindForFetchFailure = (response: FetchResponse): NavigationErrorKind =>
   response.error?.code === 'UNSUPPORTED_CONTENT_TYPE' ||
   response.error?.code === 'WBXML_DECODE_FAILED'
@@ -82,7 +99,13 @@ export interface NavigationHooks {
    * consistent, visible failure indicator (e.g. a toast) regardless of which
    * failure kind occurred, instead of only the quieter status-panel text.
    */
-  onNavigationError?(message: string, kind: NavigationErrorKind): void;
+  onNavigationError?(
+    message: string,
+    kind: NavigationErrorKind,
+    context: NavigationFailureContext
+  ): void;
+  onNavigationPhase?(context: NavigationPhaseContext): void;
+  onNavigationCancellableChange?(cancellable: boolean, requestId?: string): void;
   onStateEvent?(action: string, details?: Record<string, unknown>): void;
 }
 
@@ -111,6 +134,7 @@ export interface NavigationStateMachine {
   isExternalIntentQuarantined(intentUrl: string, requestPolicy?: FetchRequestPolicy): boolean;
   quarantineExternalIntent(intentUrl: string, requestPolicy?: FetchRequestPolicy): void;
   cancelPendingNavigation(): Promise<void> | undefined;
+  recoverToCommittedState(): void;
   getSessionState(): HostSessionState;
   getHistoryState(): HostHistoryState;
 }
@@ -208,6 +232,7 @@ export const createNavigationStateMachine = (
     const superseded = activeTransportOperation;
     activeTransportOperation = undefined;
     if (superseded) {
+      hooks.onNavigationCancellableChange?.(false);
       pendingHostCancellation = hostClient
         .cancelFetch(superseded.requestId)
         .then(() => undefined)
@@ -231,6 +256,34 @@ export const createNavigationStateMachine = (
     }
     if (activeTransportOperation?.generation === generation) {
       activeTransportOperation = undefined;
+      hooks.onNavigationCancellableChange?.(false);
+    }
+  };
+
+  const emitNavigationPhase = (
+    phase: NavigationPhase,
+    requestId: string,
+    requestedUrl: string
+  ): void => {
+    hooks.onNavigationPhase?.({ phase, requestId, requestedUrl });
+    hooks.onStateEvent?.('navigation-phase', { phase, requestId, requestedUrl });
+  };
+
+  const navigationFailureLayerForFetchFailure = (
+    response: FetchResponse
+  ): NavigationFailureLayer => {
+    switch (response.error?.code) {
+      case 'INVALID_REQUEST':
+      case 'PAYLOAD_TOO_LARGE':
+        return 'request';
+      case 'GATEWAY_TIMEOUT':
+      case 'PROTOCOL_ERROR':
+        return 'gateway';
+      case 'UNSUPPORTED_CONTENT_TYPE':
+      case 'WBXML_DECODE_FAILED':
+        return 'decode';
+      default:
+        return 'connection';
     }
   };
 
@@ -278,6 +331,16 @@ export const createNavigationStateMachine = (
       mergeSessionState({ navigationStatus: 'idle', lastError: undefined });
     }
     return pendingHostCancellation;
+  };
+
+  const recoverToCommittedState = (): void => {
+    if (hostSessionState.navigationStatus !== 'error') {
+      return;
+    }
+    mergeSessionState({
+      navigationStatus: hostSessionState.finalUrl ? 'loaded' : 'idle',
+      lastError: undefined
+    });
   };
 
   const externalIntentRequestIdentity = (
@@ -400,15 +463,37 @@ export const createNavigationStateMachine = (
       lastError: undefined
     });
 
-    const transport = await hostClient.fetchDeck({
-      url: requestedUrl,
-      method,
-      headers: options.headers,
-      timeoutMs: WAVES_CONFIG.transportFetchTimeoutMs,
-      retries: WAVES_CONFIG.transportFetchRetries,
-      requestId,
-      requestPolicy
-    });
+    emitNavigationPhase('connecting', requestId, requestedUrl);
+    if (/^waps?:/i.test(requestedUrl)) {
+      emitNavigationPhase('gateway', requestId, requestedUrl);
+    }
+
+    let transport: FetchResponse;
+    try {
+      transport = await hostClient.fetchDeck({
+        url: requestedUrl,
+        method,
+        headers: options.headers,
+        timeoutMs: WAVES_CONFIG.transportFetchTimeoutMs,
+        retries: WAVES_CONFIG.transportFetchRetries,
+        requestId,
+        requestPolicy
+      });
+    } catch (error) {
+      if (!isCurrentNavigation(generation)) {
+        return null;
+      }
+      const message = error instanceof Error ? error.message : String(error);
+      const category = navigationFailureCategory(error);
+      mergeSessionState({ navigationStatus: 'error', lastError: message });
+      hooks.onNavigationError?.(message, 'network', {
+        layer: category === 'INVALID_REQUEST' ? 'request' : 'connection',
+        category,
+        requestId,
+        requestedUrl
+      });
+      return null;
+    }
     if (!isCurrentNavigation(generation)) {
       return null;
     }
@@ -432,9 +517,16 @@ export const createNavigationStateMachine = (
       if (options.source === 'external-intent') {
         quarantineExternalIntentRequest(requestedUrl, method, requestPolicy, generation);
       }
-      hooks.onNavigationError?.(errorMessage, navigationErrorKindForFetchFailure(transport));
+      hooks.onNavigationError?.(errorMessage, navigationErrorKindForFetchFailure(transport), {
+        layer: navigationFailureLayerForFetchFailure(transport),
+        category: transport.error?.code ?? 'TRANSPORT_FAILURE',
+        requestId,
+        requestedUrl
+      });
       return null;
     }
+
+    emitNavigationPhase('decode', requestId, requestedUrl);
 
     const deckInput = transport.engineDeckInput ?? {
       wmlXml: transport.wml ?? '',
@@ -451,12 +543,18 @@ export const createNavigationStateMachine = (
       if (options.source === 'external-intent') {
         quarantineExternalIntentRequest(requestedUrl, method, requestPolicy, generation);
       }
-      hooks.onNavigationError?.(WAVES_COPY.errors.missingWmlPayload, 'parse');
+      hooks.onNavigationError?.(WAVES_COPY.errors.missingWmlPayload, 'parse', {
+        layer: 'decode',
+        category: 'MISSING_WML_PAYLOAD',
+        requestId,
+        requestedUrl
+      });
       return null;
     }
 
     let frame: EngineFrame;
     try {
+      emitNavigationPhase('deck', requestId, requestedUrl);
       frame = await hostClient.engineLoadDeckContextFrame({
         wmlXml: deckInput.wmlXml,
         baseUrl: deckInput.baseUrl,
@@ -478,7 +576,12 @@ export const createNavigationStateMachine = (
       if (options.source === 'external-intent') {
         quarantineExternalIntentRequest(requestedUrl, method, requestPolicy, generation);
       }
-      hooks.onNavigationError?.(message, 'parse');
+      hooks.onNavigationError?.(message, 'parse', {
+        layer: 'deck',
+        category: 'ENGINE_LOAD_FAILED',
+        requestId,
+        requestedUrl
+      });
       return null;
     }
     if (!isCurrentNavigation(generation)) {
@@ -497,6 +600,7 @@ export const createNavigationStateMachine = (
       focusedLinkIndex: frame.snapshot.focusedLinkIndex,
       externalNavigationIntent: frame.snapshot.externalNavigationIntent
     });
+    emitNavigationPhase('card', requestId, requestedUrl);
     if (publishLoadedFrame) {
       publishFrame(frame);
     }
@@ -558,7 +662,12 @@ export const createNavigationStateMachine = (
         if (hop === maxExternalIntentHops) {
           const message = `External intent hop limit reached (${maxExternalIntentHops}).`;
           mergeSessionState({ navigationStatus: 'error', lastError: message });
-          hooks.onNavigationError?.(message, 'network');
+          hooks.onNavigationError?.(message, 'network', {
+            layer: 'deck',
+            category: 'EXTERNAL_INTENT_HOP_LIMIT',
+            requestId,
+            requestedUrl: nextUrl
+          });
         }
       }
     }
@@ -590,6 +699,8 @@ export const createNavigationStateMachine = (
       rejectOperation = reject;
     });
     activeTransportOperation = { generation, identity, requestId, promise: operationPromise };
+    emitNavigationPhase('preparing', requestId, identity.requestedUrl);
+    hooks.onNavigationCancellableChange?.(true, requestId);
     void (async () => {
       try {
         if (pendingHostCancellation) {
@@ -808,9 +919,18 @@ export const createNavigationStateMachine = (
     isExternalIntentQuarantined,
     quarantineExternalIntent,
     cancelPendingNavigation,
+    recoverToCommittedState,
     getSessionState: () => hostSessionState,
     getHistoryState: () => hostHistory
   };
+};
+
+const navigationFailureCategory = (error: unknown): string => {
+  if (typeof error !== 'object' || error === null || !('code' in error)) {
+    return 'HOST_FAILURE';
+  }
+  const code = (error as { code?: unknown }).code;
+  return typeof code === 'string' && /^[A-Z][A-Z0-9_]{0,63}$/.test(code) ? code : 'HOST_FAILURE';
 };
 
 const historyNavigationUrl = (url: string, activeCardId?: string): string => {

--- a/browser/frontend/src/app/shell-event-bindings.test.ts
+++ b/browser/frontend/src/app/shell-event-bindings.test.ts
@@ -13,6 +13,10 @@ const BUTTON_IDS = [
   'btn-back',
   'btn-reload',
   'btn-stop-navigation',
+  'btn-navigation-retry',
+  'btn-navigation-change-route',
+  'btn-navigation-details',
+  'btn-navigation-return',
   'btn-fetch-url',
   'btn-up',
   'btn-enter',
@@ -74,6 +78,10 @@ const createActions = (): ShellEventBindingActions & Record<string, ReturnType<t
   fetchUrlEnter: vi.fn(async () => undefined),
   reload: vi.fn(async () => undefined),
   stopNavigation: vi.fn(async () => undefined),
+  retryNavigation: vi.fn(async () => undefined),
+  changeNavigationRoute: vi.fn(async () => undefined),
+  showNavigationDetails: vi.fn(async () => undefined),
+  returnFromNavigationError: vi.fn(async () => undefined),
   changeMode: vi.fn(async () => undefined),
   selectLocalExample: vi.fn(async () => undefined),
   loadLocalExample: vi.fn(async () => undefined),
@@ -127,6 +135,10 @@ describe('ShellEventBindings', () => {
     document.querySelector<HTMLButtonElement>('#btn-load-context')?.click();
     document.querySelector<HTMLButtonElement>('#btn-reload')?.click();
     document.querySelector<HTMLButtonElement>('#btn-stop-navigation')?.click();
+    document.querySelector<HTMLButtonElement>('#btn-navigation-retry')?.click();
+    document.querySelector<HTMLButtonElement>('#btn-navigation-change-route')?.click();
+    document.querySelector<HTMLButtonElement>('#btn-navigation-details')?.click();
+    document.querySelector<HTMLButtonElement>('#btn-navigation-return')?.click();
     document.querySelector<HTMLButtonElement>('#btn-fetch-url')?.click();
     document.querySelector<HTMLButtonElement>('#btn-back')?.click();
     refs.loadLocalBtnEl.click();
@@ -144,6 +156,10 @@ describe('ShellEventBindings', () => {
     expect(actions.loadRawWml).toHaveBeenCalledTimes(1);
     expect(actions.reload).toHaveBeenCalledTimes(1);
     expect(actions.stopNavigation).toHaveBeenCalledTimes(1);
+    expect(actions.retryNavigation).toHaveBeenCalledTimes(1);
+    expect(actions.changeNavigationRoute).toHaveBeenCalledTimes(1);
+    expect(actions.showNavigationDetails).toHaveBeenCalledTimes(1);
+    expect(actions.returnFromNavigationError).toHaveBeenCalledTimes(1);
     expect(actions.fetchUrl).toHaveBeenCalledTimes(1);
     expect(actions.navigateBack).toHaveBeenCalledTimes(1);
     expect(actions.loadLocalExample).toHaveBeenCalledTimes(1);

--- a/browser/frontend/src/app/shell-event-bindings.ts
+++ b/browser/frontend/src/app/shell-event-bindings.ts
@@ -17,6 +17,10 @@ export interface ShellEventBindingActions {
   fetchUrlEnter(event: Event): Promise<void>;
   reload(): Promise<void>;
   stopNavigation(): Promise<void>;
+  retryNavigation(): Promise<void>;
+  changeNavigationRoute(): Promise<void>;
+  showNavigationDetails(): Promise<void>;
+  returnFromNavigationError(): Promise<void>;
   changeMode(): Promise<void>;
   selectLocalExample(): Promise<void>;
   loadLocalExample(): Promise<void>;
@@ -61,6 +65,22 @@ export class ShellEventBindings {
     this.bindButton('#btn-fetch-url', runAction('fetch-url', actions.fetchUrl));
     this.bindButton('#btn-reload', runAction('reload', actions.reload));
     this.bindButton('#btn-stop-navigation', runAction('stop-navigation', actions.stopNavigation));
+    this.bindButton(
+      '#btn-navigation-retry',
+      runAction('retry-navigation', actions.retryNavigation)
+    );
+    this.bindButton(
+      '#btn-navigation-change-route',
+      runAction('change-navigation-route', actions.changeNavigationRoute)
+    );
+    this.bindButton(
+      '#btn-navigation-details',
+      runAction('show-navigation-details', actions.showNavigationDetails)
+    );
+    this.bindButton(
+      '#btn-navigation-return',
+      runAction('return-from-navigation-error', actions.returnFromNavigationError)
+    );
 
     const fetchUrlEnter = runAction('fetch-url-enter', async (event) => {
       if (event) {

--- a/browser/frontend/src/app/shell/navigation-phase-bar-template.ts
+++ b/browser/frontend/src/app/shell/navigation-phase-bar-template.ts
@@ -1,0 +1,38 @@
+import { WAVES_COPY } from '../waves-copy';
+
+export const navigationPhaseBarTemplate = () => `
+  <section
+    id="navigation-phase-bar"
+    class="phase-bar-slot"
+    data-navigation-state="idle"
+    aria-label="${WAVES_COPY.navigation.lifecycle}"
+    hidden
+  >
+    <div class="phase-bar-summary">
+      <span class="phase-bar-indicator" aria-hidden="true"></span>
+      <strong id="navigation-phase-label"></strong>
+      <span id="navigation-phase-detail"></span>
+      <code id="navigation-correlation-id"></code>
+    </div>
+    <div id="navigation-recovery" class="phase-bar-recovery" hidden>
+      <div class="phase-bar-error-copy">
+        <strong id="navigation-error-title"></strong>
+        <span id="navigation-error-message"></span>
+      </div>
+      <div class="phase-bar-actions" role="group" aria-label="${WAVES_COPY.navigation.recoveryActions}">
+        <button id="btn-navigation-retry" class="btn" type="button">
+          ${WAVES_COPY.navigation.retry}
+        </button>
+        <button id="btn-navigation-change-route" class="btn" type="button">
+          ${WAVES_COPY.navigation.changeRoute}
+        </button>
+        <button id="btn-navigation-details" class="btn" type="button">
+          ${WAVES_COPY.navigation.details}
+        </button>
+        <button id="btn-navigation-return" class="btn" type="button">
+          ${WAVES_COPY.navigation.returnToDeck}
+        </button>
+      </div>
+    </div>
+  </section>
+`;

--- a/browser/frontend/src/app/waves-copy.ts
+++ b/browser/frontend/src/app/waves-copy.ts
@@ -10,6 +10,7 @@ const locale = {
     back: 'Back',
     reload: 'Reload',
     go: 'Go',
+    stop: 'Stop',
     address: 'Address',
     addressPlaceholder: 'Enter a WAP or WML URL',
     historyControls: 'History controls',
@@ -193,6 +194,27 @@ const locale = {
     boundedSnapshot: 'Bounded snapshot',
     noSnapshot: 'No snapshot captured'
   },
+  navigation: {
+    lifecycle: 'Navigation lifecycle',
+    recoveryActions: 'Navigation recovery actions',
+    retry: 'Retry',
+    changeRoute: 'Change route',
+    details: 'Details',
+    returnToDeck: 'Return',
+    failed: 'Navigation failed',
+    correlation: (requestId: string) => `Request ${requestId}`,
+    phase: {
+      preparing: 'Preparing request',
+      connecting: 'Connecting',
+      gateway: 'Gateway exchange',
+      decode: 'Decoding response',
+      deck: 'Loading deck',
+      card: 'Preparing card'
+    },
+    failureTitle: (layer: string, category: string) => `${layer} · ${category}`,
+    returnedToDeck: 'Returned to the last committed deck.',
+    chooseAnotherRoute: 'Choose another address or route, then press Go.'
+  },
   statusPrefix: {
     error: 'Error:',
     fetchFailed: 'Fetch failed:',
@@ -250,6 +272,7 @@ const locale = {
     loading: (url: string) => `Loading ${url}...`,
     followingExternalIntent: (url: string) => `Following external intent: ${url}`,
     loadingPreviousPage: (url: string) => `Loading previous page: ${url}`,
+    navigationStopped: 'Navigation stopped.',
     fetchFailed: (message: string) => `Fetch failed: ${message}`,
     // Distinct from fetchFailed: the transport request itself succeeded, but the
     // payload it returned could not be parsed/used as a WML deck. Kept as

--- a/browser/frontend/src/styles.css
+++ b/browser/frontend/src/styles.css
@@ -1167,7 +1167,96 @@ pre {
 }
 
 .phase-bar-slot {
-  display: none;
+  flex: 0 0 auto;
+  padding: var(--space-xs) var(--space-md);
+  border-top: var(--rule-hair) solid var(--host-border);
+  background: var(--color-surface);
+  font-size: var(--text-sm);
+}
+
+.phase-bar-slot:not([hidden]) {
+  display: grid;
+  gap: var(--space-xs);
+}
+
+.phase-bar-summary,
+.phase-bar-recovery,
+.phase-bar-error-copy,
+.phase-bar-actions {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: var(--space-xs);
+}
+
+.phase-bar-summary {
+  overflow: hidden;
+}
+
+.phase-bar-summary > span,
+.phase-bar-summary > code {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.phase-bar-indicator {
+  width: 0.55rem;
+  height: 0.55rem;
+  flex: 0 0 auto;
+  border-radius: 50%;
+  background: var(--status-loading-indicator);
+}
+
+.phase-bar-slot[data-navigation-state='loading'] .phase-bar-indicator {
+  animation: phase-pulse 1.1s ease-in-out infinite alternate;
+}
+
+.phase-bar-slot[data-navigation-state='error'] .phase-bar-indicator {
+  background: var(--status-error-indicator);
+}
+
+.phase-bar-recovery {
+  flex-wrap: wrap;
+  justify-content: space-between;
+  padding-top: var(--space-xs);
+  border-top: var(--rule-hair) solid var(--host-border);
+}
+
+.phase-bar-error-copy {
+  flex: 1 1 20rem;
+  overflow: hidden;
+}
+
+.phase-bar-error-copy > span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.phase-bar-actions {
+  flex: 0 0 auto;
+  flex-wrap: wrap;
+}
+
+.phase-bar-actions .btn {
+  min-height: 30px;
+  padding: var(--space-2xs) var(--space-sm);
+}
+
+#navigation-correlation-id {
+  margin-left: auto;
+  color: var(--host-muted);
+  font-size: var(--text-xs);
+}
+
+@keyframes phase-pulse {
+  from {
+    opacity: 0.45;
+  }
+  to {
+    opacity: 1;
+  }
 }
 
 @media (hover: hover) and (pointer: fine) {
@@ -1367,5 +1456,9 @@ pre {
   *::after {
     scroll-behavior: auto !important;
     transition-duration: 0.01ms !important;
+  }
+
+  .phase-bar-indicator {
+    animation: none !important;
   }
 }

--- a/docs/waves/PRD-WAVES-DESKTOP-APPLICATION-COMPLETION.md
+++ b/docs/waves/PRD-WAVES-DESKTOP-APPLICATION-COMPLETION.md
@@ -626,8 +626,8 @@ Before feature UI begins:
 
 1. F1 primary frame rendering and deterministic navigation publication are complete in PRs
    `#519`, `#520`, and `#526`.
-2. Cancellable/admission-controlled navigation is complete in PR `#521`; `WBP-11` phases and
-   recovery presentation remain.
+2. Cancellable/admission-controlled navigation and `WBP-11` phase-aware recovery presentation are
+   complete; `WBP-12` safe-session/crash recovery remains.
 3. Versioned application state is complete in PR `#522`; safe projection, integrated settings,
    window restore, and local/GET-safe recovery remain.
 4. The safe Favorites/service-catalog domain is complete in PR `#517`; WAP Home/Library UI remains.

--- a/docs/waves/SPRINT_PLAN_2026-03_MASTER_PRIORITIZED.md
+++ b/docs/waves/SPRINT_PLAN_2026-03_MASTER_PRIORITIZED.md
@@ -269,9 +269,9 @@ and lanes may run concurrently subject to the noted file ownership.
 Desktop dispatch checkpoint: F1-01 through F1-03, RSL-01 through RSL-07, APP-STATE-01,
 APP-FAV-01, APP-CMD-01, and D0-01 through D0-04 are complete. D0-04 implements read-only Inspector
 consumption in its exclusive consumer/component surfaces while F2-01 remains independent on
-engine-input ownership. WBP-11 and APP-SHELL-01 follow on shared presenter/shell surfaces. RSL-07
-bounds retained history but leaves issue `#450`'s cross-deck same-card identity correction to its
-separate follow-up.
+engine-input ownership. WBP-11 phase-aware loading/recovery is complete on the shared presenter
+seam; APP-SHELL-01 follows through one shell owner. RSL-07 bounds retained history, and issue `#450`
+has completed the cross-deck same-card identity correction.
 
 Preserve completed WML, WBXML, WDP, WCMP, and WSP evidence; do not activate
 connection-oriented WSP/WTP to manufacture completion. `REN-4` and full

--- a/docs/waves/WAVES_BROWSER_PRODUCT_IMPLEMENTATION_PLAN.md
+++ b/docs/waves/WAVES_BROWSER_PRODUCT_IMPLEMENTATION_PLAN.md
@@ -403,6 +403,7 @@ Accept:
 
 ### WBP-11 Phase-aware loading and recovery presentation
 
+- `Status`: done
 - `Lane`: C with browser integration
 - `Depends On`: `WBP-03`, `WBP-10`
 
@@ -419,6 +420,21 @@ Accept:
 - delayed visual progress appears by 200 milliseconds for slow operations
 - every transport error includes a layer/category, correlation ID, and safe recovery action
 - no browser-authored error card is injected into the engine
+
+Resolution:
+
+- The browser navigation state machine publishes deterministic Preparing, Connecting,
+  route-supported Gateway, Decode, Deck, and Card boundaries with the active request ID. Immediate
+  visible feedback is synchronous and the existing non-destructive slow-navigation hint appears at
+  180 milliseconds while the previous committed frame remains intact.
+- Go changes to Stop only while a registered transport request can be cancelled. Completion,
+  failure, cancellation, and supersession restore Go without allowing stale results to publish.
+- The reserved phase-bar shell seam now presents the failing layer/category, safe correlation ID,
+  and exact-request Retry, Change route, Details, and committed-frame Return actions. The surface is
+  host-owned and never injects an error deck/card into the engine.
+- Frontend integration coverage exercises phase order, WAP gateway routing, host-command rejection,
+  correlated transport failure, Go/Stop cancellation, the 180-millisecond progress threshold,
+  exact Retry, committed-frame preservation, and the single accessible announcement channel.
 
 ### WBP-12 Persistence and crash recovery
 


### PR DESCRIPTION
## Summary

- publish deterministic Preparing, Connecting, route-supported Gateway, Decode, Deck, and Card navigation phases with request correlation
- switch Go to Stop only while a registered transport request is cancellable
- preserve the committed frame and present categorized Retry, Change route, Details, and Return recovery actions in the reserved host phase bar
- convert rejected host fetch commands into correlated recoverable failures without injecting browser-authored WML
- synchronize the active WBP-11 product and work-item documentation

## Verification

- frontend typecheck, lint, format, and production build
- frontend suite: 52 files / 377 tests
- repository pre-push gate: passed
