### PR TITLE
test(ci): guard standalone marketing lockfile

### DIFF
--- a/scripts/tests/verify.test.mjs
+++ b/scripts/tests/verify.test.mjs
@@ -124,6 +124,14 @@ test('root verification surfaces select every ordinary change lane', () => {
   assert.equal(byId(plan, 'live-kannel').selected, false);
 });
 
+test('marketing verification checks its standalone lockfile before building', () => {
+  const marketing = byId(buildPlan('change', ['marketing-site/package.json']), 'marketing-site');
+  const labels = marketing.commands.map((command) => command.label);
+  assert.ok(
+    labels.indexOf('marketing frozen lockfile') < labels.indexOf('marketing production build')
+  );
+});
+
 test('full intentionally excludes live external gates', () => {
   const plan = buildPlan('full', []);
   assert.equal(byId(plan, 'compliance').selected, true);

--- a/scripts/verify-lib.mjs
+++ b/scripts/verify-lib.mjs
@@ -313,6 +313,14 @@ export const LANES = Object.freeze([
       }
     ],
     commands: [
+      command('marketing frozen lockfile', 'pnpm', [
+        '--dir',
+        'marketing-site',
+        '--ignore-workspace',
+        'install',
+        '--frozen-lockfile',
+        '--ignore-scripts'
+      ]),
       command('marketing production build', 'pnpm', [
         '--dir',
         'marketing-site',


### PR DESCRIPTION
## Summary

- Make local change verification catch stale standalone marketing-site lockfiles before build time.
- Preserve the intentional stack on `codex/transport-clippy-cleanup`.

## What Changed

- Add a frozen, script-free marketing-site install to the marketing verification lane before the production build.
- Add an orchestration test that locks in the install-before-build ordering.

## Validation

- `node --test scripts/tests/verify.test.mjs`
- `pnpm exec prettier --check scripts/verify-lib.mjs scripts/tests/verify.test.mjs`
- `pnpm --dir marketing-site --ignore-workspace install --frozen-lockfile --ignore-scripts`
- `pnpm verify:fast`
- repository pre-push checks

## Scope Notes

- The Node advisory remediation moved into #562 because the repository-wide security audit must pass on the lower stack branch independently.
- This PR remains a draft and contains only the downstream verification guard relative to #562.
