### PR TITLE
docs(waves): sync pre-alpha evidence to current main

### DIFF
--- a/browser/README.md
+++ b/browser/README.md
@@ -233,7 +233,7 @@ group and Docker services. This pilot is scheduled/manual until the promotion cr
 2. Preserve completed WBP-06/F0 frame, input, drift, and WML-309 evidence. Keep `EngineDebug*`
    separate and retain the legacy render/key compatibility paths until the declared cutover gate.
 3. Preserve the merged typed POST history `#541`, F2-02 scrolling `#542`, F2-03 unified input
-   `#543`, and APP-SHELL-01 Library/Preferences `#545` slices; land WBP-11 phase recovery `#544`
+   `#543`, WBP-11 phase recovery `#544`, and APP-SHELL-01 Library/Preferences `#545` slices
    without destabilizing their shared browser shell seams.
 4. Use the machine-checked
    [`WBP-14` desktop-path evidence audit](../docs/waves/WBP_14_DESKTOP_PATH_EVIDENCE.md) to add

--- a/docs/waves/WAP_1_2_1_COMPLIANCE_PROGRAM.md
+++ b/docs/waves/WAP_1_2_1_COMPLIANCE_PROGRAM.md
@@ -154,7 +154,7 @@ executable evidence.
 
 ## Dependency-ordered program
 
-The program contains 13 sprints and 82 unique work items. Existing completed
+The program contains 13 sprints and 83 unique work items. Existing completed
 tickets remain historical facts; the program maps to them where relevant and
 adds work only for uncovered obligations.
 

--- a/docs/waves/WAVES_BROWSER_PRODUCT_IMPLEMENTATION_PLAN.md
+++ b/docs/waves/WAVES_BROWSER_PRODUCT_IMPLEMENTATION_PLAN.md
@@ -375,8 +375,9 @@ Accept:
 
 ### WBP-10 Cancellable fetch lifecycle
 
-- `Status`: in progress; cancellation/admission is complete in PR `#521`, while phase metadata and
-  the WBP-11 presentation handoff remain
+- `Status`: in progress; cancellation/admission is complete in PR `#521` and the WBP-11 browser
+  presentation handoff is complete in PR `#544`, while exported transport attempt/phase metadata
+  remains
 - `Lane`: C
 - `Depends On`: owning transport/WSP slice
 - `Likely Files`:
@@ -543,8 +544,9 @@ source-recovery candidates until comparable primary evidence exists.
    (`WBP-02` through `WBP-05`) with one shell-integration owner.
 4. Land the engine frame and affordance contract (`WBP-06`) through its existing F0 gate.
 5. Run Canvas/input/accessibility integration (`WBP-07` through `WBP-09`).
-6. Land transport cancellation and phase metadata (`WBP-10`).
-7. Integrate loading, recovery, and persistence (`WBP-11`, `WBP-12`).
+6. Preserve merged transport cancellation and WBP-11 recovery presentation; finish WBP-10's
+   remaining exported transport metadata.
+7. Complete WBP-12 persistence and crash recovery on the merged WBP-11 presentation seam.
 8. Land diagnostics/replay after both contract surfaces stabilize (`WBP-13`).
 9. Close MVP with complete-path evidence (`WBP-14`).
 10. Begin named compatibility profiles only after Class C reference behavior is stable (`WBP-15`);
@@ -623,6 +625,7 @@ themselves claim WBP-07 through WBP-14 complete.
 
 The redesigned shell/Developer Tools workspace, pre-release marketing refresh, versioned
 application-state foundation, Favorites domain, native command registry, safe diagnostic
-projection, D0-02/D0-03 debug source/host bridge, D0-04 read-only Inspector, and F2-01 deterministic
-click input are merged. Issue `#450` is the next shared-history correction; F2-02/F2-03, `WBP-11`,
-and `APP-SHELL-01` follow on engine-input, presenter, and shell surfaces.
+projection, D0-02/D0-03 debug source/host bridge, D0-04 read-only Inspector, F2-01 through F2-03
+input/scrolling, issue `#450` shared-history correction, WBP-11 phase recovery, and APP-SHELL-01 are
+merged. WBP-10's remaining exported transport metadata, WBP-12/WBP-13 product slices, and WBP-14
+native and packaged evidence remain explicit follow-ups.

--- a/docs/waves/WBP_14_DESKTOP_PATH_EVIDENCE.md
+++ b/docs/waves/WBP_14_DESKTOP_PATH_EVIDENCE.md
@@ -4,7 +4,7 @@ Status: `in-progress` — inventory and drift gate established; release gate not
 
 Audit date: 2026-08-02
 
-Audit base: `origin/main` at `dfe2c4c9`
+Audit base: `origin/main` at `d233426d`
 
 Machine-readable inventory: [`wbp-14-desktop-evidence.json`](wbp-14-desktop-evidence.json)
 
@@ -37,7 +37,7 @@ as a silent substitute for the other.
 | ----------------------------------------- | --------------- | ----------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
 | Startup and successful gateway navigation | complete        | Native production frontend reaches engine-ready and renders/navigates controlled WML 1.3 decks  | Add a startup budget before calling startup performance complete                                         |
 | Softkeys, keyboard, pointer, scrolling    | partial         | Unified input routing, engine frame/affordance, and deterministic scrolling fixture paths exist | Add native pointer/keyboard equivalence and text-entry/modifier coverage                                 |
-| Loading phases and ordinary recovery      | partial         | Stale-result/concurrency tests and basic native failure/recovery exist                          | Merge `#544`; measure 100/200 ms presentation budgets and exercise categorized failures natively         |
+| Loading phases and ordinary recovery      | partial         | WBP-11 phases, stale-result tests, and basic native failure/recovery exist                       | Measure 100/200 ms budgets and exercise categorized failures natively                                   |
 | History                                   | partial         | Typed replayable POST history and request-shaped engine/browser evidence exist                  | Add native GET, POST, and Back replay cases                                                              |
 | Timeout and cancellation                  | missing         | Lower-level behavior is tested                                                                  | Add controlled native cases, cancellation acknowledgement timing, and retained-frame assertions          |
 | Invalid deck                              | missing         | `WML-205` engine failure/atomicity story is green                                               | Serve malformed/invalid WML through Kannel and verify categorized native recovery without frame mutation |
@@ -48,16 +48,14 @@ as a silent substitute for the other.
 | Screen reader                             | blocked         | Manual VoiceOver procedure is documented                                                        | Enable packaging and record the packaged macOS smoke result                                              |
 | Interaction latency and memory            | missing/blocked | No release-budget artifact yet                                                                  | Add repeatable native timings and memory observations after the WBP-13 replay path exists                |
 
-## Pending implementation contribution
+## Merged implementation contribution
 
-PRs `#541`, `#542`, `#543`, and `#545` are included in the refreshed audit base. Their typed
-POST-history, deterministic scrolling, unified input, and application-shell behavior strengthen
-fixture and manual-test coverage, but native desktop-path evidence is still required. This
-remaining pull request is not counted as merged behavior:
-
-| PR     | Slice                            | WBP-14 contribution                                               |
-| ------ | -------------------------------- | ----------------------------------------------------------------- |
-| `#544` | phase-aware loading and recovery | supplies WBP-11 presentation/recovery behavior and timing targets |
+PRs `#541` through `#545` are included in the refreshed audit base. Their typed POST-history,
+deterministic scrolling, unified input, phase-aware recovery, and application-shell behavior
+strengthen fixture and manual-test coverage, but native desktop-path evidence is still required.
+In particular, merged PR `#544` supplies WBP-11 presentation/recovery behavior and timing targets;
+it does not supply the native timing and categorized-failure artifacts needed to change the
+inventory's 3 complete, 7 partial, 5 missing, and 4 blocked scenario counts.
 
 ## Compliance mapping posture
 
@@ -100,8 +98,8 @@ The native workflow uploads screenshots, page source, environment, service logs,
 
 ## Closure order
 
-1. Merge the pending phase-recovery slice; rerun stories, parity, rendered
-   accessibility, and native success evidence for the combined browser.
+1. Preserve the merged phase-recovery slice and rerun stories, parity, rendered accessibility,
+   and native success evidence for the combined browser before crediting new release evidence.
 2. Extend the controlled Kannel origin and native UI driver with timeout, actual cancellation,
    invalid-deck, and script-trap cases. Each case must assert retained committed frame, categorized
    status, correlation metadata, and successful recovery.

--- a/docs/waves/WORK_ITEMS.md
+++ b/docs/waves/WORK_ITEMS.md
@@ -90,12 +90,12 @@ evidence even though the bounded endpoint is now reachable.
 
 ## Next In Line (Desktop Evidence Checkpoint - 2026-08-02)
 
-Audit base: `origin/main` `dfe2c4c9`. PRs `#541`, `#542`, `#543`, and `#545` have merged typed POST
-history, F2-02 scrolling, F2-03 unified input, and APP-SHELL-01 Library/Preferences. PR `#544`
-still carries WBP-11 phase recovery and is not counted as merged behavior. The WBP-14 inventory in
-[`WBP_14_DESKTOP_PATH_EVIDENCE.md`](WBP_14_DESKTOP_PATH_EVIDENCE.md) records 3 complete, 7 partial,
-5 missing, and 4 blocked evidence scenarios and prevents release closure from being inferred from
-lower-level tests.
+Audit base: `origin/main` `d233426d`. PRs `#541`, `#542`, `#543`, `#544`, and `#545` have merged
+typed POST history, F2-02 scrolling, F2-03 unified input, WBP-11 phase recovery, and APP-SHELL-01
+Library/Preferences. WBP-11's merge does not by itself add native release evidence. The WBP-14
+inventory in [`WBP_14_DESKTOP_PATH_EVIDENCE.md`](WBP_14_DESKTOP_PATH_EVIDENCE.md) records 3
+complete, 7 partial, 5 missing, and 4 blocked evidence scenarios and prevents release closure from
+being inferred from lower-level tests.
 
 The selected-profile source and planning lanes are complete. The active queue
 must now turn the 198 selected parent rows and 762 planned clauses into direct
@@ -125,9 +125,10 @@ Current priority order is:
    context/history/card-table evidence, WML-304's merged request-intent and native request
    application boundary, Request A2's completed typed POST-history replay, and WMLS-501's
    completed decoder/verifier, verified-unit routing, and stack-dataflow closure. Advance
-   WMLS-502 execution as the remaining implementation lane. Preserve the completed D0-01 through D0-04 debug path and completed
-   F0/F1/F2-01 frame migration; keep F2-02 through F4, generators, and maintenance non-preemptive
-   unless separately authorized or needed to unblock a strict obligation.
+   WMLS-502 execution as the remaining implementation lane. Preserve the completed D0-01 through
+   D0-04 debug path and completed F0/F1/F2-01 through F2-03 frame migration; keep F3 through F4,
+   generators, and maintenance non-preemptive unless separately authorized or needed to unblock a
+   strict obligation.
 
 The schema-v2 WDP delivery -> fetch/WBXML decode -> native engine parity path,
 strict native/WASM validation fixtures, and paired executable stories now
@@ -187,11 +188,12 @@ The resilience board is also synchronized to current main: `RSL-01` through `RSL
 The final pair adds allowlisted diagnostic redaction followed by bounded toast, timeline, and
 host-history state on the shared presenter/history surface.
 
-Issue `#450`, typed POST replay, F2-02/F2-03, and APP-SHELL-01 are merged on the stabilized browser
-foundation. Land WBP-11 phase recovery in `#544`, then close WBP-14 in evidence order: native
-timeout/cancellation/invalid-deck/script-trap coverage; WBP-12 crash recovery; WBP-13 replay/memory;
-packaged screen-reader and latency evidence. `WMLS-502` remains a separate script lane and must not
-be inferred complete from WBP-14 evidence.
+Issue `#450`, typed POST replay, F2-02/F2-03, WBP-11 phase recovery, and APP-SHELL-01 are merged on
+the stabilized browser foundation. Keep WBP-10's remaining transport-metadata delta separate from
+the completed WBP-11 presentation, then close WBP-14 in evidence order: native timeout,
+cancellation, invalid-deck, and script-trap coverage; WBP-12 crash recovery; WBP-13 replay/memory;
+and packaged screen-reader and latency evidence. `WMLS-502` remains a separate script lane and must
+not be inferred complete from WBP-14 evidence.
 
 ### WML-203A Legacy local-example standalone-document migration
 

--- a/docs/waves/wbp-14-desktop-evidence.json
+++ b/docs/waves/wbp-14-desktop-evidence.json
@@ -4,8 +4,8 @@
   "auditedAt": "2026-08-02",
   "auditBase": {
     "ref": "origin/main",
-    "commit": "dfe2c4c9",
-    "pendingPullRequests": [544]
+    "commit": "d233426d",
+    "pendingPullRequests": []
   },
   "releaseComplete": false,
   "evidenceClasses": {
@@ -75,7 +75,7 @@
       "workItems": ["WBP-11", "WBP-14"],
       "requirements": [],
       "evidence": ["browser/frontend/src/app/navigation-state.concurrency.test.ts"],
-      "blocker": "Phase-aware recovery is in PR #544; the 100/200 millisecond presentation budgets need native evidence."
+      "blocker": "Phase-aware recovery is merged in PR #544; the 100/200 millisecond presentation budgets still need native evidence."
     },
     {
       "id": "timeout",


### PR DESCRIPTION
## Summary

- advance the active desktop-evidence audit base to current `origin/main` at `d233426d`
- record PR #544 / WBP-11 as merged and align adjacent WBP-10/WBP-11 sequencing and next-step prose
- correct the active compliance-program narrative from 82 to the machine-derived 83 unique work items
- preserve the machine-backed WBP-14 release posture at 3 complete, 7 partial, 5 missing, and 4 blocked scenarios

## Why

PR #546 was authored against the pre-#544 audit base and merged after #544, leaving active planning
prose describing phase recovery as pending even though the implementation was already on main. This
synchronizes the prose and descriptive audit metadata without manufacturing new native or packaged
evidence.

## Impact

Documentation and evidence metadata only. No runtime, browser, transport, engine, contract, or
completed-ticket behavior changes.

## Verification

- `pnpm docs:check`
- `pnpm evidence:desktop:check`
- `node scripts/check-requirement-status-drift.mjs`
- `node scripts/check-active-compliance-facts.mjs`
- `node scripts/check-wap-compliance-program.mjs`
- focused compliance-program/active-fact tests
- repository pre-push checks
